### PR TITLE
The beta artifacts used in the fcrepo4-bom module

### DIFF
--- a/fcrepo-boms/fcrepo4-bom/pom.xml
+++ b/fcrepo-boms/fcrepo4-bom/pom.xml
@@ -22,12 +22,12 @@
       <dependency>
         <groupId>org.fcrepo</groupId>
         <artifactId>fcrepo-auth-roles-basic</artifactId>
-        <version>4.0.0-beta-04-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.fcrepo</groupId>
         <artifactId>fcrepo-auth-roles-common</artifactId>
-        <version>4.0.0-beta-04-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.fcrepo</groupId>


### PR DESCRIPTION
As described in https://github.com/fcrepo4/fcrepo4/issues/683, the fcrepo4-bom module contains references to version 4.0.0-beta for some dependencies. This PR removes that.