### PR TITLE
FedoraResource::getChildren() now returns a Stream

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -54,7 +54,7 @@ public interface FedoraResource {
 
     /**
      * Get the children of this resource
-     * @return iterator
+     * @return a stream of Fedora resources
      */
     Stream<FedoraResource> getChildren();
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -18,8 +18,8 @@ package org.fcrepo.kernel.api.models;
 import java.net.URI;
 import java.util.Date;
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Node;
@@ -56,7 +56,7 @@ public interface FedoraResource {
      * Get the children of this resource
      * @return iterator
      */
-    Iterator<FedoraResource> getChildren();
+    Stream<FedoraResource> getChildren();
 
     /**
      * Get the container of this resource

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -255,12 +255,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     @SuppressWarnings("unchecked")
     private Stream<FedoraResource> nodeToGoodChildren(final Node input) throws RepositoryException {
         return iteratorToStream(input.getNodes()).filter(nastyChildren.negate())
-            .flatMap(uncheck((final Node x) -> {
-                if (x.isNodeType(FEDORA_PAIRTREE)) {
-                    return nodeToGoodChildren(x);
-                }
-                return Stream.of(nodeToObjectBinaryConverter.convert(x));
-            }));
+            .flatMap(uncheck((final Node child) -> child.isNodeType(FEDORA_PAIRTREE) ? nodeToGoodChildren(child) :
+                        Stream.of(nodeToObjectBinaryConverter.convert(child))));
     }
 
     /**

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContext.java
@@ -15,7 +15,6 @@
  */
 package org.fcrepo.kernel.modeshape.rdf.impl;
 
-import com.google.common.collect.Iterators;
 import com.hp.hpl.jena.graph.Triple;
 import com.hp.hpl.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
@@ -25,16 +24,12 @@ import org.slf4j.Logger;
 
 import javax.jcr.RepositoryException;
 
-import java.util.Iterator;
-import java.util.function.Function;
-
 import static java.util.stream.Stream.of;
-import static com.hp.hpl.jena.datatypes.xsd.XSDDatatype.XSDint;
+import static com.hp.hpl.jena.datatypes.xsd.XSDDatatype.XSDlong;
 import static com.hp.hpl.jena.graph.Triple.create;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createTypedLiteral;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_CHILD_COUNT;
-import static org.fcrepo.kernel.modeshape.utils.StreamUtils.iteratorToStream;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -62,29 +57,20 @@ public class ChildrenRdfContext extends NodeRdfContext {
             LOGGER.trace("Found children of this resource: {}", resource.getPath());
 
             // Count the number of children
-            final Iterator<FedoraResource> childrenCounter = resource().getChildren();
-            concat(of(createNumChildrenTriple(Iterators.size(childrenCounter))));
-            concat(iteratorToStream(resource().getChildren()).map(child2triple));
-
+            concat(of(createNumChildrenTriple(resource().getChildren().count())));
+            concat(resource().getChildren().peek(x -> LOGGER.info("Creating triple for child node: {}", x))
+                    .map(x -> create(subject(), CONTAINS.asNode(), x instanceof NonRdfSourceDescription ?
+                            uriFor(((NonRdfSourceDescription) x).getDescribedResource()) : uriFor(x))));
         } else {
             concat(of(createNumChildrenTriple(0)));
         }
 
-
     }
 
-    private Triple createNumChildrenTriple(final int numChildren) {
+    private Triple createNumChildrenTriple(final long numChildren) {
         return create(subject(),
                 HAS_CHILD_COUNT.asNode(),
-                createTypedLiteral(Integer.toString(numChildren), XSDint).asNode());
+                createTypedLiteral(Long.toString(numChildren), XSDlong).asNode());
     }
 
-    private final Function<FedoraResource, Triple> child2triple = child -> {
-
-        final com.hp.hpl.jena.graph.Node childSubject = child instanceof NonRdfSourceDescription ?
-                uriFor(((NonRdfSourceDescription) child).getDescribedResource()) : uriFor(child);
-
-        LOGGER.trace("Creating triple for child node: {}", child);
-        return create(subject(), CONTAINS.asNode(), childSubject);
-    };
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContext.java
@@ -58,9 +58,9 @@ public class ChildrenRdfContext extends NodeRdfContext {
 
             // Count the number of children
             concat(of(createNumChildrenTriple(resource().getChildren().count())));
-            concat(resource().getChildren().peek(x -> LOGGER.info("Creating triple for child node: {}", x))
-                    .map(x -> create(subject(), CONTAINS.asNode(), x instanceof NonRdfSourceDescription ?
-                            uriFor(((NonRdfSourceDescription) x).getDescribedResource()) : uriFor(x))));
+            concat(resource().getChildren().peek(child -> LOGGER.trace("Creating triple for child node: {}", child))
+                    .map(child -> create(subject(), CONTAINS.asNode(), child instanceof NonRdfSourceDescription ?
+                            uriFor(((NonRdfSourceDescription) child).getDescribedResource()) : uriFor(child))));
         } else {
             concat(of(createNumChildrenTriple(0)));
         }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/LdpContainerRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/LdpContainerRdfContext.java
@@ -118,7 +118,7 @@ public class LdpContainerRdfContext extends NodeRdfContext {
             insertedContainerProperty = MEMBER_SUBJECT.getURI();
         }
 
-        return iteratorToStream(container.getChildren()).flatMap(
+        return container.getChildren().flatMap(
             UncheckedFunction.<FedoraResource, Stream<Triple>>uncheck(child -> {
                 final com.hp.hpl.jena.graph.Node childSubject = child instanceof NonRdfSourceDescription
                         ? uriFor(((NonRdfSourceDescription) child).getDescribedResource()) : uriFor(child);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -747,7 +747,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         final Container container = containerService.findOrCreate(session, "/" + pid);
         final FedoraResource resource = containerService.findOrCreate(session, "/" + pid + "/a");
 
-        assertEquals(resource, container.getChildren().next());
+        assertEquals(resource, container.getChildren().findFirst().get());
     }
 
     @Test
@@ -756,7 +756,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         final Container container = containerService.findOrCreate(session, "/" + pid);
         final FedoraResource resource = binaryService.findOrCreate(session, "/" + pid + "/a");
 
-        assertEquals(resource, container.getChildren().next());
+        assertEquals(resource, container.getChildren().findFirst().get());
     }
 
     @Test
@@ -783,7 +783,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         final Container container = containerService.findOrCreate(session, "/" + pid);
         final FedoraResource resource = containerService.findOrCreate(session, "/" + pid + "/a/b/c/d");
 
-        assertEquals(resource, container.getChildren().next());
+        assertEquals(resource, container.getChildren().findFirst().get());
     }
 
     @Test
@@ -793,7 +793,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         final FedoraResource resource = containerService.findOrCreate(session, "/" + pid + "/a");
 
         resource.delete();
-        assertFalse(container.getChildren().hasNext());
+        assertFalse(container.getChildren().findFirst().isPresent());
     }
 
     @Test
@@ -802,7 +802,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         final Container container = containerService.findOrCreate(session, "/" + pid);
         containerService.findOrCreate(session, "/" + pid + "/#/a");
 
-        assertFalse(container.getChildren().hasNext());
+        assertFalse(container.getChildren().findFirst().isPresent());
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraResourceImplTest.java
@@ -47,6 +47,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
@@ -368,16 +369,16 @@ public class FedoraResourceImplTest {
     @Test
     public void testGetChildrenWithEmptyChildren() throws RepositoryException {
         when(mockNode.getNodes()).thenReturn(nodeIterator());
-        final Iterator<FedoraResource> children = testObj.getChildren();
+        final Stream<FedoraResource> children = testObj.getChildren();
 
-        assertFalse("Expected an empty iterator", children.hasNext());
+        assertFalse("Expected an empty iterator", children.findFirst().isPresent());
     }
 
     @Test
     public void testGetChildrenWithChildren() throws RepositoryException {
         when(mockNode.getNodes()).thenReturn(nodeIterator(mockChild));
         when(mockChild.getName()).thenReturn("x");
-        final Iterator<FedoraResource> children = testObj.getChildren();
+        final Iterator<FedoraResource> children = testObj.getChildren().iterator();
 
         assertTrue("Expected an iterator with values", children.hasNext());
         assertEquals("Expected to find the child", mockChild, children.next().getNode());
@@ -388,8 +389,8 @@ public class FedoraResourceImplTest {
         when(mockNode.getNodes()).thenReturn(nodeIterator(mockChild));
         when(mockChild.isNodeType("mode:system")).thenReturn(true);
         when(mockChild.getName()).thenReturn("x");
-        final Iterator<FedoraResource> children = testObj.getChildren();
-        assertFalse("Expected an empty iterator", children.hasNext());
+        final Stream<FedoraResource> children = testObj.getChildren();
+        assertFalse("Expected an empty iterator", children.iterator().hasNext());
     }
 
     @Test
@@ -397,16 +398,16 @@ public class FedoraResourceImplTest {
         when(mockNode.getNodes()).thenReturn(nodeIterator(mockChild));
         when(mockChild.isNodeType(FEDORA_TOMBSTONE)).thenReturn(true);
         when(mockChild.getName()).thenReturn("x");
-        final Iterator<FedoraResource> children = testObj.getChildren();
-        assertFalse("Expected an empty iterator", children.hasNext());
+        final Stream<FedoraResource> children = testObj.getChildren();
+        assertFalse("Expected an empty iterator", children.iterator().hasNext());
     }
 
     @Test
     public void testGetChildrenExcludesJcrContent() throws RepositoryException {
         when(mockNode.getNodes()).thenReturn(nodeIterator(mockChild));
         when(mockChild.getName()).thenReturn(JCR_CONTENT);
-        final Iterator<FedoraResource> children = testObj.getChildren();
-        assertFalse("Expected an empty iterator", children.hasNext());
+        final Stream<FedoraResource> children = testObj.getChildren();
+        assertFalse("Expected an empty iterator", children.iterator().hasNext());
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraResourceImplTest.java
@@ -45,8 +45,8 @@ import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import java.net.URI;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.jcr.NamespaceRegistry;
@@ -371,17 +371,17 @@ public class FedoraResourceImplTest {
         when(mockNode.getNodes()).thenReturn(nodeIterator());
         final Stream<FedoraResource> children = testObj.getChildren();
 
-        assertFalse("Expected an empty iterator", children.findFirst().isPresent());
+        assertFalse("Expected an empty stream", children.findFirst().isPresent());
     }
 
     @Test
     public void testGetChildrenWithChildren() throws RepositoryException {
         when(mockNode.getNodes()).thenReturn(nodeIterator(mockChild));
         when(mockChild.getName()).thenReturn("x");
-        final Iterator<FedoraResource> children = testObj.getChildren().iterator();
+        final Optional<FedoraResource> child = testObj.getChildren().findFirst();
 
-        assertTrue("Expected an iterator with values", children.hasNext());
-        assertEquals("Expected to find the child", mockChild, children.next().getNode());
+        assertTrue("Expected a stream with values", child.isPresent());
+        assertEquals("Expected to find the child", mockChild, child.get().getNode());
     }
 
     @Test
@@ -390,7 +390,7 @@ public class FedoraResourceImplTest {
         when(mockChild.isNodeType("mode:system")).thenReturn(true);
         when(mockChild.getName()).thenReturn("x");
         final Stream<FedoraResource> children = testObj.getChildren();
-        assertFalse("Expected an empty iterator", children.iterator().hasNext());
+        assertFalse("Expected an empty stream", children.findFirst().isPresent());
     }
 
     @Test
@@ -399,7 +399,7 @@ public class FedoraResourceImplTest {
         when(mockChild.isNodeType(FEDORA_TOMBSTONE)).thenReturn(true);
         when(mockChild.getName()).thenReturn("x");
         final Stream<FedoraResource> children = testObj.getChildren();
-        assertFalse("Expected an empty iterator", children.iterator().hasNext());
+        assertFalse("Expected an empty stream", children.findFirst().isPresent());
     }
 
     @Test
@@ -407,7 +407,7 @@ public class FedoraResourceImplTest {
         when(mockNode.getNodes()).thenReturn(nodeIterator(mockChild));
         when(mockChild.getName()).thenReturn(JCR_CONTENT);
         final Stream<FedoraResource> children = testObj.getChildren();
-        assertFalse("Expected an empty iterator", children.iterator().hasNext());
+        assertFalse("Expected an empty stream", children.findFirst().isPresent());
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContextTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContextTest.java
@@ -26,7 +26,9 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -37,9 +39,7 @@ import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * ChildrenRdfContextTest class.
@@ -47,6 +47,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
  * @author awoods
  * @since 2015-11-28
  */
+@RunWith(MockitoJUnitRunner.class)
 public class ChildrenRdfContextTest {
 
     @Mock
@@ -64,14 +65,21 @@ public class ChildrenRdfContextTest {
     @Mock
     private Session mockSession;
 
+    @Mock
+    private FedoraResource mockRes1;
+
+    @Mock
+    private FedoraResource mockRes2;
+
+    @Mock
+    private FedoraResource mockRes3;
+
     private IdentifierConverter<Resource, FedoraResource> idTranslator;
 
     private static final String RDF_PATH = "/resource/path";
 
     @Before
     public void setUp() throws RepositoryException {
-        initMocks(this);
-
         // Mock RDF Source
         when(mockResource.getNode()).thenReturn(mockResourceNode);
         when(mockResourceNode.getSession()).thenReturn(mockSession);
@@ -99,9 +107,6 @@ public class ChildrenRdfContextTest {
 
     @Test
     public void testChildren() throws RepositoryException {
-        final FedoraResource mockRes1 = mock(FedoraResource.class);
-        final FedoraResource mockRes2 = mock(FedoraResource.class);
-        final FedoraResource mockRes3 = mock(FedoraResource.class);
         when(mockRes1.getPath()).thenReturn(RDF_PATH + "/res1");
         when(mockRes2.getPath()).thenReturn(RDF_PATH + "/res2");
         when(mockRes3.getPath()).thenReturn(RDF_PATH + "/res3");

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContextTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContextTest.java
@@ -15,7 +15,6 @@
  */
 package org.fcrepo.kernel.modeshape.rdf.impl;
 
-import com.google.common.collect.Iterators;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.RDFNode;
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -33,8 +32,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
-import java.util.Iterator;
-
+import static java.util.stream.Stream.of;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -101,8 +99,16 @@ public class ChildrenRdfContextTest {
 
     @Test
     public void testChildren() throws RepositoryException {
+        final FedoraResource mockRes1 = mock(FedoraResource.class);
+        final FedoraResource mockRes2 = mock(FedoraResource.class);
+        final FedoraResource mockRes3 = mock(FedoraResource.class);
+        when(mockRes1.getPath()).thenReturn(RDF_PATH + "/res1");
+        when(mockRes2.getPath()).thenReturn(RDF_PATH + "/res2");
+        when(mockRes3.getPath()).thenReturn(RDF_PATH + "/res3");
         when(mockResourceNode.hasNodes()).thenReturn(true);
-        when(mockResource.getChildren()).thenReturn(childrenIterator());
+        when(mockResource.getChildren()).thenReturn(
+                    of(mockRes1, mockRes2, mockRes3),
+                    of(mockRes1, mockRes2, mockRes3));
 
         final Model results = new ChildrenRdfContext(mockResource, idTranslator).collect(toModel());
         final Resource subject = idTranslator.reverse().convert(mockResource);
@@ -115,10 +121,6 @@ public class ChildrenRdfContextTest {
         assertEquals(3, stmt.getInt());
 
         assertFalse("There should not have been a second statement!", stmts.hasNext());
-    }
-
-    private Iterator<FedoraResource> childrenIterator() {
-        return Iterators.forArray(mock(FedoraResource.class), mock(FedoraResource.class), mock(FedoraResource.class));
     }
 
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/LdpContainerRdfContextTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/LdpContainerRdfContextTest.java
@@ -15,7 +15,6 @@
  */
 package org.fcrepo.kernel.modeshape.rdf.impl;
 
-import com.google.common.collect.Iterators;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -33,6 +32,7 @@ import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.Workspace;
 
+import static java.util.stream.Stream.of;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_HAS_MEMBER_RELATION;
@@ -134,7 +134,7 @@ public class LdpContainerRdfContextTest {
     public void testLdpResourceWithBasicContainer() throws RepositoryException {
         when(mockResource.hasType(LDP_BASIC_CONTAINER)).thenReturn(true);
         when(mockNode.getReferences(LDP_MEMBER_RESOURCE)).thenReturn(new TestPropertyIterator());
-        when(mockResource.getChildren()).thenReturn(Iterators.singletonIterator(mockResource));
+        when(mockResource.getChildren()).thenReturn(of(mockResource));
         when(mockChild.getName()).thenReturn("b");
         when(mockChild.getPath()).thenReturn("/b");
         testObj = new LdpContainerRdfContext(mockResource, subjects);


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-1924

Note: the object in the `hasChildCount` triple now uses the datatype `xsd:long` instead of an `xsd:int`. This is because `Stream::count` returns a `long`, but if we want to keep the triple's datatype as an `xsd:int` I could simply cast the `long` into an `int`. I don't expect any overflows, though doing so would also introduce that limitation.