### PR TITLE
fixed outdated link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [JavaDocs](http://docs.fcrepo.org/) | 
 [Fedora Wiki](https://wiki.duraspace.org/display/FF) | 
 [Use cases](https://wiki.duraspace.org/display/FF/Use+Cases) |
-[REST API](https://wiki.duraspace.org/display/FF/RESTful+HTTP+API) |
+[REST API](https://wiki.duraspace.org/display/FEDORA4x/RESTful+HTTP+API) |
 
 Technical goals:
 * Improved scalability and performance


### PR DESCRIPTION
See: https://jira.duraspace.org/browse/FCREPO-1306

The link to the HTTP documentation was incorrect.