### PR TITLE
Add default properties to pom.xml

### DIFF
--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
@@ -15,10 +15,6 @@
  */
 package org.fcrepo.auth.integration;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.UUID;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -33,6 +29,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.UUID;
 
 /**
  * <p>Abstract AbstractResourceIT class.</p>
@@ -51,7 +51,7 @@ public abstract class AbstractResourceIT {
     }
 
     protected static final int SERVER_PORT = Integer.parseInt(System
-            .getProperty("fcrepo.test.port", "8080"));
+            .getProperty("fcrepo.dynamic.test.port", "8080"));
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-auth-common/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-auth-common/src/test/resources/spring-test/test-container.xml
@@ -15,7 +15,7 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
+    init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"
     p:configLocation="classpath:web.xml"/> 
 
 </beans>

--- a/fcrepo-configs/src/main/resources/config/activemq.xml
+++ b/fcrepo-configs/src/main/resources/config/activemq.xml
@@ -111,9 +111,9 @@
         <transportConnectors>
             <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
             <transportConnector name="openwire"
-                uri="tcp://0.0.0.0:${fcrepo.jms.port:61616}?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"
+                uri="tcp://0.0.0.0:${fcrepo.dynamic.jms.port:61616}?maximumConnections=1000&amp;wireformat.maxFrameSize=104857600"
             />
-            <transportConnector name="stomp" uri="stomp://0.0.0.0:${fcrepo.stomp.port:61613}"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:${fcrepo.dynamic.stomp.port:61613}"/>
         </transportConnectors>
 
         <!-- destroy the spring context on shutdown to stop jetty -->

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -87,7 +87,7 @@ public abstract class AbstractResourceIT {
     }
 
     protected static final int SERVER_PORT = parseInt(System.getProperty(
-            "fcrepo.test.port", "8080"));
+            "fcrepo.dynamic.test.port", "8080"));
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-http-api/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-http-api/src/test/resources/spring-test/test-container.xml
@@ -10,7 +10,7 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
+    init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"
     p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-integration-ldp/pom.xml
+++ b/fcrepo-integration-ldp/pom.xml
@@ -204,11 +204,11 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <configuration>
                     <portNames>
-                        <portName>fcrepo.test.port</portName>
+                        <portName>fcrepo.dynamic.test.port</portName>
                         <!-- reserves the stop port for jetty-maven-plugin -->
-                        <portName>jetty.port.stop</portName>
-                        <portName>fcrepo.jms.port</portName>
-                        <portName>fcrepo.stomp.port</portName>
+                        <portName>jetty.dynamic.stop.port</portName>
+                        <portName>fcrepo.dynamic.jms.port</portName>
+                        <portName>fcrepo.dynamic.stomp.port</portName>
                     </portNames>
                 </configuration>
             </plugin>
@@ -216,10 +216,10 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
+                        <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
                         <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
-                        <fcrepo.jms.port>${fcrepo.jms.port}</fcrepo.jms.port>
-                        <fcrepo.stomp.port>${fcrepo.stomp.port}</fcrepo.stomp.port>
+                        <fcrepo.dynamic.jms.port>${fcrepo.dynamic.jms.port}</fcrepo.dynamic.jms.port>
+                        <fcrepo.dynamic.stomp.port>${fcrepo.dynamic.stomp.port}</fcrepo.dynamic.stomp.port>
                         <integration-test>true</integration-test>
                     </systemPropertyVariables>
                 </configuration>

--- a/fcrepo-integration-ldp/src/test/java/org/fcrepo/integration/ldp/LdpTestSuiteIT.java
+++ b/fcrepo-integration-ldp/src/test/java/org/fcrepo/integration/ldp/LdpTestSuiteIT.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
 public class LdpTestSuiteIT {
 
     protected static final int SERVER_PORT = parseInt(System.getProperty(
-            "fcrepo.test.port", "8080"));
+            "fcrepo.dynamic.test.port", "8080"));
 
     protected static final String HOSTNAME = "localhost";
 

--- a/fcrepo-integration-ldp/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-integration-ldp/src/test/resources/spring-test/test-container.xml
@@ -10,7 +10,7 @@
 
   <bean id="containerWrapper"
         class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-        init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
+        init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"
         p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-integration-rdf/pom.xml
+++ b/fcrepo-integration-rdf/pom.xml
@@ -118,11 +118,11 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <configuration>
                     <portNames>
-                        <portName>fcrepo.test.port</portName>
+                        <portName>fcrepo.dynamic.test.port</portName>
                         <!-- reserves the stop port for jetty-maven-plugin -->
-                        <portName>jetty.port.stop</portName>
-                        <portName>fcrepo.jms.port</portName>
-                        <portName>fcrepo.stomp.port</portName>
+                        <portName>jetty.dynamic.stop.port</portName>
+                        <portName>fcrepo.dynamic.jms.port</portName>
+                        <portName>fcrepo.dynamic.stomp.port</portName>
                     </portNames>
                 </configuration>
             </plugin>
@@ -130,10 +130,10 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
+                        <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
                         <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
-                        <fcrepo.jms.port>${fcrepo.jms.port}</fcrepo.jms.port>
-                        <fcrepo.stomp.port>${fcrepo.stomp.port}</fcrepo.stomp.port>
+                        <fcrepo.dynamic.jms.port>${fcrepo.dynamic.jms.port}</fcrepo.dynamic.jms.port>
+                        <fcrepo.dynamic.stomp.port>${fcrepo.dynamic.stomp.port}</fcrepo.dynamic.stomp.port>
                         <integration-test>true</integration-test>
                     </systemPropertyVariables>
                 </configuration>

--- a/fcrepo-integration-rdf/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-integration-rdf/src/test/resources/spring-test/test-container.xml
@@ -10,7 +10,7 @@
 
   <bean id="containerWrapper"
         class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-        init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
+        init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"
         p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-mint/src/test/java/org/fcrepo/integration/mint/HttpPidMinterIT.java
+++ b/fcrepo-mint/src/test/java/org/fcrepo/integration/mint/HttpPidMinterIT.java
@@ -38,7 +38,7 @@ public class HttpPidMinterIT{
     private static String PREFIX = "http://localhost:";
 
     private static int getPort() {
-        return parseInt(System.getProperty("fcrepo.test.port", "8080"));
+        return parseInt(System.getProperty("fcrepo.dynamic.test.port", "8080"));
     }
 
     @Inject

--- a/fcrepo-mint/src/test/resources/test-container.xml
+++ b/fcrepo-mint/src/test/resources/test-container.xml
@@ -10,6 +10,6 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.integration.mint.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"/>
+    init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"/>
 
 </beans>

--- a/fcrepo-transform/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
+++ b/fcrepo-transform/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
@@ -62,7 +62,7 @@ public abstract class AbstractResourceIT {
         logger = LoggerFactory.getLogger(this.getClass());
     }
 
-    protected static final int SERVER_PORT = parseInt(getProperty("fcrepo.test.port",
+    protected static final int SERVER_PORT = parseInt(getProperty("fcrepo.dynamic.test.port",
                                                                          "8080"));
 
     protected static final String HOSTNAME = "localhost";

--- a/fcrepo-transform/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-transform/src/test/resources/spring-test/test-container.xml
@@ -15,7 +15,7 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${fcrepo.test.port:8080}"
+    init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"
     p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -317,10 +317,10 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
+            <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
             <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
-            <fcrepo.jms.port>${fcrepo.jms.port}</fcrepo.jms.port>
-            <fcrepo.stomp.port>${fcrepo.stomp.port}</fcrepo.stomp.port>
+            <fcrepo.dynamic.jms.port>${fcrepo.dynamic.jms.port}</fcrepo.dynamic.jms.port>
+            <fcrepo.dynamic.stomp.port>${fcrepo.dynamic.stomp.port}</fcrepo.dynamic.stomp.port>
             <integration-test>true</integration-test>
           </systemPropertyVariables>
         </configuration>
@@ -330,11 +330,11 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <configuration>
           <portNames>
-            <portName>fcrepo.test.port</portName>
+            <portName>fcrepo.dynamic.test.port</portName>
             <!-- reserves the stop port for jetty-maven-plugin -->
-            <portName>jetty.port.stop</portName>
-            <portName>fcrepo.jms.port</portName>
-            <portName>fcrepo.stomp.port</portName>
+            <portName>jetty.dynamic.stop.port</portName>
+            <portName>fcrepo.dynamic.jms.port</portName>
+            <portName>fcrepo.dynamic.stomp.port</portName>
           </portNames>
         </configuration>
       </plugin>
@@ -352,13 +352,13 @@
             <configuration>
               <properties>
                 <property>
-                  <name>fcrepo.jms.port</name>
-                  <value>${fcrepo.jms.port}</value>
+                  <name>fcrepo.dynamic.jms.port</name>
+                  <value>${fcrepo.dynamic.jms.port}</value>
                 </property>
 
                 <property>
-                  <name>fcrepo.stomp.port</name>
-                  <value>${fcrepo.stomp.port}</value>
+                  <name>fcrepo.dynamic.stomp.port</name>
+                  <value>${fcrepo.dynamic.stomp.port}</value>
                 </property>
 
                 <property>
@@ -399,22 +399,22 @@
             <configuration>
               <connectors>
                 <connector implementation="org.eclipse.jetty.server.nio.SelectChannelConnector">
-                  <port>${fcrepo.test.port}</port>
+                  <port>${fcrepo.dynamic.test.port}</port>
                   <maxIdleTime>60000</maxIdleTime>
                 </connector>
               </connectors>
               <daemon>true</daemon>
-              <stopPort>${jetty.port.stop}</stopPort>
+              <stopPort>${jetty.dynamic.stop.port}</stopPort>
 
               <systemProperties>
                 <systemProperty>
-                  <name>fcrepo.jms.port</name>
-                  <value>${fcrepo.jms.port}</value>
+                  <name>fcrepo.dynamic.jms.port</name>
+                  <value>${fcrepo.dynamic.jms.port}</value>
                 </systemProperty>
 
                 <systemProperty>
-                  <name>fcrepo.stomp.port</name>
-                  <value>${fcrepo.stomp.port}</value>
+                  <name>fcrepo.dynamic.stomp.port</name>
+                  <value>${fcrepo.dynamic.stomp.port}</value>
                 </systemProperty>
 
                 <systemProperty>
@@ -449,7 +449,7 @@
               <goal>stop</goal>
             </goals>
             <configuration>
-              <stopPort>${jetty.port.stop}</stopPort>
+              <stopPort>${jetty.dynamic.stop.port}</stopPort>
             </configuration>
           </execution>
         </executions>
@@ -501,7 +501,7 @@
                 <jmeter.exit.check.pause>${jmeter.exit.check.pause}</jmeter.exit.check.pause>
               </propertiesJMeter>
               <propertiesUser>
-                <fedora_4_port>${fcrepo.test.port}</fedora_4_port>
+                <fedora_4_port>${fcrepo.dynamic.test.port}</fedora_4_port>
                 <fedora_4_context>rest</fedora_4_context>
                 <loop_count>${jmeter.loop_count}</loop_count>
                 <num_threads>${jmeter.num_threads}</num_threads>

--- a/fcrepo-webapp/src/main/resources/spring/jms.xml
+++ b/fcrepo-webapp/src/main/resources/spring/jms.xml
@@ -13,7 +13,7 @@
 
   <bean id="connectionFactory"
     class="org.apache.activemq.ActiveMQConnectionFactory" depends-on="jmsBroker"
-    p:brokerURL="vm://${fcrepo.jms.host:localhost}:${fcrepo.jms.port:61616}?create=false"/>
+    p:brokerURL="vm://${fcrepo.jms.host:localhost}:${fcrepo.dynamic.jms.port:61616}?create=false"/>
 
   <bean name="jmsBroker" class="org.apache.activemq.xbean.BrokerFactoryBean"
     p:config="${fcrepo.activemq.configuration:classpath:/config/activemq.xml}" p:start="true"/>

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
@@ -73,7 +73,7 @@ public abstract class AbstractResourceIT {
     }
 
     protected static final int SERVER_PORT = parseInt(System.getProperty(
-            "fcrepo.test.port", "8080"));
+            "fcrepo.dynamic.test.port", "8080"));
 
     private static final String CONTEXT_PATH = System
             .getProperty("fcrepo.test.context.path");

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
@@ -40,7 +40,7 @@ public class SanityCheckIT {
      * The server port of the application, set as system property by
      * maven-failsafe-plugin.
      */
