### PR TITLE
Added integration test for creating blank nodes.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraBlankNodesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraBlankNodesIT.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.tika.io.IOUtils;
+import org.junit.Test;
+import org.junit.Before;
+import org.slf4j.Logger;
+
+/**
+ * @author peichman
+ */
+public class FedoraBlankNodesIT extends AbstractResourceIT {
+    private static final Logger LOGGER = getLogger(FedoraBlankNodesIT.class);
+    private static StringEntity turtleEntity;
+    private final int maxObjects = 5000;
+
+    @Before
+    public void setup() throws IOException {
+        final InputStream turtleStream = this.getClass().getResourceAsStream("/test-blank-nodes/with_blank_nodes.ttl");
+        final String turtleString = IOUtils.toString(turtleStream, "UTF-8");
+        turtleEntity = new StringEntity(turtleString);
+    }
+
+    @Test
+    public void testBlankNodes() {
+        for (int i = 1; i <= maxObjects; i++) {
+            try {
+                createWithBlankNodes(turtleEntity);
+            } catch (IOException e) {
+                fail("Only loaded " + (i - 1) + " out of " + maxObjects + " objects");
+            }
+            if (i % 100 == 0) {
+                LOGGER.info("Created " + Integer.toString(i));
+            }
+        }
+    }
+
+    private void createWithBlankNodes(final StringEntity entity) throws IOException {
+        final HttpPost httpPost = new HttpPost(serverAddress);
+        httpPost.addHeader("Content-Type", "text/turtle");
+        httpPost.setEntity(entity);
+        final HttpResponse response = client.execute(httpPost);
+        assertEquals(CREATED.getStatusCode(), response.getStatusLine().getStatusCode());
+    }
+}

--- a/fcrepo-http-api/src/test/resources/test-blank-nodes/with_blank_nodes.ttl
+++ b/fcrepo-http-api/src/test/resources/test-blank-nodes/with_blank_nodes.ttl
@@ -1,0 +1,56 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix mods: <http://www.loc.gov/mods/v3> .
+@prefix modsrdf: <http://www.loc.gov/mods/rdf/v1#> .
+@prefix madsrdf: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+<>
+    dc:description "Jerome H. Schatz was a child actor of both film and radio during the 1930s and 1940s. Schatz, performing under the name Jerry Tucker, became the youngest actor ever placed under contract to Paramount studios. His most prominent role was as the spoiled rich kid in the Our Gang comedies. Schatz left show business to join the Navy and worked as engineer after World War II." ;
+    dc:title "Jerry Tucker Shatz Papers" ;
+    modsrdf:abstract "Jerome H. Schatz was a child actor of both film and radio during the 1930s and 1940s. Schatz, performing under the name Jerry Tucker, became the youngest actor ever placed under contract to Paramount studios. His most prominent role was as the spoiled rich kid in the Our Gang comedies. Schatz left show business to join the Navy and worked as engineer after World War II." ;
+    modsrdf:dateEnd "1987"^^<xsd:string> ;
+    modsrdf:dateStart "1931"^^<xsd:string> ;
+    modsrdf:genre [
+        madsrdf:elementList ([
+                madsrdf:elementValue "Finding aid" ;
+                a madsrdf:GenreFormElement
+            ]
+        ) ;
+        a madsrdf:GenreForm ;
+        rdfs:label "Finding aid"
+    ] ;
+    modsrdf:languageOfResource <http://id.loc.gov/vocabulary/language#en> ;
+    modsrdf:locationOfResource [
+        modsrdf:locationPhysical "Mass Media and Culture" ;
+        a modsrdf:Location
+    ] ;
+    modsrdf:name [
+        madsrdf:elementList ([
+                madsrdf:elementValue "Schatz, Jerry" ;
+                a madsrdf:FullNameElement
+            ]
+        ) ;
+        a madsrdf:PersonalName ;
+        rdfs:label "Schatz, Jerry"
+    ] ;
+    modsrdf:physicalExtent "39.00 linear feet" ;
+    modsrdf:placeOfOrigin [
+        madsrdf:elementList ([
+                madsrdf:elementValue "" ;
+                a madsrdf:GeographicElement
+            ]
+        ) ;
+        a madsrdf:Geographic ;
+        rdfs:label ""
+    ] ;
+    modsrdf:titlePrincipal [
+        madsrdf:elementList ([
+                madsrdf:elementValue "Jerry Tucker Shatz Papers" ;
+                a madsrdf:MainTitleElement
+            ]
+        ) ;
+        a madsrdf:Title ;
+        rdfs:label "Jerry Tucker Shatz Papers"
+    ] ;
+    a <http://id.loc.gov/vocabulary/resourceType#Collection>, <http://id.loc.gov/vocabulary/resourceType#MixedMaterial>, modsrdf:ModsResource .


### PR DESCRIPTION
Attempts to create 5000 new LDP resources with RDF content. The RDF
graph for each one has 13 blank nodes.

Resolves: https://jira.duraspace.org/browse/FCREPO-1257