### PR TITLE
Improve and simplify fcr:versions response triples to have links only.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
@@ -17,6 +17,8 @@
 package org.fcrepo.http.api;
 
 import com.codahale.metrics.annotation.Timed;
+import com.hp.hpl.jena.graph.Triple;
+
 import org.fcrepo.http.commons.domain.PATCH;
 import org.fcrepo.http.api.versioning.VersionAwareHttpIdentifierTranslator;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierTranslator;
@@ -26,6 +28,7 @@ import org.fcrepo.http.commons.session.SessionFactory;
 import org.fcrepo.kernel.Datastream;
 import org.fcrepo.kernel.FedoraResource;
 import org.fcrepo.kernel.FedoraResourceImpl;
+import org.fcrepo.kernel.RdfLexicon;
 import org.fcrepo.kernel.utils.iterators.RdfStream;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +47,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.PathSegment;
@@ -90,7 +94,7 @@ public class FedoraVersions extends ContentExposingResource {
     private static final Logger LOGGER = getLogger(FedoraVersions.class);
 
     /**
-     * Get the list of versions for the object
+     * Get the list of versions for the object in HTML format
      *
      * @param pathList
      * @param request
@@ -100,9 +104,8 @@ public class FedoraVersions extends ContentExposingResource {
      */
     @GET
     @HtmlTemplate(value = "fcr:versions")
-    @Produces({TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X,
-                      TEXT_HTML, APPLICATION_XHTML_XML})
-    public RdfStream getVersionList(@PathParam("path")
+    @Produces({TEXT_HTML})
+    public RdfStream getVersionListAsHtml(@PathParam("path")
             final List<PathSegment> pathList,
             @Context
             final Request request,
@@ -117,7 +120,52 @@ public class FedoraVersions extends ContentExposingResource {
         return resource.getVersionTriples(nodeTranslator()).session(session).topic(
                 nodeTranslator().getSubject(resource.getNode().getPath()).asNode());
     }
+    /**
+     * Get the list of versions for the object in RDF format
+     *
+     * @param pathList
+     * @param request
+     * @param uriInfo
+     * @return
+     * @throws RepositoryException
+     */
+    @GET
+    @Produces({TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TURTLE_X,
+                       APPLICATION_XHTML_XML})
+    public RdfStream getVersionList(@PathParam("path")
+            final List<PathSegment> pathList,
+            @QueryParam("recursive")
+            final String recursive,
+            @Context
+            final Request request,
+            @Context
+            final UriInfo uriInfo) throws RepositoryException {
+        final String path = toPath(pathList);
 
+        LOGGER.trace("Getting versions list for: {}", path);
+
+        final FedoraResource resource = nodeService.getObject(session, path);
+        final RdfStream rdf = resource.getVersionTriples(nodeTranslator()).session(session).topic(
+                nodeTranslator().getSubject(resource.getNode().getPath()).asNode());
+        //Filter predicates: hasVersion, hasContent, hasChild
+        if (recursive == null || !Boolean.valueOf(recursive)) {
+            RdfStream refRdf = new RdfStream();
+            refRdf.session(session);
+            Triple triple;
+            com.hp.hpl.jena.graph.Node pre;
+            while (rdf.hasNext()) {
+                triple = rdf.next();
+                pre = triple.getPredicate();
+                if (pre.hasURI(RdfLexicon.HAS_VERSION.getURI())
+                        || pre.hasURI(RdfLexicon.HAS_CONTENT.getURI())
+                        || pre.hasURI(RdfLexicon.HAS_CHILD.getURI())) {
+                    refRdf.concat(triple);
+                }
+            }
+            return refRdf;
+        }
+        return rdf;
+    }
     /**
      * Create a new version checkpoint and tag it with the given label.  If
      * that label already describes another version it will silently be

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraVersionsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraVersionsTest.java
@@ -22,12 +22,12 @@ import static org.fcrepo.http.commons.test.util.TestHelpers.getUriInfoImpl;
 import static org.fcrepo.http.commons.test.util.TestHelpers.mockSession;
 import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -49,6 +49,7 @@ import javax.ws.rs.core.Variant;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierTranslator;
 import org.fcrepo.http.commons.session.SessionFactory;
 import org.fcrepo.kernel.FedoraResourceImpl;
+import org.fcrepo.kernel.RdfLexicon;
 import org.fcrepo.kernel.services.NodeService;
 import org.fcrepo.kernel.services.VersionService;
 import org.fcrepo.kernel.utils.iterators.RdfStream;
@@ -57,6 +58,7 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 
+import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.query.Dataset;
 
 public class FedoraVersionsTest {
@@ -94,6 +96,15 @@ public class FedoraVersionsTest {
     @Mock
     private Dataset mockDataset;
 
+    @Mock
+    private Triple mockTriple;
+
+    @Mock
+    private com.hp.hpl.jena.graph.Node mockSubject;
+
+    @Mock
+    private com.hp.hpl.jena.graph.Node mockObject;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -112,8 +123,26 @@ public class FedoraVersionsTest {
     }
 
     @Test
+    public void testGetVersionListAsHtml() throws RepositoryException {
+        final String pid = "FedoraVersioningTest";
+        when(mockRequest.selectVariant(POSSIBLE_RDF_VARIANTS)).thenReturn(
+                mockVariant);
+        when(mockNodes.getObject(any(Session.class), anyString())).thenReturn(
+                mockResource);
+        when(mockResource.getVersionTriples(any(HttpIdentifierTranslator.class)))
+                .thenReturn(mockRdfStream);
+        when(mockVariant.getMediaType()).thenReturn(
+                new MediaType("text", "html"));
+        final RdfStream response =
+                testObj.getVersionListAsHtml(createPathList(pid), mockRequest,
+                        getUriInfoImpl());
+        assertEquals("Got wrong RdfStream!", mockRdfStream, response);
+    }
+
+    @Test
     public void testGetVersionList() throws RepositoryException {
         final String pid = "FedoraVersioningTest";
+        mockRdfStream.concat(mockTriple);
         when(mockRequest.selectVariant(POSSIBLE_RDF_VARIANTS)).thenReturn(
                 mockVariant);
         when(mockNodes.getObject(any(Session.class), anyString())).thenReturn(
@@ -123,9 +152,34 @@ public class FedoraVersionsTest {
         when(mockVariant.getMediaType()).thenReturn(
                 new MediaType("text", "turtle"));
         final RdfStream response =
-            testObj.getVersionList(createPathList(pid), mockRequest,
+            testObj.getVersionList(createPathList(pid), "true", mockRequest,
                     getUriInfoImpl());
         assertEquals("Got wrong RdfStream!", mockRdfStream, response);
+    }
+
+    @Test
+    public void testGetVersionListLinksOnly() throws RepositoryException {
+        final String pid = "FedoraVersioningTest";
+        mockTriple = Triple.create(mockSubject,
+                RdfLexicon.CREATED_DATE.asNode(), mockObject);
+        mockRdfStream.concat(mockTriple);
+        mockTriple = Triple.create(mockSubject,
+                RdfLexicon.HAS_VERSION.asNode(), mockObject);
+        mockRdfStream.concat(mockTriple);
+        when(mockRequest.selectVariant(POSSIBLE_RDF_VARIANTS)).thenReturn(
+                mockVariant);
+        when(mockNodes.getObject(any(Session.class), anyString())).thenReturn(
+                mockResource);
+        when(mockResource.getVersionTriples(any(HttpIdentifierTranslator.class)))
+                .thenReturn(mockRdfStream);
+        when(mockVariant.getMediaType()).thenReturn(
+                new MediaType("text", "turtle"));
+        final RdfStream response =
+                testObj.getVersionList(createPathList(pid), "false", mockRequest,
+                        getUriInfoImpl());
+        assertTrue(response.hasNext());
+        assertEquals(response.next(), mockTriple);
+        assertFalse(response.hasNext());
     }
 
     @Test


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/70475058
There are two cases of using the fcr:version response triples, one is the html output that need a full version of the RDF triples, another is the RDF response that need improve. As we discussed during the standup meeting this morning, I've separated the html response to have its own rest api method, and filtered the fcr:version triples for the RDF response to contain only the links to the versions as the default output. However, we can still retrieve the full RDF triples for frc:version with parameter recursive=true provided, like "curl -H "Accept: text/turtle" http://localhost:8080/rest/path/to/resource/fcr:versions?recursive=true".