### PR TITLE
added proper osgi build configuration for fcrepo modules

### DIFF
--- a/fcrepo-auth-common/pom.xml
+++ b/fcrepo-auth-common/pom.xml
@@ -162,7 +162,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
-              org.fcrepo.auth.common
+              org.fcrepo.auth.common;version=${project.version}
             </Export-Package>
             <Import-Package>
               org.fcrepo.serialization,

--- a/fcrepo-auth-common/pom.xml
+++ b/fcrepo-auth-common/pom.xml
@@ -20,7 +20,6 @@
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-serialization</artifactId>
       <version>${project.version}</version>
-      <type>bundle</type>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
@@ -155,6 +154,25 @@
           <reuseForks>false</reuseForks>
         </configuration>
       </plugin>   
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>
+              org.fcrepo.auth.common
+            </Export-Package>
+            <Import-Package>
+              org.fcrepo.serialization,
+              org.fcrepo.mint,
+              org.fcrepo.http.commons
+            </Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/fcrepo-configs/pom.xml
+++ b/fcrepo-configs/pom.xml
@@ -7,12 +7,12 @@
   </parent>
   <artifactId>fcrepo-configs</artifactId>
   <name>Fedora Repository Configurations Module</name>
-  <description>The Fedora Commons repository configurations module: Provides configuration resources that are used in 
+  <description>The Fedora Commons repository configurations module: Provides configuration resources that are used in
   integration testing and deployments.</description>
   <build>
     <plugins>
       <!-- Turn this into a lifecycle -->
-      <plugin>      
+      <plugin>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <executions>
           <execution>

--- a/fcrepo-connector-file/pom.xml
+++ b/fcrepo-connector-file/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>fcrepo-connector-file</artifactId>
   <name>Fedora Repository FileSystem Connector Module</name>
   <description>The Fedora Commons repository filesystem connector module: Provides repository projection over hierarchical files/directories on the filesystem.</description>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <dependencies>
 
@@ -48,5 +48,29 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
-
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>
+              org.fcrepo.connector,
+              org.fcrepo.connector.file,
+              org.modeshape.connector.filesystem
+            </Export-Package>
+            <Import-Package>
+              org.fcrepo.kernel,
+              org.fcrepo.kernel.impl.utils,
+              org.fcrepo.kernel.impl.utils.impl
+            </Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/fcrepo-connector-file/pom.xml
+++ b/fcrepo-connector-file/pom.xml
@@ -58,9 +58,9 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
-              org.fcrepo.connector,
-              org.fcrepo.connector.file,
-              org.modeshape.connector.filesystem
+              org.fcrepo.connector;version=${project.version},
+              org.fcrepo.connector.file;version=${project.version},
+              org.modeshape.connector.filesystem;version=${project.version}
             </Export-Package>
             <Import-Package>
               org.fcrepo.kernel,

--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -214,10 +214,10 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
-              org.fcrepo.http.api,
-              org.fcrepo.http.api.repository,
-              org.fcrepo.http.api.responses,
-              org.fcrepo.http.api.url
+              org.fcrepo.http.api;version=${project.version},
+              org.fcrepo.http.api.repository;version=${project.version},
+              org.fcrepo.http.api.responses;version=${project.version},
+              org.fcrepo.http.api.url;version=${project.version}
             </Export-Package>
             <Import-Package>
               org.fcrepo.kernel.impl,

--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -27,6 +27,12 @@
   <dependencies>
     <dependency>
       <groupId>org.modeshape</groupId>
