### PR TITLE
GET w/ bad Accept header now returns proper error

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -103,7 +103,6 @@ import org.springframework.context.annotation.Scope;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import static com.google.common.base.Strings.nullToEmpty;
 
 /**
@@ -204,8 +203,7 @@ public class FedoraLdp extends ContentExposingResource {
 
         LOGGER.info("GET resource '{}'", externalPath);
 
-        final ImmutableList<MediaType> acceptableMediaTypes =
-                new ImmutableList.Builder<MediaType>().addAll(headers.getAcceptableMediaTypes()).build();
+        final List<MediaType> acceptableMediaTypes = headers.getAcceptableMediaTypes();
 
         if (acceptableMediaTypes.size() > 0) {
 
@@ -223,8 +221,8 @@ public class FedoraLdp extends ContentExposingResource {
                     x.isWildcardType() || possibleVariants.stream().anyMatch(t -> t.getMediaType().isCompatible(x)));
 
             if (!match) {
-                 LOGGER.info("Unable to produce content in the requested mime-type(s): " );
-                 acceptableMediaTypes.stream().forEach(x -> LOGGER.info(x.toString()));
+                LOGGER.info("Unable to produce content in the requested mime-type(s): " );
+                acceptableMediaTypes.stream().forEach(x -> LOGGER.info("MediaType: ", x));
 
                 return notAcceptable(possibleVariants).build();
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -198,7 +198,7 @@ public class FedoraLdp extends ContentExposingResource {
     @GET
     @Produces({TURTLE + ";qs=10", JSON_LD + ";qs=8",
             N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X,
-            TEXT_HTML, APPLICATION_XHTML_XML, "*/*"})
+            TEXT_HTML, APPLICATION_XHTML_XML})
     public Response describe(@HeaderParam("Range") final String rangeValue) throws IOException {
         checkCacheControlHeaders(request, servletResponse, resource(), session);
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -191,14 +191,14 @@ public class FedoraLdp extends ContentExposingResource {
      * Retrieve the node profile
      *
      * @param rangeValue the range value
-     * @return triples for the specified node
+     * @return a binary or the triples for the specified node
      * @throws IOException if IO exception occurred
      */
     @GET
     @Produces({TURTLE + ";qs=10", JSON_LD + ";qs=8",
             N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X,
             TEXT_HTML, APPLICATION_XHTML_XML})
-    public Response describe(@HeaderParam("Range") final String rangeValue) throws IOException {
+    public Response getResource(@HeaderParam("Range") final String rangeValue) throws IOException {
         checkCacheControlHeaders(request, servletResponse, resource(), session);
 
         LOGGER.info("GET resource '{}'", externalPath);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -18,27 +18,25 @@ package org.fcrepo.http.api;
 
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
 import static javax.ws.rs.core.MediaType.APPLICATION_XHTML_XML;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.NOT_IMPLEMENTED;
 import static javax.ws.rs.core.Response.created;
+import static javax.ws.rs.core.Response.notAcceptable;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.ok;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_IMPLEMENTED;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
-import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2;
 import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
 import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_PAIRTREE;
@@ -53,6 +51,7 @@ import java.net.URI;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
@@ -81,9 +80,11 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilderException;
+import javax.ws.rs.core.Variant;
 
 import org.fcrepo.http.commons.domain.ContentLocation;
 import org.fcrepo.http.commons.domain.PATCH;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -102,7 +103,7 @@ import org.springframework.context.annotation.Scope;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-
+import com.google.common.collect.ImmutableList;
 import static com.google.common.base.Strings.nullToEmpty;
 
 /**
@@ -177,6 +178,7 @@ public class FedoraLdp extends ContentExposingResource {
 
     /**
      * Outputs information about the supported HTTP methods, etc.
+     *
      * @return the outputs information about the supported HTTP methods, etc.
      */
     @OPTIONS
@@ -192,21 +194,45 @@ public class FedoraLdp extends ContentExposingResource {
      * Retrieve the node profile
      *
      * @param rangeValue the range value
-     * @return triples for the specified node
+     * @return the binary or the triples for the specified node
      * @throws IOException if IO exception occurred
      */
     @GET
-    @Produces({TURTLE + ";qs=10", JSON_LD + ";qs=8",
-            N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X,
-            TEXT_HTML, APPLICATION_XHTML_XML})
+    @Produces({TURTLE + ";qs=10", "*/*"})
     public Response describe(@HeaderParam("Range") final String rangeValue) throws IOException {
         checkCacheControlHeaders(request, servletResponse, resource(), session);
 
         LOGGER.info("GET resource '{}'", externalPath);
+
+        final ImmutableList<MediaType> acceptableMediaTypes =
+                new ImmutableList.Builder<MediaType>().addAll(headers.getAcceptableMediaTypes()).build();
+
+        if (acceptableMediaTypes.size() > 0) {
+
+            final List<Variant> possibleVariants = new ArrayList();
+            if (resource() instanceof FedoraBinary) {
+                final String lang = null;
+                final String enc = null;
+                possibleVariants.add(new Variant(MediaType.valueOf(((FedoraBinary) resource()).getMimeType()),
+                        lang, enc));
+            } else {
+                possibleVariants.addAll(RDFMediaType.POSSIBLE_RDF_VARIANTS);
+            }
+
+            final boolean match = acceptableMediaTypes.stream().anyMatch(x ->
+                    x.isWildcardType() || possibleVariants.stream().anyMatch(t -> t.getMediaType().isCompatible(x)));
+
+            if (!match) {
+                 LOGGER.info("Unable to produce content in the requested mime-type(s): " );
+                 acceptableMediaTypes.stream().forEach(x -> LOGGER.info(x.toString()));
+
+                return notAcceptable(possibleVariants).build();
+            }
+        }
         addResourceHttpHeaders(resource());
 
         final RdfStream rdfStream = new RdfStream().session(session)
-                    .topic(translator().reverse().convert(resource()).asNode());
+            .topic(translator().reverse().convert(resource()).asNode());
 
         return getContent(rangeValue, getChildrenLimit(), rdfStream);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -361,7 +361,7 @@ public class FedoraLdpTest {
     @Test
     public void testGet() throws Exception {
         setResource(FedoraResource.class);
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should have a Link header", mockResponse.containsHeader("Link"));
         assertTrue("Should have an Allow header", mockResponse.containsHeader("Allow"));
@@ -388,7 +388,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithObject() throws Exception {
         setResource(Container.class);
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should advertise Accept-Post flavors", mockResponse.containsHeader("Accept-Post"));
         assertTrue("Should advertise Accept-Patch flavors", mockResponse.containsHeader("Accept-Patch"));
@@ -415,7 +415,7 @@ public class FedoraLdpTest {
     public void testGetWithBasicContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
         when(resource.hasType(LDP_BASIC_CONTAINER)).thenReturn(true);
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP BasicContainer",
                 mockResponse.getHeaders("Link").contains("<" + BASIC_CONTAINER.getURI() + ">;rel=\"type\""));
@@ -425,7 +425,7 @@ public class FedoraLdpTest {
     public void testGetWithDirectContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
         when(resource.hasType(LDP_DIRECT_CONTAINER)).thenReturn(true);
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP DirectContainer",
                 mockResponse.getHeaders("Link").contains("<" + DIRECT_CONTAINER.getURI() + ">;rel=\"type\""));
@@ -435,7 +435,7 @@ public class FedoraLdpTest {
     public void testGetWithIndirectContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
         when(resource.hasType(LDP_INDIRECT_CONTAINER)).thenReturn(true);
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP IndirectContainer",
                 mockResponse.getHeaders("Link").contains("<" + INDIRECT_CONTAINER.getURI() + ">;rel=\"type\""));
@@ -446,7 +446,7 @@ public class FedoraLdpTest {
 
         setResource(Container.class);
         setField(testObj, "prefer", new MultiPrefer("return=minimal"));
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
         final RdfStream entity = (RdfStream) actual.getEntity();
@@ -471,7 +471,7 @@ public class FedoraLdpTest {
         setResource(Container.class);
         setField(testObj, "prefer",
                 new MultiPrefer("return=representation; omit=\"" + LDP_NAMESPACE + "PreferContainment\""));
-        final Response actual = testObj.describe(
+        final Response actual = testObj.getResource(
                 null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
@@ -491,7 +491,7 @@ public class FedoraLdpTest {
         setResource(Container.class);
         setField(testObj, "prefer",
                 new MultiPrefer("return=representation; omit=\"" + LDP_NAMESPACE + "PreferMembership\""));
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
         final RdfStream entity = (RdfStream) actual.getEntity();
@@ -512,7 +512,7 @@ public class FedoraLdpTest {
     public void testGetWithObjectIncludeReferences() throws ParseException, IOException, RepositoryException {
         setResource(Container.class);
         setField(testObj, "prefer", new MultiPrefer("return=representation; include=\"" + INBOUND_REFERENCES + "\""));
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
         final RdfStream entity = (RdfStream) actual.getEntity();
@@ -531,7 +531,7 @@ public class FedoraLdpTest {
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getMimeType()).thenReturn("text/plain");
         when(mockResource.getContent()).thenReturn(toInputStream("xyz"));
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP NonRDFSource",
                 mockResponse.getHeaders("Link").contains("<" + LDP_NAMESPACE + "NonRDFSource>;rel=\"type\""));
@@ -550,7 +550,7 @@ public class FedoraLdpTest {
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getMimeType()).thenReturn("message/external-body; access-type=URL; URL=\"some:uri\"");
         when(mockResource.getContent()).thenReturn(toInputStream("xyz"));
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(TEMPORARY_REDIRECT.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP NonRDFSource", mockResponse.getHeaders("Link").contains("<" + LDP_NAMESPACE +
                 "NonRDFSource>;rel=\"type\""));
@@ -569,7 +569,7 @@ public class FedoraLdpTest {
         when(mockBinary.getTriples(eq(idTranslator), any(Class.class))).thenReturn(new RdfStream());
         when(mockBinary.getTriples(eq(idTranslator), any(List.class))).thenReturn(new RdfStream(new Triple
                 (createURI("mockBinary"), createURI("called"), createURI("child:properties"))));
-        final Response actual = testObj.describe(null);
+        final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP RDFSource",
                 mockResponse.getHeaders("Link").contains("<" + LDP_NAMESPACE + "RDFSource>;rel=\"type\""));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -64,7 +64,7 @@ public class FedoraHtmlIT extends AbstractResourceIT {
         final HttpGet method =
             new HttpGet(serverAddress + pid + "/ds1");
 
-        method.addHeader("Accept", "text/plain");
+        method.addHeader("Accept", "text/html");
         assertEquals(200, getStatus(method));
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -64,7 +64,7 @@ public class FedoraHtmlIT extends AbstractResourceIT {
         final HttpGet method =
             new HttpGet(serverAddress + pid + "/ds1");
 
-        method.addHeader("Accept", "text/html");
+        method.addHeader("Accept", "text/plain");
         assertEquals(200, getStatus(method));
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -36,6 +36,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NOT_MODIFIED;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -401,6 +402,24 @@ public class FedoraLdpIT extends AbstractResourceIT {
             });
         }
     }
+
+    /**
+     * Test that a 406 gets returned in the event of an invalid or unsupported
+     * format being requested.
+     */
+    @Test
+    public void testGetRDFSourceWrongAccept() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+
+        final HttpGet get = new HttpGet(serverAddress + id);
+        get.addHeader("Accept", "application/turtle");
+
+        try (final CloseableHttpResponse response = execute(get)) {
+            assertEquals(NOT_ACCEPTABLE.getStatusCode(), getStatus(response));
+        }
+    }
+
 
     @Test
     public void testDeleteObject() {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -415,9 +415,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpGet get = new HttpGet(serverAddress + id);
         get.addHeader("Accept", "application/turtle");
 
-        try (final CloseableHttpResponse response = execute(get)) {
-            assertEquals(NOT_ACCEPTABLE.getStatusCode(), getStatus(response));
-        }
+        assertEquals(NOT_ACCEPTABLE.getStatusCode(), getStatus(get));
     }
 
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/RDFMediaType.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/RDFMediaType.java
@@ -67,10 +67,11 @@ public abstract class RDFMediaType extends MediaType {
 
     public static final List<Variant> POSSIBLE_RDF_VARIANTS = mediaTypes(
             RDF_XML_TYPE, TURTLE_TYPE, N3_TYPE, N3_ALT2_TYPE, NTRIPLES_TYPE, APPLICATION_XML_TYPE,
-            TEXT_PLAIN_TYPE, TURTLE_X_TYPE, JSON_LD_TYPE).add().build();
+            TEXT_PLAIN_TYPE, TURTLE_X_TYPE, JSON_LD_TYPE, TEXT_HTML_TYPE, APPLICATION_XHTML_XML_TYPE).add().build();
 
     public static final String POSSIBLE_RDF_RESPONSE_VARIANTS_STRING[] = {
-        TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, APPLICATION_XML, TURTLE_X, JSON_LD };
+            TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, APPLICATION_XML, TURTLE_X, JSON_LD, TEXT_HTML,
+            APPLICATION_XHTML_XML};
 
     private static MediaType typeFromString(final String type) {
         return new MediaType(type.split("/")[0], type.split("/")[1]);

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/RDFMediaType.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/RDFMediaType.java
@@ -67,11 +67,10 @@ public abstract class RDFMediaType extends MediaType {
 
     public static final List<Variant> POSSIBLE_RDF_VARIANTS = mediaTypes(
             RDF_XML_TYPE, TURTLE_TYPE, N3_TYPE, N3_ALT2_TYPE, NTRIPLES_TYPE, APPLICATION_XML_TYPE,
-            TEXT_PLAIN_TYPE, TURTLE_X_TYPE, JSON_LD_TYPE, TEXT_HTML_TYPE, APPLICATION_XHTML_XML_TYPE).add().build();
+            TEXT_PLAIN_TYPE, TURTLE_X_TYPE, JSON_LD_TYPE).add().build();
 
     public static final String POSSIBLE_RDF_RESPONSE_VARIANTS_STRING[] = {
-            TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, APPLICATION_XML, TURTLE_X, JSON_LD, TEXT_HTML,
-            APPLICATION_XHTML_XML};
+        TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, APPLICATION_XML, TURTLE_X, JSON_LD };
 
     private static MediaType typeFromString(final String type) {
         return new MediaType(type.split("/")[0], type.split("/")[1]);


### PR DESCRIPTION
- When an invalid or unsupported format type was requested the wrong
HTTP error code was returned.  Now it returns the correct one.

Resolves: https://jira.duraspace.org/browse/FCREPO-1840