### PR TITLE
reusable acl nodes

### DIFF
--- a/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest.java
+++ b/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest.java
@@ -119,20 +119,28 @@ public class BasicRolesAuthorizationDelegateRemoveChildrenRecursiveTest {
 
         when(accessRolesProvider.findRolesForPath(parentPath, mockSession))
                 .thenReturn(writerAcl);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(parentPath, mockSession))
+                .thenReturn(writerAcl);
         when(accessRolesProvider.getRoles(parentNode, false)).thenReturn(
                 writerAcl);
 
         when(accessRolesProvider.findRolesForPath(writablePath, mockSession))
+                .thenReturn(writerAcl);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(writablePath, mockSession))
                 .thenReturn(writerAcl);
         when(accessRolesProvider.getRoles(writableNode, false)).thenReturn(
                 writerAcl);
 
         when(accessRolesProvider.findRolesForPath(readablePath, mockSession))
                 .thenReturn(readerAcl);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(readablePath, mockSession))
+                .thenReturn(readerAcl);
         when(accessRolesProvider.getRoles(readableNode, false)).thenReturn(
                 readerAcl);
 
         when(accessRolesProvider.findRolesForPath(noAclPath, mockSession))
+                .thenReturn(null);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(noAclPath, mockSession))
                 .thenReturn(null);
         when(accessRolesProvider.getRoles(noAclNode, false)).thenReturn(null);
 

--- a/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateTest.java
+++ b/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegateTest.java
@@ -121,16 +121,34 @@ public class BasicRolesAuthorizationDelegateTest {
 
         when(accessRolesProvider.findRolesForPath(adminablePath, mockSession))
                 .thenReturn(adminAcl);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(adminablePath, mockSession))
+                .thenReturn(adminAcl);
+
         when(accessRolesProvider.findRolesForPath(writablePath, mockSession))
                 .thenReturn(writerAcl);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(writablePath, mockSession))
+                .thenReturn(writerAcl);
+
         when(accessRolesProvider.findRolesForPath(readablePath, mockSession))
                 .thenReturn(readerAcl);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(readablePath, mockSession))
+                .thenReturn(readerAcl);
+
         when(accessRolesProvider.findRolesForPath(unreadablePath, mockSession))
                 .thenReturn(emptyAcl);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(unreadablePath, mockSession))
+                .thenReturn(emptyAcl);
+
         when(
                 accessRolesProvider.findRolesForPath(unrecognizablePath,
                         mockSession)).thenReturn(unrecognizableAcl);
+        when(
+                accessRolesProvider.findRolesInExternalNodeForPath(unrecognizablePath,
+                        mockSession)).thenReturn(unrecognizableAcl);
+
         when(accessRolesProvider.findRolesForPath(authzPath, mockSession))
