### PR TITLE
clean up OSGi exports

### DIFF
--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -232,7 +232,8 @@
               org.fcrepo.http.commons.domain,
               org.fcrepo.http.commons.domain.ldp,
               org.fcrepo.http.commons.responses,
-              org.fcrepo.http.commons.session
+              org.fcrepo.http.commons.session,
+              org.fcrepo.connector.file
             </Import-Package>
           </instructions>
         </configuration>

--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -232,9 +232,7 @@
               org.fcrepo.http.commons.domain,
               org.fcrepo.http.commons.domain.ldp,
               org.fcrepo.http.commons.responses,
-              org.fcrepo.http.commons.session,
-              org.fcrepo.connector.filesystem,
-              org.modeshape.connector.filesystem
+              org.fcrepo.http.commons.session
             </Import-Package>
           </instructions>
         </configuration>

--- a/fcrepo-http-api/src/main/resources/META-INF/spring/rest.xml
+++ b/fcrepo-http-api/src/main/resources/META-INF/spring/rest.xml
@@ -18,7 +18,7 @@
     <context:component-scan base-package="org.fcrepo"/>
 
     <bean name="modeshapeRepofactory"
-          class="org.fcrepo.kernel.spring.ModeShapeRepositoryFactoryBean">
+          class="org.fcrepo.kernel.impl.spring.ModeShapeRepositoryFactoryBean">
       <property name="repositoryConfiguration" value="${fcrepo.modeshape.configuration:config/minimal-default/repository.json}"/>
     </bean>
 


### PR DESCRIPTION
See: https://jira.duraspace.org/browse/FCREPO-1562

Also: org.fcrepo.kernel.spring.ModeShapeRepositoryFactoryBean doesn't exist. It should be org.fcrepo.kernel.impl.spring.ModeShapeRepositoryFactoryBean