+      <artifactId>modeshape-jcr</artifactId>
+      <version>${modeshape.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.modeshape</groupId>
       <artifactId>modeshape-web-jcr</artifactId>
       <version>${modeshape.version}</version>
     </dependency>
@@ -66,6 +72,16 @@
       <artifactId>spring-context</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-annotation</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -193,6 +209,36 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>
+              org.fcrepo.http.api,
+              org.fcrepo.http.api.repository,
+              org.fcrepo.http.api.responses,
+              org.fcrepo.http.api.url
+            </Export-Package>
+            <Import-Package>
+              org.fcrepo.kernel.impl,
+              org.fcrepo.kernel.impl.rdf,
+              org.fcrepo.kernel.impl.utils,
+              org.fcrepo.kernel.impl.utils.impl,
+              org.fcrepo.kernel.impl.utils.iterators,
+              org.fcrepo.kernel.impl.utils.infinispan,
+              org.fcrepo.auth.common,
+              org.fcrepo.mint,
+              org.fcrepo.serialization,
+              org.fcrepo.http.commons.api.rdf,
+              org.fcrepo.http.commons.domain,
+              org.fcrepo.http.commons.domain.ldp,
+              org.fcrepo.http.commons.responses,
+              org.fcrepo.http.commons.session,
+              org.fcrepo.connector.filesystem,
+              org.modeshape.connector.filesystem
+            </Import-Package>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -313,6 +313,29 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>
+              org.fcrepo.http.commons,
+              org.fcrepo.http.commons.api,
+              org.fcrepo.http.commons.api.rdf,
+              org.fcrepo.http.commons.domain,
+              org.fcrepo.http.commons.domain.ldp,
+              org.fcrepo.http.commons.responses,
+              org.fcrepo.http.commons.session,
+              org.fcrepo.http.commons.exceptionhandlers,
+            </Export-Package>
+            <Import-Package>
+              org.fcrepo.metrics,
+              org.fcrepo.mint,
+              org.fcrepo.kernel.impl,
+              org.fcrepo.serialization
+            </Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>

--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -318,14 +318,14 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
-              org.fcrepo.http.commons,
-              org.fcrepo.http.commons.api,
-              org.fcrepo.http.commons.api.rdf,
-              org.fcrepo.http.commons.domain,
-              org.fcrepo.http.commons.domain.ldp,
-              org.fcrepo.http.commons.responses,
-              org.fcrepo.http.commons.session,
-              org.fcrepo.http.commons.exceptionhandlers,
+              org.fcrepo.http.commons;version=${project.version},
+              org.fcrepo.http.commons.api;version=${project.version},
+              org.fcrepo.http.commons.api.rdf;version=${project.version},
+              org.fcrepo.http.commons.domain;version=${project.version},
+              org.fcrepo.http.commons.domain.ldp;version=${project.version},
+              org.fcrepo.http.commons.responses;version=${project.version},
+              org.fcrepo.http.commons.session;version=${project.version},
+              org.fcrepo.http.commons.exceptionhandlers;version=${project.version}
             </Export-Package>
             <Import-Package>
               org.fcrepo.metrics,

--- a/fcrepo-jms/pom.xml
+++ b/fcrepo-jms/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
+      <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -109,6 +109,21 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>
+              org.fcrepo.jms.headers,
+              org.fcrepo.jms.observer
+            </Export-Package>
+            <Import-Package>
+              org.fcrepo.kernel,
+              org.fcrepo.kernel.impl
+            </Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/fcrepo-jms/pom.xml
+++ b/fcrepo-jms/pom.xml
@@ -114,8 +114,8 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
-              org.fcrepo.jms.headers,
-              org.fcrepo.jms.observer
+              org.fcrepo.jms.headers;version=${project.version},
+              org.fcrepo.jms.observer;version=${project.version}
             </Export-Package>
             <Import-Package>
               org.fcrepo.kernel,

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -143,25 +143,27 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
-              org.fcrepo.kernel.impl,
-              org.fcrepo.kernel.impl.identifiers,
-              org.fcrepo.kernel.impl.observer,
-              org.fcrepo.kernel.impl.observer.eventmappings,
-              org.fcrepo.kernel.impl.rdf,
-              org.fcrepo.kernel.impl.rdf.converters,
-              org.fcrepo.kernel.impl.rdf.impl,
-              org.fcrepo.kernel.impl.rdf.impl.mappings,
-              org.fcrepo.kernel.impl.services,
-              org.fcrepo.kernel.impl.services.functions,
-              org.fcrepo.kernel.impl.spring,
-              org.fcrepo.kernel.impl.utils,
-              org.fcrepo.kernel.impl.utils.impl,
-              org.fcrepo.kernel.impl.utils.infinispan,
-              org.fcrepo.kernel.impl.utils.iterators,
-              org.modeshape.jcr,
-              org.modeshape.jcr.value.binary.infinispan
+              org.fcrepo.kernel.impl;version=${project.version},
+              org.fcrepo.kernel.impl.identifiers;version=${project.version},
+              org.fcrepo.kernel.impl.observer;version=${project.version},
+              org.fcrepo.kernel.impl.observer.eventmappings;version=${project.version},
+              org.fcrepo.kernel.impl.rdf;version=${project.version},
+              org.fcrepo.kernel.impl.rdf.converters;version=${project.version},
+              org.fcrepo.kernel.impl.rdf.impl;version=${project.version},
+              org.fcrepo.kernel.impl.rdf.impl.mappings;version=${project.version},
+              org.fcrepo.kernel.impl.services;version=${project.version},
+              org.fcrepo.kernel.impl.services.functions;version=${project.version},
+              org.fcrepo.kernel.impl.spring;version=${project.version},
+              org.fcrepo.kernel.impl.utils;version=${project.version},
+              org.fcrepo.kernel.impl.utils.impl;version=${project.version},
+              org.fcrepo.kernel.impl.utils.infinispan;version=${project.version},
+              org.fcrepo.kernel.impl.utils.iterators;version=${project.version},
+              org.modeshape.jcr;version=${project.version},
+              org.modeshape.jcr.value.binary.infinispan;version=${project.version}
             </Export-Package>
-            <Import-Package>org.fcrepo.kernel.*</Import-Package>
+            <Import-Package>
+              org.fcrepo.kernel.*,
+            </Import-Package>
             <Embed-Transitive>true</Embed-Transitive>
           </instructions>
         </configuration>

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
+      <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
@@ -138,6 +138,33 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>
+              org.fcrepo.kernel.impl,
+              org.fcrepo.kernel.impl.identifiers,
+              org.fcrepo.kernel.impl.observer,
+              org.fcrepo.kernel.impl.observer.eventmappings,
+              org.fcrepo.kernel.impl.rdf,
+              org.fcrepo.kernel.impl.rdf.converters,
+              org.fcrepo.kernel.impl.rdf.impl,
+              org.fcrepo.kernel.impl.rdf.impl.mappings,
+              org.fcrepo.kernel.impl.services,
+              org.fcrepo.kernel.impl.services.functions,
+              org.fcrepo.kernel.impl.spring,
+              org.fcrepo.kernel.impl.utils,
+              org.fcrepo.kernel.impl.utils.impl,
+              org.fcrepo.kernel.impl.utils.infinispan,
+              org.fcrepo.kernel.impl.utils.iterators,
+              org.modeshape.jcr,
+              org.modeshape.jcr.value.binary.infinispan
+            </Export-Package>
+            <Import-Package>org.fcrepo.kernel.*</Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/fcrepo-kernel/pom.xml
+++ b/fcrepo-kernel/pom.xml
@@ -21,17 +21,17 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Export-Package>
-              org.fcrepo.kernel,
-              org.fcrepo.kernel.exception,
-              org.fcrepo.kernel.identifiers,
-              org.fcrepo.kernel.observer,
-              org.fcrepo.kernel.observer.eventmappings,
-              org.fcrepo.kernel.models,
-              org.fcrepo.kernel.services,
-              org.fcrepo.kernel.services.functions,
-              org.fcrepo.kernel.services.policies,
-              org.fcrepo.kernel.utils,
-              org.fcrepo.kernel.utils.iterators
+              org.fcrepo.kernel;version=${project.version},
+              org.fcrepo.kernel.exception;version=${project.version},
+              org.fcrepo.kernel.identifiers;version=${project.version},
+              org.fcrepo.kernel.observer;version=${project.version},
+              org.fcrepo.kernel.observer.eventmappings;version=${project.version},
+              org.fcrepo.kernel.models;version=${project.version},
+              org.fcrepo.kernel.services;version=${project.version},
+              org.fcrepo.kernel.services.functions;version=${project.version},
+              org.fcrepo.kernel.services.policies;version=${project.version},
+              org.fcrepo.kernel.utils;version=${project.version},
+              org.fcrepo.kernel.utils.iterators;version=${project.version}
             </Export-Package>
             <Embed-Transitive>true</Embed-Transitive>
           </instructions>

--- a/fcrepo-kernel/pom.xml
+++ b/fcrepo-kernel/pom.xml
@@ -17,6 +17,25 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>
+              org.fcrepo.kernel,
+              org.fcrepo.kernel.exception,
+              org.fcrepo.kernel.identifiers,
+              org.fcrepo.kernel.observer,
+              org.fcrepo.kernel.observer.eventmappings,
+              org.fcrepo.kernel.models,
+              org.fcrepo.kernel.services,
+              org.fcrepo.kernel.services.functions,
+              org.fcrepo.kernel.services.policies,
+              org.fcrepo.kernel.utils,
+              org.fcrepo.kernel.utils.iterators
+            </Export-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/fcrepo-metrics/pom.xml
+++ b/fcrepo-metrics/pom.xml
@@ -78,36 +78,10 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Export-Package>org.fcrepo.metrics</Export-Package>
-            <Import-Package>
-            </Import-Package>
+            <Export-Package>org.fcrepo.metrics;version=${project.version}</Export-Package>
             <Embed-Transitive>true</Embed-Transitive>
           </instructions>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>1.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <artifactSet>
-                <includes>
-                  <include>io.dropwizard.metrics:metrics-core</include>
-                  <include>io.dropwizard.metrics:metrics-graphite</include>
-                  <include>io.dropwizard.metrics:metrics-jersey2</include>
-                  <include>io.dropwizard.metrics:metrics-servlets</include>
-                </includes>
-              </artifactSet>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/fcrepo-metrics/pom.xml
+++ b/fcrepo-metrics/pom.xml
@@ -74,6 +74,40 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>org.fcrepo.metrics</Export-Package>
+            <Import-Package>
+            </Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>io.dropwizard.metrics:metrics-core</include>
+                  <include>io.dropwizard.metrics:metrics-graphite</include>
+                  <include>io.dropwizard.metrics:metrics-jersey2</include>
+                  <include>io.dropwizard.metrics:metrics-servlets</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/fcrepo-mint/pom.xml
+++ b/fcrepo-mint/pom.xml
@@ -91,7 +91,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Export-Package>org.fcrepo.mint</Export-Package>
+            <Export-Package>org.fcrepo.mint;version=${project.version}</Export-Package>
             <Import-Package>
               org.fcrepo.kernel,
               org.fcrepo.metrics

--- a/fcrepo-mint/pom.xml
+++ b/fcrepo-mint/pom.xml
@@ -27,6 +27,16 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-annotation</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.glassfish.hk2.external</groupId>
@@ -77,6 +87,18 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>org.fcrepo.mint</Export-Package>
+            <Import-Package>
+              org.fcrepo.kernel,
+              org.fcrepo.metrics
+            </Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/fcrepo-serialization/pom.xml
+++ b/fcrepo-serialization/pom.xml
@@ -52,6 +52,15 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>org.fcrepo.serialization</Export-Package>
+            <Import-Package>org.fcrepo.kernel</Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/fcrepo-serialization/pom.xml
+++ b/fcrepo-serialization/pom.xml
@@ -56,7 +56,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Export-Package>org.fcrepo.serialization</Export-Package>
+            <Export-Package>org.fcrepo.serialization;version=${project.version}</Export-Package>
             <Import-Package>org.fcrepo.kernel</Import-Package>
             <Embed-Transitive>true</Embed-Transitive>
           </instructions>

--- a/fcrepo-transform/pom.xml
+++ b/fcrepo-transform/pom.xml
@@ -193,6 +193,19 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>org.fcrepo.transform</Export-Package>
+            <Import-Package>
+              org.fcrepo.kernel.impl,
+              org.fcrepo.http.commons,
+              org.fcrepo.http.api
+            </Import-Package>
+            <Embed-Transitive>true</Embed-Transitive>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>

--- a/fcrepo-transform/pom.xml
+++ b/fcrepo-transform/pom.xml
@@ -197,7 +197,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Export-Package>org.fcrepo.transform</Export-Package>
+            <Export-Package>org.fcrepo.transform;version=${project.version}</Export-Package>
             <Import-Package>
               org.fcrepo.kernel.impl,
               org.fcrepo.http.commons,

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -103,6 +103,30 @@
         </exclusion>
       </exclusions>
     </dependency>
+    
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-servlets</artifactId>
+      <version>${metrics.version}</version>
+
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
@@ -179,6 +203,10 @@
       <artifactId>htmlunit-core-js</artifactId>
       <scope>test</scope>
       <version>${htmlunit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
This begins to address: https://jira.duraspace.org/browse/FCREPO-1276

The existing maven configuration is incorrect for the various fcrepo-* modules in that it does not create proper OSGi bundles. Certainly not deployable OSGi bundles.

This PR adds proper configuration for OSGi bundles.