### PR TITLE
Remove ignored IT test in FedoraResourceImplIT as a patch is not desired...

### DIFF
--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraResourceImplIT.java
@@ -83,7 +83,6 @@ import org.fcrepo.kernel.utils.iterators.RdfStream;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.modeshape.jcr.security.SimplePrincipal;
 import org.springframework.test.context.ContextConfiguration;
@@ -449,36 +448,6 @@ public class FedoraResourceImplIT extends AbstractIT {
                 subjects,
                 "INSERT { <> <http://purl.org/dc/elements/1.1/title> \"test-update\". }"
                         + " WHERE { }", new RdfStream());
-    }
-
-    @Ignore("Until ticket has been resolved: https://jira.duraspace.org/browse/FCREPO-1381")
-    @Test
-    public void testSparqlUpdatePrefixUriSubstitution() throws RepositoryException {
-        final FedoraResource object =
-                containerService.findOrCreate(session, "/testRefObject");
-
-        object.updateProperties(
-                subjects,
-                "PREFIX dsc:<http://myurl.org> \n" +
-                        "PREFIX     esc:<http://myurl555.org> \n" +
-                        "PREFIX fsc:<http://myurl.org#> \n" +
-                        "PREFIX gsc:<http://myurl.org/u> \n" +
-                        "INSERT { <> dsc:p \"aaa\" . \n <> esc:p \"bbb\" . \n " +
-                        "<> fsc:p \"ccc\" . \n <> gsc:p \"ddd\" ;} WHERE { }",
-                new RdfStream());
-
-        final javax.jcr.Node n = object.getNode();
-        assertEquals(n.getProperty("dsc:p").getValues().length, 1);
-        assertEquals(n.getProperty("dsc:p").getValues()[0].getString(), "aaa");
-
-        assertEquals(n.getProperty("esc:p").getValues().length, 1);
-        assertEquals(n.getProperty("esc:p").getValues()[0].getString(), "bbb");
-
-        assertEquals(n.getProperty("fsc:p").getValues().length, 1);
-        assertEquals(n.getProperty("fsc:p").getValues()[0].getString(), "ccc");
-
-        assertEquals(n.getProperty("gsc:p").getValues().length, 1);
-        assertEquals(n.getProperty("gsc:p").getValues()[0].getString(), "ddd");
     }
 
     @Test


### PR DESCRIPTION
... any longer

The IT was meant to check any patch to Jena or the PropertyConverter to prevent "wrong" namespace usage. It has been decided to scrap this effort in favor of adding a wiki page or comment.

https://github.com/fcrepo4/fcrepo4/pull/739#issuecomment-85341505

Original JIRA Ticket:

https://jira.duraspace.org/browse/FCREPO-1381