### PR TITLE
aliasing any jcr-namespaced properties to fedora:

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/GetNamespacedProperties.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/GetNamespacedProperties.java
@@ -53,7 +53,7 @@ public class GetNamespacedProperties implements Function<FedoraEvent, FedoraEven
         for (String property : evt.getProperties()) {
             final String[] parts = property.split(":", 2);
             if (parts.length == 2) {
-                final String prefix = parts[0];
+                final String prefix = parts[0].equals("jcr") ? "fedora" : parts[0];
                 try {
                     event.addProperty(namespaceRegistry.getURI(prefix) + parts[1]);
                 } catch (RepositoryException ex) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/GetNamespacedProperties.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/GetNamespacedProperties.java
@@ -23,6 +23,9 @@ import javax.jcr.NamespaceRegistry;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import static com.hp.hpl.jena.rdf.model.ResourceFactory.createProperty;
+import static org.fcrepo.kernel.RdfLexicon.jcrProperties;
+import static org.fcrepo.kernel.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.utils.NamespaceTools.getNamespaceRegistry;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -53,12 +56,22 @@ public class GetNamespacedProperties implements Function<FedoraEvent, FedoraEven
         for (String property : evt.getProperties()) {
             final String[] parts = property.split(":", 2);
             if (parts.length == 2) {
-                final String prefix = parts[0].equals("jcr") ? "fedora" : parts[0];
-                try {
-                    event.addProperty(namespaceRegistry.getURI(prefix) + parts[1]);
-                } catch (RepositoryException ex) {
-                    LOGGER.trace("Prefix could not be dereferenced using the namespace registry: {}", property);
-                    event.addProperty(property);
+                final String prefix = parts[0];
+                if ("jcr".equals(prefix)) {
+                    if (jcrProperties.contains(createProperty(REPOSITORY_NAMESPACE + parts[1]))) {
+                        event.addProperty(REPOSITORY_NAMESPACE + parts[1]);
+                    } else if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Swallowing jcr property: {}", property);
+                    }
+                } else {
+                    try {
+                        event.addProperty(namespaceRegistry.getURI(prefix) + parts[1]);
+                    } catch (RepositoryException ex) {
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug("Prefix could not be dereferenced using the namespace registry: {}", property);
+                        }
+                        event.addProperty(property);
+                    }
                 }
             } else {
                 event.addProperty(property);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/observer/SimpleObserverIT.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/observer/SimpleObserverIT.java
@@ -16,7 +16,7 @@
 package org.fcrepo.integration.kernel.impl.observer;
 
 import static org.fcrepo.kernel.FedoraJcrTypes.FEDORA_CONTAINER;
-import static org.fcrepo.kernel.RdfLexicon.JCR_NAMESPACE;
+import static org.fcrepo.kernel.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -84,7 +84,7 @@ public class SimpleObserverIT extends AbstractIT {
         final Set<String> properties = e.getProperties();
         assertNotNull(properties);
 
-        final String expected = JCR_NAMESPACE + "mixinTypes";
+        final String expected = REPOSITORY_NAMESPACE + "mixinTypes";
         assertTrue("Should contain: " + expected + properties, properties.contains(expected));
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/GetNamespacedPropertiesTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/GetNamespacedPropertiesTest.java
@@ -110,7 +110,7 @@ public class GetNamespacedPropertiesTest {
         final String expected1 = FEDORA_CONTAINER.replace("fedora:", REPOSITORY_NAMESPACE);
         final String expected2 = FEDORA_TOMBSTONE.replace("fedora:", REPOSITORY_NAMESPACE);
         final String expected3 = LDP_BASIC_CONTAINER.replace("ldp:", LDP_NAMESPACE);
-        final String expected4 = JCR_MIXIN_TYPES.replace("jcr:", JCR_NAMESPACE);
+        final String expected4 = JCR_MIXIN_TYPES.replace("jcr:", REPOSITORY_NAMESPACE);
 
         assertTrue("Should contain: " + expected1 + ", " + properties, properties.contains(expected1));
         assertTrue("Should contain: " + expected2 + ", " + properties, properties.contains(expected2));


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/684825/stories/83411334

any `jcr:` properties are transformed to `fedora:` before sending to the JMS broker.

This potentially causes **any** `jcr:` property to populate the `fedora:` namespace, which may not be desired.