### PR TITLE
Add configuration for a MySQL backend, instead of LevelDB

### DIFF
--- a/fcrepo-configs/src/main/resources/config/infinispan/jdbc-mysql/infinispan.xml
+++ b/fcrepo-configs/src/main/resources/config/infinispan/jdbc-mysql/infinispan.xml
@@ -38,7 +38,7 @@
           <jdbc:string-keyed-table prefix="ispn_entry"
                                    create-on-start="true"
                                    drop-on-exit="false">
-            <jdbc:id-column name="id" type="VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_cs"/>
+            <jdbc:id-column name="id" type="VARCHAR(255)"/>
             <jdbc:data-column name="datum" type="LONGBLOB"/>
             <jdbc:timestamp-column name="version" type="BIGINT"/>
           </jdbc:string-keyed-table>

--- a/fcrepo-configs/src/main/resources/config/infinispan/jdbc-mysql/infinispan.xml
+++ b/fcrepo-configs/src/main/resources/config/infinispan/jdbc-mysql/infinispan.xml
@@ -1,0 +1,52 @@
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="urn:infinispan:config:7.2"
+            xmlns:jdbc="urn:infinispan:config:store:jdbc:7.2"
+            xsi:schemaLocation="urn:infinispan:config:7.2 http://www.infinispan.org/schemas/infinispan-config-7.2.xsd urn:infinispan:config:store:jdbc:7.2 http://infinispan.org/schemas/infinispan-cachestore-jdbc-config-7.2.xsd">
+
+  <cache-container default-cache="FedoraRepository">
+
+    <jmx duplicate-domains="true"/>
+
+    <local-cache name="FedoraRepository" statistics="true">
+
+      <transaction transaction-manager-lookup="org.infinispan.transaction.lookup.GenericTransactionManagerLookup"
+                   mode="NON_XA"
+                   locking="PESSIMISTIC"/>
+
+      <eviction max-entries="500" strategy="LIRS" thread-policy="DEFAULT"/>
+
+      <!--
+          Define the cache loaders (i.e., cache stores). Passivation is false because we want *all*
+          data to be persisted, not just what doesn't fit into memory. Shared is false because there
+          are no other caches sharing this jdbc store. We set preload to false for lazy loading;
+          may be improved by preloading and configuring eviction.
+
+          We can have multiple cache loaders, which get chained. But we'll define just one.
+
+          See: https://docs.jboss.org/infinispan/7.2/configdocs/infinispan-cachestore-jdbc-config-7.2.html
+       -->
+      <persistence passivation="false">
+        <jdbc:string-keyed-jdbc-store shared="false"
+                                 preload="false"
+                                 fetch-state="true"
+                                 read-only="false"
+                                 purge="false">
+          <jdbc:connection-pool connection-url="jdbc:mysql://${fcrepo.ispn.mysql.host:localhost}:${fcrepo.ispn.mysql.port:3306}/ispn?createDatabaseIfNotExist=true"
+                                driver="com.mysql.jdbc.Driver"
+                                username="${fcrepo.ispn.mysql.username}"
+                                password="${fcrepo.ispn.mysql.password}"/>
+          <jdbc:string-keyed-table prefix="ispn_entry"
+                                   create-on-start="true"
+                                   drop-on-exit="false">
+            <jdbc:id-column name="id" type="VARCHAR(255) CHARACTER SET latin1 COLLATE latin1_general_cs"/>
+            <jdbc:data-column name="datum" type="LONGBLOB"/>
+            <jdbc:timestamp-column name="version" type="BIGINT"/>
+          </jdbc:string-keyed-table>
+
+        </jdbc:string-keyed-jdbc-store>
+
+      </persistence>
+    </local-cache>
+  </cache-container>
+
+</infinispan>

--- a/fcrepo-configs/src/main/resources/config/jdbc-mysql/repository.json
+++ b/fcrepo-configs/src/main/resources/config/jdbc-mysql/repository.json
@@ -1,0 +1,28 @@
+{
+    "name" : "repo",
+    "jndiName" : "",
+    "workspaces" : {
+        "predefined" : ["default"],
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "storage" : {
+        "cacheName" : "FedoraRepository",
+        "cacheConfiguration" : "${fcrepo.ispn.configuration:config/infinispan/jdbc-mysql/infinispan.xml}",
+        "binaryStorage" : {
+            "type" : "file",
+            "directory" : "${fcrepo.binary.directory:target/binaries}",
+            "minimumBinarySizeInBytes" : 4096
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        },
+        "providers" : [
+            { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
+        ]
+    },
+    "node-types" : ["fedora-node-types.cnd"]
+}

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -129,6 +129,21 @@
       <version>1.4.01</version>
     </dependency>
 
+    <!--MySQL dependencies-->
+    <dependency>
+      <groupId>com.mchange</groupId>
+      <artifactId>c3p0</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.38</version>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-cachestore-jdbc</artifactId>
+    </dependency>
+
     <!-- test gear -->
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
As of this update, the default backend is still LevelDB.
To use the MySQL object store, you need to:
1. Install an instance of MySQL
2. Run Fedora with the following JAVA_OPTS:
```
JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.modeshape.configuration=classpath:/config/jdbc-mysql/repository.json"
JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.ispn.mysql.username=<username>"
JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.ispn.mysql.password=<password>"
JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.ispn.mysql.host=<default=localhost>"
JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.ispn.mysql.port=<default=3306>"
```
Note, the database and table used by ISPN are auto-created.

Resolves: https://jira.duraspace.org/browse/FCREPO-1833