### PR TITLE
Hierarchy transparent

### DIFF
--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
@@ -56,8 +56,11 @@ public class AccessRolesResources implements UriAwareResourceModelFactory {
 
         if (resource.getNode().isNodeType(
                 FedoraJcrTypes.FEDORA_RESOURCE)) {
+            if (resource.getPath(graphSubjects) == null) {
+                System.out.println("resource.getPath() is Null ");
+            }
             final Map<String, String> pathMap =
-                    singletonMap("path", resource.getPath().substring(1));
+                    singletonMap("path", resource.getPath(graphSubjects).substring(1));
             final Resource acl = model.createResource(uriInfo.getBaseUriBuilder().path(
                     AccessRoles.class).buildFromMap(pathMap).toASCIIString());
             model.add(s, RdfLexicon.HAS_ACCESS_ROLES_SERVICE, acl);

--- a/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
+++ b/fcrepo-auth-roles-common/src/main/java/org/fcrepo/auth/roles/common/AccessRolesResources.java
@@ -57,7 +57,7 @@ public class AccessRolesResources implements UriAwareResourceModelFactory {
         if (resource.getNode().isNodeType(
                 FedoraJcrTypes.FEDORA_RESOURCE)) {
             if (resource.getPath(graphSubjects) == null) {
-                System.out.println("resource.getPath() is Null ");
+                throw new RepositoryException("resource.getPath(graphSubjects) is Null: " + resource.getPath());
             }
             final Map<String, String> pathMap =
                     singletonMap("path", resource.getPath(graphSubjects).substring(1));

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesResourcesTest.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/AccessRolesResourcesTest.java
@@ -27,10 +27,10 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.ws.rs.core.UriInfo;
 
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierTranslator;
 import org.fcrepo.jcr.FedoraJcrTypes;
 import org.fcrepo.kernel.FedoraResource;
 import org.fcrepo.kernel.RdfLexicon;
-import org.fcrepo.kernel.rdf.IdentifierTranslator;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
@@ -48,7 +48,7 @@ import com.hp.hpl.jena.rdf.model.Resource;
 public class AccessRolesResourcesTest {
 
     @Mock
-    private IdentifierTranslator graphSubjects;
+    private HttpIdentifierTranslator graphSubjects;
 
     @Mock
     private FedoraResource fedoraResource;
@@ -99,12 +99,11 @@ public class AccessRolesResourcesTest {
 
     @Test
     public void testCreateModelForResource() throws RepositoryException {
-
         when(resourceNode.isNodeType(eq(FedoraJcrTypes.FEDORA_RESOURCE)))
                 .thenReturn(true);
 
-        when(fedoraResource.getPath()).thenReturn("/" + pathString);
-
+        when(resourceNode.getPath()).thenReturn("/" + pathString);
+        when(fedoraResource.getPath(graphSubjects)).thenReturn("/" + pathString);
         final Model model =
                 resources.createModelForResource(fedoraResource, uriInfo,
                         graphSubjects);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraImport.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraImport.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.http.api;
 
+import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
 import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.status;
@@ -91,13 +92,14 @@ public class FedoraImport extends AbstractResource {
 
         final HttpIdentifierTranslator subjects =
             new HttpIdentifierTranslator(session, FedoraNodes.class, uriInfo);
-
+        final String jcrPath = getJCRPath(createResource(uriInfo.getBaseUri() + path), subjects);
+        LOGGER.trace("GET: Using auto hierarchy path {} to retrieve resource.", jcrPath);
         try {
             serializers.getSerializer(format)
-                    .deserialize(session, path, stream);
+                    .deserialize(session, jcrPath, stream);
             session.save();
-            return created(new URI(subjects.getSubject(path).getURI())).build();
-        } catch ( ItemExistsException ex ) {
+            return created(new URI(subjects.getSubject(jcrPath).getURI())).build();
+        } catch ( final ItemExistsException ex ) {
             return status(CONFLICT).entity("Item already exists").build();
         } finally {
             session.logout();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLocks.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLocks.java
@@ -114,7 +114,7 @@ public class FedoraLocks extends AbstractResource implements FedoraJcrTypes {
         throws RepositoryException, URISyntaxException {
         try {
             final String path = toPath(pathList);
-            LOGGER.trace("Getting lock profile for: {}", path);
+            LOGGER.trace("Creating lock for: {}", path);
             final HttpIdentifierTranslator subjects =
                     new HttpIdentifierTranslator(session, FedoraNodes.class, uriInfo);
             final String jcrPath = getJCRPath(createResource(uriInfo.getBaseUri() + path), subjects);
@@ -141,7 +141,7 @@ public class FedoraLocks extends AbstractResource implements FedoraJcrTypes {
         throws RepositoryException, URISyntaxException {
         try {
             final String path = toPath(pathList);
-            LOGGER.trace("Getting lock profile for: {}", path);
+            LOGGER.trace("Deleting lock for: {}", path);
             final HttpIdentifierTranslator subjects =
                     new HttpIdentifierTranslator(session, FedoraNodes.class, uriInfo);
             final String jcrPath = getJCRPath(createResource(uriInfo.getBaseUri() + path), subjects);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/url/HttpApiResources.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/url/HttpApiResources.java
@@ -79,31 +79,31 @@ public class HttpApiResources implements UriAwareResourceModelFactory {
         if (resource.getNode().getPrimaryNodeType().isNodeType(ROOT)) {
             addRepositoryStatements(uriInfo, model, s);
         } else {
-            addNodeStatements(resource, uriInfo, model, s);
+            addNodeStatements(resource, uriInfo, model, s, graphSubjects);
         }
 
         if (resource.hasContent()) {
-            addContentStatements(resource, uriInfo, model, s);
+            addContentStatements(resource, uriInfo, model, s, graphSubjects);
         }
 
         return model;
     }
 
     private static void addContentStatements(final FedoraResource resource, final UriInfo uriInfo,
-        final Model model, final Resource s) throws RepositoryException {
+        final Model model, final Resource s, final IdentifierTranslator graphSubjects) throws RepositoryException {
         // fcr:fixity
         final Map<String, String> pathMap =
-            singletonMap("path", resource.getPath().substring(1));
+            singletonMap("path", resource.getPath(graphSubjects).substring(1));
         model.add(s, HAS_FIXITY_SERVICE, createResource(uriInfo
                 .getBaseUriBuilder().path(FedoraFixity.class).buildFromMap(
                         pathMap).toASCIIString()));
     }
 
     private void addNodeStatements(final FedoraResource resource, final UriInfo uriInfo,
-        final Model model, final Resource s) throws RepositoryException {
+        final Model model, final Resource s, final IdentifierTranslator graphSubjects) throws RepositoryException {
 
         final Map<String, String> pathMap =
-                singletonMap("path", resource.getPath().substring(1));
+                singletonMap("path", resource.getPath(graphSubjects).substring(1));
 
         // hasLock
         if (resource.getNode().isLocked()) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/versioning/VersionAwareHttpIdentifierTranslator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/versioning/VersionAwareHttpIdentifierTranslator.java
@@ -138,7 +138,7 @@ public class VersionAwareHttpIdentifierTranslator extends HttpIdentifierTranslat
 
         pathWithinVersionable = versionableFrozenNode.getIdentifier()
                 + (pathWithinVersionable.length() > 0 ? pathWithinVersionable : "");
-        final String pathToVersionable = versionableNode.getPath();
+        final String pathToVersionable = getSubjectPath(getSubject(versionableNode.getPath()));
         LOGGER.debug("frozen node found with id {}.", versionableFrozenNode.getIdentifier());
         String path =  pathToVersionable + "/" + FCR_VERSIONS + "/" + pathWithinVersionable;
         if (path.endsWith(JCR_CONTENT)) {
@@ -205,8 +205,8 @@ public class VersionAwareHttpIdentifierTranslator extends HttpIdentifierTranslat
      * uses the JCR UUID for the frozen node as the system-assigned label.
      */
     private Node getFrozenNodeByLabel(final String subjectUri, final String label) throws RepositoryException {
-        final String baseResourcePath
-            = getPathFromGraphSubject(subjectUri.substring(0, subjectUri.indexOf("/" + FCR_VERSIONS)));
+        final String baseVersionUri = subjectUri.substring(0, subjectUri.indexOf("/" + FCR_VERSIONS));
+        final String baseResourcePath = getPathFromSubject(createResource(baseVersionUri));
         try {
             final Node frozenNode = internalSession.getNodeByIdentifier(label);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraBatchTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraBatchTest.java
@@ -16,6 +16,7 @@
 package org.fcrepo.http.api;
 
 import static java.util.Arrays.asList;
+import static javax.jcr.PropertyType.PATH;
 import static javax.ws.rs.core.Response.notModified;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NOT_MODIFIED;
@@ -51,6 +52,8 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
 import javax.jcr.Workspace;
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.version.VersionManager;
@@ -119,6 +122,12 @@ public class FedoraBatchTest {
     @Mock
     private Datastream mockDatastream;
 
+    @Mock
+    private Value mockValue;
+
+    @Mock
+    private ValueFactory mockValueFactory;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -137,6 +146,8 @@ public class FedoraBatchTest {
         when(mockDsNodeType.getName()).thenReturn("nt:file");
         when(mockNode.getPrimaryNodeType()).thenReturn(mockDsNodeType);
         when(mockDatastream.getNode()).thenReturn(mockNode);
+        when(mockSession.getValueFactory()).thenReturn(mockValueFactory);
+        when(mockValueFactory.createValue("a", PATH)).thenReturn(mockValue);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraExportTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraExportTest.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.http.api;
 
+import static javax.jcr.PropertyType.PATH;
 import static org.fcrepo.http.commons.test.util.PathSegmentImpl.createPathList;
 import static org.fcrepo.http.commons.test.util.TestHelpers.mockSession;
 import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
@@ -28,6 +29,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 
 import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
 import javax.ws.rs.core.StreamingOutput;
 
 import org.fcrepo.http.commons.test.util.TestHelpers;
@@ -62,6 +65,12 @@ public class FedoraExportTest {
     @Mock
     private FedoraObject mockObject;
 
+    @Mock
+    private Value mockValue;
+
+    @Mock
+    private ValueFactory mockValueFactory;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -73,6 +82,8 @@ public class FedoraExportTest {
         setField(testObj, "serializers", mockSerializers);
         setField(testObj, "uriInfo", TestHelpers.getUriInfoImpl());
         setField(testObj, "session", mockSession);
+        when(mockSession.getValueFactory()).thenReturn(mockValueFactory);
+        when(mockValueFactory.createValue("a", PATH)).thenReturn(mockValue);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraFixityTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraFixityTest.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.http.api;
 
+import static javax.jcr.PropertyType.PATH;
 import static org.fcrepo.http.commons.test.util.PathSegmentImpl.createPathList;
 import static org.fcrepo.http.commons.test.util.TestHelpers.getUriInfoImpl;
 import static org.fcrepo.http.commons.test.util.TestHelpers.mockDatastream;
@@ -29,6 +30,8 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.UriInfo;
 
@@ -62,6 +65,12 @@ public class FedoraFixityTest {
     @Mock
     private Node mockNode;
 
+    @Mock
+    private Value mockValue;
+
+    @Mock
+    private ValueFactory mockValueFactory;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -71,6 +80,8 @@ public class FedoraFixityTest {
         setField(testObj, "uriInfo", uriInfo);
         mockSession = mockSession(testObj);
         setField(testObj, "session", mockSession);
+        when(mockSession.getValueFactory()).thenReturn(mockValueFactory);
+        when(mockValueFactory.createValue("a", PATH)).thenReturn(mockValue);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraImportTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraImportTest.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.http.api;
 
+import static javax.jcr.PropertyType.PATH;
 import static org.fcrepo.http.commons.test.util.PathSegmentImpl.createPathList;
 import static org.fcrepo.http.commons.test.util.TestHelpers.getUriInfoImpl;
 import static org.fcrepo.http.commons.test.util.TestHelpers.mockSession;
@@ -27,6 +28,8 @@ import java.io.InputStream;
 
 import javax.jcr.Node;
 import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
 import javax.jcr.nodetype.NodeType;
 
 import org.fcrepo.serialization.FedoraObjectSerializer;
@@ -61,6 +64,12 @@ public class FedoraImportTest {
     @Mock
     private NodeType mockNodeType;
 
+    @Mock
+    private Value mockValue;
+
+    @Mock
+    private ValueFactory mockValueFactory;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -75,6 +84,8 @@ public class FedoraImportTest {
         setField(testObj, "session", mockSession);
         when(mockNodeType.getName()).thenReturn("nt:folder");
         when(mockNode.getPrimaryNodeType()).thenReturn(mockNodeType);
+        when(mockSession.getValueFactory()).thenReturn(mockValueFactory);
+        when(mockValueFactory.createValue("a", PATH)).thenReturn(mockValue);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLocksTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLocksTest.java
@@ -27,12 +27,15 @@ import org.mockito.Mock;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
 import javax.jcr.nodetype.NodeType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URISyntaxException;
 import java.util.UUID;
 
+import static javax.jcr.PropertyType.PATH;
 import static org.fcrepo.http.commons.test.util.PathSegmentImpl.createPathList;
 import static org.fcrepo.http.commons.test.util.TestHelpers.getUriInfoImpl;
 import static org.fcrepo.http.commons.test.util.TestHelpers.mockSession;
@@ -66,6 +69,12 @@ public class FedoraLocksTest {
 
     private UriInfo mockUriInfo;
 
+    @Mock
+    private Value mockValue;
+
+    @Mock
+    private ValueFactory mockValueFactory;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -75,6 +84,8 @@ public class FedoraLocksTest {
         mockSession = mockSession(testObj);
         setField(testObj, "session", mockSession);
         when(mockLock.getLockToken()).thenReturn("token");
+        when(mockSession.getValueFactory()).thenReturn(mockValueFactory);
+        when(mockValueFactory.createValue("a", PATH)).thenReturn(mockValue);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraVersionsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraVersionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.http.api;
 
+import static javax.jcr.PropertyType.PATH;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_VARIANTS;
 import static org.fcrepo.http.commons.test.util.PathSegmentImpl.createPathList;
 import static org.fcrepo.http.commons.test.util.TestHelpers.getUriInfoImpl;
@@ -36,6 +37,8 @@ import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
 import javax.jcr.Workspace;
 import javax.jcr.nodetype.NodeType;
 import javax.ws.rs.core.MediaType;
@@ -96,6 +99,12 @@ public class FedoraVersionsTest {
     @Mock
     private Dataset mockDataset;
 
+    @Mock
+    private Value mockValue;
+
+    @Mock
+    private ValueFactory mockValueFactory;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -111,6 +120,8 @@ public class FedoraVersionsTest {
         when(mockResource.getNode()).thenReturn(mockNode);
         when(mockNodeType.getName()).thenReturn("nt:folder");
         when(mockNode.getPrimaryNodeType()).thenReturn(mockNodeType);
+        when(mockSession.getValueFactory()).thenReturn(mockValueFactory);
+        when(mockValueFactory.createValue("a", PATH)).thenReturn(mockValue);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/versioning/VersionAwareHttpGraphSubjectsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/versioning/VersionAwareHttpGraphSubjectsTest.java
@@ -58,6 +58,7 @@ public class VersionAwareHttpGraphSubjectsTest extends GraphSubjectsTest {
     public void setUpForThisClass() throws RepositoryException {
         when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
         when(mockWorkspace.getVersionManager()).thenReturn(mockVersionManager);
+        when(mockWorkspace.getName()).thenReturn("default");
     }
 
     @Override

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierTranslator.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierTranslator.java
@@ -327,7 +327,7 @@ public class HttpIdentifierTranslator extends SpringContextAwareIdentifierTransl
         singletonList((InternalIdentifierConverter) new NamespaceConverter());
 
     /**
-     * Hierarchy levels. Default 1 for converters other than the HierarchyConverter.
+     * Hierarchy levels. Default 0 for converters other than the HierarchyConverter.
      * @return
      */
     @Override

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierTranslator.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierTranslator.java
@@ -132,7 +132,7 @@ public class HttpIdentifierTranslator extends SpringContextAwareIdentifierTransl
         LOGGER.debug("Resolving graph subjects to a base URI of \"{}\"",
                 normalizedBasePath);
         resetTranslationChain();
-        for (InternalIdentifierConverter converter : translationChain) {
+        for (final InternalIdentifierConverter converter : translationChain) {
             if (converter instanceof HierarchyConverter) {
                 hierarchyLevels = converter.getLevels();
                 break;
@@ -333,5 +333,10 @@ public class HttpIdentifierTranslator extends SpringContextAwareIdentifierTransl
     @Override
     public int getHierarchyLevels() {
         return hierarchyLevels;
+    }
+
+    @Override
+    public String getSubjectPath(final Resource subject) {
+        return subject.getURI().substring(pathIx);
     }
 }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierTranslatorTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierTranslatorTest.java
@@ -237,6 +237,13 @@ public class HttpIdentifierTranslatorTest extends GraphSubjectsTest {
         assertTrue(testObj.getHierarchyLevels() >= 0);
     }
 
+    @Test
+    public void testSubjectPath() {
+        final String path = "/abc";
+        assertEquals(path, testObj.getSubjectPath(
+                ResourceFactory.createResource("http://localhost:8080/fcrepo/rest" + path)));
+    }
+
     @Path("/rest/{path}")
     protected class MockNodeController {
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/FedoraResource.java
@@ -152,9 +152,16 @@ public interface FedoraResource {
      * @return
      * @throws RepositoryException
      */
-    Node getParent(final IdentifierTranslator graphSubjects)
-        throws RepositoryException;
+    Node getParent(final IdentifierTranslator graphSubjects) throws RepositoryException;
 
+    /**
+     * return the path of a subject
+     * @param graphSubjects
+     * @return
+     * @throws RepositoryException
+     */
+    String getPath(final IdentifierTranslator graphSubjects)
+        throws RepositoryException;
 
     /**
      * Serialize the JCR versions information as an RDF dataset

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/rdf/IdentifierTranslator.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/rdf/IdentifierTranslator.java
@@ -63,4 +63,10 @@ public interface IdentifierTranslator {
      * @return
      */
     int getHierarchyLevels();
+
+    /**
+     * Reverse to get the transparent path
+     * @return
+     */
+    String getSubjectPath(final Resource subject);
 }

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/FedoraResourceImpl.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/FedoraResourceImpl.java
@@ -488,4 +488,12 @@ public class FedoraResourceImpl extends JcrTools implements FedoraJcrTypes, Fedo
         }
         return parent;
     }
+
+     /*
+     * Get the path of the object
+     */
+    @Override
+    public String getPath(final IdentifierTranslator graphSubjects) throws RepositoryException {
+        return graphSubjects.getSubjectPath(graphSubjects.getSubject(node.getPath()));
+    }
 }

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/DefaultIdentifierTranslator.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/DefaultIdentifierTranslator.java
@@ -90,4 +90,9 @@ public class DefaultIdentifierTranslator implements IdentifierTranslator {
         return 0;
     }
 
+    @Override
+    public String getSubjectPath(final Resource subject) {
+        return subject.getURI().substring(RESOURCE_NAMESPACE.length() - 1);
+    }
+
 }


### PR DESCRIPTION
Hi Andrew,
As discussed during the stand up meeting this morning, I put all my codes together for you to review the working transparent hierarchy features except the getParent() implantation, which is separated and expressed in https://github.com/fcrepo4/fcrepo4/pull/388.  This includes the transparent hierarchy support for versions and all other components in the main fcrepo4 repository.