### PR TITLE
remove jul-to-slf4j dependency; import * in osgi config

### DIFF
--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -43,6 +43,8 @@
       org.springframework.context,
       org.springframework.stereotype,
       org.springframework.web.context,
+
+      *
     </osgi.import.packages>
     <osgi.export.packages>
       org.fcrepo.http.commons.*;version=${project.version},
@@ -139,10 +141,6 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jul-to-slf4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
@@ -33,7 +33,6 @@ import org.fcrepo.kernel.api.services.ContainerService;
 import org.fcrepo.kernel.api.services.VersionService;
 
 import org.jvnet.hk2.annotations.Optional;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import com.google.common.eventbus.EventBus;
 
@@ -43,13 +42,6 @@ import com.google.common.eventbus.EventBus;
  * @author ajs6f
  */
 public class AbstractResource {
-
-    static {
-        // the SLF4J to JUL bridge normally adds its attachments
-        // we want them to _replace_ the JUL loggers, to avoid logging outputs except those controlled by SLF4J
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
-    }
 
     /**
      * Useful for constructing URLs

--- a/pom.xml
+++ b/pom.xml
@@ -448,11 +448,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jul-to-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.jayway.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${awaitility.version}</version>


### PR DESCRIPTION
See: https://jira.duraspace.org/browse/FCREPO-1776

This change causes integration testing in fcrepo-http-api to generate more error output (the tests do not fail, though). That error output, however, is currently only _masked_ in the integration tests. In a live system (e.g. in tomcat) that error output still appears.