### PR TITLE
Ignore Bibframe IT test, pending resolution in FCREPO-1979

### DIFF
--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/BibframeIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/BibframeIT.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.integration.rdf;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -23,6 +24,7 @@ import org.junit.Test;
  */
 public class BibframeIT extends AbstractIntegrationRdfIT {
 
+    @Ignore("Test fails when run from non-UTF8 platform (Windows). Character encoding fix pending:  FCREPO-1979")
     @Test
     public void testBibframe() {
         final String bibframe = "@prefix bf: <http://bibframe.org/vocab/> .\n" +


### PR DESCRIPTION
Ignore the Bibframe test until we can come up with a real fix for how requests without UTF8 charset encodings are handled.