### PR TITLE
Only return false after the ajax call is complete.

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/common.js
+++ b/fcrepo-http-api/src/main/resources/views/common.js
@@ -291,17 +291,20 @@ function createVersionSnapshot()
         name = "version." + d.getFullYear().toString() + (d.getMonth()+1).toString() + d.getDate().toString() + d.getHours() + d.getMinutes() + d.getSeconds();
     } 
     var postURI = uri + "/fcr:versions";
-      $.ajax({
-        type: "POST",
-        beforeSend: function (request)
-        {
-          request.setRequestHeader("Slug", name);
-        },
-        url: postURI,
-        success: function() { window.location = postURI }
-      }).fail( ajaxErrorHandler);
-
-    return false;
+    
+    $.ajax({
+      type: "POST",
+      beforeSend: function (request)
+      {
+        request.setRequestHeader("Slug", name);
+      },
+      url: postURI,
+      success: function() { window.location = postURI },
+      error: ajaxErrorHandler,
+      complete: function() {
+        return false;
+      }
+    });
 
 }
 


### PR DESCRIPTION
Resolved [FCREPO-1981](https://jira.duraspace.org/browse/FCREPO-1981)

Tested with Firefox 45.0.1 on OS X 
Should be tested on Linux and Windows.