### PR TITLE
clean up trivial build warnings

### DIFF
--- a/fcrepo-connector-file/pom.xml
+++ b/fcrepo-connector-file/pom.xml
@@ -13,11 +13,8 @@
   <properties>
     <osgi.import.packages>
       org.fcrepo.kernel.api.*,
-      org.fcrepo.kernel.modeshape.*,
 
       javax.jcr.*,
-
-      com.google.common.*,
 
       org.infinispan.schematic.*,
       org.modeshape.connector.filesystem,

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -198,6 +198,7 @@ public class FedoraLdpTest {
         when(mockHeaders.getHeaderString("user-agent")).thenReturn("Test UserAgent");
     }
 
+    @SuppressWarnings("unchecked")
     private FedoraResource setResource(final Class<? extends FedoraResource> klass) throws RepositoryException {
         final FedoraResource mockResource = mock(klass);
 
@@ -559,6 +560,7 @@ public class FedoraLdpTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testGetWithBinaryDescription() throws RepositoryException, IOException {
 
         final NonRdfSourceDescription mockResource
@@ -693,6 +695,7 @@ public class FedoraLdpTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testPatchBinaryDescription() throws RepositoryException, MalformedRdfException, IOException {
 
         final NonRdfSourceDescription mockObject = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/PropertiesRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/PropertiesRdfContext.java
@@ -64,6 +64,7 @@ public class PropertiesRdfContext extends NodeRdfContext {
     private Iterator<Triple> triplesFromProperties(final FedoraResource n)
         throws RepositoryException {
         LOGGER.trace("Creating triples for node: {}", n);
+        @SuppressWarnings("unchecked")
         final Iterator<Property> nodeProps = n.getNode().getProperties();
         final Iterator<Property> properties = Iterators.filter(nodeProps,
                 isInternalProperty.negate()::test);


### PR DESCRIPTION
See: https://jira.duraspace.org/browse/FCREPO-1822

This does not address the Jersey injection (runtime) warnings described in FCREPO-1785