### PR TITLE
clean up stack traces from integration tests

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -227,6 +227,7 @@ public abstract class AbstractResourceIT {
                     logger.trace(EntityUtils.toString(response.getEntity()));
                 }
             }
+            EntityUtils.consume(response.getEntity());
             return result;
         } catch (final IOException e) {
             throw new RuntimeException(e);
@@ -242,6 +243,7 @@ public abstract class AbstractResourceIT {
      */
     protected static String getLocation(final HttpUriRequest req) throws IOException {
         try (final CloseableHttpResponse response = execute(req)) {
+            EntityUtils.consume(response.getEntity());
             return getLocation(response);
         }
     }
@@ -260,6 +262,7 @@ public abstract class AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(method)) {
             final int result = getStatus(response);
             assertEquals(OK.getStatusCode(), result);
+            EntityUtils.consume(response.getEntity());
             return response.getFirstHeader("Content-Type").getValue();
         }
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TransactionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TransactionServiceImpl.java
@@ -100,7 +100,7 @@ public class TransactionServiceImpl extends AbstractService implements Transacti
                         try {
                             tx.rollback();
                         } catch (final RepositoryRuntimeException e) {
-                            LOGGER.error("Got exception rolling back expired transaction {}: {}", tx, e);
+                            LOGGER.error("Got exception rolling back expired transaction {}: {}", tx, e.getMessage());
                         }
                         transactions.remove(key);
                     });

--- a/fcrepo-mint/src/main/java/org/fcrepo/mint/HttpPidMinter.java
+++ b/fcrepo-mint/src/main/java/org/fcrepo/mint/HttpPidMinter.java
@@ -102,7 +102,7 @@ public class HttpPidMinter implements UniqueValueSupplier {
             try {
                 this.xpath = XPathFactory.newInstance().newXPath().compile(xpath);
             } catch ( final XPathException ex ) {
-                LOGGER.warn("Error parsing xpath ({}): {}", xpath, ex );
+                LOGGER.warn("Error parsing xpath ({}): {}", xpath, ex.getMessage());
                 throw new IllegalArgumentException("Error parsing xpath" + xpath, ex);
             }
         }
@@ -183,10 +183,10 @@ public class HttpPidMinter implements UniqueValueSupplier {
             final HttpResponse resp = client.execute( minterRequest() );
             return responseToPid( EntityUtils.toString(resp.getEntity()) );
         } catch ( final IOException ex ) {
-            LOGGER.warn("Error minting pid from {}: {}", url, ex);
+            LOGGER.warn("Error minting pid from {}: {}", url, ex.getMessage());
             throw new PidMintingException("Error minting pid", ex);
         } catch ( final Exception ex ) {
-            LOGGER.warn("Error processing minter response", ex);
+            LOGGER.warn("Error processing minter response", ex.getMessage());
             throw new PidMintingException("Error processing minter response", ex);
         }
     }


### PR DESCRIPTION
See: https://jira.duraspace.org/browse/FCREPO-1778

Now the only stack traces in the integration tests are from the LDP test suite (which we have no control over) and the WildcardExceptionManager tests, and there, the stack trace appears to be by design(?).