### PR TITLE
Remove modeshape's ServletCredentials from the HTTP layers

### DIFF
--- a/fcrepo-connector-file/pom.xml
+++ b/fcrepo-connector-file/pom.xml
@@ -49,6 +49,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
     </dependency>

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionFactory.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionFactory.java
@@ -31,9 +31,9 @@ import javax.ws.rs.BadRequestException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.SessionMissingException;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.services.CredentialsService;
 import org.fcrepo.kernel.api.services.TransactionService;
 
-import org.modeshape.jcr.api.ServletCredentials;
 import org.slf4j.Logger;
 
 /**
@@ -67,6 +67,9 @@ public class SessionFactory {
 
     @Inject
     private TransactionService transactionService;
+
+    @Inject
+    private CredentialsService credentialsService;
 
     /**
      * Default constructor
@@ -145,11 +148,8 @@ public class SessionFactory {
      */
     protected Session createSession(final HttpServletRequest servletRequest) throws RepositoryException {
 
-        final ServletCredentials creds =
-                new ServletCredentials(servletRequest);
-
         LOGGER.debug("Returning an authenticated session in the default workspace");
-        return  repo.login(creds);
+        return  repo.login(credentialsService.getCredentials(servletRequest));
     }
 
     /**

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/session/SessionFactoryTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/session/SessionFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.http.commons.session;
 
+import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -33,6 +34,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.SessionMissingException;
+import org.fcrepo.kernel.api.services.CredentialsService;
 import org.fcrepo.kernel.api.services.TransactionService;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,6 +65,9 @@ public class SessionFactoryTest {
     private TransactionService mockTxService;
 
     @Mock
+    private CredentialsService mockCredService;
+
+    @Mock
     private Transaction mockTx;
 
     @Mock
@@ -75,6 +80,7 @@ public class SessionFactoryTest {
     public void setUp() {
         initMocks(this);
         testObj = new SessionFactory(mockRepo, mockTxService);
+        setField(testObj, "credentialsService", mockCredService);
         testObj.init();
     }
 

--- a/fcrepo-jms/pom.xml
+++ b/fcrepo-jms/pom.xml
@@ -100,6 +100,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <osgi.import.packages>
       javax.jcr.*,
+      javax.servlet.http,
 
       com.google.common.*,
       com.hp.hpl.jena.*,
@@ -63,6 +64,10 @@
     <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
 
     <!-- test gear -->

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CredentialsService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CredentialsService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import javax.jcr.Credentials;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author acoburn
+ * @since Jun 2, 2016
+ */
+public interface CredentialsService {
+
+    /**
+     * Get the credentials for the given servlet request
+     *
+     * @param request the servlet request
+     * @return the JCR credentials for the given request
+     */
+    Credentials getCredentials(final HttpServletRequest request);
+
+}

--- a/fcrepo-kernel-modeshape/pom.xml
+++ b/fcrepo-kernel-modeshape/pom.xml
@@ -23,6 +23,7 @@
       javax.jcr.*,
       javax.inject,
       javax.annotation,
+      javax.servlet.http,
 
       org.apache.commons.codec.digest,
       org.apache.commons.io.input,
@@ -108,6 +109,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
     </dependency>
 
     <!-- test gear -->

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/CredentialsServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/CredentialsServiceImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.modeshape.services;
+
+import javax.jcr.Credentials;
+import javax.servlet.http.HttpServletRequest;
+
+import org.fcrepo.kernel.api.services.CredentialsService;
+import org.modeshape.jcr.api.ServletCredentials;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author acoburn
+ * @since Jun 2, 2016
+ */
+@Component
+public class CredentialsServiceImpl implements CredentialsService {
+
+    @Override
+    public Credentials getCredentials(final HttpServletRequest request) {
+        return new ServletCredentials(request);
+    }
+}


### PR DESCRIPTION
Addresses: https://jira.duraspace.org/browse/FCREPO-1694

I am taking these one at a time now. Please bear with me. The `Repository::login` method requires a `javax.jcr.Credentials` object (which is a simple marker class: it doesn't do anything on its own), and the fcrepo-auth-* modules expect that the `Credentials` object is an `instanceof` modeshape's `ServletCredentials`.

Thus, in order to remove this particular modeshape dependency from `fcrepo-http-commons`, I added a `CredentialsService` as an injected "shim". There may be other ways to implement this, but I couldn't think of another way to do this without extensive changes. I would appreciate a review of this.