### PR TITLE
Confine all internal mode/jcr properties and type to fcrepo-kernel-modeshape

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -40,6 +40,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedNamespace;
+import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicateURI;
 import static org.fcrepo.kernel.api.RequiredRdfContext.EMBED_RESOURCES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_CONTAINMENT;
@@ -47,7 +48,6 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RequiredRdfContext.MINIMAL;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
-import static org.fcrepo.kernel.modeshape.rdf.ManagedRdf.isManagedTriple;
 import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.getNamespaces;
 
 import java.io.IOException;
@@ -140,7 +140,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     private static final Predicate<Triple> IS_MANAGED_TYPE = t -> t.getPredicate().equals(type.asNode()) &&
             isManagedNamespace.test(t.getObject().getNameSpace());
-    private static final Predicate<Triple> IS_MANAGED_TRIPLE = IS_MANAGED_TYPE.or(isManagedTriple::test);
+    private static final Predicate<Triple> IS_MANAGED_TRIPLE = IS_MANAGED_TYPE
+        .or(t -> isManagedPredicateURI.test(t.getPredicate().getURI()));
 
     protected abstract String externalPath();
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -73,6 +73,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.HAS_PRIMARY_IDENTIFIER;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_PRIMARY_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.JCR_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.JCR_NT_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
@@ -1351,6 +1352,26 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final Iterator<Quad> iterator =
                     graphStore.find(ANY, createURI(location), HAS_MIXIN_TYPE.asNode(), ANY);
             assertFalse("Graph should not contain a mixinType!", iterator.hasNext());
+        }
+    }
+
+    @Test
+    public void testGetObjectGraphLacksJcrTypes() throws Exception {
+        final String location = getLocation(postObjMethod());
+        final HttpGet getObjMethod = new HttpGet(location);
+        try (final CloseableGraphStore graphStore = getGraphStore(getObjMethod)) {
+            graphStore.find(ANY, createURI(location), type.asNode(), ANY).forEachRemaining(q -> {
+                    final Node o = q.asTriple().getObject();
+                    assertTrue("Type should be a URI", o.isURI());
+                    assertFalse("Graph should not contain an internal JCR type",
+                        o.getURI().startsWith(JCR_NAMESPACE));
+                    assertFalse("Graph should not contain an internal JCR type",
+                        o.getURI().startsWith(MODE_NAMESPACE));
+                    assertFalse("Graph should not contain an internal JCR type",
+                        o.getURI().startsWith(MIX_NAMESPACE));
+                    assertFalse("Graph should not contain an internal JCR type",
+                        o.getURI().startsWith(JCR_NT_NAMESPACE));
+                });
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
@@ -427,12 +427,14 @@ public class FedoraVersionsIT extends AbstractResourceIT {
         final Node subject = createURI(serverAddress + id);
         try (final CloseableGraphStore originalObjectProperties = getContent(serverAddress + id)) {
             assertFalse("Node must not have versionable mixin.", originalObjectProperties.contains(ANY,
-                    subject, type.asNode(), createURI(MIX_NAMESPACE + "versionable")));
+                    subject, HAS_VERSION_HISTORY.asNode(), ANY));
         }
         postObjectVersion(id, "label");
         try (final CloseableGraphStore updatedObjectProperties = getContent(serverAddress + id)) {
             assertTrue("Node is expected to contain hasVersions triple.", updatedObjectProperties.contains(ANY,
                     subject, HAS_VERSION_HISTORY.asNode(), ANY));
+            assertFalse("Node must not have versionable mixin.", updatedObjectProperties.contains(ANY,
+                    subject, type.asNode(), createURI(MIX_NAMESPACE + "versionable")));
         }
     }
 
