### PR TITLE
Allow an admin user to specify a delegated user.

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/HttpHeaderPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/HttpHeaderPrincipalProvider.java
@@ -17,14 +17,14 @@ package org.fcrepo.auth.common;
 
 import static java.util.Collections.emptySet;
 
-import org.modeshape.jcr.api.ServletCredentials;
+import java.security.Principal;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.jcr.Credentials;
 import javax.servlet.http.HttpServletRequest;
 
-import java.security.Principal;
-import java.util.HashSet;
-import java.util.Set;
+import org.modeshape.jcr.api.ServletCredentials;
 
 /**
  * An example principal provider that extracts principals from request headers.
@@ -131,6 +131,21 @@ public class HttpHeaderPrincipalProvider implements PrincipalProvider {
 
         return principals;
 
+    }
+
+    /**
+     * @param credentials
+     * @return the first principal found
+     */
+    public Principal getFirstPrincipal(final Credentials credentials) {
+        final Set<Principal> principals = getPrincipals(credentials);
+        if (principals != null && principals.size() > 0) {
+            final Principal[] ps = principals.toArray(new Principal[0]);
+            final Principal firstPrincipal = ps[0];
+            return firstPrincipal;
+        } else {
+            return null;
+        }
     }
 
 }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * @author Gregory Jansen
  */
 public final class ServletContainerAuthenticationProvider implements
