### PR TITLE
update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ jdk:
   - oraclejdk8
 before_install:  
  - "echo $JAVA_OPTS"
- - "export JAVA_OPTS=-Xmx512m"
+ - "export JAVA_OPTS=-Xmx2048m"
 
 script:
- - mvn install -B -V
+ - mvn install -B -V -Dfcrepo.log=WARN -Dfcrepo.log.kernel=WARN -Dfcrepo.log.http.api=WARN
 
 notifications:
   irc: "irc.freenode.org#fcrepo"


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-1690

This also bumps the memory allocation to 2GB. Travis gives us 3GB, so there's no reason to run this all in only 1/2 GB.