+                .thenReturn(writerAcl);
+        when(accessRolesProvider.findRolesInExternalNodeForPath(authzPath, mockSession))
                 .thenReturn(writerAcl);
 
         // Identify authzPath as an ACL node

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AbstractRolesAuthorizationDelegate.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AbstractRolesAuthorizationDelegate.java
@@ -95,7 +95,7 @@ public abstract class AbstractRolesAuthorizationDelegate implements FedoraAuthor
         try {
             final Session internalSession = sessionFactory.getInternalSession();
             final Map<String, List<String>> acl =
-                    accessRolesProvider.findRolesForPath(absPath,
+                    accessRolesProvider.findRolesInExternalNodeForPath(absPath,
                             internalSession);
             roles = resolveUserRoles(acl, allPrincipals);
             LOGGER.debug("roles for this request: {}", roles);

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
@@ -144,7 +144,6 @@ public class AccessRoles extends AbstractResource {
             String fullPath =  ACCESS_ROLES_FOLDER + path;
             final FedoraResource accessRoleObject =
                         nodeService.findOrCreateObject(session,fullPath);
-;
             this.getAccessRolesProvider().postRoles(accessRoleObject.getNode(), data);
             session.save();
             LOGGER.debug("Saved access roles {}", data);

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
@@ -104,7 +104,6 @@ public class AccessRoles extends AbstractResource {
         Response.ResponseBuilder response;
         String fullPath =  ACCESS_ROLES_FOLDER + path;
         try {
-            //final Node node = nodeService.getObject(session, path).getNode();
             final Node node = nodeService.getObject(session, fullPath).getNode();
             final Map<String, List<String>> data =
                     this.getAccessRolesProvider().getRoles(node,
@@ -142,13 +141,10 @@ public class AccessRoles extends AbstractResource {
         try {
             validatePOST(data);
 
-            //final FedoraResource resource =
-            //        nodeService.getObject(session, path);
             String fullPath =  ACCESS_ROLES_FOLDER + path;
             final FedoraResource accessRoleObject =
                         nodeService.findOrCreateObject(session,fullPath);
-
-            //this.getAccessRolesProvider().postRoles(resource.getNode(), data);
+;
             this.getAccessRolesProvider().postRoles(accessRoleObject.getNode(), data);
             session.save();
             LOGGER.debug("Saved access roles {}", data);

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
@@ -102,7 +102,7 @@ public class AccessRoles extends AbstractResource {
         LOGGER.debug("Get access roles for: {}", path);
         LOGGER.debug("effective: {}", effective);
         Response.ResponseBuilder response;
-        String fullPath =  ACCESS_ROLES_FOLDER + path;
+        final String fullPath =  ACCESS_ROLES_FOLDER + path;
         try {
             final Node node = nodeService.getObject(session, fullPath).getNode();
             final Map<String, List<String>> data =
@@ -141,10 +141,11 @@ public class AccessRoles extends AbstractResource {
         try {
             validatePOST(data);
 
-            String fullPath =  ACCESS_ROLES_FOLDER + path;
+            final String fullPath =  ACCESS_ROLES_FOLDER + path;
             final FedoraResource accessRoleObject =
                         nodeService.findOrCreateObject(session,fullPath);
             this.getAccessRolesProvider().postRoles(accessRoleObject.getNode(), data);
+            accessRoleObject.getNode().addMixin("mix:referenceable");
             session.save();
             LOGGER.debug("Saved access roles {}", data);
             response =

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRoles.java
@@ -75,6 +75,8 @@ public class AccessRoles extends AbstractResource {
     @Context
     protected HttpServletRequest request;
 
+    public static final String ACCESS_ROLES_FOLDER = "/fedora:system/fedora:accessroles";
+
 
     /**
      * @return the accessRolesProvider
@@ -100,8 +102,10 @@ public class AccessRoles extends AbstractResource {
         LOGGER.debug("Get access roles for: {}", path);
         LOGGER.debug("effective: {}", effective);
         Response.ResponseBuilder response;
+        String fullPath =  ACCESS_ROLES_FOLDER + path;
         try {
-            final Node node = nodeService.getObject(session, path).getNode();
+            //final Node node = nodeService.getObject(session, path).getNode();
+            final Node node = nodeService.getObject(session, fullPath).getNode();
             final Map<String, List<String>> data =
                     this.getAccessRolesProvider().getRoles(node,
                             (effective != null));
@@ -138,9 +142,14 @@ public class AccessRoles extends AbstractResource {
         try {
             validatePOST(data);
 
-            final FedoraResource resource =
-                    nodeService.getObject(session, path);
-            this.getAccessRolesProvider().postRoles(resource.getNode(), data);
+            //final FedoraResource resource =
+            //        nodeService.getObject(session, path);
+            String fullPath =  ACCESS_ROLES_FOLDER + path;
+            final FedoraResource accessRoleObject =
+                        nodeService.findOrCreateObject(session,fullPath);
+
+            //this.getAccessRolesProvider().postRoles(resource.getNode(), data);
+            this.getAccessRolesProvider().postRoles(accessRoleObject.getNode(), data);
             session.save();
             LOGGER.debug("Saved access roles {}", data);
             response =

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesProvider.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesProvider.java
@@ -246,7 +246,7 @@ public class AccessRolesProvider {
             for (Path p = absPath; p != null; p = p.getParent()) {
                 boolean pathFound = true;
                 try {
-                    //checks for existence of authz:hasAssignment property on node found for a path
+                    //checks for existence of fedora:acReference property on node found for a path
                     prop = session.getNode(p.getString()).getProperty(FEDORA_ACCESS_CONTROL_REFERENCE);
                 } catch (PathNotFoundException e) {
                     if (p.isRoot()) {
@@ -255,8 +255,6 @@ public class AccessRolesProvider {
                     pathFound = false;
                 }
                 if (pathFound) {
-                    //rbaclID = prop.getValues()[0].getString();
-                    rbaclID = prop.getValue().getString();
                     break;
                 }
             }
@@ -265,8 +263,8 @@ public class AccessRolesProvider {
             return DEFAULT_ACCESS_ROLES;
         }
         try {
-            //rbaclNode = session.getNode(ACCESS_ROLES_FOLDER + "/" + rbaclID);
-            rbaclNode = session.getNodeByIdentifier(rbaclID);
+            //get the Assignable node in system space
+            rbaclNode = prop.getNode();
         } catch (final Exception e) {
             LOGGER.debug("Could not find a rbaclNode {}", rbaclID, e);
             return DEFAULT_ACCESS_ROLES;

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesProviderTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesProviderTest.java
@@ -705,16 +705,16 @@ public class AccessRolesProviderTest {
 
         final Property property = mock(Property.class);
         final Value value = mock(Value.class);
-        final String rbaclString = "rbacl";
+        final String rbaclString = "cb1cbb50-c183-41f9-98fa-85c03f80c7ab";
         final Map<String,List<String>> mockData = new HashMap<>();
         final List<String> mockRole = Arrays.asList("arole","anotherRole");
         mockData.put("aprinciple",mockRole);
 
         when(session.getNode(eq(path.getString()))).thenReturn(node);
         when(node.getProperty(anyString())).thenReturn(property);
-        when(property.getValues()).thenReturn(new Value[]{value});
-        when(property.getValues()[0].getString()).thenReturn(rbaclString);
-        when(session.getNode(eq(ACCESS_ROLES_FOLDER + "/" + rbaclString))).thenReturn(rbaclNode);
+        when(property.getValue()).thenReturn(value);
+        when(property.getValue().getString()).thenReturn(rbaclString);
+        when(session.getNodeByIdentifier(eq(rbaclString))).thenReturn(rbaclNode);
         when(mockProvider.getRoles(rbaclNode,false)).thenReturn(mockData);
         when(rbaclNode.getSession()).thenReturn(session);
         when(rbaclNode.isNodeType(anyString())).thenReturn(true);
@@ -739,16 +739,16 @@ public class AccessRolesProviderTest {
 
         final Property property = mock(Property.class);
         final Value value = mock(Value.class);
-        final String rbaclString = "rbacl";
+        final String rbaclString = "cb1cbb50-c183-41f9-98fa-85c03f80c7ab";
         final Map<String,List<String>> mockData = new HashMap<>();
         final List<String> mockRole = Arrays.asList("arole","anotherRole");
         mockData.put("aprinciple",mockRole);
 
         final Node parentNode = mock(Node.class);
         when(parentNode.getProperty(anyString())).thenReturn(property);
-        when(property.getValues()).thenReturn(new Value[] {value});
-        when(property.getValues()[0].getString()).thenReturn(rbaclString);
-        when(session.getNode(eq(ACCESS_ROLES_FOLDER + "/" + rbaclString))).thenReturn(rbaclNode);
+        when(property.getValue()).thenReturn(value);
+        when(property.getValue().getString()).thenReturn(rbaclString);
+        when(session.getNodeByIdentifier(eq(rbaclString))).thenReturn(rbaclNode);
         when(mockProvider.getRoles(rbaclNode,false)).thenReturn(mockData);
         when(rbaclNode.getSession()).thenReturn(session);
         when(rbaclNode.isNodeType(anyString())).thenReturn(true);

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesProviderTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesProviderTest.java
@@ -712,9 +712,7 @@ public class AccessRolesProviderTest {
 
         when(session.getNode(eq(path.getString()))).thenReturn(node);
         when(node.getProperty(anyString())).thenReturn(property);
-        when(property.getValue()).thenReturn(value);
-        when(property.getValue().getString()).thenReturn(rbaclString);
-        when(session.getNodeByIdentifier(eq(rbaclString))).thenReturn(rbaclNode);
+        when(property.getNode()).thenReturn(rbaclNode);
         when(mockProvider.getRoles(rbaclNode,false)).thenReturn(mockData);
         when(rbaclNode.getSession()).thenReturn(session);
         when(rbaclNode.isNodeType(anyString())).thenReturn(true);
@@ -746,9 +744,7 @@ public class AccessRolesProviderTest {
 
         final Node parentNode = mock(Node.class);
         when(parentNode.getProperty(anyString())).thenReturn(property);
-        when(property.getValue()).thenReturn(value);
-        when(property.getValue().getString()).thenReturn(rbaclString);
-        when(session.getNodeByIdentifier(eq(rbaclString))).thenReturn(rbaclNode);
+        when(property.getNode()).thenReturn(rbaclNode);
         when(mockProvider.getRoles(rbaclNode,false)).thenReturn(mockData);
         when(rbaclNode.getSession()).thenReturn(session);
         when(rbaclNode.isNodeType(anyString())).thenReturn(true);
@@ -785,9 +781,7 @@ public class AccessRolesProviderTest {
 
         when(session.getNode(eq(path.getString()))).thenReturn(node);
         when(node.getProperty(anyString())).thenReturn(property);
-        when(property.getValues()).thenReturn(new Value[]{value});
-        when(property.getValues()[0].getString()).thenReturn(rbaclString);
-        when(session.getNode(eq(ACCESS_ROLES_FOLDER + "/" + rbaclString))).thenThrow(new PathNotFoundException());
+        when(property.getNode()).thenThrow(new PathNotFoundException());
 
         final Map<String, List<String>> data =
                 provider.findRolesInExternalNodeForPath(path, session);

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTest.java
@@ -79,6 +79,9 @@ public class AccessRolesTest {
     @Mock
     private PathSegment rootPath;
 
+    @Mock
+    private Node node;
+
     private Session session;
 
     private AccessRoles accessRoles;
@@ -98,6 +101,8 @@ public class AccessRolesTest {
 
         when(nodeService.findOrCreateObject(any(Session.class), anyString()))
                 .thenReturn(fedoraResource);
+
+        when(fedoraResource.getNode()).thenReturn(node);
 
         paths = new ArrayList<>();
         when(rootPath.getPath()).thenReturn("");

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesTest.java
@@ -96,6 +96,9 @@ public class AccessRolesTest {
         when(nodeService.getObject(any(Session.class), anyString()))
                 .thenReturn(fedoraResource);
 
+        when(nodeService.findOrCreateObject(any(Session.class), anyString()))
+                .thenReturn(fedoraResource);
+
         paths = new ArrayList<>();
         when(rootPath.getPath()).thenReturn("");
         paths.add(rootPath);

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
@@ -37,6 +37,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.AbstractHttpMessage;
 import org.apache.http.util.EntityUtils;
+import org.apache.tika.io.IOUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
 import org.junit.Before;
@@ -415,7 +416,35 @@ public abstract class AbstractRolesIT {
         addDatastreams(obj);
     }
 
+    protected void
+    ingestObjectWithReference(final String path,final String uriID)
+            throws Exception {
+        final HttpPost method = postObjMethod(path);
+        setAuth(method, "fedoraAdmin");
+        method.addHeader("Content-Type", "application/sparql-update");
+        String reference = "INSERT {" +
+                "<> <http://fedora.info/definitions/v4/rest-api#acReference> <" + uriID + "> ." +
+                "} WHERE { }";
+        final StringEntity entity = new StringEntity(reference, "utf-8");
+        method.setEntity(entity);
+        final HttpResponse response = client.execute(method);
+        final String content = EntityUtils.toString(response.getEntity());
+        final int status = response.getStatusLine().getStatusCode();
+        assertEquals("Didn't get a CREATED response! Got content:\n" + content,
+                CREATED.getStatusCode(), status);
+    }
 
+    protected int deleteTestObjectByPath(
+            final String path) throws Exception {
+        final HttpDelete method = deleteObjMethod(path);
+        setAuth(method, "fedoraAdmin");
+        final HttpResponse response = client.execute(method);
+        logger.debug("delete response code: \n {}", response.getStatusLine().getStatusCode());
+        assertNotNull("There must be content for a post.", response.getEntity());
+        final String content = EntityUtils.toString(response.getEntity());
+        logger.debug("delete response content by path: \n {}", content);
+        return response.getStatusLine().getStatusCode();
+    }
 
     protected String makeJson(final Map<String, List<String>> roles) {
         final ObjectMapper mapper = new ObjectMapper();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/jcr/FedoraJcrTypes.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/jcr/FedoraJcrTypes.java
@@ -54,4 +54,6 @@ public interface FedoraJcrTypes {
     String FROZEN_NODE = "nt:frozenNode";
 
     String FROZEN_MIXIN_TYPES = "jcr:frozenMixinTypes";
+
+    String FEDORA_ACCESS_CONTROL_REFERENCE = "fedora:acReference";
 }

--- a/fcrepo-kernel/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel/src/main/resources/fedora-node-types.cnd
@@ -86,9 +86,15 @@
   - dc:type (STRING) multiple
 
 /*
+ * A Fedora access control mixin.
+ */
+[fedora:access] mixin
+  - fedora:acReference (reference)
+
+/*
  * Any Fedora resource.
  */
-[fedora:resource] > fedora:relations, mix:created, mix:lastModified, mix:lockable, mix:referenceable, dc:describable mixin
+[fedora:resource] > fedora:relations, mix:created, mix:lastModified, mix:lockable, mix:referenceable, dc:describable, fedora:access mixin
   - rdf:type (URI) multiple
   - * (undefined) multiple
   - * (undefined)


### PR DESCRIPTION
functionality enabling creation of reusuable acl nodes that can be referenced via fedora:acReference

1) create reusauble acl node : 
curl -X POST -H "Content-Type: application/json" --data-binary "@reader_role.txt" "http://testadmin:password@localhost:8080/rest/testaddrole1/fcr:accessroles"

@reader_role.txt
{"testuser":["reader"],"testuser2":["patron","editor","curator"]}

which creates rbacl nodes under:
http://localhost:8080/rest/fedora:system/fedora:accessroles/testaddrole1

2) reference it in the node you want security constraints on:
curl -X PATCH -H "Content-Type: application/sparql-update" --data-binary "@rbacl_assignment.txt" "http://testadmin:password@localhost:8080/rest/example2"

@rbacl_assignment.txt
INSERT {
<> <http://fedora.info/definitions/v4/rest-api#acReference> <http://localhost:8080/rest/fedora:system/fedora:accessroles/testaddrole1> .
} WHERE { }