### PR TITLE
Adding FedoraResource.setURIProperty method

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
@@ -263,6 +263,14 @@ public class FedoraResourceImpl extends JcrTools implements FedoraJcrTypes, Fedo
         }
     }
 
+    /**
+     * Set the given property value for this resource as a URI, without translating any URIs that
+     * appear to be references to repository resources.  Using untranslated URIs to refer to
+     * repository resources will disable referential integrity checking, but also allows referring
+     * to resources that do not exist, have been deleted, etc.
+     * @param relPath the given path
+     * @param value the URI value
+     */
     @Override
     public void setURIProperty(final String relPath, final URI value) {
         try {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
@@ -37,6 +37,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -48,6 +49,7 @@ import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
+import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
@@ -256,6 +258,15 @@ public class FedoraResourceImpl extends JcrTools implements FedoraJcrTypes, Fedo
     public Property getProperty(final String relPath) {
         try {
             return getNode().getProperty(relPath);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+    @Override
+    public void setURIProperty(final String relPath, final URI value) {
+        try {
+            getNode().setProperty(relPath, value.toString(), PropertyType.URI);
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraResourceImplIT.java
@@ -41,6 +41,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -667,6 +669,23 @@ public class FedoraResourceImplIT extends AbstractIT {
         containerService.findOrCreate(session, "/" + pid + "/#/a");
 
         assertFalse(container.getChildren().hasNext());
+    }
+
+    @Test
+    public void testSetURIProperty() throws URISyntaxException, RepositoryException {
+        final String pid1 = getRandomPid();
+        final String pid2 = getRandomPid();
+        final String prop = "premis:hasEventRelatedObject";
+        final FedoraResource resource1 = containerService.findOrCreate(session, "/" + pid1);
+        final FedoraResource resource2 = containerService.findOrCreate(session, "/" + pid2);
+        final String uri = createGraphSubjectNode(resource2).getURI();
+        resource1.setURIProperty(prop, new URI(uri));
+        resource2.delete();
+        session.save();
+
+        // URI property should survive the linked resource being deleted
+        assertTrue(resource1.hasProperty(prop));
+        assertEquals(resource1.getProperty(prop).getString(), uri);
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/FedoraResourceImplTest.java
@@ -38,6 +38,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
@@ -45,6 +47,7 @@ import java.util.Iterator;
 import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
+import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Workspace;
@@ -392,6 +395,14 @@ public class FedoraResourceImplTest {
         when(mockNode.getProperty("xyz")).thenReturn(mockProp);
         final Property actual = testObj.getProperty("xyz");
         assertEquals(mockProp, actual);
+    }
+
+    @Test
+    public void testSetURIProperty() throws URISyntaxException, RepositoryException {
+        final String prop = "premis:hasEventRelatedObject";
+        final String uri = "http://localhost:8080/rest/1";
+        testObj.setURIProperty(prop, new URI(uri));
+        verify(mockNode).setProperty(prop, uri, PropertyType.URI);
     }
 
     @Test

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/models/FedoraResource.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/models/FedoraResource.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.kernel.models;
 
+import java.net.URI;
 import java.util.Date;
 import java.util.Iterator;
 
@@ -82,6 +83,13 @@ public interface FedoraResource {
      * @return the property
      */
     Property getProperty(String relPath);
+
+    /**
+     * Set the given property value for this resource
+     * @param relPath the given path
+     * @param value the URI value
+     */
+    void setURIProperty(String relPath, URI value);
 
     /**
      * Delete this resource, and any inbound references to it


### PR DESCRIPTION
Adds kernel API for setting URI properties without conversion to reference types, to support the audit use case of preserving audit events that link to repository resources after those resources have been deleted.  See https://github.com/fcrepo4-labs/fcrepo-audit/commit/3d7d6d348424df73940bf992b2770cdbc92dc3d5#commitcomment-10865344