### PR TITLE
use correct postgres JDBC connector

### DIFF
--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -140,9 +140,9 @@
       <version>5.1.38</version>
     </dependency>
     <dependency>
-	  <groupId>postgresql</groupId>
+	  <groupId>org.postgresql</groupId>
 	  <artifactId>postgresql</artifactId>
-	  <version>9.1-901-1.jdbc4</version>
+	  <version>9.4.1208</version>
     </dependency>
 
     <!-- test gear -->


### PR DESCRIPTION
By upgrading the postgresql JDBC connector to the latest version, I was able to build and run a postgres-based Fedora-on-Modeshape5 repository locally.

Relates to: https://jira.duraspace.org/browse/FCREPO-1994