### PR TITLE
FedoraEvent now mints internal UUID for downstream use (FCREPO-1507)

### DIFF
--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -46,7 +46,6 @@
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-mint</artifactId>
       <version>${project.version}</version>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
@@ -50,7 +50,7 @@ import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.identifiers.PidMinter;
+import org.fcrepo.mint.PidMinter;
 import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.services.NodeService;
 import org.fcrepo.kernel.services.ContainerService;

--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -31,7 +31,6 @@
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-mint</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
@@ -25,7 +25,7 @@ import com.hp.hpl.jena.rdf.model.Resource;
 import org.fcrepo.http.commons.session.SessionFactory;
 import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.identifiers.IdentifierConverter;
-import org.fcrepo.kernel.identifiers.PidMinter;
+import org.fcrepo.mint.PidMinter;
 import org.fcrepo.kernel.services.BinaryService;
 import org.fcrepo.kernel.services.NodeService;
 import org.fcrepo.kernel.services.ContainerService;

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/AbstractResourceTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/AbstractResourceTest.java
@@ -22,7 +22,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
-import org.fcrepo.kernel.identifiers.PidMinter;
+import org.fcrepo.mint.PidMinter;
 import org.fcrepo.kernel.services.NodeService;
 import org.junit.Before;
 import org.junit.Test;