-    private static final String SERVER_PORT = System.getProperty("fcrepo.test.port");
+    private static final String SERVER_PORT = System.getProperty("fcrepo.dynamic.test.port");
 
     /**
     * The context path of the application (including the leading "/"), set as

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,9 @@
     <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
     <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.unit.file}</sonar.jacoco.reportPath>
     <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
+    <!-- default properties that can be altered on the command line -->
+    <fcrepo.test.port>8080</fcrepo.test.port>
+    <fcrepo.test.context.path/>
   </properties>
   <modules>
     <module>fcrepo-boms</module>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.unit.file}</sonar.jacoco.reportPath>
     <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
     <!-- default properties that can be altered on the command line -->
-    <fcrepo.test.port>8080</fcrepo.test.port>
     <fcrepo.test.context.path/>
   </properties>
   <modules>
@@ -608,7 +607,7 @@
           <version>2.17</version>
           <configuration>
             <systemPropertyVariables>
-              <fcrepo.test.port>${fcrepo.test.port}</fcrepo.test.port>
+              <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
               <fcrepo.test.context.path>${fcrepo.test.context.path}</fcrepo.test.context.path>
               <com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean.default.objectStoreDir>
                 ${project.build.directory}/object-store-default
@@ -704,11 +703,11 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>1.8</version>
-          <!-- reserve a port under the property ${fcrepo.test.port} for integration 
+          <!-- reserve a port under the property ${fcrepo.dynamic.test.port} for integration
             tests -->
           <configuration>
             <portNames>
-              <portName>fcrepo.test.port</portName>
+              <portName>fcrepo.dynamic.test.port</portName>
             </portNames>
           </configuration>
           <executions>


### PR DESCRIPTION
A couple of system properties are referenced throughout the POMs and code but never declared in any POM. These properties can be set in Maven command line executions: ```mvn ... -Dfcrepo.test.port=8080```

The properties should be declared in the man POM using some default values. They can than be overridden by command line arguments. 