### PR TITLE
Make header and body markup consistent with BS standards

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/common-node-header.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-header.vsl
@@ -1,8 +1,9 @@
 
 #parse("views/common-header.vsl")
-
-<div class="row">
-    <div class="col-md-9">
-        <h1>$esc.html($helpers.getObjectTitle($rdf, $topic))</h1>
-    </div>
+<div class="container">
+  <div class="row">
+      <div class="col-md-9">
+          <h1>$esc.html($helpers.getObjectTitle($rdf, $topic))</h1>
+      </div>
+  </div>
 </div>

--- a/fcrepo-http-api/src/main/resources/views/mode-root.vsl
+++ b/fcrepo-http-api/src/main/resources/views/mode-root.vsl
@@ -12,10 +12,10 @@
 
 
 <body class="mode_root">
-<div id="main" class="container" resource="$topic.getURI()">
+<div id="main" resource="$topic.getURI()">
 
     #parse("views/common-node-header.vsl")
-
+<div class="container">
     <div class="row">
         <div class="col-md-12">
         #parse("views/common-breadcrumb.vsl")
@@ -72,7 +72,7 @@
         </div>
 
       </div>
-
+</div>
 
   </div>
   </body>


### PR DESCRIPTION
This is a minor change that will allow for better presentation. The nav element should be exclusive of the container element for flow to be consistent with other sites using bootstrap. 