--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/headers/DefaultMessageFactory.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/headers/DefaultMessageFactory.java
@@ -64,6 +64,7 @@ public class DefaultMessageFactory implements JMSEventMessageFactory {
 
     public static final String USER_HEADER_NAME = JMS_NAMESPACE + "user";
     public static final String USER_AGENT_HEADER_NAME = JMS_NAMESPACE + "userAgent";
+    public static final String EVENT_ID_HEADER_NAME = JMS_NAMESPACE + "eventID";
 
     private String baseURL;
     private String userAgent;
@@ -108,6 +109,7 @@ public class DefaultMessageFactory implements JMSEventMessageFactory {
         message.setStringProperty(USER_HEADER_NAME, jcrEvent.getUserID());
         message.setStringProperty(USER_AGENT_HEADER_NAME, userAgent);
         message.setStringProperty(PROPERTIES_HEADER_NAME, String.join(",", jcrEvent.getProperties()));
+        message.setStringProperty(EVENT_ID_HEADER_NAME, jcrEvent.getEventID());
 
         LOGGER.trace("getMessage() returning: {}", message);
         return message;

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/HeadersJMSIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/HeadersJMSIT.java
@@ -205,7 +205,7 @@ public class HeadersJMSIT implements MessageListener {
                     @Override
                     public boolean apply(final Message message) {
                         try {
-                            return getIdentifier(message).equals(id) && getEventTypes(message).contains(eventType)
+                            return getPath(message).equals(id) && getEventTypes(message).contains(eventType)
                                     && (property == null || getProperties(message).contains(property));
                         } catch (final JMSException e) {
                             throw propagate(e);
@@ -236,10 +236,9 @@ public class HeadersJMSIT implements MessageListener {
     public void onMessage(final Message message) {
         try {
             LOGGER.debug(
-                    "Received JMS message: {} with identifier: {}, timestamp: {}, event type: {}, properties: {},"
-                            + " and baseURL: {}", message.getJMSMessageID(), getIdentifier(message),
-                    getTimestamp(message),
-                    getEventTypes(message), getProperties(message), getBaseURL(message));
+                    "Received JMS message: {} with path: {}, timestamp: {}, event type: {}, properties: {},"
+                            + " and baseURL: {}", message.getJMSMessageID(), getPath(message), getTimestamp(message),
+                            getEventTypes(message), getProperties(message), getBaseURL(message));
         } catch (final JMSException e) {
             propagate(e);
         }
@@ -268,7 +267,7 @@ public class HeadersJMSIT implements MessageListener {
         connection.close();
     }
 
-    private static String getIdentifier(final Message msg) throws JMSException {
+    private static String getPath(final Message msg) throws JMSException {
         final String id = msg.getStringProperty(IDENTIFIER_HEADER_NAME);
         LOGGER.debug("Processing an event with identifier: {}", id);
         return id;

--- a/fcrepo-jms/src/test/java/org/fcrepo/jms/headers/DefaultMessageFactoryTest.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/jms/headers/DefaultMessageFactoryTest.java
@@ -24,6 +24,7 @@ import static org.fcrepo.jms.headers.DefaultMessageFactory.PROPERTIES_HEADER_NAM
 import static org.fcrepo.jms.headers.DefaultMessageFactory.TIMESTAMP_HEADER_NAME;
 import static org.fcrepo.jms.headers.DefaultMessageFactory.USER_AGENT_HEADER_NAME;
 import static org.fcrepo.jms.headers.DefaultMessageFactory.USER_HEADER_NAME;
+import static org.fcrepo.jms.headers.DefaultMessageFactory.EVENT_ID_HEADER_NAME;
 import static org.fcrepo.kernel.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
@@ -114,6 +115,8 @@ public class DefaultMessageFactoryTest {
         when(mockEvent.getTypes()).thenReturn(testTypes);
         final String prop = "test-property";
         when(mockEvent.getProperties()).thenReturn(singleton(prop));
+        final String eventID = "abcdefg12345678";
+        when(mockEvent.getEventID()).thenReturn(eventID);
 
         final Message msg = testDefaultMessageFactory.getMessage(mockEvent, mockSession);
 
@@ -128,6 +131,7 @@ public class DefaultMessageFactoryTest {
         assertEquals("Got wrong property in message", prop, msg.getStringProperty(PROPERTIES_HEADER_NAME));
         assertEquals("Got wrong userID in message", testUser, msg.getStringProperty(USER_HEADER_NAME));
         assertEquals("Got wrong userAgent in message", userAgent, msg.getStringProperty(USER_AGENT_HEADER_NAME));
+        assertEquals("Got wrong eventID in message", eventID, msg.getStringProperty(EVENT_ID_HEADER_NAME));
         return msg;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/JcrRdfTools.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/JcrRdfTools.java
@@ -50,7 +50,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.hp.hpl.jena.rdf.model.AnonId;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Statement;
-import org.fcrepo.kernel.identifiers.PidMinter;
+import org.fcrepo.mint.PidMinter;
 import org.fcrepo.kernel.impl.services.AbstractService;
 import org.fcrepo.kernel.models.FedoraResource;
 import org.fcrepo.kernel.RdfLexicon;

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/eventmappings/AllNodeEventsOneEventTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/eventmappings/AllNodeEventsOneEventTest.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Iterators.size;
 import static javax.jcr.observation.Event.NODE_ADDED;
 import static javax.jcr.observation.Event.PROPERTY_ADDED;
 import static javax.jcr.observation.Event.PROPERTY_CHANGED;
-import static org.jgroups.util.UUID.randomUUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -48,23 +47,15 @@ import java.util.Iterator;
  */
 public class AllNodeEventsOneEventTest {
 
-    private static final String TEST_IDENTIFIER1 = randomUUID().toString();
 
     private static final String TEST_PATH1 = "/test/node1";
 
-    private static final String TEST_IDENTIFIER2 = TEST_IDENTIFIER1;
-
     private static final String TEST_PATH2 = TEST_PATH1 + "/dc:title";
 
-    private static final String TEST_IDENTIFIER3 = randomUUID().toString();
-
-    private static final String TEST_PATH3 = "/test/node2";
-
-    private static final String TEST_IDENTIFIER4 = randomUUID().toString();
+    private static final String TEST_NODE_PATH3 = "/test/node2";
+    private static final String TEST_PATH3 = TEST_NODE_PATH3 + "/dc:description";
 
     private static final String TEST_PATH4 = "/test/node3";
-
-    private static final String TEST_IDENTIFIER5 = randomUUID().toString();
 
     private static final String TEST_PATH5 = "/test/node3/" + JCR_CONTENT;
 
@@ -97,22 +88,17 @@ public class AllNodeEventsOneEventTest {
     @Before
     public void setUp() throws RepositoryException {
         initMocks(this);
-        when(mockEvent1.getIdentifier()).thenReturn(TEST_IDENTIFIER1);
         when(mockEvent1.getPath()).thenReturn(TEST_PATH1);
         when(mockEvent1.getType()).thenReturn(NODE_ADDED);
-        when(mockEvent2.getIdentifier()).thenReturn(TEST_IDENTIFIER2);
         when(mockEvent2.getPath()).thenReturn(TEST_PATH2);
         when(mockEvent2.getType()).thenReturn(PROPERTY_ADDED);
-        when(mockEvent3.getIdentifier()).thenReturn(TEST_IDENTIFIER3);
         when(mockEvent3.getPath()).thenReturn(TEST_PATH3);
         when(mockEvent3.getType()).thenReturn(PROPERTY_CHANGED);
         when(mockIterator.next()).thenReturn(mockEvent1, mockEvent2, mockEvent3);
         when(mockIterator.hasNext()).thenReturn(true, true, true, false);
 
-        when(mockEvent4.getIdentifier()).thenReturn(TEST_IDENTIFIER4);
         when(mockEvent4.getPath()).thenReturn(TEST_PATH4);
         when(mockEvent4.getType()).thenReturn(NODE_ADDED);
-        when(mockEvent5.getIdentifier()).thenReturn(TEST_IDENTIFIER5);
         when(mockEvent5.getPath()).thenReturn(TEST_PATH5);
         when(mockEvent5.getType()).thenReturn(NODE_ADDED);
         when(mockIterator2.next()).thenReturn(mockEvent4, mockEvent5);
@@ -148,7 +134,7 @@ public class AllNodeEventsOneEventTest {
     @Test(expected = RuntimeException.class)
     public void testBadEvent() throws RepositoryException {
         reset(mockEvent1);
-        when(mockEvent1.getIdentifier()).thenThrow(new RepositoryException("Expected."));
+        when(mockEvent1.getPath()).thenThrow(new RepositoryException("Expected."));
         testMapping.apply(mockIterator);
     }
 
@@ -161,7 +147,7 @@ public class AllNodeEventsOneEventTest {
         boolean found = false;
         while (iterator.hasNext()) {
             final FedoraEvent event = iterator.next();
-            if (TEST_IDENTIFIER3.equals(event.getIdentifier())) {
+            if (TEST_NODE_PATH3.equals(event.getPath())) {
                 assertEquals("Expected one event property", 1, event.getProperties().size());
                 found = true;
             }

--- a/fcrepo-kernel/pom.xml
+++ b/fcrepo-kernel/pom.xml
@@ -54,6 +54,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-mint</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/observer/FedoraEvent.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/observer/FedoraEvent.java
@@ -34,6 +34,9 @@ import javax.jcr.observation.Event;
 import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.utils.EventType;
 
+import org.fcrepo.mint.PidMinter;
+import org.fcrepo.mint.UUIDPathMinter;
+
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
@@ -48,9 +51,12 @@ import com.google.common.collect.Iterables;
 public class FedoraEvent {
 
     private Event e;
+    private String eventID;
 
     private Set<Integer> eventTypes = new HashSet<>();
     private Set<String> eventProperties = new HashSet<>();
+
+    private static final PidMinter pidMinter = new UUIDPathMinter();
 
     /**
      * Wrap a JCR Event with our FedoraEvent decorators
@@ -59,6 +65,7 @@ public class FedoraEvent {
      */
     public FedoraEvent(final Event e) {
         checkArgument(e != null, "null cannot support a FedoraEvent!");
+        eventID = pidMinter.mintPid();
         this.e = e;
     }
 
@@ -70,6 +77,7 @@ public class FedoraEvent {
      */
     public FedoraEvent(final FedoraEvent e) {
         checkArgument(e != null, "null cannot support a FedoraEvent!");
+        eventID = e.getEventID();
         this.e = e.e;
     }
 
@@ -182,6 +190,13 @@ public class FedoraEvent {
         } catch (RepositoryException e1) {
             throw new RepositoryRuntimeException("Error getting event date!", e1);
         }
+    }
+
+    /**
+     * Get the event ID.
+    **/
+    public String getEventID() {
+        return eventID;
     }
 
     @Override

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/observer/FedoraEvent.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/observer/FedoraEvent.java
@@ -51,7 +51,7 @@ import com.google.common.collect.Iterables;
 public class FedoraEvent {
 
     private Event e;
-    private String eventID;
+    private final String eventID;
 
     private Set<Integer> eventTypes = new HashSet<>();
     private Set<String> eventProperties = new HashSet<>();
@@ -149,17 +149,6 @@ public class FedoraEvent {
     }
 
     /**
-     * @return the node identifer of the underlying JCR {@link Event}s
-     */
-    public String getIdentifier() {
-        try {
-            return e.getIdentifier();
-        } catch (RepositoryException e1) {
-            throw new RepositoryRuntimeException("Error getting event identifier!", e1);
-        }
-    }
-
-    /**
      * @return the info map of the underlying JCR {@link Event}s
      */
     public Map<Object, Object> getInfo() {
@@ -194,6 +183,7 @@ public class FedoraEvent {
 
     /**
      * Get the event ID.
+     * @return Event identifier to use for building event URIs (e.g., in an external triplestore).
     **/
     public String getEventID() {
         return eventID;

--- a/fcrepo-kernel/src/test/java/org/fcrepo/kernel/observer/FedoraEventTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/kernel/observer/FedoraEventTest.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.Iterators.contains;
 import static java.util.Collections.singleton;
 import static javax.jcr.observation.Event.PROPERTY_CHANGED;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
@@ -80,6 +81,13 @@ public class FedoraEventTest {
     public void testGetUserID() {
 
         assertEquals("UserId", e.getUserID());
+
+    }
+
+    @Test
+    public void testGetEventID() {
+
+        assertNotNull(e.getEventID());
 
     }
 

--- a/fcrepo-kernel/src/test/java/org/fcrepo/kernel/observer/FedoraEventTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/kernel/observer/FedoraEventTest.java
@@ -92,13 +92,6 @@ public class FedoraEventTest {
     }
 
     @Test
-    public void testGetIdentifier() throws Exception {
-
-        assertEquals("Identifier", e.getIdentifier());
-
-    }
-
-    @Test
     public void testGetInfo() throws Exception {
         final Map<?, ?> m = e.getInfo();
 
@@ -144,7 +137,6 @@ public class FedoraEventTest {
         assertTrue("Should contain date: " + text, text.contains(Long.toString(e.getDate())));
 
         assertFalse("Should not contain user-data: " + text, text.contains(e.getUserData()));
-        assertFalse("Should not contain identifier: " + text, text.contains(e.getIdentifier()));
         assertFalse("Should not contain user-id: " + text, text.contains(e.getUserID()));
     }
 

--- a/fcrepo-mint/pom.xml
+++ b/fcrepo-mint/pom.xml
@@ -13,13 +13,23 @@
   <dependencies>
     <dependency>
       <groupId>org.fcrepo</groupId>
-      <artifactId>fcrepo-kernel</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-metrics</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
 
     <dependency>

--- a/fcrepo-mint/src/main/java/org/fcrepo/mint/HttpPidMinter.java
+++ b/fcrepo-mint/src/main/java/org/fcrepo/mint/HttpPidMinter.java
@@ -182,10 +182,10 @@ public class HttpPidMinter implements PidMinter {
             return responseToPid( EntityUtils.toString(resp.getEntity()) );
         } catch ( IOException ex ) {
             LOGGER.warn("Error minting pid from {}: {}", url, ex);
-            throw new RuntimeException("Error minting pid", ex);
+            throw new PidMinterException("Error minting pid", ex);
         } catch ( Exception ex ) {
             LOGGER.warn("Error processing minter response", ex);
-            throw new RuntimeException("Error processing minter response", ex);
+            throw new PidMinterException("Error processing minter response", ex);
         }
     }
 }

--- a/fcrepo-mint/src/main/java/org/fcrepo/mint/HttpPidMinter.java
+++ b/fcrepo-mint/src/main/java/org/fcrepo/mint/HttpPidMinter.java
@@ -19,7 +19,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static com.google.common.base.Preconditions.checkArgument;
 
-import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.slf4j.Logger;
 
 import com.codahale.metrics.annotation.Timed;
@@ -51,7 +50,6 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.fcrepo.kernel.identifiers.PidMinter;
 import org.xml.sax.SAXException;
 
 
@@ -184,10 +182,10 @@ public class HttpPidMinter implements PidMinter {
             return responseToPid( EntityUtils.toString(resp.getEntity()) );
         } catch ( IOException ex ) {
             LOGGER.warn("Error minting pid from {}: {}", url, ex);
-            throw new RepositoryRuntimeException("Error minting pid", ex);
+            throw new RuntimeException("Error minting pid", ex);
         } catch ( Exception ex ) {
             LOGGER.warn("Error processing minter response", ex);
-            throw new RepositoryRuntimeException("Error processing minter response", ex);
+            throw new RuntimeException("Error processing minter response", ex);
         }
     }
 }

--- a/fcrepo-mint/src/main/java/org/fcrepo/mint/PidMinter.java
+++ b/fcrepo-mint/src/main/java/org/fcrepo/mint/PidMinter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.identifiers;
+package org.fcrepo.mint;
 
 /**
  * Defines the behavior of a component that can accept responsibility

--- a/fcrepo-mint/src/main/java/org/fcrepo/mint/PidMinterException.java
+++ b/fcrepo-mint/src/main/java/org/fcrepo/mint/PidMinterException.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.mint;
+
+/**
+ * Runtime exception when PID minting fails.
+ *
+ * @since 2015-06-05
+ * @author escowles
+ */
+public class PidMinterException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor with message.
+     * @param msg Exception message.
+    **/
+    public PidMinterException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructor with cause.
+     * @param cause Original exception.
+    **/
+    public PidMinterException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructor with message and cause.
+     * @param msg Exception message.
+     * @param cause Original exception.
+    **/
+    public PidMinterException(final String msg, final Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/fcrepo-mint/src/main/java/org/fcrepo/mint/UUIDPathMinter.java
+++ b/fcrepo-mint/src/main/java/org/fcrepo/mint/UUIDPathMinter.java
@@ -21,7 +21,6 @@ import static java.util.UUID.randomUUID;
 import java.util.stream.IntStream;
 import java.util.StringJoiner;
 
-import org.fcrepo.kernel.identifiers.PidMinter;
 import org.fcrepo.metrics.RegistryService;
 
 import com.codahale.metrics.Timer;


### PR DESCRIPTION
* Reversing kernel/mint dependency so FedoraEvent can use UUIDPathMinter to mint IDs.
* First step in https://jira.duraspace.org/browse/FCREPO-1507