### PR TITLE
Fix ETag handling for Binaries and Binary descriptions

### DIFF
--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -81,6 +81,7 @@
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-connector-file</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -497,13 +497,16 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         // must change.
         if (resource instanceof NonRdfSourceDescription) {
             final NonRdfSourceDescription description = (NonRdfSourceDescription)resource;
+            // Use a weak ETag for the LDP-RS
             etag = new EntityTag(description.getDescribedResource().getEtagValue(), true);
             date = description.getDescribedResource().getLastModifiedDate();
         } else if (resource instanceof NonRdfSource) {
             final NonRdfSource binary = (NonRdfSource)resource;
+            // Use a strong ETag for the LDP-NR
             etag = new EntityTag(binary.getDescription().getEtagValue());
             date = binary.getDescription().getLastModifiedDate();
         } else {
+            // Use a weak ETag for the LDP-RS
             etag = new EntityTag(resource.getEtagValue(), true);
             date = resource.getLastModifiedDate();
         }
@@ -553,13 +556,16 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         // ContentExposingResource::addCacheControlHeaders function
         if (resource instanceof NonRdfSourceDescription) {
             final NonRdfSourceDescription description = (NonRdfSourceDescription)resource;
+            // Use a weak ETag for the LDP-RS
             etag = new EntityTag(description.getDescribedResource().getEtagValue(), true);
             date = description.getDescribedResource().getLastModifiedDate();
         } else if (resource instanceof NonRdfSource) {
             final NonRdfSource binary = (NonRdfSource)resource;
+            // Use a strong ETag for the LDP-NR
             etag = new EntityTag(binary.getDescription().getEtagValue());
             date = binary.getDescription().getLastModifiedDate();
         } else {
+            // Use a weak ETag for the LDP-RS
             etag = new EntityTag(resource.getEtagValue(), true);
             date = resource.getLastModifiedDate();
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -479,6 +479,22 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         final EntityTag etag;
         final Date date;
 
+        // The HTTP headers for ETags and Last-Modified dates are swapped for fedora:Binary
+        // resources and their descriptions. This may seem twisted.
+        //
+        // Here we are drawing a distinction between the HTTP resoruce and the LDP resource.
+        // As an HTTP resource, the last-modified header should reflect when the resource
+        // at the given URL was last changed. With fedora:Binary resources and their descriptions,
+        // this gets a little complicated, for the descriptions have, as their subjects, the
+        // binary itself. And the `fedora:lastModified` property produced by that NonRdfSourceDescription
+        // refers to the last-modified date of the binary -- not the last-modified date of the
+        // NonRdfSourceDescription. While that works for LDP, that falls on its face for HTTP.
+        //
+        // The reason being that a change to the NonRdfSourceDescription (e.g. adding or removing
+        // a property) does not change the fedora:lastModified date of the binary, yet, the
+        // representation of the triples in that NonRdfSourceDescription _did_ change. So, while
+        // the triple for fedora:lastModified will not change, the HTTP header for last-modified
+        // must change.
         if (resource instanceof NonRdfSourceDescription) {
             final NonRdfSourceDescription description = (NonRdfSourceDescription)resource;
             etag = new EntityTag(description.getDescribedResource().getEtagValue(), true);
@@ -533,6 +549,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         final Date date;
         final Date roundedDate = new Date();
 
+        // See the related note about the next block of code in the
+        // ContentExposingResource::addCacheControlHeaders function
         if (resource instanceof NonRdfSourceDescription) {
             final NonRdfSourceDescription description = (NonRdfSourceDescription)resource;
             etag = new EntityTag(description.getDescribedResource().getEtagValue(), true);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -358,7 +358,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 builder = ok(content);
             }
 
-
             // we set the content-type explicitly to avoid content-negotiation from getting in the way
             return builder.type(binary.getMimeType())
                     .cacheControl(cc)
@@ -477,10 +476,21 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             return;
         }
 
-        final FedoraResource mutableResource = resource instanceof NonRdfSourceDescription
-                ? ((NonRdfSourceDescription) resource).getDescribedResource() : resource;
-        final EntityTag etag = new EntityTag(mutableResource.getEtagValue());
-        final Date date = mutableResource.getLastModifiedDate();
+        final EntityTag etag;
+        final Date date;
+
+        if (resource instanceof NonRdfSourceDescription) {
+            final NonRdfSourceDescription description = (NonRdfSourceDescription)resource;
+            etag = new EntityTag(description.getDescribedResource().getEtagValue(), true);
+            date = description.getDescribedResource().getLastModifiedDate();
+        } else if (resource instanceof NonRdfSource) {
+            final NonRdfSource binary = (NonRdfSource)resource;
+            etag = new EntityTag(binary.getDescription().getEtagValue());
+            date = binary.getDescription().getLastModifiedDate();
+        } else {
+            etag = new EntityTag(resource.getEtagValue(), true);
+            date = resource.getLastModifiedDate();
+        }
 
         if (!etag.getValue().isEmpty()) {
             servletResponse.addHeader("ETag", etag.toString());
@@ -519,9 +529,22 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             return;
         }
 
-        final EntityTag etag = new EntityTag(resource.getEtagValue());
-        final Date date = resource.getLastModifiedDate();
+        final EntityTag etag;
+        final Date date;
         final Date roundedDate = new Date();
+
+        if (resource instanceof NonRdfSourceDescription) {
+            final NonRdfSourceDescription description = (NonRdfSourceDescription)resource;
+            etag = new EntityTag(description.getDescribedResource().getEtagValue(), true);
+            date = description.getDescribedResource().getLastModifiedDate();
+        } else if (resource instanceof NonRdfSource) {
+            final NonRdfSource binary = (NonRdfSource)resource;
+            etag = new EntityTag(binary.getDescription().getEtagValue());
+            date = binary.getDescription().getLastModifiedDate();
+        } else {
+            etag = new EntityTag(resource.getEtagValue(), true);
+            date = resource.getLastModifiedDate();
+        }
 
         if (date != null) {
             roundedDate.setTime(date.getTime() - date.getTime() % 1000);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -17,6 +17,7 @@ package org.fcrepo.http.api;
 
 
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_XHTML_XML;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
@@ -32,7 +33,6 @@ import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.notAcceptable;
 import static javax.ws.rs.core.Response.ok;
-
 import static javax.ws.rs.core.Variant.mediaTypes;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
@@ -420,7 +420,7 @@ public class FedoraLdp extends ContentExposingResource {
         }
 
         try {
-            final String requestBody = IOUtils.toString(requestBodyStream);
+            final String requestBody = IOUtils.toString(requestBodyStream, UTF_8);
             if (isBlank(requestBody)) {
                 throw new BadRequestException("SPARQL-UPDATE requests must have content!");
             }
@@ -557,7 +557,7 @@ public class FedoraLdp extends ContentExposingResource {
 
                 } else if (contentTypeString.equals(contentTypeSPARQLUpdate)) {
                     LOGGER.trace("Found SPARQL-Update content, applying..");
-                    patchResourcewithSparql(resource, IOUtils.toString(requestBodyStream), resourceTriples);
+                    patchResourcewithSparql(resource, IOUtils.toString(requestBodyStream, UTF_8), resourceTriples);
                 } else {
                     if (requestBodyStream.read() != -1) {
                         throw new ClientErrorException("Invalid Content Type " + contentTypeString,

--- a/fcrepo-http-api/src/main/resources/views/common.js
+++ b/fcrepo-http-api/src/main/resources/views/common.js
@@ -147,7 +147,7 @@ function checkIfNonRdfResource(e) {
 
     var url = this.href;
 
-    $.ajax({type: "HEAD", url: url}).success(function(data, status, xhr) {
+    $.ajax({type: "HEAD", url: url, success: function(data, status, xhr) {
         if (status != "success" || xhr.getResponseHeader("Link") == null) {
             location.href = url;
             return;
@@ -169,7 +169,7 @@ function checkIfNonRdfResource(e) {
         }
 
         location.href = url;
-    });
+    }, error: ajaxErrorHandler});
     e.preventDefault();
     return false;
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -61,7 +61,6 @@ import java.text.ParseException;
 import java.util.EnumSet;
 import java.util.List;
 
-import javax.jcr.AccessDeniedException;
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -693,7 +692,7 @@ public class FedoraLdpTest {
     }
 
     @Test(expected = BadRequestException.class)
-    public void testPatchWithoutContent() throws MalformedRdfException, AccessDeniedException, IOException {
+    public void testPatchWithoutContent() throws MalformedRdfException, IOException {
         testObj.updateSparql(null);
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2092,7 +2092,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
         httpPut.addHeader("If-Match", etag);
 
         try (final CloseableHttpResponse response = execute(httpPut)) {
-            assertEquals("Should be a 409 Conflict!", CONFLICT.getStatusCode(), getStatus(response));
+            assertEquals("Should be a 412 Precondition Failed!", PRECONDITION_FAILED.getStatusCode(),
+                    getStatus(response));
         }
 
         // PUT improperly formatted etag ... not quoted.

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -706,6 +706,98 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testBinaryEtags() throws IOException, InterruptedException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String location = serverAddress + id + "/binary";
+        final HttpPut method = new HttpPut(location);
+        method.setEntity(new StringEntity("foo"));
+
+        final String binaryEtag1, binaryEtag2, binaryEtag3, descEtag1, descEtag2, descEtag3;
+        final String binaryLastModed1, binaryLastModed2, binaryLastModed3;
+        final String descLastModed1, descLastModed2, descLastModed3;
+        final String descLocation;
+
+        try (final CloseableHttpResponse response = execute(method)) {
+            binaryEtag1 = response.getFirstHeader("ETag").getValue();
+            binaryLastModed1 = response.getFirstHeader("Last-Modified").getValue();
+            descLocation = Link.valueOf(response.getFirstHeader("Link").getValue()).getUri().toString();
+        }
+
+        // First check ETags and Last-Modified headers for the binary
+        final HttpGet get1 = new HttpGet(location);
+        get1.addHeader("If-None-Match", binaryEtag1);
+        assertEquals("Expected 304 Not Modified", NOT_MODIFIED.getStatusCode(), getStatus(get1));
+
+        final HttpGet get2 = new HttpGet(location);
+        get2.addHeader("If-Modified-Since", binaryLastModed1);
+        assertEquals("Expected 304 Not Modified", NOT_MODIFIED.getStatusCode(), getStatus(get2));
+
+        // Next, check ETags and Last-Modified headers on the description
+        final HttpGet get3 = new HttpGet(descLocation);
+        try (final CloseableHttpResponse response = execute(get3)) {
+            descEtag1 = response.getFirstHeader("ETag").getValue();
+            descLastModed1 = response.getFirstHeader("Last-Modified").getValue();
+        }
+
+        assertNotEquals("Binary, description ETags should be different", binaryEtag1, descEtag1);
+
+        final HttpGet get4 = new HttpGet(descLocation);
+        get4.addHeader("If-None-Match", descEtag1);
+        assertEquals("Expected 304 Not Modified", NOT_MODIFIED.getStatusCode(), getStatus(get4));
+
+        final HttpGet get5 = new HttpGet(descLocation);
+        get5.addHeader("If-Modified-Since", descLastModed1);
+        assertEquals("Expected 304 Not Modified", NOT_MODIFIED.getStatusCode(), getStatus(get5));
+
+        // Pause two seconds before updating the description
+        sleep(2000);
+
+        // Next, update the description
+        final HttpPatch httpPatch = patchObjMethod(id + "/binary/fcr:metadata");
+        httpPatch.addHeader("Content-Type", "application/sparql-update");
+        httpPatch.setEntity(new StringEntity(
+                "INSERT { <> <http://purl.org/dc/elements/1.1/title> 'this is a title' } WHERE {}"));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpPatch));
+
+        // Next, check headers for the binary; they should not have changed
+        final HttpHead head1 = new HttpHead(location);
+        try (final CloseableHttpResponse response = execute(head1)) {
+            binaryEtag2 = response.getFirstHeader("ETag").getValue();
+            binaryLastModed2 = response.getFirstHeader("Last-Modified").getValue();
+        }
+
+        assertEquals("ETags should be the same", binaryEtag1, binaryEtag2);
+        assertEquals("Last-Modified should be the same", binaryLastModed1, binaryLastModed2);
+
+        final HttpGet get6 = new HttpGet(location);
+        get6.addHeader("If-None-Match", binaryEtag1.toString());
+        assertEquals("Expected 304 Not Modified", NOT_MODIFIED.getStatusCode(), getStatus(get6));
+
+        final HttpGet get7 = new HttpGet(location);
+        get7.addHeader("If-Modified-Since", binaryLastModed2);
+        assertEquals("Expected 304 Not Modified", NOT_MODIFIED.getStatusCode(), getStatus(get7));
+
+        // Next, check headers for the description; they should have changed
+        final HttpHead head2 = new HttpHead(descLocation);
+        try (final CloseableHttpResponse response = execute(head2)) {
+            descEtag2 = response.getFirstHeader("ETag").getValue();
+            descLastModed2 = response.getFirstHeader("Last-Modified").getValue();
+        }
+
+        assertNotEquals("ETags should not be the same", descEtag1, descEtag2);
+        assertNotEquals("Last-Modified should not be the same", descLastModed1, descLastModed2);
+
+        final HttpGet get8 = new HttpGet(descLocation);
+        get8.addHeader("If-None-Match", descEtag2);
+        assertEquals("Expected 304 Not Modified", NOT_MODIFIED.getStatusCode(), getStatus(get8));
+
+        final HttpGet get9 = new HttpGet(descLocation);
+        get9.addHeader("If-Modified-Since", descLastModed2);
+        assertEquals("Expected 304 Not Modified", NOT_MODIFIED.getStatusCode(), getStatus(get9));
+    }
+
+    @Test
     public void testPutDatastreamContentOnObject() throws IOException {
         final String content = "foo";
         final String id = getRandomUniqueId();

--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/WebAccessControlIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/WebAccessControlIT.java
@@ -17,14 +17,12 @@ package org.fcrepo.integration.rdf;
 
 import org.junit.Test;
 
-import java.io.IOException;
-
 /**
  * @author cabeer
  */
 public class WebAccessControlIT extends AbstractIntegrationRdfIT {
     @Test
-    public void testExample() throws IOException {
+    public void testExample() {
         final String pid = getRandomUniqueId();
         final String card = createObject(pid + "-card").getFirstHeader("Location").getValue();
         final String s = "@prefix acl: <http://www.w3.org/ns/auth/acl#> . \n" +

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/TombstoneImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/TombstoneImpl.java
@@ -21,6 +21,8 @@ import javax.jcr.RepositoryException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.Tombstone;
 
+import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATED;
+
 /**
  * @author cabeer
  * @since 10/16/14
@@ -55,6 +57,20 @@ public class TombstoneImpl extends FedoraResourceImpl implements Tombstone {
         try {
             node.remove();
         } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        try {
+            String txt = node.getPath();
+            if (node.hasProperty(JCR_CREATED)) {
+                txt += ", departed: ";
+                txt += node.getProperty(JCR_CREATED).getString();
+            }
+            return txt;
+        } catch (RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }
     }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/ContainerImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/ContainerImplIT.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import javax.inject.Inject;
-import javax.jcr.AccessDeniedException;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -192,7 +191,7 @@ public class ContainerImplIT extends AbstractIT {
     }
 
     @Test
-    public void testUpdatingObjectGraphWithErrors() throws AccessDeniedException {
+    public void testUpdatingObjectGraphWithErrors() {
         final String pid = getRandomPid();
         final Container object = containerService.findOrCreate(session, pid);
 
@@ -235,7 +234,7 @@ public class ContainerImplIT extends AbstractIT {
     }
 
     @Test(expected = MalformedRdfException.class)
-    public void testUpdatingObjectGraphWithOutOfDomainSubjects() throws AccessDeniedException, MalformedRdfException {
+    public void testUpdatingObjectGraphWithOutOfDomainSubjects() throws MalformedRdfException {
         final Container object =
             containerService.findOrCreate(session, "/graphObject");
 

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -462,7 +462,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test(expected = MalformedRdfException.class)
-    public void testAddMissingReference() throws RepositoryException, MalformedRdfException {
+    public void testAddMissingReference() throws MalformedRdfException {
         final FedoraResource object =
                 containerService.findOrCreate(session, "/testRefObject");
 
@@ -501,7 +501,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test (expected = IllegalArgumentException.class)
-    public void testInvalidSparqlUpdateValidation() throws RepositoryException {
+    public void testInvalidSparqlUpdateValidation() {
         final String pid = UUID.randomUUID().toString();
         final FedoraResource object =
                 containerService.findOrCreate(session, pid);
@@ -513,7 +513,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test (expected = InvalidPrefixException.class)
-    public void testInvalidPrefixSparqlUpdateValidation() throws RepositoryException {
+    public void testInvalidPrefixSparqlUpdateValidation() {
         final String pid = UUID.randomUUID().toString();
         final FedoraResource object =
                 containerService.findOrCreate(session, pid);
@@ -530,7 +530,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testValidSparqlUpdateWithLiteralTrailingSlash() throws RepositoryException {
+    public void testValidSparqlUpdateWithLiteralTrailingSlash() {
         final String pid = UUID.randomUUID().toString();
         final FedoraResource object = containerService.findOrCreate(session, pid);
         object.updateProperties(
@@ -541,7 +541,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testValidSparqlUpdateValidationAltSyntax() throws RepositoryException {
+    public void testValidSparqlUpdateValidationAltSyntax() {
         final String pid = UUID.randomUUID().toString();
         final FedoraResource object = containerService.findOrCreate(session, pid);
         object.updateProperties(subjects,
@@ -554,7 +554,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test (expected = IllegalArgumentException.class)
-    public void testInvalidSparqlUpdateValidationAltSyntax() throws RepositoryException {
+    public void testInvalidSparqlUpdateValidationAltSyntax() {
         final String pid = UUID.randomUUID().toString();
         final FedoraResource object = containerService.findOrCreate(session, pid);
         object.updateProperties(subjects,
@@ -567,7 +567,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testValidSparqlUpdateValidation1() throws RepositoryException {
+    public void testValidSparqlUpdateValidation1() {
         final String pid = UUID.randomUUID().toString();
         final FedoraResource object =
                 containerService.findOrCreate(session, pid);
@@ -578,7 +578,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testValidSparqlUpdateValidation2() throws RepositoryException {
+    public void testValidSparqlUpdateValidation2() {
         final String pid = UUID.randomUUID().toString();
         final FedoraResource object =
                 containerService.findOrCreate(session, pid);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/TombstoneImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/TombstoneImplIT.java
@@ -32,6 +32,8 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import static org.fcrepo.kernel.modeshape.TombstoneImpl.hasMixin;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -82,6 +84,17 @@ public class TombstoneImplIT extends AbstractIT {
         } catch (final RepositoryRuntimeException e) {
             //ok
         }
+    }
+
+    @Test
+    public void testTombstoneMessage() {
+        final String pid = getRandomPid();
+        final Container container = containerService.findOrCreate(session, "/" + pid);
+        final TombstoneImpl tombstone = new TombstoneImpl(container.getNode());
+
+        final String msg = tombstone.toString();
+        assertFalse("Msg should not contain 'jcr:': " + msg, msg.contains("jcr:"));
+        assertTrue("Msg should contain id: " + pid + " : " + msg, msg.contains(pid));
     }
 
     @Test (expected = RepositoryRuntimeException.class)

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/TombstoneImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/TombstoneImplTest.java
@@ -19,11 +19,14 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import javax.jcr.Node;
+import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_TOMBSTONE;
+import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATED;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
@@ -76,6 +79,17 @@ public class TombstoneImplTest {
     public void testHasMixinException() throws RepositoryException {
         doThrow(new RepositoryException()).when(mockNode).isNodeType(FEDORA_TOMBSTONE);
         assertTrue(TombstoneImpl.hasMixin(mockNode));
+    }
+
+    @Test
+    public void testToString() throws RepositoryException {
+        when(mockNode.getPath()).thenReturn("/path");
+        when(mockNode.hasProperty(JCR_CREATED)).thenReturn(true);
+        when(mockNode.getProperty(JCR_CREATED)).thenReturn(Mockito.mock(Property.class));
+
+        final String msg = testObj.toString();
+        assertFalse("Msg should not contain 'jcr:': " + msg, msg.contains("jcr:"));
+        assertTrue("Msg should contain '/path': " + msg, msg.contains("/path"));
     }
 
 }

--- a/fcrepo-metrics/src/main/java/org/fcrepo/metrics/RegistryService.java
+++ b/fcrepo-metrics/src/main/java/org/fcrepo/metrics/RegistryService.java
@@ -21,7 +21,7 @@ import com.codahale.metrics.MetricRegistry;
 
 /**
  * Provide helpers for working with the Metrics registry
- * 
+ *
  * @author cbeer
  * @since Mar 22, 2013
  */
@@ -49,10 +49,11 @@ public final class RegistryService {
 
     /**
      * Get the current registry service
-     * 
+     *
      * TODO the new upstream SharedMetricRegistries may make this obsolete
      * @return the current registry service
      */
+    @SuppressWarnings("static-method")
     public MetricRegistry getMetrics() {
         return METRICS;
     }

--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -48,7 +48,7 @@
     <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <doxia-markdown.plugin.version>1.6</doxia-markdown.plugin.version>
     <failsafe.plugin.version>2.18.1</failsafe.plugin.version>
-    <fcrepo-build-tools.version>4.3.0</fcrepo-build-tools.version>
+    <fcrepo-build-tools.version>4.4.1</fcrepo-build-tools.version>
     <github-site.plugin.version>0.12</github-site.plugin.version>
     <gpg.plugin.version>1.6</gpg.plugin.version>
     <install.plugin.version>2.5.2</install.plugin.version>


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-1983
Resolves: https://jira.duraspace.org/browse/FCREPO-1754

This is an alternate resolution of this issue. See #1022 for a different approach.

The advantage of this PR (from my perspective) is that ETag and last-mod values on the fedora:Binary and associated description are decoupled.

Note: this PR also addresses the Strong/Weak ETag issue: Binaries produce strong ETags, everything else produces a weak ETag. So it also supersedes #991  

See: http://irclogs.fcrepo.org/2016-04-18.html for further discussion of this.

Based on discussion, this approach is to be pursued instead of #1022 