### PR TITLE
Fix sonar warnings related to null array return, null variable dereferen...

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
@@ -98,8 +98,11 @@ public class FedoraVersions extends ContentExposingResource {
         this.pathIntoVersion = pathIntoVersion;
     }
 
+    /**
+     * Initialization method. Clients don't invoke this.
+     */
     @PostConstruct
-    private void postConstruct() {
+    public void postConstruct() {
         this.path = externalPath + "/" + FCR_VERSIONS + "/" + pathListIntoVersion;
         this.label = pathListIntoVersion.split("/", 2)[0];
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
@@ -98,11 +98,8 @@ public class FedoraVersions extends ContentExposingResource {
         this.pathIntoVersion = pathIntoVersion;
     }
 
-    /**
-     * Initialization method. Clients don't invoke this.
-     */
     @PostConstruct
-    public void postConstruct() {
+    private void postConstruct() {
         this.path = externalPath + "/" + FCR_VERSIONS + "/" + pathListIntoVersion;
         this.label = pathListIntoVersion.split("/", 2)[0];
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
@@ -41,8 +41,6 @@ public class LdpPreferTag extends PreferTag {
 
     private final boolean references;
 
-    private final boolean preferMinimalContainer;
-
     private final boolean embed;
 
     private final boolean managedProperties;
@@ -64,7 +62,7 @@ public class LdpPreferTag extends PreferTag {
 
         final boolean minimal = preferTag.getValue().equals("minimal") || received.or("").equals("minimal");
 
-        preferMinimalContainer = includes.contains(LDP_NAMESPACE + "PreferMinimalContainer") || minimal;
+        final boolean preferMinimalContainer = includes.contains(LDP_NAMESPACE + "PreferMinimalContainer") || minimal;
 
         membership = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferMembership")) ||
                 includes.contains(LDP_NAMESPACE + "PreferMembership");

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/impl/TypeRdfContext.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/impl/TypeRdfContext.java
@@ -66,10 +66,12 @@ public class TypeRdfContext extends NodeRdfContext {
         final NodeType primaryNodeType = resource().getNode().getPrimaryNodeType();
         nodeTypesB.add(primaryNodeType);
 
-        if (primaryNodeType != null && primaryNodeType.getSupertypes() != null) {
+        try {
             final Set<NodeType> primarySupertypes = ImmutableSet.<NodeType>builder()
                     .add(primaryNodeType.getSupertypes()).build();
             nodeTypesB.addAll(primarySupertypes);
+        } catch (NullPointerException e) {
+            // ignore
         }
 
         final NodeType[] mixinNodeTypesArr = resource().getNode().getMixinNodeTypes();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/impl/TypeRdfContext.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/impl/TypeRdfContext.java
@@ -64,7 +64,10 @@ public class TypeRdfContext extends NodeRdfContext {
         final ImmutableList.Builder<NodeType> nodeTypesB = ImmutableList.<NodeType>builder();
 
         final NodeType primaryNodeType = resource().getNode().getPrimaryNodeType();
-        nodeTypesB.add(primaryNodeType);
+
+        if (primaryNodeType != null) {
+            nodeTypesB.add(primaryNodeType);
+        }
 
         try {
             final Set<NodeType> primarySupertypes = ImmutableSet.<NodeType>builder()

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/infinispan/CacheLoaderChunkInputStream.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/infinispan/CacheLoaderChunkInputStream.java
@@ -175,7 +175,7 @@ public class CacheLoaderChunkInputStream extends InputStream {
 
     private void fillBuffer(final int chunkNumber) {
         buffer = readChunk(chunkNumber);
-        if (buffer == null || buffer.length == 0) {
+        if (buffer == null) {
             endOfStream();
         } else {
             indexInBuffer = 0;
@@ -194,6 +194,6 @@ public class CacheLoaderChunkInputStream extends InputStream {
         if (blobCache.contains(chunkKey)) {
             return blobCache.load(chunkKey).getValue();
         }
-        return new byte[]{};
+        return null;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/infinispan/CacheLoaderChunkInputStream.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/infinispan/CacheLoaderChunkInputStream.java
@@ -39,7 +39,7 @@ public class CacheLoaderChunkInputStream extends InputStream {
     private int chunkNumber;
 
     /**
-     * Appease checkstyles..
+     * Constructor
      * @param blobCache
      * @param key
      * @param chunkSize
@@ -175,7 +175,7 @@ public class CacheLoaderChunkInputStream extends InputStream {
 
     private void fillBuffer(final int chunkNumber) {
         buffer = readChunk(chunkNumber);
-        if (buffer == null) {
+        if (buffer == null || buffer.length == 0) {
             endOfStream();
         } else {
             indexInBuffer = 0;
@@ -194,6 +194,6 @@ public class CacheLoaderChunkInputStream extends InputStream {
         if (blobCache.contains(chunkKey)) {
             return blobCache.load(chunkKey).getValue();
         }
-        return null;
+        return new byte[]{};
     }
 }


### PR DESCRIPTION
...cing, indirectly invoked but otherwise unused variable, etc.

https://jira.duraspace.org/browse/FCREPO-1335

All addressed except # 1 in the ticket description.

But the following are addressed in this PR:

Unused private method	1 file:	http://sonar.fcrepo.org/drilldown/issues/1?&rule=squid%3AUnusedPrivateMethod&rule_sev=MAJOR&severity=MAJOR
Singular Field	1 file: http://sonar.fcrepo.org/drilldown/issues/1?&rule=pmd%3ASingularField&rule_sev=MAJOR&severity=MAJOR
Correctness - Nullcheck of value previously dereferenced	1 file: http://sonar.fcrepo.org/drilldown/issues/1?&rule=findbugs%3ARCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE&rule_sev=MAJOR&severity=MAJOR
Empty arrays and collections should be returned instead of null	1 file: http://sonar.fcrepo.org/drilldown/issues/1?&rule=squid%3AS1168&rule_sev=MAJOR&severity=MAJOR