### PR TITLE
move JCR-based eventing interfaces into the modeshape impl

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/DefaultFilter.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/DefaultFilter.java
@@ -29,7 +29,6 @@ import javax.jcr.nodetype.NodeType;
 import javax.jcr.observation.Event;
 
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.observer.EventFilter;
 
 import org.slf4j.Logger;
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/EventFilter.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/EventFilter.java
@@ -13,20 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.observer.eventmappings;
+package org.fcrepo.kernel.modeshape.observer;
 
-import java.util.Iterator;
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import javax.jcr.observation.Event;
 
-import org.fcrepo.kernel.api.observer.FedoraEvent;
-
 /**
- * Maps {@link Iterator}s of {@link Event}s to {@link Iterator}s of {@link FedoraEvent}s according to some algorithm
+ * Filter JCR events to remove extraneous events
  *
+ * @author eddies
  * @author ajs6f
- * @since Feb 27, 2014
+ * @since Feb 7, 2013
  */
-public interface InternalExternalEventMapper extends Function<Iterator<Event>, Iterator<FedoraEvent>> {
+public interface EventFilter extends Predicate<Event> {
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/SimpleObserver.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/SimpleObserver.java
@@ -38,9 +38,8 @@ import javax.jcr.observation.Event;
 import javax.jcr.observation.EventListener;
 
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.observer.EventFilter;
 import org.fcrepo.kernel.api.observer.FedoraEvent;
-import org.fcrepo.kernel.api.observer.eventmappings.InternalExternalEventMapper;
+import org.fcrepo.kernel.modeshape.observer.eventmappings.InternalExternalEventMapper;
 
 import org.modeshape.jcr.api.Repository;
 import org.slf4j.Logger;

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/eventmappings/AllNodeEventsOneEvent.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/eventmappings/AllNodeEventsOneEvent.java
@@ -33,7 +33,6 @@ import javax.jcr.observation.Event;
 
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.observer.FedoraEvent;
-import org.fcrepo.kernel.api.observer.eventmappings.InternalExternalEventMapper;
 import org.fcrepo.kernel.modeshape.observer.FedoraEventImpl;
 
 import org.slf4j.Logger;

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/eventmappings/InternalExternalEventMapper.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/eventmappings/InternalExternalEventMapper.java
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.observer;
+package org.fcrepo.kernel.modeshape.observer.eventmappings;
 
-import java.util.function.Predicate;
+import java.util.Iterator;
+import java.util.function.Function;
 
 import javax.jcr.observation.Event;
 
+import org.fcrepo.kernel.api.observer.FedoraEvent;
+
 /**
- * Filter JCR events to remove extraneous events
+ * Maps {@link Iterator}s of {@link Event}s to {@link Iterator}s of {@link FedoraEvent}s according to some algorithm
  *
- * @author eddies
  * @author ajs6f
- * @since Feb 7, 2013
+ * @since Feb 27, 2014
  */
-public interface EventFilter extends Predicate<Event> {
+public interface InternalExternalEventMapper extends Function<Iterator<Event>, Iterator<FedoraEvent>> {
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/eventmappings/OneToOne.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/eventmappings/OneToOne.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import javax.jcr.observation.Event;
 
 import org.fcrepo.kernel.api.observer.FedoraEvent;
-import org.fcrepo.kernel.api.observer.eventmappings.InternalExternalEventMapper;
 import org.fcrepo.kernel.modeshape.observer.FedoraEventImpl;
 
 /**

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/observer/SimpleObserverTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/observer/SimpleObserverTest.java
@@ -31,9 +31,8 @@ import javax.jcr.observation.Event;
 import javax.jcr.observation.EventIterator;
 import javax.jcr.observation.ObservationManager;
 
-import org.fcrepo.kernel.modeshape.observer.eventmappings.OneToOne;
-import org.fcrepo.kernel.api.observer.EventFilter;
 import org.fcrepo.kernel.api.observer.FedoraEvent;
+import org.fcrepo.kernel.modeshape.observer.eventmappings.OneToOne;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-1866

These interfaces rely on JCR types and are therefore relocated to the modeshape implementation.