### PR TITLE
Fix for behaviour described in fcrepo4-777

### DIFF
--- a/fcrepo-connector-file/src/main/java/org/fcrepo/connector/file/FedoraFileSystemConnector.java
+++ b/fcrepo-connector-file/src/main/java/org/fcrepo/connector/file/FedoraFileSystemConnector.java
@@ -176,11 +176,9 @@ public class FedoraFileSystemConnector extends FileSystemConnector {
             final Map<Name, Property> extraProperties = extraPropertiesStore().getProperties(id);
             final Name digestName = nameFrom(CONTENT_DIGEST);
             if (extraProperties.containsKey(digestName)) {
-                if (!hasBeenModifiedSincePropertiesWereStored(file, extraProperties.get(nameFrom(JCR_CREATED)))) {
                     LOGGER.trace("Found sha1 for {} in extra properties store.", id);
                     final String uriStr = ((URI) extraProperties.get(digestName).getFirstValue()).toString();
                     return uriStr.substring(uriStr.indexOf("sha1:") + 5);
-                }
             }
         } else {
             LOGGER.trace("No cache configured to contain object hashes.");


### PR DESCRIPTION
Modify federated file system connector to use initial sha1 as the basis for comparison as per the fixity check behaviour described in https://wiki.duraspace.org/display/FEDORA40/How+to+audit+fixity+in+a+filesystem+federation