### PR TITLE
Enable LDP indirect containers to update referenced container

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
@@ -386,6 +386,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraJcrTypes, Fedo
                         = context.getDeclaredConstructor(FedoraResource.class, IdentifierConverter.class);
 
                 final RdfStream rdfStream = declaredConstructor.newInstance(this, idTranslator);
+                rdfStream.session(getSession());
 
                 stream.concat(rdfStream);
             } catch (final NoSuchMethodException |

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/impl/LdpContainerRdfContext.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/impl/LdpContainerRdfContext.java
@@ -53,6 +53,7 @@ import static org.fcrepo.kernel.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.RdfLexicon.MEMBER_SUBJECT;
 import static org.fcrepo.kernel.impl.identifiers.NodeResourceConverter.nodeConverter;
 import static org.fcrepo.kernel.impl.rdf.converters.PropertyConverter.getPropertyNameFromPredicate;
+import static org.fcrepo.kernel.impl.utils.FedoraTypesUtils.getReferencePropertyName;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -180,11 +181,19 @@ public class LdpContainerRdfContext extends NodeRdfContext {
 
                     return singletonIterator(create(subject(), memberRelation, childSubject));
                 }
-                final String insertedContentProperty = getPropertyNameFromPredicate(resource().getNode(),
+                String insertedContentProperty = getPropertyNameFromPredicate(resource().getNode(),
                         createResource(insertedContainerProperty),
                         null);
 
-                if (!child.hasProperty(insertedContentProperty)) {
+                if (child.hasProperty(insertedContentProperty)) {
+                    // do nothing, insertedContentProperty is good
+
+                } else if (child.hasProperty(getReferencePropertyName(insertedContentProperty))) {
+                    // The insertedContentProperty is a pseudo reference property
+                    insertedContentProperty = getReferencePropertyName(insertedContentProperty);
+
+                } else {
+                    // No property found!
                     return emptyIterator();
                 }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/rdf/impl/LdpContainerRdfContextTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/rdf/impl/LdpContainerRdfContextTest.java
@@ -224,6 +224,43 @@ public class LdpContainerRdfContextTest {
     }
 
     @Test
+    public void testLdpResourceWithIndirectContainerAssertingRelationReference() throws RepositoryException {
+
+        when(mockNode.getReferences(LDP_MEMBER_RESOURCE)).thenReturn(new TestPropertyIterator(mockProperty));
+        when(mockProperty.getParent()).thenReturn(mockContainerNode);
+        when(mockContainerNode.getSession()).thenReturn(mockSession);
+        when(mockContainerNode.isNodeType(LDP_INDIRECT_CONTAINER)).thenReturn(true);
+        when(mockContainerNode.hasProperty(LDP_INSERTED_CONTENT_RELATION)).thenReturn(true);
+        when(mockContainerNode.getProperty(LDP_INSERTED_CONTENT_RELATION)).thenReturn
+                (mockInsertedContentRelationProperty);
+        when(mockInsertedContentRelationProperty.getString()).thenReturn("some:relation");
+        when(mockNamespaceRegistry.isRegisteredUri("some:")).thenReturn(true);
+        when(mockNamespaceRegistry.getPrefix("some:")).thenReturn("some");
+        when(mockContainerNode.getNodes()).thenReturn(new TestNodeIterator(mockChild));
+        when(mockChild.getPath()).thenReturn("/b");
+        when(mockChild.getName()).thenReturn("b");
+        when(mockChild.hasProperty("some:relation")).thenReturn(false);
+        when(mockChild.hasProperty("some:relation_ref")).thenReturn(true);
+        when(mockChild.getProperty("some:relation_ref")).thenReturn(mockRelationProperty);
+        when(mockRelationProperty.isMultiple()).thenReturn(false);
+        when(mockRelationProperty.getValue()).thenReturn(mockRelationValue);
+        when(mockRelationValue.getString()).thenReturn("x");
+        final Property mockRelation = mock(Property.class);
+        when(mockRelation.getString()).thenReturn("some:property");
+        when(mockContainerNode.hasProperty(LDP_HAS_MEMBER_RELATION)).thenReturn(true);
+        when(mockContainerNode.getProperty(LDP_HAS_MEMBER_RELATION)).thenReturn(mockRelation);
+        testObj = new LdpContainerRdfContext(mockResource, subjects);
+
+        final Model model = testObj.asModel();
+
+        assertTrue("Expected stream to have one triple", model.size() == 1);
+        assertTrue(model.contains(
+                subjects.reverse().convert(mockResource),
+                ResourceFactory.createProperty("some:property"),
+                ResourceFactory.createPlainLiteral("x")));
+    }
+
+    @Test
     public void testLdpResourceWithIndirectContainerWithoutRelation() throws RepositoryException {
 
         when(mockNode.getReferences(LDP_MEMBER_RESOURCE)).thenReturn(new TestPropertyIterator(mockProperty));


### PR DESCRIPTION
* Handle 'insertedContainerProperty' that has been converted to a reference property
* Provide current session to RdfContexts when constructed in FedoraResourceImpl

Resolves: https://jira.duraspace.org/browse/FCREPO-1383