### PR TITLE
Reduce the console logging when running the one-click-run application.

### DIFF
--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -272,6 +272,40 @@
       <plugin>
         <groupId>org.mortbay.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
+        
+                <dependencies>
+          <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.7</version>
+          </dependency>
+          <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.0.7</version>
+          </dependency>
+          <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.6</version>
+          </dependency>
+          <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.6</version>
+          </dependency>
+          <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.6</version>
+          </dependency>
+          <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.6</version>
+          </dependency>
+        </dependencies>
+        
         <configuration>
           <loginServices>
             <loginService implementation="org.eclipse.jetty.security.HashLoginService">
@@ -284,7 +318,13 @@
           <webApp>
             <contextPath>${test.context.path}</contextPath>
           </webApp>
-
+          
+          <systemPropertyVariables>
+            <systemProperty>
+              <name>org.eclipse.jetty.util.log.class</name>
+              <value>org.eclipse.jetty.util.log.Slf4jLog</value>
+            </systemProperty>
+          </systemPropertyVariables>
         </configuration>
         <executions>
           <execution>

--- a/fcrepo-webapp/src/main/resources/jetty-jul-to-slf4j.xml
+++ b/fcrepo-webapp/src/main/resources/jetty-jul-to-slf4j.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+ 
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call class="org.slf4j.bridge.SLF4JBridgeHandler" name="removeHandlersForRootLogger"/>
+  <Call class="org.slf4j.bridge.SLF4JBridgeHandler" name="install"/>
+</Configure>

--- a/fcrepo-webapp/src/main/resources/logback.xml
+++ b/fcrepo-webapp/src/main/resources/logback.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE configuration>
 <configuration>
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+      <resetJUL>true</resetJUL>
+    </contextListener>
+    
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>                                                           
             <pattern>%p %d{HH:mm:ss.SSS} \(%c{0}\) %m%n</pattern>
@@ -10,7 +14,7 @@
   <logger name="org.fcrepo" additivity="false" level="INFO">
     <appender-ref ref="STDOUT"/>
   </logger>
-    <root additivity="false" level="WARN">
+    <root additivity="false" level="OFF">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
The jetty console logging should be reduced and only jetty startup messages and Fedora info included when the user clicks on the one-click-run fcrepo-webapp-4.0.0-alpha-5-SNAPSHOT-jetty-console.war. -- http://www.pivotaltracker.com/story/show/63493246