### PR TITLE
Updating range retrieval test to have configurable file size

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraContentIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraContentIT.java
@@ -16,6 +16,7 @@
 package org.fcrepo.integration.http.api;
 
 import static java.util.TimeZone.getTimeZone;
+import static java.util.UUID.randomUUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -228,18 +229,30 @@ public class FedoraContentIT extends AbstractResourceIT {
         final String pid = getRandomUniquePid();
         createObject(pid);
 
-        final HttpPost createDSMethod = postDSMethod(pid, "ds1", "marbles for everyone");
+        final int buflen = 8192;
+        final long skip = Long.parseLong( System.getProperty("fcrepo.rangetest.skip",String.valueOf(buflen)) );
+        final String byteRange = skip + "-" + (skip + buflen - 1);
+        final String byteResp = byteRange + "/" + (skip + buflen);
+
+        final StringBuffer buf = new StringBuffer();
+        while ( buf.length() < buflen ) {
+            buf.append( randomUUID().toString() );
+        }
+        final String randomString = buf.toString().substring(0,buflen);
+
+        final HttpPost createDSMethod = new HttpPost(serverAddress + pid + "/ds1/fcr:content");
+        createDSMethod.setEntity(new RangeTestEntity(skip,randomString.getBytes()));
+
         assertEquals(201, getStatus(createDSMethod));
 
         final HttpGet method_test_get = new HttpGet(serverAddress + pid + "/ds1/fcr:content");
-        method_test_get.setHeader("Range", "bytes=1-3");
+        method_test_get.setHeader("Range", "bytes=" + byteRange);
         assertEquals(206, getStatus(method_test_get));
 
         final HttpResponse response = client.execute(method_test_get);
         logger.debug("Returned from HTTP GET, now checking content...");
-        assertEquals("Got the wrong content back!", "arb",EntityUtils.toString(response.getEntity()));
-        assertEquals("bytes 1-3/20", response.getFirstHeader("Content-Range").getValue());
-
+        assertEquals("Got the wrong content back!", randomString, EntityUtils.toString(response.getEntity()));
+        assertEquals("bytes " + byteResp, response.getFirstHeader("Content-Range").getValue());
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeTestEntity.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeTestEntity.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static org.apache.http.entity.ContentType.APPLICATION_OCTET_STREAM;
+import org.apache.http.entity.InputStreamEntity;
+
+/**
+ * Entity for testing range queries.
+**/
+public class RangeTestEntity extends InputStreamEntity {
+    public RangeTestEntity( long size, byte[] data ) {
+        super(new RangeTestInputStream(size,data), size + data.length, APPLICATION_OCTET_STREAM);
+    }
+	public boolean isRepeatable() {
+        return true;
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeTestEntity.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeTestEntity.java
@@ -20,6 +20,8 @@ import org.apache.http.entity.InputStreamEntity;
 
 /**
  * Entity for testing range queries.
+ * @author Esme Cowles
+ * @since 2014-05-13
 **/
 public class RangeTestEntity extends InputStreamEntity {
     public RangeTestEntity( long size, byte[] data ) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeTestInputStream.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeTestInputStream.java
@@ -20,6 +20,8 @@ import java.io.InputStream;
 
 /**
  * InputStream implementation for testing range queries.
+ * @author Esme Cowles
+ * @since 2014-05-13
 **/
 public class RangeTestInputStream extends InputStream {
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeTestInputStream.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeTestInputStream.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * InputStream implementation for testing range queries.
+**/
+public class RangeTestInputStream extends InputStream {
+
+    private final long skip;
+    private final byte[] data;
+    private long bytesRead = 0L;
+
+    public RangeTestInputStream(long skip, byte[] data) {
+        super();
+        this.skip = skip;
+        this.data = data;
+    }
+
+    @Override
+    public int read() throws IOException {
+        bytesRead++;
+        final long pos = bytesRead - (skip + 1);
+        if ( pos < 0 ) {
+            return 47;
+        } else if ( pos < data.length ) {
+            return (int) data[ (int)pos ];
+        } else {
+            return -1;
+        }
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        int i = 0;
+        for ( ; i < b.length; ++i) {
+            b[i] = (byte) read();
+        }
+        return i;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int i = off;
+        for ( ; i < len; ++i ) {
+            b[i] = (byte) read();
+        }
+        return i;
+    }
+}


### PR DESCRIPTION
* Allows testing large files by setting a system property (fcrepo.rangetest.skip)

Related to https://www.pivotaltracker.com/story/show/71236292