### PR TITLE
Resolve Jersey session injection error

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -22,12 +22,14 @@ import com.hp.hpl.jena.rdf.model.Resource;
 import org.apache.commons.lang3.StringUtils;
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
+import org.fcrepo.kernel.api.exception.SessionMissingException;
 import org.fcrepo.kernel.api.exception.TombstoneException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.Tombstone;
 import org.slf4j.Logger;
 
+import javax.inject.Inject;
 import javax.jcr.Session;
 import javax.jcr.observation.ObservationManager;
 import javax.ws.rs.core.HttpHeaders;
@@ -43,9 +45,10 @@ abstract public class FedoraBaseResource extends AbstractResource {
 
     private static final Logger LOGGER = getLogger(FedoraBaseResource.class);
 
-    protected IdentifierConverter<Resource, FedoraResource> idTranslator;
+    @Inject
+    protected Session session;
 
-    protected abstract Session session();
+    protected IdentifierConverter<Resource, FedoraResource> idTranslator;
 
     protected IdentifierConverter<Resource, FedoraResource> translator() {
         if (idTranslator == null) {
@@ -93,8 +96,8 @@ abstract public class FedoraBaseResource extends AbstractResource {
                 json.put("userAgent", headers.getHeaderString("user-agent"));
             }
             obs.setUserData(mapper.writeValueAsString(json));
-        } catch ( final Exception ex ) {
-            LOGGER.warn("Error setting baseURL", ex);
+        } catch (final Exception ex) {
+            LOGGER.warn("Error setting baseURL", ex.getMessage());
         }
     }
 
@@ -110,5 +113,12 @@ abstract public class FedoraBaseResource extends AbstractResource {
             return uriInfo.getBaseUriBuilder().uri(propBaseURL).toString();
         }
         return "";
+    }
+
+    protected Session session() {
+        if (session == null) {
+            throw new SessionMissingException("Invalid session");
+        }
+        return session;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraExport.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraExport.java
@@ -22,9 +22,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import javax.inject.Inject;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -54,9 +52,6 @@ public class FedoraExport extends FedoraBaseResource {
 
     @Autowired
     protected SerializerUtil serializers;
-
-    @Inject
-    protected Session session;
 
     private static final Logger LOGGER = getLogger(FedoraExport.class);
 
@@ -109,8 +104,4 @@ public class FedoraExport extends FedoraBaseResource {
 
     }
 
-    @Override
-    protected Session session() {
-        return session;
-    }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -29,8 +29,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.getNamespaces;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import javax.inject.Inject;
-import javax.jcr.Session;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
@@ -58,9 +56,6 @@ import com.codahale.metrics.annotation.Timed;
 public class FedoraFixity extends ContentExposingResource {
 
     private static final Logger LOGGER = getLogger(FedoraFixity.class);
-
-    @Inject
-    protected Session session;
 
     @PathParam("path") protected String externalPath;
 
@@ -105,11 +100,6 @@ public class FedoraFixity extends ContentExposingResource {
                 new DefaultRdfStream(translator().reverse().convert(resource()).asNode(),
                     ((FedoraBinary)resource()).getFixity(translator())),
                 getNamespaces(session()));
-    }
-
-    @Override
-    protected Session session() {
-        return session;
     }
 
     @Override

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraImport.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraImport.java
@@ -25,10 +25,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.inject.Inject;
 import javax.jcr.ItemExistsException;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -54,9 +52,6 @@ import org.springframework.context.annotation.Scope;
 @Scope("prototype")
 @Path("/{path: .*}/fcr:import")
 public class FedoraImport extends FedoraBaseResource {
-
-    @Inject
-    protected Session session;
 
     @Autowired
     protected SerializerUtil serializers;
@@ -98,8 +93,4 @@ public class FedoraImport extends FedoraBaseResource {
         }
     }
 
-    @Override
-    protected Session session() {
-        return session;
-    }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -61,12 +61,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
+import javax.annotation.PostConstruct;
 import javax.jcr.AccessDeniedException;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
@@ -123,10 +122,6 @@ import static com.google.common.base.Strings.nullToEmpty;
 @Scope("request")
 @Path("/{path: .*}")
 public class FedoraLdp extends ContentExposingResource {
-
-
-    @Inject
-    protected Session session;
 
     private static final Logger LOGGER = getLogger(FedoraLdp.class);
 
@@ -777,11 +772,6 @@ public class FedoraLdp extends ContentExposingResource {
         }
 
         return result;
-    }
-
-    @Override
-    protected Session session() {
-        return session;
     }
 
     private String mintNewPid(final String slug) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
@@ -25,11 +25,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 import javax.jcr.ItemExistsException;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.HeaderParam;
@@ -60,9 +58,6 @@ import com.hp.hpl.jena.rdf.model.ResourceFactory;
 @Scope("request")
 @Path("/{path: .*}")
 public class FedoraNodes extends ContentExposingResource {
-
-    @Inject
-    protected Session session;
 
     private static final Logger LOGGER = getLogger(FedoraNodes.class);
 
@@ -199,11 +194,6 @@ public class FedoraNodes extends ContentExposingResource {
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }
-    }
-
-    @Override
-    protected Session session() {
-        return session;
     }
 
     @Override

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
@@ -21,9 +21,7 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
 
-import javax.inject.Inject;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -42,9 +40,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class FedoraTombstones extends FedoraBaseResource {
 
     private static final Logger LOGGER = getLogger(FedoraTombstones.class);
-
-    @Inject
-    protected Session session;
 
     @PathParam("path") protected String externalPath;
 
@@ -86,11 +81,4 @@ public class FedoraTombstones extends FedoraBaseResource {
     protected FedoraResource resource() {
         return translator().convert(translator().toDomain(externalPath));
     }
-
-
-    @Override
-    protected Session session() {
-        return session;
-    }
-
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTransactions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTransactions.java
@@ -25,8 +25,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.Principal;
 
-import javax.inject.Inject;
-import javax.jcr.Session;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -55,9 +53,6 @@ public class FedoraTransactions extends FedoraBaseResource {
 
     @Autowired
     private TransactionService txService;
-
-    @Inject
-    protected Session session;
 
     /**
      * Create a new transaction resource and add it to the registry
@@ -153,10 +148,5 @@ public class FedoraTransactions extends FedoraBaseResource {
             txService.rollback(txId);
         }
         return noContent().build();
-    }
-
-    @Override
-    protected Session session() {
-        return session;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -38,9 +38,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
 
-import javax.inject.Inject;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -73,9 +71,6 @@ import com.google.common.annotations.VisibleForTesting;
 @Scope("request")
 @Path("/{path: .*}/fcr:versions")
 public class FedoraVersioning extends FedoraBaseResource {
-
-    @Inject
-    protected Session session;
 
     private static final Logger LOGGER = getLogger(FedoraVersioning.class);
 
@@ -191,8 +186,4 @@ public class FedoraVersioning extends FedoraBaseResource {
         return resource;
     }
 
-    @Override
-    protected Session session() {
-        return session;
-    }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
@@ -34,9 +34,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -64,9 +62,6 @@ import com.google.common.annotations.VisibleForTesting;
 @Scope("request")
 @Path("/{path: .*}/fcr:versions/{labelAndOptionalPathIntoVersion: .*}")
 public class FedoraVersions extends ContentExposingResource {
-
-    @Inject
-    protected Session session;
 
     private static final Logger LOGGER = getLogger(FedoraVersions.class);
 
@@ -183,11 +178,5 @@ public class FedoraVersions extends ContentExposingResource {
     @Override
     protected String externalPath() {
         return externalPath;
-    }
-
-
-    @Override
-    protected Session session() {
-        return session;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryExport.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryExport.java
@@ -18,8 +18,6 @@ package org.fcrepo.http.api.repository;
 import org.fcrepo.http.api.FedoraExport;
 import org.springframework.context.annotation.Scope;
 
-import javax.inject.Inject;
-import javax.jcr.Session;
 import javax.ws.rs.Path;
 
 /**
@@ -38,8 +36,4 @@ import javax.ws.rs.Path;
 @Path("/fcr:export")
 @Deprecated
 public class FedoraRepositoryExport extends FedoraExport {
-
-    @Inject
-    protected Session session;
-
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryImport.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryImport.java
@@ -15,8 +15,6 @@
  */
 package org.fcrepo.http.api.repository;
 
-import javax.inject.Inject;
-import javax.jcr.Session;
 import javax.ws.rs.Path;
 
 import org.fcrepo.http.api.FedoraImport;
@@ -37,8 +35,4 @@ import org.springframework.context.annotation.Scope;
 @Path("/fcr:import")
 @Deprecated
 public class FedoraRepositoryImport extends FedoraImport {
-
-    @Inject
-    protected Session session;
-
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryTransactions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryTransactions.java
@@ -15,8 +15,6 @@
  */
 package org.fcrepo.http.api.repository;
 
-import javax.inject.Inject;
-import javax.jcr.Session;
 import javax.ws.rs.Path;
 
 import org.fcrepo.http.api.FedoraTransactions;
@@ -32,7 +30,4 @@ import org.springframework.context.annotation.Scope;
 @Scope("prototype")
 @Path("/fcr:tx")
 public class FedoraRepositoryTransactions extends FedoraTransactions {
-
-    @Inject
-    protected Session session;
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/SessionMissingExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/SessionMissingExceptionMapper.java
@@ -21,20 +21,20 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.fcrepo.kernel.api.exception.TransactionMissingException;
+import org.fcrepo.kernel.api.exception.SessionMissingException;
 
 /**
- * If a transaction is requested that has been closed (or never existed), just
+ * If a session is requested that has been closed (or never existed), just
  * return an HTTP 410 Gone.
  *
  * @author awoods
  */
 @Provider
-public class TransactionMissingExceptionMapper implements
-        ExceptionMapper<TransactionMissingException> {
+public class SessionMissingExceptionMapper implements
+        ExceptionMapper<SessionMissingException> {
 
     @Override
-    public Response toResponse(final TransactionMissingException exception) {
+    public Response toResponse(final SessionMissingException exception) {
         return status(GONE).entity(exception.getMessage()).build();
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapper.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.fcrepo.kernel.api.exception.TransactionMissingException;
+import org.fcrepo.kernel.api.exception.SessionMissingException;
 import org.slf4j.Logger;
 
 /**
@@ -46,9 +46,9 @@ public class WildcardExceptionMapper implements ExceptionMapper<Exception> {
     @Override
     public Response toResponse(final Exception e) {
 
-        if (e.getCause() instanceof TransactionMissingException) {
-            return new TransactionMissingExceptionMapper()
-                    .toResponse((TransactionMissingException) e.getCause());
+        if (e.getCause() instanceof SessionMissingException) {
+            return new SessionMissingExceptionMapper()
+                    .toResponse((SessionMissingException) e.getCause());
         }
 
         if ( e.getCause() instanceof RepositoryException) {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionFactory.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionFactory.java
@@ -16,7 +16,7 @@
 package org.fcrepo.http.commons.session;
 
 import static java.util.Objects.requireNonNull;
-import static javax.ws.rs.core.Response.Status.GONE;
+//import static javax.ws.rs.core.Response.Status.GONE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.security.Principal;
@@ -28,10 +28,10 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.ClientErrorException;
+//import javax.ws.rs.ClientErrorException;
 
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.exception.TransactionMissingException;
+import org.fcrepo.kernel.api.exception.SessionMissingException;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.services.TransactionService;
 
@@ -127,8 +127,10 @@ public class SessionFactory {
             } else {
                 session = getSessionFromTransaction(servletRequest, txId);
             }
-        } catch (final TransactionMissingException e) {
-            throw new ClientErrorException(GONE, e);
+        } catch (final SessionMissingException e) {
+            LOGGER.warn("Transaction missing: {}", e.getMessage());
+            return null;
+            //throw new ClientErrorException(GONE, e);
         } catch (final RepositoryException e) {
             throw new BadRequestException(e);
         }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionFactory.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionFactory.java
@@ -16,7 +16,6 @@
 package org.fcrepo.http.commons.session;
 
 import static java.util.Objects.requireNonNull;
-//import static javax.ws.rs.core.Response.Status.GONE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.security.Principal;
@@ -28,7 +27,6 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
-//import javax.ws.rs.ClientErrorException;
 
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.SessionMissingException;
@@ -130,7 +128,6 @@ public class SessionFactory {
         } catch (final SessionMissingException e) {
             LOGGER.warn("Transaction missing: {}", e.getMessage());
             return null;
-            //throw new ClientErrorException(GONE, e);
         } catch (final RepositoryException e) {
             throw new BadRequestException(e);
         }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/session/SessionFactoryTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/session/SessionFactoryTest.java
@@ -32,7 +32,7 @@ import javax.jcr.Session;
 import javax.servlet.http.HttpServletRequest;
 
 import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.exception.TransactionMissingException;
+import org.fcrepo.kernel.api.exception.SessionMissingException;
 import org.fcrepo.kernel.api.services.TransactionService;
 import org.junit.Before;
 import org.junit.Test;
@@ -114,13 +114,13 @@ public class SessionFactoryTest {
         when(mockRequest.getPathInfo()).thenReturn("/tx:123/some/path");
         when(mockTx.getSession()).thenReturn(mock(Session.class));
         when(mockTxService.getTransaction("123", null)).thenThrow(
-                new TransactionMissingException(""));
+                new SessionMissingException(""));
         try {
             testObj.getSession(mockRequest);
         } catch (final RuntimeException e) {
             final Throwable rootCause = Throwables.getRootCause(e);
             assertTrue("TransactionMissionException expected",
-                    rootCause instanceof TransactionMissingException);
+                    rootCause instanceof SessionMissingException);
         }
     }
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/SessionMissingException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/SessionMissingException.java
@@ -20,7 +20,7 @@ package org.fcrepo.kernel.api.exception;
  *
  * @author awoods
  */
-public class TransactionMissingException extends RepositoryRuntimeException {
+public class SessionMissingException extends RepositoryRuntimeException {
 
     private static final long serialVersionUID = 2139084821001303830L;
 
@@ -28,7 +28,7 @@ public class TransactionMissingException extends RepositoryRuntimeException {
      *
      * @param s the exception message
      */
-    public TransactionMissingException(final String s) {
+    public SessionMissingException(final String s) {
         super(s);
     }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TransactionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TransactionServiceImpl.java
@@ -33,7 +33,7 @@ import com.google.common.collect.ImmutableSet;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TxSession;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.exception.TransactionMissingException;
+import org.fcrepo.kernel.api.exception.SessionMissingException;
 import org.fcrepo.kernel.api.services.TransactionService;
 import org.fcrepo.kernel.modeshape.TransactionImpl;
 
@@ -129,10 +129,10 @@ public class TransactionServiceImpl extends AbstractService implements Transacti
     @Override
     public Transaction getTransaction(final String txId, final String userName) {
         final Transaction tx = transactions.computeIfAbsent(txId, s -> {
-            throw new TransactionMissingException("Transaction with id: " + s + " is not available");
+            throw new SessionMissingException("Transaction with id: " + s + " is not available");
         });
         if (!tx.isAssociatedWithUser(userName)) {
-            throw new TransactionMissingException("Transaction with id " +
+            throw new SessionMissingException("Transaction with id " +
                         txId + " is not available for user " + userName);
         }
         return tx;
@@ -143,18 +143,18 @@ public class TransactionServiceImpl extends AbstractService implements Transacti
      *
      * @param session the session
      * @return the given session's current Transaction
-     * @throws TransactionMissingException if transaction missing exception occurred
+     * @throws SessionMissingException if transaction missing exception occurred
      */
     @Override
     public Transaction getTransaction(final Session session) {
         final String txId = getCurrentTransactionId(session);
 
         if (txId == null) {
-            throw new TransactionMissingException(
+            throw new SessionMissingException(
                     "Transaction is not available");
         }
         return transactions.computeIfAbsent(txId, s -> {
-            throw new TransactionMissingException("Transaction with id: " + s + " is not available");
+            throw new SessionMissingException("Transaction with id: " + s + " is not available");
         });
     }
 
@@ -196,7 +196,7 @@ public class TransactionServiceImpl extends AbstractService implements Transacti
     public Transaction commit(final String txid) {
         final Transaction tx = transactions.remove(txid);
         if (tx == null) {
-            throw new TransactionMissingException("Transaction with id " + txid +
+            throw new SessionMissingException("Transaction with id " + txid +
                     " is not available");
         }
         tx.commit();
@@ -213,7 +213,7 @@ public class TransactionServiceImpl extends AbstractService implements Transacti
     public Transaction rollback(final String txid) {
         final Transaction tx = transactions.remove(txid);
         if (tx == null) {
-            throw new TransactionMissingException("Transaction with id " + txid +
+            throw new SessionMissingException("Transaction with id " + txid +
                     " is not available");
         }
         tx.rollback();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/TransactionServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/TransactionServiceImplTest.java
@@ -36,7 +36,7 @@ import javax.jcr.Session;
 
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.exception.TransactionMissingException;
+import org.fcrepo.kernel.api.exception.SessionMissingException;
 import org.fcrepo.kernel.api.services.TransactionService;
 
 import org.junit.Before;
@@ -115,26 +115,26 @@ public class TransactionServiceImplTest {
         assertNotNull(tx);
     }
 
-    @Test(expected = TransactionMissingException.class)
+    @Test(expected = SessionMissingException.class)
     public void testHijackingNotPossible() {
         final Transaction tx = service.beginTransaction(mockSession, USER_NAME);
         service.getTransaction(tx.getId(), ANOTHER_USER_NAME);
     }
 
-    @Test(expected = TransactionMissingException.class)
+    @Test(expected = SessionMissingException.class)
     public void testHijackingNotPossibleWithAnonUser() {
         final Transaction tx = service.beginTransaction(mockSession, USER_NAME);
         service.getTransaction(tx.getId(), null);
     }
 
-    @Test(expected = TransactionMissingException.class)
+    @Test(expected = SessionMissingException.class)
     public void testHijackingNotPossibleWhenStartedAnonUser() {
         final Transaction tx = service.beginTransaction(mockSession, null);
         service.getTransaction(tx.getId(), USER_NAME);
     }
 
-    @Test(expected = TransactionMissingException.class)
-    public void testGetNonTx() throws TransactionMissingException {
+    @Test(expected = SessionMissingException.class)
+    public void testGetNonTx() throws SessionMissingException {
         service.getTransaction(NOT_A_TX, null);
     }
 
@@ -145,7 +145,7 @@ public class TransactionServiceImplTest {
         assertEquals(IS_A_TX, tx.getId());
     }
 
-    @Test(expected = TransactionMissingException.class)
+    @Test(expected = SessionMissingException.class)
     public void testGetTxForNonTxSession() throws RepositoryException {
         when(mockSession.getNamespaceURI(FCREPO4_TX_ID)).thenThrow(new NamespaceException(""));
         service.getTransaction(mockSession);
@@ -164,7 +164,7 @@ public class TransactionServiceImplTest {
         verify(mockTx).commit();
     }
 
-    @Test(expected = TransactionMissingException.class)
+    @Test(expected = SessionMissingException.class)
     public void testCommitRemovedTransaction() throws Exception {
         final Transaction tx = service.commit(IS_A_TX);
         service.getTransaction(tx.getId(), null);
@@ -177,18 +177,18 @@ public class TransactionServiceImplTest {
         verify(mockTx).rollback();
     }
 
-    @Test(expected = TransactionMissingException.class)
+    @Test(expected = SessionMissingException.class)
     public void testRollbackRemovedTransaction() throws Exception {
         final Transaction tx = service.rollback(IS_A_TX);
         service.getTransaction(tx.getId(), null);
     }
 
-    @Test(expected = TransactionMissingException.class)
+    @Test(expected = SessionMissingException.class)
     public void testRollbackWithNonTx() {
         service.rollback(NOT_A_TX);
     }
 
-    @Test(expected = TransactionMissingException.class)
+    @Test(expected = SessionMissingException.class)
     public void testCommitWithNonTx() {
         service.commit(NOT_A_TX);
     }


### PR DESCRIPTION
See: https://jira.duraspace.org/browse/FCREPO-1785

This changes the SessionFactory in `fcrepo-http-commons` so that it doesn't throw a `TransactionMissingException` during Jersey injection (which causes lots of Jersey errors and is arguably a bad implementation) but rather returns a `null` value for a `Session` in the case of a missing transaction ID. This also led to a refactoring of `FedoraBaseResource` so that calls to `session()` all involve an appropriate `null` check.

The `TransactionMissingException` class was renamed to `SessionMissingException` to better capture what this exception really means with this implementation.