### PR TITLE
FCREPO-2025: Switch to a version of Jersey that does not leak memory

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -86,7 +86,7 @@ public class FedoraFixity extends ContentExposingResource {
     @GET
     @Timed
     @HtmlTemplate(value = "fcr:fixity")
-    @Produces({TURTLE + ";qs=10", JSON_LD + ";qs=8",
+    @Produces({TURTLE + ";qs=1.0", JSON_LD + ";qs=0.8",
             N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X,
             TEXT_HTML, APPLICATION_XHTML_XML, "*/*"})
     public RdfNamespacedStream getDatastreamFixity() {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -200,7 +200,7 @@ public class FedoraLdp extends ContentExposingResource {
      * @throws IOException if IO exception occurred
      */
     @GET
-    @Produces({TURTLE + ";qs=10", JSON_LD + ";qs=8",
+    @Produces({TURTLE + ";qs=1.0", JSON_LD + ";qs=0.8",
             N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X,
             TEXT_HTML, APPLICATION_XHTML_XML})
     public Response getResource(@HeaderParam("Range") final String rangeValue) throws IOException {
@@ -456,9 +456,6 @@ public class FedoraLdp extends ContentExposingResource {
     /**
      * Creates a new object.
      *
-     * application/octet-stream;qs=1001 is a workaround for JERSEY-2636, to ensure
-     * requests without a Content-Type get routed here.
-     *
      * @param checksum the checksum value
      * @param contentDisposition the content Disposition value
      * @param requestContentType the request content type
@@ -482,8 +479,12 @@ public class FedoraLdp extends ContentExposingResource {
     /**
      * Creates a new object.
      *
-     * application/octet-stream;qs=1001 is a workaround for JERSEY-2636, to ensure
-     * requests without a Content-Type get routed here.
+     * This originally used application/octet-stream;qs=1001 as a workaround
+     * for JERSEY-2636, to ensure requests without a Content-Type get routed here.
+     * This qs value does not parse with newer versions of Jersey, as qs values
+     * must be between 0 and 1.  We use qs=1.000 to mark where this historical
+     * anomaly had been.
+     *
      *
      * @param checksumDeprecated the checksum value
      * @param contentDisposition the content Disposition value
@@ -498,9 +499,9 @@ public class FedoraLdp extends ContentExposingResource {
      * @throws MalformedRdfException if malformed rdf exception occurred
      */
     @POST
-    @Consumes({MediaType.APPLICATION_OCTET_STREAM + ";qs=1001", WILDCARD})
+    @Consumes({MediaType.APPLICATION_OCTET_STREAM + ";qs=1.000", WILDCARD})
     @Timed
-    @Produces({TURTLE + ";qs=10", JSON_LD + ";qs=8",
+    @Produces({TURTLE + ";qs=1.0", JSON_LD + ";qs=0.8",
             N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X,
             TEXT_HTML, APPLICATION_XHTML_XML, "*/*"})
     public Response createObject(@QueryParam("checksum") final String checksumDeprecated,

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -166,7 +166,7 @@ public class FedoraVersioning extends FedoraBaseResource {
     @SuppressWarnings("resource")
     @GET
     @HtmlTemplate(value = "fcr:versions")
-    @Produces({TURTLE + ";qs=10", JSON_LD + ";qs=8", N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN,
+    @Produces({TURTLE + ";qs=1.0", JSON_LD + ";qs=0.8", N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN,
             TURTLE_X, TEXT_HTML, APPLICATION_XHTML_XML, "*/*"})
     public RdfNamespacedStream getVersionList() {
         if (!resource().isVersioned()) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
@@ -135,7 +135,7 @@ public class FedoraVersions extends ContentExposingResource {
      */
     @SuppressWarnings("resource")
     @GET
-    @Produces({TURTLE + ";qs=10", JSON_LD + ";qs=8",
+    @Produces({TURTLE + ";qs=1.0", JSON_LD + ";qs=0.8",
             N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X,
             TEXT_HTML, APPLICATION_XHTML_XML, "*/*"})
     public Response getVersion(@HeaderParam("Range") final String rangeValue) throws IOException {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/MultiPrefer.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/MultiPrefer.java
@@ -15,7 +15,6 @@
  */
 package org.fcrepo.http.commons.domain;
 
-import java.text.ParseException;
 import java.util.Set;
 
 import javax.ws.rs.HeaderParam;
@@ -30,17 +29,15 @@ public class MultiPrefer extends SinglePrefer {
 
     /**
      * @param header the header
-     * @throws ParseException if parse exception occurred
      */
-    public MultiPrefer(final String header) throws ParseException {
+    public MultiPrefer(final String header) {
         super(header);
     }
 
     /**
      * @param prefers the prefers
-     * @throws ParseException if parse exception occurred
      */
-    public MultiPrefer(final @HeaderParam("Prefer") Set<SinglePrefer> prefers) throws ParseException {
+    public MultiPrefer(final @HeaderParam("Prefer") Set<SinglePrefer> prefers) {
         super("");
         prefers.forEach(p -> preferTags().addAll(p.preferTags()));
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/PreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/PreferTag.java
@@ -38,11 +38,7 @@ public class PreferTag implements Comparable<PreferTag> {
      * @return the empty PreferTag
      */
     public static PreferTag emptyTag() {
-        try {
-            return new PreferTag((String)null);
-        } catch (final ParseException e) {
-            throw new AssertionError(e);
-        }
+        return new PreferTag((String)null);
     }
 
     /**
@@ -58,30 +54,33 @@ public class PreferTag implements Comparable<PreferTag> {
     /**
      * Parse the prefer tag and parameters out of the header
      * @param reader the reader
-     * @throws ParseException if parse exception occurred
      */
-    public PreferTag(final HttpHeaderReader reader) throws ParseException {
+    public PreferTag(final HttpHeaderReader reader) {
 
         // Skip any white space
         reader.hasNext();
 
         if (reader.hasNext()) {
-            tag = Optional.ofNullable(reader.nextToken())
-                      .map(CharSequence::toString).orElse(null);
+            try {
+                tag = Optional.ofNullable(reader.nextToken())
+                          .map(CharSequence::toString).orElse(null);
 
-            if (reader.hasNextSeparator('=', true)) {
-                reader.next();
+                if (reader.hasNextSeparator('=', true)) {
+                    reader.next();
 
-                value = Optional.ofNullable(reader.nextTokenOrQuotedString())
-                            .map(CharSequence::toString)
-                            .orElse(null);
-            }
-
-            if (reader.hasNext()) {
-                params = HttpHeaderReader.readParameters(reader);
-                if ( params == null ) {
-                    params = new HashMap<>();
+                    value = Optional.ofNullable(reader.nextTokenOrQuotedString())
+                            .    map(CharSequence::toString)
+                                .orElse(null);
                 }
+
+                if (reader.hasNext()) {
+                    params = HttpHeaderReader.readParameters(reader);
+                    if ( params == null ) {
+                        params = new HashMap<>();
+                    }
+                }
+            } catch (ParseException e) {
+                throw new IllegalArgumentException("Could not parse 'Prefer' header", e);
             }
         } else {
             tag = "";
@@ -91,9 +90,8 @@ public class PreferTag implements Comparable<PreferTag> {
     /**
      * Create a blank prefer tag
      * @param inputTag the input tag
-     * @throws ParseException if parse exception occurred
      */
-    public PreferTag(final String inputTag) throws ParseException {
+    public PreferTag(final String inputTag) {
         this(HttpHeaderReader.newInstance(inputTag));
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/PreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/PreferTag.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Parse a single prefer tag, value and any optional parameters
@@ -65,12 +66,15 @@ public class PreferTag implements Comparable<PreferTag> {
         reader.hasNext();
 
         if (reader.hasNext()) {
-            tag = reader.nextToken();
+            tag = Optional.ofNullable(reader.nextToken())
+                      .map(CharSequence::toString).orElse(null);
 
             if (reader.hasNextSeparator('=', true)) {
                 reader.next();
 
-                value = reader.nextTokenOrQuotedString();
+                value = Optional.ofNullable(reader.nextTokenOrQuotedString())
+                            .map(CharSequence::toString)
+                            .orElse(null);
             }
 
             if (reader.hasNext()) {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/SinglePrefer.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/SinglePrefer.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toSet;
 import static org.fcrepo.http.commons.domain.PreferTag.emptyTag;
 
-import java.text.ParseException;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -38,16 +37,11 @@ public class SinglePrefer {
      * Parse a Prefer: header
      *
      * @param header the header
-     * @throws ParseException if parse exception occurred
      */
-    public SinglePrefer(final String header) throws ParseException {
-        preferTags.addAll(stream(header.split(",")).map(h -> {
-            try {
-                return new PreferTag(h);
-            } catch (final ParseException e) {
-                throw new IllegalArgumentException("Could not parse 'Prefer' header", e);
-            }
-        }).collect(toSet()));
+    public SinglePrefer(final String header) {
+        preferTags.addAll(stream(header.split(","))
+                .map(PreferTag::new)
+                .collect(toSet()));
     }
 
     /**

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/SinglePrefer.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/SinglePrefer.java
@@ -15,13 +15,13 @@
  */
 package org.fcrepo.http.commons.domain;
 
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toSet;
 import static org.fcrepo.http.commons.domain.PreferTag.emptyTag;
 
 import java.text.ParseException;
-import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 /**
  * JAX-RS HTTP parameter parser for the Prefer header
@@ -41,13 +41,13 @@ public class SinglePrefer {
      * @throws ParseException if parse exception occurred
      */
     public SinglePrefer(final String header) throws ParseException {
-        preferTags.addAll(Arrays.asList(header.split(",")).stream().map(h -> {
+        preferTags.addAll(stream(header.split(",")).map(h -> {
             try {
                 return new PreferTag(h);
-            } catch (ParseException e) {
+            } catch (final ParseException e) {
                 throw new IllegalArgumentException("Could not parse 'Prefer' header", e);
             }
-        }).collect(Collectors.toSet()));
+        }).collect(toSet()));
     }
 
     /**

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/SinglePrefer.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/SinglePrefer.java
@@ -18,10 +18,10 @@ package org.fcrepo.http.commons.domain;
 import static org.fcrepo.http.commons.domain.PreferTag.emptyTag;
 
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
-
-import org.glassfish.jersey.message.internal.HttpHeaderReader;
+import java.util.stream.Collectors;
 
 /**
  * JAX-RS HTTP parameter parser for the Prefer header
@@ -41,7 +41,13 @@ public class SinglePrefer {
      * @throws ParseException if parse exception occurred
      */
     public SinglePrefer(final String header) throws ParseException {
-        preferTags.addAll(HttpHeaderReader.readList(PreferTag::new, header));
+        preferTags.addAll(Arrays.asList(header.split(",")).stream().map(h -> {
+            try {
+                return new PreferTag(h);
+            } catch (ParseException e) {
+                throw new IllegalArgumentException("Could not parse 'Prefer' header", e);
+            }
+        }).collect(Collectors.toSet()));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <jboss-logging.version>3.1.3.GA</jboss-logging.version>
     <jcr.version>2.0</jcr.version>
     <jena.version>2.13.0</jena.version>
-    <jersey.version>2.13</jersey.version>
+    <jersey.version>2.8</jersey.version>
     <jgroups.version>3.6.2.Final</jgroups.version>
     <jsonld.version>0.5.1</jsonld.version>
     <logback.version>1.1.2</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <jboss-logging.version>3.1.3.GA</jboss-logging.version>
     <jcr.version>2.0</jcr.version>
     <jena.version>2.13.0</jena.version>
-    <jersey.version>2.8</jersey.version>
+    <jersey.version>2.22.2</jersey.version>
     <jgroups.version>3.6.2.Final</jgroups.version>
     <jsonld.version>0.5.1</jsonld.version>
     <logback.version>1.1.2</logback.version>


### PR DESCRIPTION
2.8 does not have the memory leak reported in
https://java.net/jira/browse/HK2-216

A possible fix was applied in Jersey 2.17, but this and newer
Jersey versions aren't drop-in compatible with 2.13/2.8.