### PR TITLE
Remove more modeshape dependencies from the HTTP layers

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -48,7 +48,6 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RequiredRdfContext.MINIMAL;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
-import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.getNamespaces;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -182,7 +181,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                     outputStream = new RdfNamespacedStream(
                             new DefaultRdfStream(rdfStream.topic(), concat(rdfStream,
                                     DefaultRdfStream.fromModel(rdfStream.topic(), inputModel))),
-                            getNamespaces(session()));
+                            namespaceService.getNamespaces(session()));
                 }
 
 
@@ -206,7 +205,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             outputStream = new RdfNamespacedStream(
                     new DefaultRdfStream(rdfStream.topic(), concat(rdfStream,
                         getResourceTriples(limit))),
-                    getNamespaces(session()));
+                    namespaceService.getNamespaces(session()));
             if (prefer != null) {
                 prefer.getReturn().addResponseHeaders(servletResponse);
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -26,7 +26,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
 import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
-import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.getNamespaces;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.ws.rs.GET;
@@ -99,7 +98,7 @@ public class FedoraFixity extends ContentExposingResource {
         return new RdfNamespacedStream(
                 new DefaultRdfStream(asNode(resource()),
                     ((FedoraBinary)resource()).getFixity(translator())),
-                getNamespaces(session()));
+                namespaceService.getNamespaces(session()));
     }
 
     @Override

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -49,7 +49,6 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_PAIRTREE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.modeshape.services.TransactionServiceImpl.getCurrentTransactionId;
-import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.getNamespaces;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -617,7 +616,8 @@ public class FedoraLdp extends ContentExposingResource {
                 prefer.getReturn().addResponseHeaders(servletResponse);
             }
             final RdfNamespacedStream rdfStream = new RdfNamespacedStream(
-                new DefaultRdfStream(asNode(resource()), getResourceTriples()), getNamespaces(session()));
+                new DefaultRdfStream(asNode(resource()), getResourceTriples()),
+                    namespaceService.getNamespaces(session()));
             return builder.entity(rdfStream).build();
         }
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -33,7 +33,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.nodeToResource;
-import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.getNamespaces;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
@@ -176,7 +175,7 @@ public class FedoraVersioning extends FedoraBaseResource {
         return new RdfNamespacedStream(new DefaultRdfStream(
                 asNode(resource()),
                 resource().getTriples(translator(), VERSIONS)),
-                getNamespaces(session()));
+                namespaceService.getNamespaces(session()));
     }
 
     protected FedoraResource resource() {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -18,6 +18,7 @@ package org.fcrepo.http.api;
 import static com.google.common.base.Predicates.containsPattern;
 import static com.hp.hpl.jena.graph.NodeFactory.createURI;
 import static java.util.stream.Stream.of;
+import static java.util.Collections.emptyMap;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
@@ -93,6 +94,7 @@ import org.fcrepo.kernel.api.TripleCategory;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.ContainerService;
+import org.fcrepo.kernel.api.services.NamespaceService;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.junit.Before;
 import org.junit.Test;
@@ -155,6 +157,9 @@ public class FedoraLdpTest {
     private BinaryService mockBinaryService;
 
     @Mock
+    private NamespaceService mockNamespaceService;
+
+    @Mock
     private FedoraHttpConfiguration mockHttpConfiguration;
 
     @Mock
@@ -190,10 +195,12 @@ public class FedoraLdpTest {
         setField(testObj, "containerService", mockContainerService);
         setField(testObj, "binaryService", mockBinaryService);
         setField(testObj, "httpConfiguration", mockHttpConfiguration);
+        setField(testObj, "namespaceService", mockNamespaceService);
 
         when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
         when(mockWorkspace.getNamespaceRegistry()).thenReturn(mockNamespaceRegistry);
         when(mockNamespaceRegistry.getPrefixes()).thenReturn(new String[]{});
+        when(mockNamespaceService.getNamespaces(any(Session.class))).thenReturn(emptyMap());
 
         when(mockHttpConfiguration.putRequiresIfMatch()).thenReturn(false);
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
@@ -28,6 +28,7 @@ import org.fcrepo.http.commons.session.SessionFactory;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.services.BinaryService;
+import org.fcrepo.kernel.api.services.NamespaceService;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.api.services.ContainerService;
 import org.fcrepo.kernel.api.services.VersionService;
@@ -83,6 +84,12 @@ public class AbstractResource {
      */
     @Inject
     protected VersionService versionService;
+
+    /**
+     * The namespace service
+     */
+    @Inject
+    protected NamespaceService namespaceService;
 
     @Inject
     @Optional

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -26,7 +26,6 @@ import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.node
 import static org.fcrepo.kernel.modeshape.services.TransactionServiceImpl.getCurrentTransactionId;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getClosestExistingAncestor;
 import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.validatePath;
-import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.web.context.ContextLoader.getCurrentWebApplicationContext;
 
@@ -369,16 +368,13 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
      * @return
      */
     private String doBackwardPathOnly(final FedoraResource resource) {
-        String path = reverse.convert(getPath(resource));
+        final String path = reverse.convert(getPath(resource));
         if (path != null) {
 
             if (resource instanceof NonRdfSourceDescription) {
-                path = path + "/" + FCR_METADATA;
+                return path + "/" + FCR_METADATA;
             }
 
-            if (path.endsWith(JCR_CONTENT)) {
-                path = replaceOnce(path, "/" + JCR_CONTENT, EMPTY);
-            }
             return path;
         }
         throw new RepositoryRuntimeException("Unable to process reverse chain for resource " + resource);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/NamespaceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/NamespaceService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import java.util.Map;
+
+import javax.jcr.Session;
+
+/**
+ * @author acoburn
+ * @since 5/20/2016
+ */
+public interface NamespaceService {
+    /**
+     * Retrieve a namespace map using a session.
+     *
+     * @param session the session
+     * @return a namespace mapping (prefix to URI)
+     */
+    Map<String, String> getNamespaces(final Session session);
+}

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/NamespaceServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/NamespaceServiceImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.modeshape.services;
+
+import java.util.Map;
+
+import javax.jcr.Session;
+
+import org.fcrepo.kernel.api.services.NamespaceService;
+import org.fcrepo.kernel.modeshape.utils.NamespaceTools;
+import org.springframework.stereotype.Component;
+
+/**
+ * This implements a Namespace service that can be injected
+ * into other layers of Fedora. It is used for extracting
+ * a Map of namespaces (prefix to URI).
+ *
+ * @author acoburn
+ * @since 5/20/16
+ */
+@Component
+public class NamespaceServiceImpl implements NamespaceService {
+
+    @Override
+    public Map<String, String> getNamespaces(final Session session) {
+        return NamespaceTools.getNamespaces(session);
+    }
+}


### PR DESCRIPTION
Partially resolves: https://jira.duraspace.org/browse/FCREPO-1694

In particular, this removes the dependency on the modeshape-based namespace service,
~~and extracts the TransactionServiceImpl from the HTTP layer.~~