### PR TITLE
Override "equals(Object obj)" to comply with the contract of the "compar...

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/PreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/PreferTag.java
@@ -137,4 +137,13 @@ public class PreferTag implements Comparable<PreferTag> {
     public int compareTo(final PreferTag otherTag) {
         return getTag().compareTo(otherTag.getTag());
     }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ((obj != null) && (obj instanceof PreferTag)) {
+            return getTag().equals(((PreferTag) obj).getTag());
+        } else {
+            return false;
+        }
+    }
 }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/PreferTagTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/PreferTagTest.java
@@ -17,7 +17,10 @@ package org.fcrepo.http.commons.domain;
 
 import org.junit.Test;
 
+import java.text.ParseException;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -31,5 +34,18 @@ public class PreferTagTest {
         assertEquals("", preferTag.getTag());
         assertEquals("", preferTag.getValue());
         assertTrue(preferTag.getParams().isEmpty());
+    }
+
+    @Test
+    public void testEquals() throws ParseException {
+        final PreferTag preferTag1 = new PreferTag("handling=lenient; received=\"minimal\"");
+        final PreferTag preferTag2 = new PreferTag("handling=lenient; received=\"minimal\"");
+        final PreferTag preferTag3 = PreferTag.emptyTag();
+        assertTrue(preferTag1.equals(preferTag2));
+        assertTrue(preferTag1.equals(preferTag1));  // ensure consistency
+        assertTrue(preferTag2.equals(preferTag1));
+        assertFalse(preferTag1.equals(preferTag3));
+        assertFalse(preferTag1.equals(null));
+        assertFalse(preferTag1.equals("some string"));
     }
 }


### PR DESCRIPTION
...eTo(T o)" method

- Add equals(Object obj) in PreferTag.java
- Add unit test in PreferTagTest.java
- old PR: https://github.com/fcrepo4/fcrepo4/pull/699

Resolves: https://jira.duraspace.org/browse/FCREPO-1307