### PR TITLE
FCREPO-1713. Refactor EVERYONE user principal into the FAD.

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/FedoraAuthorizationDelegate.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/FedoraAuthorizationDelegate.java
@@ -15,9 +15,11 @@
  */
 package org.fcrepo.auth.common;
 
-import org.modeshape.jcr.value.Path;
+import java.security.Principal;
 
 import javax.jcr.Session;
+
+import org.modeshape.jcr.value.Path;
 
 /**
  * An interface that can authorize access to specific resources within
@@ -77,5 +79,12 @@ public interface FedoraAuthorizationDelegate {
      *         the given actions, or false otherwise
      */
     boolean hasPermission(Session session, Path absPath, String[] actions);
+
+    /**
+     * The principal that this delegate uses to represent the public "EVERYONE" user.
+     *
+     * @return principal
+     */
+    public Principal getEveryonePrincipal();
 
 }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/FedoraUserSecurityContext.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/FedoraUserSecurityContext.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * @author Gregory Jansen
  */
 public class FedoraUserSecurityContext implements SecurityContext,
-AdvancedAuthorizationProvider {
+        AdvancedAuthorizationProvider {
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(FedoraUserSecurityContext.class);

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/FedoraUserSecurityContext.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/FedoraUserSecurityContext.java
@@ -15,15 +15,13 @@
  */
 package org.fcrepo.auth.common;
 
-import static org.fcrepo.auth.common.ServletContainerAuthenticationProvider.EVERYONE;
+import java.security.Principal;
 
 import org.modeshape.jcr.security.AdvancedAuthorizationProvider;
 import org.modeshape.jcr.security.SecurityContext;
 import org.modeshape.jcr.value.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.security.Principal;
 
 /**
  * The security context for Fedora servlet users. These users are not
@@ -34,7 +32,7 @@ import java.security.Principal;
  * @author Gregory Jansen
  */
 public class FedoraUserSecurityContext implements SecurityContext,
-        AdvancedAuthorizationProvider {
+AdvancedAuthorizationProvider {
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(FedoraUserSecurityContext.class);
@@ -112,7 +110,7 @@ public class FedoraUserSecurityContext implements SecurityContext,
         if (this.loggedIn && this.userPrincipal != null) {
             return this.userPrincipal;
         }
-        return EVERYONE;
+        return fad.getEveryonePrincipal();
     }
 
     /**

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
@@ -39,32 +39,13 @@ import org.slf4j.LoggerFactory;
  * @author Gregory Jansen
  */
 public final class ServletContainerAuthenticationProvider implements
-        AuthenticationProvider {
+AuthenticationProvider {
 
     private static ServletContainerAuthenticationProvider instance = null;
 
     private ServletContainerAuthenticationProvider() {
         instance = this;
     }
-
-    public static final String EVERYONE_NAME = "EVERYONE";
-
-    /**
-     * The security principal for every request.
-     */
-    public static final Principal EVERYONE = new Principal() {
-
-        @Override
-        public String getName() {
-            return ServletContainerAuthenticationProvider.EVERYONE_NAME;
-        }
-
-        @Override
-        public String toString() {
-            return getName();
-        }
-
-    };
 
     /**
      * User role for Fedora's admin users
@@ -116,23 +97,19 @@ public final class ServletContainerAuthenticationProvider implements
     /**
      * Authenticate the user that is using the supplied credentials.
      * <p>
-     * If the credentials given establish that the authenticated user has the
-     * fedoraAdmin role, construct an ExecutionContext with
-     * FedoraAdminSecurityContext as the SecurityContext. Otherwise, construct
-     * an ExecutionContext with FedoraUserSecurityContext as the
-     * SecurityContext.
+     * If the credentials given establish that the authenticated user has the fedoraAdmin role, construct an
+     * ExecutionContext with FedoraAdminSecurityContext as the SecurityContext. Otherwise, construct an
+     * ExecutionContext with FedoraUserSecurityContext as the SecurityContext.
      * </p>
      * <p>
-     * If the authenticated user does not have the fedoraAdmin role, session
-     * attributes will be assigned in the sessionAttributes map:
+     * If the authenticated user does not have the fedoraAdmin role, session attributes will be assigned in the
+     * sessionAttributes map:
      * </p>
      * <ul>
-     * <li>FEDORA_SERVLET_REQUEST will be assigned the ServletRequest instance
-     * associated with credentials.</li>
-     * <li>FEDORA_ALL_PRINCIPALS will be assigned the union of all principals
-     * obtained from configured PrincipalProvider instances plus the
-     * authenticated user's principal; FEDORA_ALL_PRINCIPALS will be assigned
-     * the singleton set containing the EVERYONE principal otherwise.</li>
+     * <li>FEDORA_SERVLET_REQUEST will be assigned the ServletRequest instance associated with credentials.</li>
+     * <li>FEDORA_ALL_PRINCIPALS will be assigned the union of all principals obtained from configured
+     * PrincipalProvider instances plus the authenticated user's principal; FEDORA_ALL_PRINCIPALS will be assigned the
+     * singleton set containing the fad.getEveryonePrincipal() principal otherwise.</li>
      * </ul>
      */
     @Override
@@ -168,7 +145,7 @@ public final class ServletContainerAuthenticationProvider implements
 
             final Set<Principal> principals = collectPrincipals(credentials);
             principals.add(userPrincipal);
-            principals.add(EVERYONE);
+            principals.add(fad.getEveryonePrincipal());
 
             sessionAttributes.put(
                     FedoraAuthorizationDelegate.FEDORA_ALL_PRINCIPALS,
@@ -177,12 +154,12 @@ public final class ServletContainerAuthenticationProvider implements
         } else {
 
             sessionAttributes
-                    .put(FedoraAuthorizationDelegate.FEDORA_USER_PRINCIPAL,
-                            EVERYONE);
+            .put(FedoraAuthorizationDelegate.FEDORA_USER_PRINCIPAL,
+                    fad.getEveryonePrincipal());
 
             sessionAttributes.put(
                     FedoraAuthorizationDelegate.FEDORA_ALL_PRINCIPALS,
-                    Collections.singleton(EVERYONE));
+                    Collections.singleton(fad.getEveryonePrincipal()));
 
         }
 
@@ -217,5 +194,14 @@ public final class ServletContainerAuthenticationProvider implements
         }
 
         return principals;
+    }
+
+    /**
+     * Get the principal that the injected authorization delegate uses to represent the "EVERYONE" user.
+     *
+     * @return principal representing "EVERYONE"
+     */
+    public Principal getEveryonePrincipal() {
+        return fad.getEveryonePrincipal();
     }
 }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * @author Gregory Jansen
  */
 public final class ServletContainerAuthenticationProvider implements
-AuthenticationProvider {
+        AuthenticationProvider {
 
     private static ServletContainerAuthenticationProvider instance = null;
 
@@ -153,8 +153,7 @@ AuthenticationProvider {
 
         } else {
 
-            sessionAttributes
-            .put(FedoraAuthorizationDelegate.FEDORA_USER_PRINCIPAL,
+            sessionAttributes.put(FedoraAuthorizationDelegate.FEDORA_USER_PRINCIPAL,
                     fad.getEveryonePrincipal());
 
             sessionAttributes.put(
@@ -194,14 +193,5 @@ AuthenticationProvider {
         }
 
         return principals;
-    }
-
-    /**
-     * Get the principal that the injected authorization delegate uses to represent the "EVERYONE" user.
-     *
-     * @return principal representing "EVERYONE"
-     */
-    public Principal getEveryonePrincipal() {
-        return fad.getEveryonePrincipal();
     }
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/FedoraUserSecurityContextTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/FedoraUserSecurityContextTest.java
@@ -24,16 +24,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.security.Principal;
+
+import javax.jcr.Session;
+import javax.servlet.http.HttpServletRequest;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.modeshape.jcr.security.AdvancedAuthorizationProvider.Context;
 import org.modeshape.jcr.value.Path;
-
-import javax.jcr.Session;
-import javax.servlet.http.HttpServletRequest;
-
-import java.security.Principal;
 
 /**
  * @author bbpennel
@@ -48,12 +48,17 @@ public class FedoraUserSecurityContextTest {
     private Principal principal;
 
     @Mock
+    private Principal everyone;
+
+    @Mock
     private HttpServletRequest request;
 
     @Before
     public void setUp() {
         initMocks(this);
         when(request.getUserPrincipal()).thenReturn(principal);
+        when(fad.getEveryonePrincipal()).thenReturn(everyone);
+        when(everyone.getName()).thenReturn("EVERYONE");
     }
 
     @SuppressWarnings("unused")
@@ -85,14 +90,14 @@ public class FedoraUserSecurityContextTest {
 
         context.logout();
         assertEquals("User principal when logged out should be EVERYONE",
-                ServletContainerAuthenticationProvider.EVERYONE, context
+                fad.getEveryonePrincipal(), context
                 .getEffectiveUserPrincipal());
 
         context = new FedoraUserSecurityContext(null, fad);
 
         assertEquals(
                 "Effective user principal should be EVERYONE when none is provided",
-                ServletContainerAuthenticationProvider.EVERYONE, context
+                fad.getEveryonePrincipal(), context
                 .getEffectiveUserPrincipal());
     }
 
@@ -100,7 +105,7 @@ public class FedoraUserSecurityContextTest {
     public void testGetAnonymousUserName() {
         final FedoraUserSecurityContext context =
                 new FedoraUserSecurityContext(null, fad);
-        assertEquals(ServletContainerAuthenticationProvider.EVERYONE.getName(),
+        assertEquals(fad.getEveryonePrincipal().getName(),
                 context.getUserName());
     }
 

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticationProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticationProviderTest.java
@@ -16,7 +16,6 @@
 package org.fcrepo.auth.common;
 
 import static org.fcrepo.auth.common.FedoraAuthorizationDelegate.FEDORA_ALL_PRINCIPALS;
-import static org.fcrepo.auth.common.ServletContainerAuthenticationProvider.EVERYONE;
 import static org.fcrepo.auth.common.ServletContainerAuthenticationProvider.FEDORA_ADMIN_ROLE;
 import static org.fcrepo.auth.common.ServletContainerAuthenticationProvider.FEDORA_USER_ROLE;
 import static org.fcrepo.auth.common.ServletContainerAuthenticationProvider.getInstance;
@@ -68,6 +67,9 @@ public class ServletContainerAuthenticationProviderTest {
     private Principal principal;
 
     @Mock
+    private Principal everyone;
+
+    @Mock
     private HttpServletRequest request;
 
     private Map<String, Object> sessionAttributes;
@@ -81,6 +83,8 @@ public class ServletContainerAuthenticationProviderTest {
     public void setUp() {
         initMocks(this);
         when(request.getUserPrincipal()).thenReturn(principal);
+        when(fad.getEveryonePrincipal()).thenReturn(everyone);
+        when(everyone.getName()).thenReturn("EVERYONE");
         when(creds.getRequest()).thenReturn(request);
         context = new ExecutionContext();
         sessionAttributes = new HashMap<>();
@@ -167,7 +171,7 @@ public class ServletContainerAuthenticationProviderTest {
 
         assertEquals(2, resultPrincipals.size());
         assertTrue("EVERYONE principal must be present", resultPrincipals
-                .contains(EVERYONE));
+                .contains(fad.getEveryonePrincipal()));
         assertTrue("User principal must be present", resultPrincipals
                 .contains(principal));
 
@@ -214,7 +218,7 @@ public class ServletContainerAuthenticationProviderTest {
 
         assertEquals(3, resultPrincipals.size());
         assertTrue("EVERYONE principal must be present", resultPrincipals
-                .contains(EVERYONE));
+                .contains(fad.getEveryonePrincipal()));
         assertTrue("User principal must be present", resultPrincipals.contains(principal));
         assertTrue("Group Principal from factory must be present", resultPrincipals.contains(groupPrincipal));
 
@@ -265,7 +269,7 @@ public class ServletContainerAuthenticationProviderTest {
         final Set<Principal> resultPrincipals = (Set<Principal>) sessionAttributes.get(FEDORA_ALL_PRINCIPALS);
 
         assertEquals(expected, resultPrincipals.size());
-        assertTrue("EVERYONE principal must be present", resultPrincipals.contains(EVERYONE));
+        assertTrue("EVERYONE principal must be present", resultPrincipals.contains(fad.getEveryonePrincipal()));
 
         final Iterator<Principal> iterator = resultPrincipals.iterator();
         boolean succeeds = false;
@@ -273,11 +277,11 @@ public class ServletContainerAuthenticationProviderTest {
         while (iterator.hasNext()) {
             final String name = iterator.next().getName();
 
-            if (name != null && name.equals(EVERYONE.getName())) {
+            if (name != null && name.equals(fad.getEveryonePrincipal().getName())) {
                 succeeds = true;
             }
         }
 
-        assertTrue("Expected to find: " + EVERYONE.getName(), succeeds);
+        assertTrue("Expected to find: " + fad.getEveryonePrincipal().getName(), succeeds);
     }
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/PermitRootAndPathEndsWithPermitSuffixFAD.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/PermitRootAndPathEndsWithPermitSuffixFAD.java
@@ -15,6 +15,8 @@
  */
 package org.fcrepo.auth.integration;
 
+import java.security.Principal;
+
 import javax.jcr.Session;
 
 import org.fcrepo.auth.common.FedoraAuthorizationDelegate;
@@ -26,10 +28,27 @@ import org.slf4j.LoggerFactory;
  * @author Gregory Jansen
  */
 public class PermitRootAndPathEndsWithPermitSuffixFAD implements
-        FedoraAuthorizationDelegate {
+FedoraAuthorizationDelegate {
 
     Logger logger = LoggerFactory
             .getLogger(PermitRootAndPathEndsWithPermitSuffixFAD.class);
+
+    /**
+     * The security principal for every request.
+     */
+    private static final Principal EVERYONE = new Principal() {
+
+        @Override
+        public String getName() {
+            return "EVERYONE";
+        }
+
+        @Override
+        public String toString() {
+            return getName();
+        }
+
+    };
 
     /*
      * (non-Javadoc)
@@ -70,6 +89,11 @@ public class PermitRootAndPathEndsWithPermitSuffixFAD implements
                 .getLastSegment().getName().getLocalName().toLowerCase()
                 .endsWith("permit"));
 
+    }
+
+    @Override
+    public Principal getEveryonePrincipal() {
+        return EVERYONE;
     }
 
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/PermitRootAndPathEndsWithPermitSuffixFAD.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/PermitRootAndPathEndsWithPermitSuffixFAD.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * @author Gregory Jansen
  */
 public class PermitRootAndPathEndsWithPermitSuffixFAD implements
-FedoraAuthorizationDelegate {
+        FedoraAuthorizationDelegate {
 
     Logger logger = LoggerFactory
             .getLogger(PermitRootAndPathEndsWithPermitSuffixFAD.class);


### PR DESCRIPTION
Instead of a single static principal named EVERYONE in the ServletContainerAuthenticationProvider class, rely on each delegate to supply a Principal that it uses to represent the EVERYONE user through a getEveryonePrincipal() method.

Updated the integration tests with mocks for the EVERYONE principal for their mock FAD objects.