### PR TITLE
Remove javaee-api dependency from fcrepo-kernel

### DIFF
--- a/fcrepo-kernel/pom.xml
+++ b/fcrepo-kernel/pom.xml
@@ -101,11 +101,6 @@
       <artifactId>modeshape-jcr-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>javax</groupId>
-      <artifactId>javaee-api</artifactId>
-    </dependency>
-
     <!-- test gear -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-1608