### PR TITLE
normalized configuration values

### DIFF
--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
@@ -51,7 +51,7 @@ public abstract class AbstractResourceIT {
     }
 
     protected static final int SERVER_PORT = Integer.parseInt(System
-            .getProperty("test.port", "8080"));
+            .getProperty("fcrepo.test.port", "8080"));
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-auth-common/src/test/resources/config/basic-authn/repository.json
+++ b/fcrepo-auth-common/src/test/resources/config/basic-authn/repository.json
@@ -8,7 +8,7 @@
     },
     "storage" : {
         "cacheName" : "FedoraRepository",
-        "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/testing/infinispan-basic.xml}",
+        "cacheConfiguration" : "${fcrepo.ispn.configuration:config/testing/infinispan-basic.xml}",
         "binaryStorage" : {
             "type" : "cache",
             "dataCacheName" : "FedoraRepositoryBinaryData",

--- a/fcrepo-auth-common/src/test/resources/logback-test.xml
+++ b/fcrepo-auth-common/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.auth" additivity="false" level="${log.fcrepo.auth:-INFO}">
+  <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <root additivity="false" level="WARN">

--- a/fcrepo-auth-common/src/test/resources/repository.json
+++ b/fcrepo-auth-common/src/test/resources/repository.json
@@ -8,7 +8,7 @@
     },
     "storage" : {
         "cacheName" : "FedoraRepository",
-        "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/testing/infinispan-basic.xml}",
+        "cacheConfiguration" : "${fcrepo.ispn.configuration:config/testing/infinispan-basic.xml}",
         "binaryStorage" : {
             "type" : "cache",
             "dataCacheName" : "FedoraRepositoryBinaryData",

--- a/fcrepo-auth-common/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-auth-common/src/test/resources/spring-test/test-container.xml
@@ -15,7 +15,7 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${test.port:8080}"
+    init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
     p:configLocation="classpath:web.xml"/> 
 
 </beans>

--- a/fcrepo-configs/src/main/resources/config/activemq.xml
+++ b/fcrepo-configs/src/main/resources/config/activemq.xml
@@ -7,7 +7,7 @@
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
     http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
 
-    <context:property-placeholder/>    
+    <context:property-placeholder/>
 
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
@@ -17,9 +17,9 @@
         <!--
             For better performances use VM cursor and small memory limit.
             For more information, see:
-            
+
             http://activemq.apache.org/message-cursors.html
-            
+
             Also, if your producer is "hanging", it's probably due to producer flow control.
             For more information, see:
             http://activemq.apache.org/producer-flow-control.html
@@ -33,9 +33,9 @@
                          slow topic consumers to block producers and affect other consumers
                          by limiting the number of messages that are retained
                          For more information, see:
-                         
+
                          http://activemq.apache.org/slow-consumer-handling.html
-                         
+
                     -->
                         <pendingMessageLimitStrategy>
                             <constantPendingMessageLimitStrategy limit="1000"/>
@@ -44,9 +44,9 @@
                     <policyEntry queue=">" producerFlowControl="true" memoryLimit="1mb">
                         <!-- Use VM cursor for better latency
                        For more information, see:
-                       
+
                        http://activemq.apache.org/message-cursors.html
-                       
+
                   <pendingQueuePolicy>
                     <vmQueueCursor/>
                   </pendingQueuePolicy>
@@ -61,7 +61,7 @@
             The managementContext is used to configure how ActiveMQ is exposed in
             JMX. By default, ActiveMQ uses the MBean server that is started by
             the JVM. For more information, see:
-            
+
             http://activemq.apache.org/jmx.html
         -->
         <managementContext>
@@ -72,11 +72,11 @@
             Configure message persistence for the broker. The default persistence
             mechanism is the KahaDB store (identified by the kahaDB tag).
             For more information, see:
-            
+
             http://activemq.apache.org/persistence.html
         -->
         <persistenceAdapter>
-            <kahaDB directory="${fcrepo.activemq.dir:ActiveMQ/kahadb}"/>
+            <kahaDB directory="${fcrepo.activemq.directory:ActiveMQ/kahadb}"/>
         </persistenceAdapter>
 
 
@@ -105,15 +105,15 @@
         <!--
             The transport connectors expose ActiveMQ over a given protocol to
             clients and other brokers. For more information, see:
-            
+
             http://activemq.apache.org/configuring-transports.html
         -->
         <transportConnectors>
             <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
             <transportConnector name="openwire"
-                uri="tcp://0.0.0.0:${jms.port:61616}?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"
+                uri="tcp://0.0.0.0:${fcrepo.jms.port:61616}?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"
             />
-            <transportConnector name="stomp" uri="stomp://0.0.0.0:${stomp.port:61613}"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:${fcrepo.stomp.port:61613}"/>
         </transportConnectors>
 
         <!-- destroy the spring context on shutdown to stop jetty -->
@@ -126,9 +126,9 @@
 
     <!--
         Enable web consoles, REST and Ajax APIs and demos
-        
+
         Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
-    
+
     <import resource="jetty.xml"/>
     -->
 </beans>

--- a/fcrepo-configs/src/main/resources/config/clustered/repository.json
+++ b/fcrepo-configs/src/main/resources/config/clustered/repository.json
@@ -8,7 +8,7 @@
     },
     "storage" : {
         "cacheName" : "FedoraRepository",
-        "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/infinispan/leveldb/infinispan.xml}",
+        "cacheConfiguration" : "${fcrepo.ispn.configuration:config/infinispan/leveldb/infinispan.xml}",
         "binaryStorage" : {
             "type" : "cache",
             "dataCacheName" : "FedoraRepositoryBinaryData",

--- a/fcrepo-configs/src/main/resources/config/infinispan/clustered/infinispan.xml
+++ b/fcrepo-configs/src/main/resources/config/infinispan/clustered/infinispan.xml
@@ -61,7 +61,7 @@
                   preload="false"
                   fetchPersistentState="true"
                   purgeOnStartup="false"
-                  location="${fcrepo.ispn.repo.CacheDirPath:target/FedoraRepository/storage}"/>
+                  location="${fcrepo.ispn.repo.cache:target/FedoraRepository/storage}"/>
     </persistence>
   </namedCache>
 
@@ -99,7 +99,7 @@
                   preload="false"
                   fetchPersistentState="true"
                   purgeOnStartup="false"
-                  location="${fcrepo.ispn.CacheDirPath:target/FedoraRepositoryMetaData/storage}"/>
+                  location="${fcrepo.ispn.cache:target/FedoraRepositoryMetaData/storage}"/>
     </persistence>
   </namedCache>
 
@@ -139,7 +139,7 @@
                   preload="false"
                   fetchPersistentState="true"
                   purgeOnStartup="false"
-                  location="${fcrepo.ispn.binary.CacheDirPath:target/FedoraRepositoryBinaryData/storage}"/>
+                  location="${fcrepo.ispn.binary.cache:target/FedoraRepositoryBinaryData/storage}"/>
     </persistence>
   </namedCache>
 </infinispan>

--- a/fcrepo-configs/src/main/resources/config/infinispan/file/infinispan.xml
+++ b/fcrepo-configs/src/main/resources/config/infinispan/file/infinispan.xml
@@ -31,7 +31,7 @@
                   preload="false"
                   fetchPersistentState="true"
                   purgeOnStartup="false"
-                  location="${fcrepo.ispn.repo.CacheDirPath:target/FedoraRepository/storage}" />
+                  location="${fcrepo.ispn.repo.cache:target/FedoraRepository/storage}" />
     </persistence>
 
   </namedCache>

--- a/fcrepo-configs/src/main/resources/config/infinispan/leveldb-default/infinispan.xml
+++ b/fcrepo-configs/src/main/resources/config/infinispan/leveldb-default/infinispan.xml
@@ -25,8 +25,8 @@
          into memory. -->
     <persistence passivation="false">
       <store:leveldbStore
-          location="${fcrepo.ispn.repo.CacheDirPath:target}/data"
-          expiredLocation="${fcrepo.ispn.repo.CacheDirPath:target}/expired"/>
+          location="${fcrepo.ispn.repo.cache:target}/data"
+          expiredLocation="${fcrepo.ispn.repo.cache:target}/expired"/>
     </persistence>
 
   </namedCache>

--- a/fcrepo-configs/src/main/resources/config/infinispan/leveldb/infinispan.xml
+++ b/fcrepo-configs/src/main/resources/config/infinispan/leveldb/infinispan.xml
@@ -28,8 +28,8 @@
 
     <persistence passivation="false">
       <store:leveldbStore
-          location="${fcrepo.ispn.repo.CacheDirPath:target/repo}/data"
-          expiredLocation="${fcrepo.ispn.repo.CacheDirPath:target/repo}/expired"/>
+          location="${fcrepo.ispn.repo.cache:target/repo}/data"
+          expiredLocation="${fcrepo.ispn.repo.cache:target/repo}/expired"/>
     </persistence>
 
   </namedCache>
@@ -52,8 +52,8 @@
 
     <persistence passivation="false">
       <store:leveldbStore
-          location="${fcrepo.ispn.CacheDirPath:target}/data"
-          expiredLocation="${fcrepo.ispn.CacheDirPath:target}/expired"/>
+          location="${fcrepo.ispn.cache:target}/data"
+          expiredLocation="${fcrepo.ispn.cache:target}/expired"/>
     </persistence>
 
 </namedCache>
@@ -79,7 +79,7 @@
                 preload="false"
                 fetchPersistentState="true"
                 purgeOnStartup="false"
-                location="${fcrepo.ispn.binary.CacheDirPath:target/FedoraRepositoryBinaryData/storage}" />
+                location="${fcrepo.ispn.binary.cache:target/FedoraRepositoryBinaryData/storage}" />
   </persistence>
 
 </namedCache>

--- a/fcrepo-configs/src/main/resources/config/minimal-default/repository.json
+++ b/fcrepo-configs/src/main/resources/config/minimal-default/repository.json
@@ -8,10 +8,10 @@
     },
     "storage" : {
         "cacheName" : "FedoraRepository",
-        "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/infinispan/leveldb-default/infinispan.xml}",
+        "cacheConfiguration" : "${fcrepo.ispn.configuration:config/infinispan/leveldb-default/infinispan.xml}",
         "binaryStorage" : {
             "type" : "file",
-            "directory" : "${fcrepo.binary-store-path:target/binaries}",
+            "directory" : "${fcrepo.binary.directory:target/binaries}",
             "minimumBinarySizeInBytes" : 4096
         }
     },

--- a/fcrepo-configs/src/main/resources/config/minimal/repository.json
+++ b/fcrepo-configs/src/main/resources/config/minimal/repository.json
@@ -10,7 +10,7 @@
         "binaryStorage" : {
             "type" : "file",
             "minimumBinarySizeInBytes" : 1024,
-            "directory":"${fcrepo.binary-store-path:target/binaries}"
+            "directory":"${fcrepo.binary.directory:target/binaries}"
         }
     },
     "security" : {

--- a/fcrepo-configs/src/main/resources/config/servlet-auth/repository.json
+++ b/fcrepo-configs/src/main/resources/config/servlet-auth/repository.json
@@ -8,10 +8,10 @@
     },
     "storage" : {
         "cacheName" : "FedoraRepository",
-        "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/infinispan/leveldb-default/infinispan.xml}",
+        "cacheConfiguration" : "${fcrepo.ispn.configuration:config/infinispan/leveldb-default/infinispan.xml}",
         "binaryStorage" : {
             "type" : "file",
-            "directory" : "${fcrepo.binary-store-path:target/binaries}",
+            "directory" : "${fcrepo.binary.directory:target/binaries}",
             "minimumBinarySizeInBytes" : 4096
         }
     },

--- a/fcrepo-connector-file/src/test/java/org/fcrepo/integration/connector/file/AbstractFedoraFileSystemConnectorIT.java
+++ b/fcrepo-connector-file/src/test/java/org/fcrepo/integration/connector/file/AbstractFedoraFileSystemConnectorIT.java
@@ -125,9 +125,9 @@ public abstract class AbstractFedoraFileSystemConnectorIT {
      */
     protected abstract String getFederationRoot();
 
-    private final static String PROP_TEST_DIR1 = "fcrepo.test.dir1";
-    private final static String PROP_TEST_DIR2 = "fcrepo.test.dir2";
-    private final static String PROP_EXT_TEST_DIR = "fcrepo.test.properties.dir";
+    private final static String PROP_TEST_DIR1 = "fcrepo.test.connector.file.directory1";
+    private final static String PROP_TEST_DIR2 = "fcrepo.test.connector.file.directory2";
+    private final static String PROP_EXT_TEST_DIR = "fcrepo.test.connector.file.properties.directory";
 
     protected String getReadWriteFederationRoot() {
         return getProperty(PROP_TEST_DIR1);

--- a/fcrepo-connector-file/src/test/resources/config/testing/repository.json
+++ b/fcrepo-connector-file/src/test/resources/config/testing/repository.json
@@ -9,7 +9,7 @@
     "externalSources" : {
         "federated-directory" : {
             "classname" : "org.fcrepo.connector.file.FedoraFileSystemConnector",
-            "directoryPath" : "${fcrepo.test.dir1:must-be-provided}",
+            "directoryPath" : "${fcrepo.test.connector.file.directory1:must-be-provided}",
             "projections" : [ "default:/federated => /" ],
             "contentBasedSha1" : "false",
             "readonly" : false,
@@ -17,8 +17,8 @@
         },
         "federated-directory-read-only" : {
             "classname" : "org.fcrepo.connector.file.FedoraFileSystemConnector",
-            "directoryPath" : "${fcrepo.test.dir2:must-be-provided}",
-            "propertiesDirectoryPath" : "${fcrepo.test.properties.dir:must-be-provided}",
+            "directoryPath" : "${fcrepo.test.connector.file.directory2:must-be-provided}",
+            "propertiesDirectoryPath" : "${fcrepo.test.connector.file.properties.directory:must-be-provided}",
             "projections" : [ "default:/readonly-federated => /" ],
             "contentBasedSha1" : "true",
             "cacheTtlSeconds" : 0,

--- a/fcrepo-connector-file/src/test/resources/logback-test.xml
+++ b/fcrepo-connector-file/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.connector.file" additivity="false" level="${log.fcrepo.connector.file:-INFO}">
+  <logger name="org.fcrepo.connector.file" additivity="false" level="${fcrepo.log.connector.file:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <root additivity="false" level="WARN">

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -87,7 +87,7 @@ public abstract class AbstractResourceIT {
     }
 
     protected static final int SERVER_PORT = parseInt(System.getProperty(
-            "test.port", "8080"));
+            "fcrepo.test.port", "8080"));
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraBackupLevelDBIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraBackupLevelDBIT.java
@@ -25,7 +25,7 @@ import org.junit.BeforeClass;
  */
 public class FedoraBackupLevelDBIT extends FedoraBackupIT {
 
-    private static final String CACHE_CONFIG_FILE = "fcrepo.infinispan.cache_configuration";
+    private static final String CACHE_CONFIG_FILE = "fcrepo.ispn.configuration";
 
     @BeforeClass
     public static void beforeClass() {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraCrudConcurrentIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraCrudConcurrentIT.java
@@ -36,13 +36,13 @@ import org.junit.Test;
  * It takes roughly 2 minutes to complete and should only be run if the timing metrics are wanted.
  * In order to activate this utility, the following System Property must be set:
  * <p/>
- * mvn -DRUN_TEST_CRUD_CONCURRENT install
+ * mvn -Dfcrepo.test.http.concurrent install
  *
  * @author lsitu
  */
 public class FedoraCrudConcurrentIT extends AbstractResourceIT {
 
-    private static final String TEST_ACTIVATION_PROPERTY = "RUN_TEST_CRUD_CONCURRENT";
+    private static final String TEST_ACTIVATION_PROPERTY = "fcrepo.test.http.concurrent";
 
     @Test
     public void testConcurrentIngest() throws Exception {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTransactionsIT.java
@@ -116,7 +116,7 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
         } finally {
             System.setProperty(TIMEOUT_SYSTEM_PROPERTY, Long
                     .toString(DEFAULT_TIMEOUT));
-            System.clearProperty("fcrepo4.tx.timeout");
+            System.clearProperty("fcrepo.transactions.timeout");
         }
     }
 

--- a/fcrepo-http-api/src/test/resources/logback-test.xml
+++ b/fcrepo-http-api/src/test/resources/logback-test.xml
@@ -7,13 +7,13 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.http.api" additivity="false" level="${log.fcrepo.http.api:-INFO}">
+  <logger name="org.fcrepo.http.api" additivity="false" level="${fcrepo.log.http.api:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.integration.http" additivity="false" level="${log.fcrepo.integration.http:-INFO}">
+  <logger name="org.fcrepo.integration.http" additivity="false" level="${fcrepo.log.integration.http:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <logger name="com.gargoylesoftware.htmlunit" additivity="false" level="ERROR">

--- a/fcrepo-http-api/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-http-api/src/test/resources/spring-test/test-container.xml
@@ -10,7 +10,7 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${test.port:8080}"
+    init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
     p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-http-api/src/test/resources/test_repository.json
+++ b/fcrepo-http-api/src/test/resources/test_repository.json
@@ -8,7 +8,7 @@
   },
   "storage" : {
     "cacheName" : "FedoraRepository",
-    "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/testing/infinispan-basic.xml}",
+    "cacheConfiguration" : "${fcrepo.ispn.configuration:config/testing/infinispan-basic.xml}",
     "binaryStorage" : {
       "type" : "cache",
       "dataCacheName" : "FedoraRepositoryBinaryData",

--- a/fcrepo-http-commons/src/test/resources/logback-test.xml
+++ b/fcrepo-http-commons/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.http.commons" additivity="false" level="${log.fcrepo.http.commons:-INFO}">
+  <logger name="org.fcrepo.http.commons" additivity="false" level="${fcrepo.log.http.commons:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <root additivity="false" level="WARN">

--- a/fcrepo-integration-ldp/pom.xml
+++ b/fcrepo-integration-ldp/pom.xml
@@ -218,8 +218,8 @@
                     <systemPropertyVariables>
                         <test.port>${test.port}</test.port>
                         <test.context.path>${test.context.path}</test.context.path>
-                        <jms.port>${jms.port}</jms.port>
-                        <stomp.port>${stomp.port}</stomp.port>
+                        <fcrepo.jms.port>${jms.port}</fcrepo.jms.port>
+                        <fcrepo.stomp.port>${stomp.port}</fcrepo.stomp.port>
                         <integration-test>true</integration-test>
                     </systemPropertyVariables>
                 </configuration>

--- a/fcrepo-integration-ldp/pom.xml
+++ b/fcrepo-integration-ldp/pom.xml
@@ -204,11 +204,11 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <configuration>
                     <portNames>
-                        <portName>test.port</portName>
+                        <portName>fcrepo.test.port</portName>
                         <!-- reserves the stop port for jetty-maven-plugin -->
                         <portName>jetty.port.stop</portName>
-                        <portName>jms.port</portName>
-                        <portName>stomp.port</portName>
+                        <portName>fcrepo.jms.port</portName>
+                        <portName>fcrepo.stomp.port</portName>
                     </portNames>
                 </configuration>
             </plugin>
@@ -216,10 +216,10 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <test.port>${test.port}</test.port>
-                        <test.context.path>${test.context.path}</test.context.path>
-                        <fcrepo.jms.port>${jms.port}</fcrepo.jms.port>
-                        <fcrepo.stomp.port>${stomp.port}</fcrepo.stomp.port>
+                        <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
+                        <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
+                        <fcrepo.jms.port>${fcrepo.jms.port}</fcrepo.jms.port>
+                        <fcrepo.stomp.port>${fcrepo.stomp.port}</fcrepo.stomp.port>
                         <integration-test>true</integration-test>
                     </systemPropertyVariables>
                 </configuration>

--- a/fcrepo-integration-ldp/src/test/java/org/fcrepo/integration/ldp/LdpTestSuiteIT.java
+++ b/fcrepo-integration-ldp/src/test/java/org/fcrepo/integration/ldp/LdpTestSuiteIT.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
 public class LdpTestSuiteIT {
 
     protected static final int SERVER_PORT = parseInt(System.getProperty(
-            "test.port", "8080"));
+            "fcrepo.test.port", "8080"));
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-integration-ldp/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-integration-ldp/src/test/resources/spring-test/test-container.xml
@@ -10,7 +10,7 @@
 
   <bean id="containerWrapper"
         class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-        init-method="start" destroy-method="stop" p:port="${test.port:8080}"
+        init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
         p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-integration-rdf/pom.xml
+++ b/fcrepo-integration-rdf/pom.xml
@@ -132,8 +132,8 @@
                     <systemPropertyVariables>
                         <test.port>${test.port}</test.port>
                         <test.context.path>${test.context.path}</test.context.path>
-                        <jms.port>${jms.port}</jms.port>
-                        <stomp.port>${stomp.port}</stomp.port>
+                        <fcrepo.jms.port>${jms.port}</fcrepo.jms.port>
+                        <fcrepo.stomp.port>${stomp.port}</fcrepo.stomp.port>
                         <integration-test>true</integration-test>
                     </systemPropertyVariables>
                 </configuration>

--- a/fcrepo-integration-rdf/pom.xml
+++ b/fcrepo-integration-rdf/pom.xml
@@ -118,11 +118,11 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <configuration>
                     <portNames>
-                        <portName>test.port</portName>
+                        <portName>fcrepo.test.port</portName>
                         <!-- reserves the stop port for jetty-maven-plugin -->
                         <portName>jetty.port.stop</portName>
-                        <portName>jms.port</portName>
-                        <portName>stomp.port</portName>
+                        <portName>fcrepo.jms.port</portName>
+                        <portName>fcrepo.stomp.port</portName>
                     </portNames>
                 </configuration>
             </plugin>
@@ -130,10 +130,10 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <test.port>${test.port}</test.port>
-                        <test.context.path>${test.context.path}</test.context.path>
-                        <fcrepo.jms.port>${jms.port}</fcrepo.jms.port>
-                        <fcrepo.stomp.port>${stomp.port}</fcrepo.stomp.port>
+                        <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
+                        <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
+                        <fcrepo.jms.port>${fcrepo.jms.port}</fcrepo.jms.port>
+                        <fcrepo.stomp.port>${fcrepo.stomp.port}</fcrepo.stomp.port>
                         <integration-test>true</integration-test>
                     </systemPropertyVariables>
                 </configuration>

--- a/fcrepo-integration-rdf/src/test/resources/logback-test.xml
+++ b/fcrepo-integration-rdf/src/test/resources/logback-test.xml
@@ -7,28 +7,28 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.auth" additivity="false" level="${log.fcrepo.auth:-INFO}">
+  <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.connector.file" additivity="false" level="${log.fcrepo.connector.file:-INFO}">
+  <logger name="org.fcrepo.connector.file" additivity="false" level="${fcrepo.log.connector.file:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.http.api" additivity="false" level="${log.fcrepo.http.api:-INFO}">
+  <logger name="org.fcrepo.http.api" additivity="false" level="${fcrepo.log.http.api:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.http.commons" additivity="false" level="${log.fcrepo.http.commons:-INFO}">
+  <logger name="org.fcrepo.http.commons" additivity="false" level="${fcrepo.log.http.commons:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.jms" additivity="false" level="${log.fcrepo.jms:-INFO}">
+  <logger name="org.fcrepo.jms" additivity="false" level="${fcrepo.log.jms:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.kernel" additivity="false" level="${log.fcrepo.kernel:-INFO}">
+  <logger name="org.fcrepo.kernel" additivity="false" level="${fcrepo.log.kernel:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.transform" additivity="false" level="${log.fcrepo.transform:-INFO}">
+  <logger name="org.fcrepo.transform" additivity="false" level="${fcrepo.log.transform:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
     <root additivity="false" level="WARN">

--- a/fcrepo-integration-rdf/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-integration-rdf/src/test/resources/spring-test/test-container.xml
@@ -10,7 +10,7 @@
 
   <bean id="containerWrapper"
         class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-        init-method="start" destroy-method="stop" p:port="${test.port:8080}"
+        init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
         p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-jms/src/test/resources/logback-test.xml
+++ b/fcrepo-jms/src/test/resources/logback-test.xml
@@ -7,16 +7,16 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.jms" additivity="false" level="${log.fcrepo.jms:-INFO}">
+  <logger name="org.fcrepo.jms" additivity="false" level="${fcrepo.log.jms:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.integration.jms" additivity="false" level="${log.fcrepo.integration.jms:-INFO}">
+  <logger name="org.fcrepo.integration.jms" additivity="false" level="${fcrepo.log.integration.jms:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.kernel.impl.observer" additivity="false" level="${log.fcrepo.kernel.observer:-INFO}">
+  <logger name="org.fcrepo.kernel.impl.observer" additivity="false" level="${fcrepo.log.kernel.observer:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <root additivity="false" level="WARN">

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -42,7 +42,7 @@ public class TransactionImpl implements Transaction {
     // the default timeout is 3 minutes
     public static final long DEFAULT_TIMEOUT = 3L * 60L * 1000L;
 
-    public static final String TIMEOUT_SYSTEM_PROPERTY = "fcrepo4.tx.timeout";
+    public static final String TIMEOUT_SYSTEM_PROPERTY = "fcrepo.transactions.timeout";
 
     private final Session session;
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/spring/DefaultPropertiesLoader.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/spring/DefaultPropertiesLoader.java
@@ -49,14 +49,14 @@ public class DefaultPropertiesLoader {
         DEFAULT_OBJECT_STORE(
                 "com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean.default.objectStoreDir"),
         OBJECT_STORE("com.arjuna.ats.arjuna.objectstore.objectStoreDir"),
-        ISPN_CACHE("fcrepo.ispn.CacheDirPath"),
-        ISPN_BIN_CACHE("fcrepo.ispn.binary.CacheDirPath"),
-        BIN_STORE_PATH("fcrepo.binary-store-path"),
-        MODE_INDEX("fcrepo.modeshape.index.location"),
-        ISPN_ALT_CACHE("fcrepo.ispn.alternative.CacheDirPath"),
-        ISPN_BIN_ALT_CACHE("fcrepo.ispn.binary.alternative.CacheDirPath"),
-        ISPN_REPO_CACHE("fcrepo.ispn.repo.CacheDirPath"),
-        ACTIVE_MQ("fcrepo.activemq.dir");
+        ISPN_CACHE("fcrepo.ispn.cache"),
+        ISPN_BIN_CACHE("fcrepo.ispn.binary.cache"),
+        BIN_STORE_PATH("fcrepo.binary.directory"),
+        MODE_INDEX("fcrepo.modeshape.index.directory"),
+        ISPN_ALT_CACHE("fcrepo.ispn.alternative.cache"),
+        ISPN_BIN_ALT_CACHE("fcrepo.ispn.binary.alternative.cache"),
+        ISPN_REPO_CACHE("fcrepo.ispn.repo.cache"),
+        ACTIVE_MQ("fcrepo.activemq.directory");
 
         private String text;
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/spring/DefaultPropertiesLoaderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/spring/DefaultPropertiesLoaderTest.java
@@ -31,7 +31,7 @@ public class DefaultPropertiesLoaderTest {
     private DefaultPropertiesLoader loader;
 
     private static final String PROP_FLAG = "integration-test";
-    private static final String PROP_TEST = "fcrepo.ispn.repo.CacheDirPath";
+    private static final String PROP_TEST = "fcrepo.ispn.repo.cache";
     private static final String HOME_PROP = "fcrepo.home";
 
     @Before

--- a/fcrepo-kernel-impl/src/test/resources/config/testing/infinispan-chained.xml
+++ b/fcrepo-kernel-impl/src/test/resources/config/testing/infinispan-chained.xml
@@ -35,7 +35,7 @@
                    preload="false"
                    fetchPersistentState="true"
                    purgeOnStartup="false"
-                   location="${fcrepo.ispn.CacheDirPath:target/FedoraRepository/storage}" />
+                   location="${fcrepo.ispn.cache:target/FedoraRepository/storage}" />
      </persistence>
 
         <!--
@@ -71,7 +71,7 @@
                   preload="false"
                   fetchPersistentState="true"
                   purgeOnStartup="false"
-                  location="${fcrepo.ispn.binary.CacheDirPath:target/FedoraRepositoryBinaryData/storage}" />
+                  location="${fcrepo.ispn.binary.cache:target/FedoraRepositoryBinaryData/storage}" />
     </persistence>
 
       <!--

--- a/fcrepo-kernel-impl/src/test/resources/logback-test.xml
+++ b/fcrepo-kernel-impl/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.kernel" additivity="false" level="${log.fcrepo.kernel:-INFO}">
+  <logger name="org.fcrepo.kernel" additivity="false" level="${fcrepo.log.kernel:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/fcrepo-mint/src/test/java/org/fcrepo/integration/mint/HttpPidMinterIT.java
+++ b/fcrepo-mint/src/test/java/org/fcrepo/integration/mint/HttpPidMinterIT.java
@@ -38,7 +38,7 @@ public class HttpPidMinterIT{
     private static String PREFIX = "http://localhost:";
 
     private static int getPort() {
-        return parseInt(System.getProperty("test.port", "8080"));
+        return parseInt(System.getProperty("fcrepo.test.port", "8080"));
     }
 
     @Inject

--- a/fcrepo-mint/src/test/resources/logback-test.xml
+++ b/fcrepo-mint/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.mint" additivity="false" level="${log.fcrepo.mint:-INFO}">
+  <logger name="org.fcrepo.mint" additivity="false" level="${fcrepo.log.mint:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/fcrepo-mint/src/test/resources/test-container.xml
+++ b/fcrepo-mint/src/test/resources/test-container.xml
@@ -10,6 +10,6 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.integration.mint.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${test.port:8080}"/>
+    init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"/>
 
 </beans>

--- a/fcrepo-transform/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
+++ b/fcrepo-transform/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
@@ -62,7 +62,7 @@ public abstract class AbstractResourceIT {
         logger = LoggerFactory.getLogger(this.getClass());
     }
 
-    protected static final int SERVER_PORT = parseInt(getProperty("test.port",
+    protected static final int SERVER_PORT = parseInt(getProperty("fcrepo.test.port",
                                                                          "8080"));
 
     protected static final String HOSTNAME = "localhost";

--- a/fcrepo-transform/src/test/resources/logback-test.xml
+++ b/fcrepo-transform/src/test/resources/logback-test.xml
@@ -7,10 +7,10 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.transform" additivity="false" level="${log.fcrepo.transform:-INFO}">
+  <logger name="org.fcrepo.transform" additivity="false" level="${fcrepo.log.transform:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <root additivity="false" level="WARN">

--- a/fcrepo-transform/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-transform/src/test/resources/spring-test/test-container.xml
@@ -15,7 +15,7 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${test.port:8080}"
+    init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
     p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -319,8 +319,8 @@
           <systemPropertyVariables>
             <test.port>${test.port}</test.port>
             <test.context.path>${test.context.path}</test.context.path>
-            <jms.port>${jms.port}</jms.port>
-            <stomp.port>${stomp.port}</stomp.port>
+            <fcrepo.jms.port>${fcrepo.jms.port}</fcrepo.jms.port>
+            <fcrepo.stomp.port>${fcrepo.stomp.port}</fcrepo.stomp.port>
             <integration-test>true</integration-test>
           </systemPropertyVariables>
         </configuration>
@@ -333,8 +333,8 @@
             <portName>test.port</portName>
             <!-- reserves the stop port for jetty-maven-plugin -->
             <portName>jetty.port.stop</portName>
-            <portName>jms.port</portName>
-            <portName>stomp.port</portName>
+            <portName>fcrepo.jms.port</portName>
+            <portName>fcrepo.stomp.port</portName>
           </portNames>
         </configuration>
       </plugin>
@@ -352,13 +352,13 @@
             <configuration>
               <properties>
                 <property>
-                  <name>jms.port</name>
-                  <value>${jms.port}</value>
+                  <name>fcrepo.jms.port</name>
+                  <value>${fcrepo.jms.port}</value>
                 </property>
 
                 <property>
-                  <name>stomp.port</name>
-                  <value>${stomp.port}</value>
+                  <name>fcrepo.stomp.port</name>
+                  <value>${fcrepo.stomp.port}</value>
                 </property>
 
                 <property>
@@ -408,13 +408,13 @@
 
               <systemProperties>
                 <systemProperty>
-                  <name>jms.port</name>
-                  <value>${jms.port}</value>
+                  <name>fcrepo.jms.port</name>
+                  <value>${fcrepo.jms.port}</value>
                 </systemProperty>
 
                 <systemProperty>
-                  <name>stomp.port</name>
-                  <value>${stomp.port}</value>
+                  <name>fcrepo.stomp.port</name>
+                  <value>${fcrepo.stomp.port}</value>
                 </systemProperty>
 
                 <systemProperty>
@@ -435,7 +435,7 @@
                 </systemProperty>
 
                 <systemProperty>
-                  <name>fcrepo.activemq.dir</name>
+                  <name>fcrepo.activemq.directory</name>
                   <value>${project.build.directory}/active-mq</value>
                 </systemProperty>
               </systemProperties>

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <!-- integration test properties -->
-    <test.context.path>/</test.context.path>
+    <fcrepo.test.context.path>/</fcrepo.test.context.path>
     
     <!-- jmeter -->
     <jmeter.loop_count>100</jmeter.loop_count>
@@ -317,8 +317,8 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <test.port>${test.port}</test.port>
-            <test.context.path>${test.context.path}</test.context.path>
+            <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
+            <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
             <fcrepo.jms.port>${fcrepo.jms.port}</fcrepo.jms.port>
             <fcrepo.stomp.port>${fcrepo.stomp.port}</fcrepo.stomp.port>
             <integration-test>true</integration-test>
@@ -330,7 +330,7 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <configuration>
           <portNames>
-            <portName>test.port</portName>
+            <portName>fcrepo.test.port</portName>
             <!-- reserves the stop port for jetty-maven-plugin -->
             <portName>jetty.port.stop</portName>
             <portName>fcrepo.jms.port</portName>
@@ -384,7 +384,7 @@
           <scanIntervalSeconds>2</scanIntervalSeconds>
           <stopKey>STOP</stopKey>
           <webApp>
-            <contextPath>${test.context.path}</contextPath>
+            <contextPath>${fcrepo.test.context.path}</contextPath>
           </webApp>
 
         </configuration>
@@ -399,7 +399,7 @@
             <configuration>
               <connectors>
                 <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                  <port>${test.port}</port>
+                  <port>${fcrepo.test.port}</port>
                   <maxIdleTime>60000</maxIdleTime>
                 </connector>
               </connectors>
@@ -501,7 +501,7 @@
                 <jmeter.exit.check.pause>${jmeter.exit.check.pause}</jmeter.exit.check.pause>
               </propertiesJMeter>
               <propertiesUser>
-                <fedora_4_port>${test.port}</fedora_4_port>
+                <fedora_4_port>${fcrepo.test.port}</fedora_4_port>
                 <fedora_4_context>rest</fedora_4_context>
                 <loop_count>${jmeter.loop_count}</loop_count>
                 <num_threads>${jmeter.num_threads}</num_threads>

--- a/fcrepo-webapp/src/main/resources/logback.xml
+++ b/fcrepo-webapp/src/main/resources/logback.xml
@@ -7,28 +7,28 @@
         </encoder>
     </appender>
 
-  <logger name="org.fcrepo.auth" additivity="false" level="${log.fcrepo.auth:-INFO}">
+  <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.connector.file" additivity="false" level="${log.fcrepo.connector.file:-INFO}">
+  <logger name="org.fcrepo.connector.file" additivity="false" level="${fcrepo.log.connector.file:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.http.api" additivity="false" level="${log.fcrepo.http.api:-INFO}">
+  <logger name="org.fcrepo.http.api" additivity="false" level="${fcrepo.log.http.api:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.http.commons" additivity="false" level="${log.fcrepo.http.commons:-INFO}">
+  <logger name="org.fcrepo.http.commons" additivity="false" level="${fcrepo.log.http.commons:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.jms" additivity="false" level="${log.fcrepo.jms:-INFO}">
+  <logger name="org.fcrepo.jms" additivity="false" level="${fcrepo.log.jms:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.kernel" additivity="false" level="${log.fcrepo.kernel:-INFO}">
+  <logger name="org.fcrepo.kernel" additivity="false" level="${fcrepo.log.kernel:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo.transform" additivity="false" level="${log.fcrepo.transform:-INFO}">
+  <logger name="org.fcrepo.transform" additivity="false" level="${fcrepo.log.transform:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
     <root additivity="false" level="WARN">

--- a/fcrepo-webapp/src/main/resources/spring/jms.xml
+++ b/fcrepo-webapp/src/main/resources/spring/jms.xml
@@ -13,10 +13,10 @@
 
   <bean id="connectionFactory"
     class="org.apache.activemq.ActiveMQConnectionFactory" depends-on="jmsBroker"
-    p:brokerURL="vm://${jms.host:localhost}:${jms.port:61616}?create=false"/>
+    p:brokerURL="vm://${fcrepo.jms.host:localhost}:${fcrepo.jms.port:61616}?create=false"/>
 
   <bean name="jmsBroker" class="org.apache.activemq.xbean.BrokerFactoryBean"
-    p:config="classpath:/config/activemq.xml" p:start="true"/>
+    p:config="${fcrepo.activemq.configuration:classpath:/config/activemq.xml}" p:start="true"/>
 
   <!-- translates events into JMS header-only format-->
   <bean class="org.fcrepo.jms.headers.DefaultMessageFactory"/>

--- a/fcrepo-webapp/src/main/resources/spring/master.xml
+++ b/fcrepo-webapp/src/main/resources/spring/master.xml
@@ -6,11 +6,11 @@
     
     <!-- Master context for fcrepo4. -->
 
-    <import resource="classpath:/spring/repo.xml"/>
-    <import resource="classpath:/spring/rest.xml"/>
-    <import resource="${fcrepo.minter.config:classpath:/spring/minter.xml}"/>
-    <import resource="classpath:/spring/eventing.xml"/>
-    <import resource="classpath:/spring/jms.xml"/>
-    <import resource="classpath:/spring/transactions.xml"/>
+    <import resource="${fcrepo.spring.repo.configuration:classpath:/spring/repo.xml}"/>
+    <import resource="${fcrepo.spring.rest.configuration:classpath:/spring/rest.xml}"/>
+    <import resource="${fcrepo.spring.minter.configuration:classpath:/spring/minter.xml}"/>
+    <import resource="${fcrepo.spring.eventing.configuration:classpath:/spring/eventing.xml}"/>
+    <import resource="${fcrepo.spring.jms.configuration:classpath:/spring/jms.xml}"/>
+    <import resource="${fcrepo.spring.transactions.configuration:classpath:/spring/transactions.xml}"/>
     
 </beans>

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
@@ -73,10 +73,10 @@ public abstract class AbstractResourceIT {
     }
 
     protected static final int SERVER_PORT = parseInt(System.getProperty(
-            "test.port", "8080"));
+            "fcrepo.test.port", "8080"));
 
     private static final String CONTEXT_PATH = System
-            .getProperty("test.context.path");
+            .getProperty("fcrepo.test.context.path");
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
@@ -40,14 +40,14 @@ public class SanityCheckIT {
      * The server port of the application, set as system property by
      * maven-failsafe-plugin.
      */
-    private static final String SERVER_PORT = System.getProperty("test.port");
+    private static final String SERVER_PORT = System.getProperty("fcrepo.test.port");
 
     /**
     * The context path of the application (including the leading "/"), set as
     * system property by maven-failsafe-plugin.
     */
     private static final String CONTEXT_PATH = System
-            .getProperty("test.context.path");
+            .getProperty("fcrepo.test.context.path");
 
     protected Logger logger;
 

--- a/pom.xml
+++ b/pom.xml
@@ -605,8 +605,8 @@
           <version>2.17</version>
           <configuration>
             <systemPropertyVariables>
-              <test.port>${test.port}</test.port>
-              <test.context.path>${test.context.path}</test.context.path>
+              <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
+              <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
               <com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean.default.objectStoreDir>
                 ${project.build.directory}/object-store-default
               </com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean.default.objectStoreDir>
@@ -701,11 +701,11 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>1.8</version>
-          <!-- reserve a port under the property ${test.port} for integration 
+          <!-- reserve a port under the property ${fcrepo.test.port} for integration 
             tests -->
           <configuration>
             <portNames>
-              <portName>test.port</portName>
+              <portName>fcrepo.test.port</portName>
             </portNames>
           </configuration>
           <executions>


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-1288

This PR does not add a central fcrepo.properties file (I wasn't able to get that to work consistently)

I am not wedded to any of the following changes, so if there are better naming conventions, please make suggestions.

The basic conventions I adopted were: 
  * prefix everything with `fcrepo`
  * for spring-related configuration, prefix with `fcrepo.spring`
  * for infinispan-related configuration, use `fcrepo.ispn`
  * for infinispan caches, use `cache` (instead of CacheDirPath)
  * for all other directories, use `directory`
  * for configuration files, use `configuration`

This renames the following configuration values:
`fcrepo.activemq.dir` => `fcrepo.activemq.directory`
`fcrepo.binary-store-path` => `fcrepo.binary.directory`
`fcrepo.infinispan.cache_configuration` => `fcrepo.ispn.configuration`
`fcrepo.ispn.CacheDirPath` => `fcrepo.ispn.cache`
`fcrepo.ispn.alternative.CacheDirPath` => `fcrepo.ispn.alternative.cache`
`fcrepo.ispn.binary.CacheDirPath` => `fcrepo.ispn.binary.cache`
`fcrepo.ispn.binary.alternative.CacheDirPath` => `fcrepo.ispn.binary.alternative.cache`
`fcrepo.ispn.repo.CacheDirPath` => `fcrepo.ispn.repo.cache`
`fcrepo.minter.config` => `fcrepo.spring.minter.configuration`
`fcrepo.modeshape.index.location` => `fcrepo.modeshape.index.directory`
`jms.host` => `fcrepo.jms.host`
`jms.port` => `fcrepo.jms.port`
`stomp.port` => `fcrepo.stomp.port`

The following configuration values were added:
`fcrepo.activemq.configuration`
`fcrepo.spring.repo.configuration`
`fcrepo.spring.rest.configuration`
`fcrepo.spring.eventing.configuration`
`fcrepo.spring.jms.configuration`
`fcrepo.spring.transactions.configuration`

The following values stayed the same:
`fcrepo.home`
`fcrepo.ispn.jgroups.configuration`
`fcrepo.ispn.numOwners`
`fcrepo.ispn.replication.timeout`
`fcrepo.modeshape.configuration`
`fcrepo.uuid.path.length`
`fcrepo.uuid.path.count`
`com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean.default.objectStoreDir`
`com.arjuna.ats.arjuna.objectstore.objectStoreDir`

Also, all of the `log.fcrepo.*` values stayed the same, but I wonder whether they shouldn't be `fcrepo.log.*`?