@@ -453,9 +455,11 @@ public class FedoraVersionsIT extends AbstractResourceIT {
         // datastream should not be versionable
         try (final CloseableGraphStore originalObjectProperties =
                 getContent(serverAddress + pid + "/" + dsid + "/fcr:metadata")) {
-            assertFalse("Node must not have versionable mixin.",
-                    originalObjectProperties.contains(ANY, createURI(serverAddress + pid + "/" + dsid),
-                            type.asNode(), createURI(MIX_NAMESPACE + "versionable")));
+            final Node subject = createURI(serverAddress + pid + "/" + dsid);
+            assertFalse("Node must not have versionable mixin.", originalObjectProperties.contains(ANY,
+                    subject, type.asNode(), createURI(MIX_NAMESPACE + "versionable")));
+            assertFalse("Node is expected to contain hasVersions triple.", originalObjectProperties.contains(ANY,
+                    subject, HAS_VERSION_HISTORY.asNode(), ANY));
         }
         // creating a version should succeed
         final HttpPost httpPost = new HttpPost(serverAddress + pid + "/" + dsid + "/fcr:versions");
@@ -477,9 +481,8 @@ public class FedoraVersionsIT extends AbstractResourceIT {
         // datastream should then be versionable
         try (final CloseableGraphStore updatedDSProperties =
                 getContent(serverAddress + pid + "/" + dsid + "/fcr:metadata")) {
-            assertTrue("Node must have versionable mixin.", updatedDSProperties.contains(ANY,
-                    createURI(serverAddress + pid + "/" + dsid), type.asNode(),
-                    createURI(MIX_NAMESPACE + "versionable")));
+            assertTrue("Node is expected to contain hasVersions triple.", updatedDSProperties.contains(
+                    ANY, createURI(serverAddress + pid + "/" + dsid), HAS_VERSION_HISTORY.asNode(), ANY));
         }
         // update the content
         final String updatedContent = "This is the updated content";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
@@ -458,7 +458,7 @@ public class FedoraVersionsIT extends AbstractResourceIT {
             final Node subject = createURI(serverAddress + pid + "/" + dsid);
             assertFalse("Node must not have versionable mixin.", originalObjectProperties.contains(ANY,
                     subject, type.asNode(), createURI(MIX_NAMESPACE + "versionable")));
-            assertFalse("Node is expected to contain hasVersions triple.", originalObjectProperties.contains(ANY,
+            assertFalse("Node must not contain any hasVersions triples.", originalObjectProperties.contains(ANY,
                     subject, HAS_VERSION_HISTORY.asNode(), ANY));
         }
         // creating a version should succeed

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraJcrConstants.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraJcrConstants.java
@@ -26,6 +26,8 @@ public final class FedoraJcrConstants {
 
     public static final String JCR_LASTMODIFIED = "jcr:lastModified";
 
+    public static final String JCR_LASTMODIFIEDBY = "jcr:lastModifiedBy";
+
     public static final String JCR_CREATED = "jcr:created";
 
     public static final String JCR_CREATEDBY = "jcr:createdBy";

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -41,9 +41,9 @@ import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.node
 import static org.fcrepo.kernel.modeshape.rdf.JcrRdfTools.getRDFNamespaceForJcrNamespace;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.isFrozen;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.property2values;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.hasInternalNamespace;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isFrozenNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isInternalNode;
-import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isInternalType;
 import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.getNamespaceRegistry;
 import static org.fcrepo.kernel.modeshape.utils.StreamUtils.iteratorToStream;
 import static org.fcrepo.kernel.modeshape.utils.UncheckedFunction.uncheck;
@@ -451,10 +451,10 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
                 .forEach(nodeTypes::add);
 
             final List<URI> types = nodeTypes.stream()
-                .filter(isInternalType.negate())
                 .map(uncheck(NodeType::getName))
+                .filter(hasInternalNamespace.negate())
                 .distinct()
-                .map(nodeTypeNameToURI::apply)
+                .map(nodeTypeNameToURI)
                 .peek(x -> LOGGER.debug("node has rdf:type {}", x))
                 .collect(Collectors.toList());
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/TypeRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/TypeRdfContext.java
@@ -16,15 +16,10 @@
 package org.fcrepo.kernel.modeshape.rdf.impl;
 
 import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.graph.Triple;
 
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.models.NonRdfSource;
 import org.slf4j.Logger;
-
-import java.util.stream.Stream;
-import java.util.stream.Stream.Builder;
 
 import javax.jcr.RepositoryException;
 
@@ -32,7 +27,6 @@ import static com.hp.hpl.jena.graph.NodeFactory.createURI;
 import static com.hp.hpl.jena.graph.Triple.create;
 import static com.hp.hpl.jena.vocabulary.RDF.type;
 
-import static org.fcrepo.kernel.api.RdfLexicon.MIX_NAMESPACE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -55,15 +49,6 @@ public class TypeRdfContext extends NodeRdfContext {
             throws RepositoryException {
         super(resource, idTranslator);
 
-        final Stream.Builder<Triple> other = Stream.builder();
-        if (resource instanceof NonRdfSource) {
-            // gather versionability info from the parent
-            if (resource.getNode().getParent().isNodeType("mix:versionable")) {
-                other.accept(create(subject(), type.asNode(), createURI(MIX_NAMESPACE + "versionable")));
-            }
-        }
-        concat(Stream.concat(
-                resource.getTypes().stream().map(uri -> create(subject(), type.asNode(), createURI(uri.toString()))),
-                other.build()));
+        concat(resource.getTypes().stream().map(uri -> create(subject(), type.asNode(), createURI(uri.toString()))));
     }
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -168,13 +168,14 @@ public class FedoraResourceImplIT extends AbstractIT {
 
     @Test
     public void testRandomNodeGraph() {
-        final FedoraResource object =
-            containerService.findOrCreate(session, "/testNodeGraph");
-
+        final FedoraResource object = containerService.findOrCreate(session, "/testNodeGraph");
         final Node s = subjects.reverse().convert(object).asNode();
-        final Node p = HAS_PRIMARY_TYPE.asNode();
-        final Node o = createLiteral("nt:folder");
-        assertFalse(object.getTriples(subjects, PROPERTIES).collect(toModel()).getGraph().contains(s, p, o));
+        final Model rdf = object.getTriples(subjects, PROPERTIES).collect(toModel());
+
+        assertFalse(rdf.getGraph().contains(s, HAS_PRIMARY_IDENTIFIER.asNode(), ANY));
+        assertFalse(rdf.getGraph().contains(s, HAS_PRIMARY_TYPE.asNode(), ANY));
+        assertFalse(rdf.getGraph().contains(s, HAS_NODE_TYPE.asNode(), ANY));
+        assertFalse(rdf.getGraph().contains(s, HAS_MIXIN_TYPE.asNode(), ANY));
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraResourceImplTest.java
@@ -195,11 +195,11 @@ public class FedoraResourceImplTest {
                 mockNodeTypePrefix + ":" + mockMixinSuperNodeTypeName);
 
         final List<URI> types = testObj.getTypes();
-        assertTrue(types.contains(URI.create(REPOSITORY_NAMESPACE + mockPrimaryNodeTypeName)));
-        assertTrue(types.contains(URI.create(REPOSITORY_NAMESPACE + mockMixinNodeTypeName)));
-        assertTrue(types.contains(URI.create(REPOSITORY_NAMESPACE + mockPrimarySuperNodeTypeName)));
-        assertTrue(types.contains(URI.create(REPOSITORY_NAMESPACE + mockMixinSuperNodeTypeName)));
-        assertEquals(4, types.size());
+        assertFalse(types.contains(URI.create(REPOSITORY_NAMESPACE + mockPrimaryNodeTypeName)));
+        assertFalse(types.contains(URI.create(REPOSITORY_NAMESPACE + mockMixinNodeTypeName)));
+        assertFalse(types.contains(URI.create(REPOSITORY_NAMESPACE + mockPrimarySuperNodeTypeName)));
+        assertFalse(types.contains(URI.create(REPOSITORY_NAMESPACE + mockMixinSuperNodeTypeName)));
+        assertEquals(0, types.size());
     }
 
     @Test


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-1935

Confines all internal modeshape/jcr types and properties to the fcrepo-kernel-modeshape module.

Previously, these values were escaping to the fcrepo-http-api layer and then filtered out (because of how template rendering worked).