-AuthenticationProvider {
+        AuthenticationProvider {
 
     private static ServletContainerAuthenticationProvider instance = null;
 

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
@@ -17,22 +17,23 @@ package org.fcrepo.auth.common;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.security.Principal;
+import java.util.Set;
+
+import javax.jcr.Credentials;
+import javax.servlet.http.HttpServletRequest;
 
 import org.fcrepo.auth.common.HttpHeaderPrincipalProvider.HttpHeaderPrincipal;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.modeshape.jcr.api.ServletCredentials;
-
-import javax.jcr.Credentials;
-import javax.servlet.http.HttpServletRequest;
-
-import java.security.Principal;
-import java.util.Set;
 
 /**
  * @author daines
@@ -72,6 +73,35 @@ public class HttpHeaderPrincipalProviderTest {
                 .contains(new HttpHeaderPrincipal("a")));
         assertTrue("The principals should contain 'b'", principals
                 .contains(new HttpHeaderPrincipal("b")));
+
+    }
+
+    @Test
+    public void testFirstPrincipalExtractedFromHeaders() {
+
+        when(request.getHeader("Groups")).thenReturn("a,b");
+
+        provider.setHeaderName("Groups");
+        provider.setSeparator(",");
+
+        final Principal principal = provider.getFirstPrincipal(credentials);
+
+        assertTrue("The first principal should be 'a'", principal
+                .equals(new HttpHeaderPrincipal("a")));
+
+    }
+
+    @Test
+    public void testFirstPrincipalExtractedFromMissingHeader() {
+
+        when(request.getHeader("Groups")).thenReturn(null);
+
+        provider.setHeaderName("Groups");
+        provider.setSeparator(",");
+
+        final Principal principal = provider.getFirstPrincipal(credentials);
+
+        assertNull("The first principal should be null", principal);
 
     }
 

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/DelegatedUserIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/DelegatedUserIT.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.security.Principal;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.auth.BasicUserPrincipal;
+import org.fcrepo.auth.common.FedoraAuthorizationDelegate;
+import org.fcrepo.auth.common.ServletContainerAuthenticationProvider;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.services.ContainerService;
+import org.fcrepo.kernel.modeshape.services.ContainerServiceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.modeshape.jcr.api.ServletCredentials;
+import org.modeshape.jcr.value.Path;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Peter Eichman
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "/spring-test/mocked-fad-repo-3.xml" })
+public class DelegatedUserIT {
+
+    private static Logger logger =
+            getLogger(DelegatedUserIT.class);
+
+    @Autowired
+    private Repository repo;
+
+    @Autowired
+    private FedoraAuthorizationDelegate fad;
+
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+
+    @Test
+    public void testFactory() {
+        Assert.assertNotNull(
+                "AuthenticationProvider must return a AuthenticationProvider",
+                ServletContainerAuthenticationProvider.getInstance());
+    }
+
+    @Test
+    public void testDelegatedUserAccess() throws RepositoryException {
+
+        // mock request by an admin user, on behalf of a regular user
+        when(request.getRemoteUser()).thenReturn("admin1");
+        when(request.getUserPrincipal()).thenReturn(new BasicUserPrincipal("admin1"));
+        when(request.isUserInRole(eq(ServletContainerAuthenticationProvider.FEDORA_ADMIN_ROLE))).thenReturn(true);
+        when(request.getHeader("On-Behalf-Of")).thenReturn("user1");
+
+        Mockito.reset(fad);
+        // set up a restrictive mock FAD, which should deny non-admin users
+        when(fad.hasPermission(any(Session.class), any(Path.class), any(String[].class))).thenReturn(false);
+
+        final ServletCredentials credentials = new ServletCredentials(request);
+        final Session session = repo.login(credentials);
+        assertEquals("Session user principal is user1",
+                "user1",
+                ((Principal) session.getAttribute(FedoraAuthorizationDelegate.FEDORA_USER_PRINCIPAL)).getName());
+
+        // try to create an object, this should fail because it is being executed as a non-admin user
+        final ContainerService os = new ContainerServiceImpl();
+        try {
+            os.findOrCreate(session, "/myobject");
+        } catch (final RepositoryRuntimeException e) {
+            final Throwable cause = e.getCause();
+            if (cause != null && cause instanceof AccessDeniedException) {
+                logger.debug("caught expected access denied exception");
+            } else {
+                throw e;
+            }
+        }
+        verify(fad, atLeastOnce()).hasPermission(any(Session.class), any(Path.class), any(String[].class));
+    }
+
+}

--- a/fcrepo-auth-common/src/test/resources/spring-test/mocked-fad-repo-3.xml
+++ b/fcrepo-auth-common/src/test/resources/spring-test/mocked-fad-repo-3.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+    <context:annotation-config/>
+
+    <context:component-scan base-package="org.fcrepo"/>
+
+    <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
+          depends-on="authenticationProvider"
+          p:repositoryConfiguration="${fcrepo.modeshape.configuration:repository.json}"/>
+
+    <bean name="fad" class="org.mockito.Mockito" factory-method="mock"
+          c:classToMock="org.fcrepo.auth.common.FedoraAuthorizationDelegate"/>
+
+    <bean name="containerRolesPrincipalProvider" class="org.fcrepo.auth.common.ContainerRolesPrincipalProvider"
+          p:roleNames="test"/>
+          
+    <bean name="delegatedPrincipalProvider" class="org.fcrepo.auth.common.HttpHeaderPrincipalProvider"
+          p:headerName="On-Behalf-Of" p:separator=","/>
+
+    <bean name="authenticationProvider" class="org.fcrepo.auth.common.ServletContainerAuthenticationProvider"
+          p:fad-ref="fad" p:principalProviders-ref="containerRolesPrincipalProvider"
+          p:delegatedPrincipalProvider-ref="delegatedPrincipalProvider"/>
+
+    <bean class="org.modeshape.jcr.ModeShapeEngine" init-method="start"/>
+
+    <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager"/>
+
+</beans>


### PR DESCRIPTION
The delegation is specified in an HTTP Header. The header is configured using a separate HttpHeaderPrincipalProvider bean named delegatedPrincipalProvider. If it is configured and a matching header is present in the request, the ServletContainerAuthenticationProvider will replace the userPrincipal in the request with the first principal found in the header.

- Added a getFirstPrincipal() convenience method to the HttpHeaderPrincipalProvider.
- Added unit tests for the delegated user functionality of the ServletContainerAuthenticationProvider. Check that admins can delegate but regular users cannot.
- Added unit test for the getFirstPrincipal method of HttpHeaderPrincipalProvider.
- Added an integration test with an On-Behalf-Of header and a mock FAD.

Resolves: https://jira.duraspace.org/browse/FCREPO-1790