### PR TITLE
Update link to current fcrepo-java-client documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
             <a href="https://github.com/fcrepo4-exts/fcrepo-java-client" title="GitHub repository"><i class="fa fa-github"></i>GitHub</a></h4>
           <ul>
             <li><a href="http://fcrepo4-exts.github.io/fcrepo-java-client/site/0.1.1/fcrepo-java-client/apidocs/">0.1.1</a></li>
+            <li><a href="http://fcrepo4-exts.github.io/fcrepo-java-client/site/0.1.2/fcrepo-java-client/apidocs/">0.1.2</a></li>
           </ul>
         </section>
       </section>


### PR DESCRIPTION
This adds a link to the new `fcrepo-java-client` documentation.