### PR TITLE
Tie binary description ETags/lastModified dates to the binaries they describe

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
@@ -19,6 +19,8 @@ import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isNonRdfSourceD
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.util.Date;
+
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
@@ -49,6 +51,21 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
     @Override
     public NonRdfSource getDescribedResource() {
         return new FedoraBinaryImpl(getContentNode());
+    }
+
+    @Override
+    public String getEtagValue() {
+        return getDescribedResource().getEtagValue();
+    }
+
+    @Override
+    public Date getCreatedDate() {
+        return getDescribedResource().getCreatedDate();
+    }
+
+    @Override
+    public Date getLastModifiedDate() {
+        return getDescribedResource().getLastModifiedDate();
     }
 
     private Node getContentNode() {

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImplTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 
 /**
  * <p>{@link NonRdfSourceDescriptionImplTest} class.</p>
@@ -66,6 +67,9 @@ public class NonRdfSourceDescriptionImplTest implements FedoraTypes {
     private Node mockDsNode;
 
     @Mock
+    private Node mockContentNode;
+
+    @Mock
     private InputStream mockStream;
 
     @Mock
@@ -83,6 +87,7 @@ public class NonRdfSourceDescriptionImplTest implements FedoraTypes {
             when(mockDsNode.getMixinNodeTypes()).thenReturn(nodeTypes);
             when(mockDsNode.getName()).thenReturn(testDsId);
             when(mockDsNode.getSession()).thenReturn(mockSession);
+            when(mockDsNode.getNode(JCR_CONTENT)).thenReturn(mockContentNode);
             final NodeType mockNodeType = mock(NodeType.class);
             when(mockNodeType.getName()).thenReturn("nt:file");
             when(mockDsNode.getPrimaryNodeType()).thenReturn(mockNodeType);
@@ -112,8 +117,8 @@ public class NonRdfSourceDescriptionImplTest implements FedoraTypes {
         cal.setTime(expected);
         final Property mockProp = mock(Property.class);
         when(mockProp.getDate()).thenReturn(cal);
-        when(mockDsNode.hasProperty(JCR_CREATED)).thenReturn(true);
-        when(mockDsNode.getProperty(JCR_CREATED)).thenReturn(mockProp);
+        when(mockContentNode.hasProperty(JCR_CREATED)).thenReturn(true);
+        when(mockContentNode.getProperty(JCR_CREATED)).thenReturn(mockProp);
         final Date actual = testObj.getCreatedDate();
         assertEquals(expected.getTime(), actual.getTime());
     }
@@ -125,8 +130,8 @@ public class NonRdfSourceDescriptionImplTest implements FedoraTypes {
         cal.setTime(expected);
         final Property mockProp = mock(Property.class);
         when(mockProp.getDate()).thenReturn(cal);
-        when(mockDsNode.hasProperty(JCR_LASTMODIFIED)).thenReturn(true);
-        when(mockDsNode.getProperty(JCR_LASTMODIFIED)).thenReturn(mockProp);
+        when(mockContentNode.hasProperty(JCR_LASTMODIFIED)).thenReturn(true);
+        when(mockContentNode.getProperty(JCR_LASTMODIFIED)).thenReturn(mockProp);
         final Date actual = testObj.getLastModifiedDate();
         assertEquals(expected.getTime(), actual.getTime());
     }


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-1983

The current behavior advertises ETags/lastModified dates as if they are the same for binaries and binary descriptions. This PR makes this the _behavior_ of Fedora by relying on the same lastModified property for both binaries and their descriptions.

If, on the other hand, binaries and their descriptions are to contain _different_ ETag and lastModified dates, then a different implementation should be pursued. At the very least, though, this fixes the currently broken behavior.

With this impl, the ETag value for both a binary and binary description will be the same. Likewise, the last-modified date will be the same. The NonRdfSourceDescription simply proxies those calls to the FedoraBinary. If a property of the binary description is changed, then the ETag and last-modified date will change for both. If it is problematic to reuse the ETag value for both resources, there is an easy way around that.