### PR TITLE
FCREPO-1627 (https://jira.duraspace.org/browse/FCREPO-1627)

### DIFF
--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -74,6 +74,12 @@
 
     <dependency>
       <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-kernel-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-kernel-modeshape</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -78,10 +78,10 @@ import javax.ws.rs.core.UriBuilderException;
 
 import org.fcrepo.http.commons.domain.ContentLocation;
 import org.fcrepo.http.commons.domain.PATCH;
+import org.fcrepo.kernel.api.exception.ForbiddenResourceModificationException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.http.api.exception.ForbiddenResourceModificationException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -260,10 +260,6 @@ public class FedoraLdp extends ContentExposingResource {
             resource = resource();
             response = noContent();
 
-            if (resource.hasType(FEDORA_PAIRTREE)) {
-              throw new ForbiddenResourceModificationException("Resources cannot be manually created " +
-                                                               "under pairtree elements!");
-            }
         } else {
             final MediaType effectiveContentType
                     = requestBodyStream == null || requestContentType == null ? null : contentType;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/exception/ForbiddenResourceModificationException.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/exception/ForbiddenResourceModificationException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api.exception;
+import javax.ws.rs.ForbiddenException;
+
+/**
+ * An extension of {@link javax.ws.rs.ForbiddenException} that may be thrown when attempting a
+ * forbidden or unsupported operation on a resource.
+ *
+ * @author jrgriffiniii
+ */
+public class ForbiddenResourceModificationException extends ForbiddenException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Default constructor.
+     * @param message the message
+     */
+    public ForbiddenResourceModificationException(final String message) {
+        super(message);
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -608,6 +609,7 @@ public class FedoraLdpTest {
 
         when(mockNodeService.exists(mockSession, "/some/path")).thenReturn(false);
         when(mockContainerService.findOrCreate(mockSession, "/some/path")).thenReturn(mockContainer);
+        when(mockSession.getNode(anyString())).thenReturn(mockNode);
 
         final Response actual = testObj.createOrReplaceObjectRdf(null, null, null, null, null, null);
 
@@ -628,6 +630,7 @@ public class FedoraLdpTest {
 
         when(mockNodeService.exists(mockSession, "/some/path")).thenReturn(false);
         when(mockContainerService.findOrCreate(mockSession, "/some/path")).thenReturn(mockContainer);
+        when(mockSession.getNode(anyString())).thenReturn(mockNode);
 
         final Response actual = testObj.createOrReplaceObjectRdf(NTRIPLES_TYPE,
                 toInputStream("_:a <info:x> _:c ."), null, null, null, null);
@@ -643,6 +646,7 @@ public class FedoraLdpTest {
 
         when(mockNodeService.exists(mockSession, "/some/path")).thenReturn(false);
         when(mockBinaryService.findOrCreate(mockSession, "/some/path")).thenReturn(mockBinary);
+        when(mockSession.getNode(anyString())).thenReturn(mockNode);
 
         final Response actual = testObj.createOrReplaceObjectRdf(TEXT_PLAIN_TYPE,
                 toInputStream("xyz"), null, null, null, null);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -708,20 +708,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     /**
      * Ensure that graphs cannot be created or replaced for pairtree child resources
-     *
-     * @throws IOException in case of IOException
      */
     @Test
     public void testPutOnPairtree() throws IOException {
-
         final String objName = getLocation(postObjMethod());
         final String pairtreeName = objName.substring(serverAddress.length(), objName.lastIndexOf('/'));
-        final String subjectURI = serverAddress + pairtreeName;
 
         final HttpPut put = putObjMethod(pairtreeName + "/test");
-        put.addHeader("Content-Type", "application/n3");
-        put.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
-
         assertEquals("Created a resource under a pairtree node!", FORBIDDEN.getStatusCode(), getStatus(put));
     }
 
@@ -1119,6 +1112,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String pid1 = uuid + "/parent";
         final String pid2 = uuid + "/child1";
         final String pid3 = uuid + "/child2";
+        createObjectAndClose(uuid);
         createObjectAndClose(pid1);
         createObjectAndClose(pid2);
         createObjectAndClose(pid3);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -706,6 +706,25 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 BAD_REQUEST.getStatusCode(), getStatus(put));
     }
 
+    /**
+     * Ensure that graphs cannot be created or replaced for pairtree child resources
+     *
+     * @throws IOException in case of IOException
+     */
+    @Test
+    public void testPutOnPairtree() throws IOException {
+
+        final String objName = getLocation(postObjMethod());
+        final String pairtreeName = objName.substring(serverAddress.length(), objName.lastIndexOf('/'));
+        final String subjectURI = serverAddress + pairtreeName;
+
+        final HttpPut put = putObjMethod(pairtreeName + "/test");
+        put.addHeader("Content-Type", "application/n3");
+        put.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
+
+        assertEquals("Created a resource under a pairtree node!", FORBIDDEN.getStatusCode(), getStatus(put));
+    }
+
     @Test
     public void testIngest() throws IOException {
         final String id = getRandomUniqueId();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
@@ -73,7 +73,8 @@ public class FedoraNodesIT extends AbstractResourceIT {
     public void testCopyInvalidDest() throws IOException {
         final String location1 = getLocation(postObjMethod());
         final HttpCopy request = new HttpCopy(location1);
-        request.addHeader("Destination", serverAddress + "non/existent/path");
+        final String pid = getRandomUniqueId();
+        request.addHeader("Destination", serverAddress + pid + "/non/existent/path");
         assertEquals(CONFLICT.getStatusCode(), getStatus(request));
     }
 
@@ -122,7 +123,8 @@ public class FedoraNodesIT extends AbstractResourceIT {
     @Test
     public void testMoveInvalidDest() throws IOException {
         final HttpMove request = new HttpMove(getLocation(postObjMethod()));
-        request.addHeader("Destination", serverAddress + "non/existent/destination");
+        final String pid = getRandomUniqueId();
+        request.addHeader("Destination", serverAddress + pid + "/non/existent/destination");
         assertEquals(CONFLICT.getStatusCode(), getStatus(request));
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ForbiddenResourceModificationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ForbiddenResourceModificationExceptionMapper.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import org.fcrepo.kernel.api.exception.ForbiddenResourceModificationException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.status;
+
+/**
+ * @author awoods
+ * @since 2015-09-10
+ */
+@Provider
+public class ForbiddenResourceModificationExceptionMapper implements
+        ExceptionMapper<ForbiddenResourceModificationException> {
+
+    @Override
+    public Response toResponse(final ForbiddenResourceModificationException e) {
+        final String msg = e.getMessage();
+        return status(FORBIDDEN).entity(msg).build();
+    }
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ForbiddenResourceModificationException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ForbiddenResourceModificationException.java
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.http.api.exception;
-import javax.ws.rs.ForbiddenException;
+package org.fcrepo.kernel.api.exception;
 
 /**
- * An extension of {@link javax.ws.rs.ForbiddenException} that may be thrown when attempting a
- * forbidden or unsupported operation on a resource.
+ * An exception that may be thrown when attempting a forbidden or unsupported operation on a resource.
  *
  * @author jrgriffiniii
+ * @since 2015-09-10
  */
-public class ForbiddenResourceModificationException extends ForbiddenException {
+public class ForbiddenResourceModificationException extends RepositoryRuntimeException {
 
     private static final long serialVersionUID = 1L;
 

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -627,6 +627,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     public void testDeleteObjectWithInboundReferences() throws RepositoryException {
 
         final String pid = getRandomPid();
+        containerService.findOrCreate(session, "/" + pid);
         final FedoraResource resourceA = containerService.findOrCreate(session, "/" + pid + "/a");
         final FedoraResource resourceB = containerService.findOrCreate(session, "/" + pid + "/b");
 

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImplTest.java
@@ -28,12 +28,14 @@ import javax.jcr.Session;
 import javax.jcr.nodetype.NodeType;
 
 import org.fcrepo.kernel.api.FedoraJcrTypes;
+import org.fcrepo.kernel.api.exception.ForbiddenResourceModificationException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.exception.TombstoneException;
 import org.fcrepo.kernel.api.services.ContainerService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.modeshape.jcr.api.JcrTools;
 
 /**
@@ -75,6 +77,8 @@ public class ContainerServiceImplTest implements FedoraJcrTypes {
         when(mockRoot.getNode(testPath.substring(1))).thenReturn(mockNode);
         when(mockNode.getParent()).thenReturn(mockRoot);
         when(mockRoot.isNew()).thenReturn(false);
+        when(mockRoot.getPath()).thenReturn("/");
+        when(mockRoot.isNodeType(FEDORA_PAIRTREE)).thenReturn(false);
     }
 
     @Test
@@ -135,8 +139,19 @@ public class ContainerServiceImplTest implements FedoraJcrTypes {
         when(mockNode.isNew()).thenReturn(true);
 
         testObj.findOrCreate(mockSession, "/foo/bar");
-
     }
 
+    @Test (expected = ForbiddenResourceModificationException.class)
+    public void testCreateUnderPairtree() throws Exception {
+        final String containerPath = "/foo";
+        final String testPath = "/foo/bar";
+
+        final Node mockContainer = Mockito.mock(Node.class);
+        when(mockSession.nodeExists(containerPath)).thenReturn(true);
+        when(mockSession.getNode(containerPath)).thenReturn(mockContainer);
+        when(mockContainer.getPath()).thenReturn(containerPath);
+        when(mockContainer.isNodeType(FEDORA_PAIRTREE)).thenReturn(true);
+        testObj.findOrCreate(mockSession, testPath);
+    }
 
 }


### PR DESCRIPTION
After failed attempts to rebase the fcrepo-1627 branch, this pull request deprecates #841.

> Raising a ClientErrorException with a 403 status code for attempts to create graphs using PUT requests for resources under pairtree Nodes within FedoraLdp#createOrReplaceObjectRdf; Implementing FedoraLdpIT#testPutOnPairtree for the case in which clients attempt to PUT graphs under pairtree Nodes