### PR TITLE
FCREPO-1505 (https://jira.duraspace.org/browse/FCREPO-1505)

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -391,10 +391,6 @@ public class FedoraLdp extends ContentExposingResource {
      * application/octet-stream;qs=1001 is a workaround for JERSEY-2636, to ensure
      * requests without a Content-Type get routed here.
      *
-     * @author griffinj
-     * Ensure that the parent resource is not a pairtree
-     * @see <a href="https://jira.duraspace.org/browse/FCREPO-1505">FCREPO-1505</a>
-     *
      * @param checksum the checksum value
      * @param contentDisposition the content Disposition value
      * @param requestContentType the request content type
@@ -422,8 +418,7 @@ public class FedoraLdp extends ContentExposingResource {
         if (!(resource() instanceof Container)) {
             throw new ClientErrorException("Object cannot have child nodes", CONFLICT);
         } else if (resource().hasType(FEDORA_PAIRTREE)) {
-
-            throw new ClientErrorException("Object cannot themselves be children of a pairtree child node", FORBIDDEN);
+            throw new ClientErrorException("Objects cannot be created under the children of pairtree nodes", FORBIDDEN);
         }
 
         final MediaType contentType = getSimpleContentType(requestContentType);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -418,7 +418,7 @@ public class FedoraLdp extends ContentExposingResource {
         if (!(resource() instanceof Container)) {
             throw new ClientErrorException("Object cannot have child nodes", CONFLICT);
         } else if (resource().hasType(FEDORA_PAIRTREE)) {
-            throw new ClientErrorException("Objects cannot be created under the children of pairtree nodes", FORBIDDEN);
+            throw new ClientErrorException("Objects cannot be created under pairtree nodes", FORBIDDEN);
         }
 
         final MediaType contentType = getSimpleContentType(requestContentType);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -28,6 +28,7 @@ import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.ok;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
 import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
@@ -39,6 +40,7 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.FedoraJcrTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.FedoraJcrTypes.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.FedoraJcrTypes.FEDORA_PAIRTREE;
 import static org.fcrepo.kernel.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.impl.services.TransactionServiceImpl.getCurrentTransactionId;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -389,6 +391,10 @@ public class FedoraLdp extends ContentExposingResource {
      * application/octet-stream;qs=1001 is a workaround for JERSEY-2636, to ensure
      * requests without a Content-Type get routed here.
      *
+     * @author griffinj
+     * Ensure that the parent resource is not a pairtree
+     * @see <a href="https://jira.duraspace.org/browse/FCREPO-1505">FCREPO-1505</a>
+     *
      * @param checksum the checksum value
      * @param contentDisposition the content Disposition value
      * @param requestContentType the request content type
@@ -415,6 +421,9 @@ public class FedoraLdp extends ContentExposingResource {
 
         if (!(resource() instanceof Container)) {
             throw new ClientErrorException("Object cannot have child nodes", CONFLICT);
+        } else if (resource().hasType(FEDORA_PAIRTREE)) {
+
+            throw new ClientErrorException("Object cannot themselves be children of a pairtree child node", FORBIDDEN);
         }
 
         final MediaType contentType = getSimpleContentType(requestContentType);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1047,24 +1047,21 @@ public class FedoraLdpIT extends AbstractResourceIT {
      */
     @Test
     public void testIngestOnPairtree() throws Exception {
-        HttpPost method = postObjMethod("");
-        HttpResponse response = client.execute(method);
+        HttpResponse response = createObject("");
 
         //  Following the approach undertaken for FedoraExportIT#shouldRoundTripOnePairtree
         final String objName = response.getFirstHeader("Location").getValue();
         final String pairtreeName = objName.substring(serverAddress.length(), objName.lastIndexOf('/'));
 
-        final GraphStore graphStore = getGraphStore(new HttpGet(serverAddress + pairtreeName));
+        final GraphStore graphStore = getGraphStore(getObjMethod(pairtreeName));
         assertTrue("Resource \"" + objName + " " + pairtreeName + "\" must be pairtree.", graphStore.contains(ANY,
                 createResource(serverAddress + pairtreeName).asNode(),
                 createURI(REPOSITORY_NAMESPACE + "mixinTypes"),
                 createLiteral(FEDORA_PAIRTREE)));
 
         // Attempting to POST to the child of the pairtree node...
-        method = new HttpPost(serverAddress + pairtreeName);
-        response = client.execute(method);
-        final int status = response.getStatusLine().getStatusCode();
-        assertEquals("Created an Object under the child of a pairtree node!", FORBIDDEN.getStatusCode(), status);
+        final int status = getStatus(postObjMethod(pairtreeName));
+        assertEquals("Created an Object under a pairtree node!", FORBIDDEN.getStatusCode(), status);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1047,7 +1047,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
      */
     @Test
     public void testIngestOnPairtree() throws Exception {
-        HttpResponse response = createObject("");
+        final HttpResponse response = createObject("");
 
         //  Following the approach undertaken for FedoraExportIT#shouldRoundTripOnePairtree
         final String objName = response.getFirstHeader("Location").getValue();


### PR DESCRIPTION
Extending the FedoraLdp#createObject method for handling the creation of child objects for pairtree child resources; Implementing the FedoraLdpIT#testIngestOnPairTree method for integration testing.