### PR TITLE
Remove symbolic link image reference to fix maven jettyconsole jar windo...

### DIFF
--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -308,7 +308,7 @@
               <goal>createconsole</goal>
             </goals>
             <configuration>
-              <backgroundImage>${basedir}/src/main/jettyconsole/fedora_logo_10in.png</backgroundImage>
+              <backgroundImage>${basedir}/src/main/webapp/images/fedora_logo_10in.png</backgroundImage>
               <destinationFile>${project.build.directory}${file.separator}${project.artifactId}-${project.version}-jetty-console.jar</destinationFile>
             </configuration>
           </execution>

--- a/fcrepo-webapp/src/main/jettyconsole/fedora_logo_10in.png
+++ b/fcrepo-webapp/src/main/jettyconsole/fedora_logo_10in.png
@@ -1,1 +1,0 @@
-../webapp/images/fedora_logo_10in.png


### PR DESCRIPTION
...ws problem

FCREPO-1414

The current background image does not open/resolve on windows. This prevents the launch of the one-click jar.

I think the issue got introduced here:

https://github.com/fcrepo4/fcrepo4/commit/c3b14a8163e4563c20f4a2427b782b50c48c502e