### PR TITLE
Follow-on to https://jira.duraspace.org/browse/FCREPO-1667

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -67,6 +67,7 @@ import javax.ws.rs.core.Response;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.jena.atlas.RuntimeIOException;
+import org.apache.jena.riot.RiotException;
 import org.fcrepo.http.commons.api.rdf.HttpTripleUtil;
 import org.fcrepo.http.commons.domain.MultiPrefer;
 import org.fcrepo.http.commons.domain.PreferTag;
@@ -584,7 +585,10 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         try {
             inputModel.read(requestBodyStream, getUri(resource).toString(), format.getName().toUpperCase());
 
-        } catch (RuntimeIOException e) {
+        } catch (final RiotException e) {
+            throw new BadRequestException("RDF was not parsable: " + e.getMessage(), e);
+
+        } catch (final RuntimeIOException e) {
             if (e.getCause() instanceof JsonParseException) {
                 throw new MalformedRdfException(e.getCause());
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -90,7 +90,6 @@ import org.fcrepo.kernel.api.utils.iterators.RdfStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.riot.RiotException;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -289,11 +288,7 @@ public class FedoraLdp extends ContentExposingResource {
             replaceResourceBinaryWithStream((FedoraBinary) resource,
                     requestBodyStream, contentDisposition, requestContentType, checksum);
         } else if (isRdfContentType(contentType.toString())) {
-            try {
-                replaceResourceWithStream(resource, requestBodyStream, contentType, resourceTriples);
-            } catch (final RiotException e) {
-                throw new BadRequestException("RDF was not parsable: " + e.getMessage(), e);
-            }
+            replaceResourceWithStream(resource, requestBodyStream, contentType, resourceTriples);
         } else if (!resource.isNew()) {
             boolean emptyRequest = true;
             try {


### PR DESCRIPTION
Remove use of Jena-atlas runtime exception, 
...which added a non-OSGi friendly dependency.