### PR TITLE
FCREPO-2065 DelegateHeaderPrincipalProvider leaking on-behalf-of header when called with non-admin

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
@@ -208,10 +208,14 @@ public final class ServletContainerAuthenticationProvider implements
 
         // TODO add exception handling for principal providers
         for (final PrincipalProvider p : this.getPrincipalProviders()) {
-            final Set<Principal> ps = p.getPrincipals(credentials);
+            // if the provider is DelegateHeader, it is either already processed (if logged user has fedora admin role)
+            // or should be ignored completely (the user was not in admin role, so on-behalf-of header must be ignored)
+            if (!(p instanceof DelegateHeaderPrincipalProvider)) {
+                final Set<Principal> ps = p.getPrincipals(credentials);
 
-            if (ps != null) {
-                principals.addAll(p.getPrincipals(credentials));
+                if (ps != null) {
+                    principals.addAll(p.getPrincipals(credentials));
+                }
             }
         }
 

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticationProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticationProviderTest.java
@@ -42,6 +42,7 @@ import javax.jcr.Credentials;
 import javax.jcr.Session;
 import javax.servlet.http.HttpServletRequest;
 
+import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -178,8 +179,8 @@ public class ServletContainerAuthenticationProviderTest {
         when(delegatePrincipal.getName()).thenReturn("delegatedUserName");
 
         // delegateProvider being HeaderProvider returns the header content in getPrincipals regardless of logged user
-        when(delegateProvider.getPrincipals(creds)).thenReturn(
-                new HashSet<>(Collections.singletonList(delegatePrincipal)));
+        when(delegateProvider.getPrincipals(creds)).thenReturn(Sets.newHashSet(delegatePrincipal));
+
 
         final ExecutionContext result =
                 provider.authenticate(creds, "repo", "workspace", context,
@@ -200,7 +201,7 @@ public class ServletContainerAuthenticationProviderTest {
         assertFalse(
                 "The sessionAttributes must not contain delegatedUserName " +
                         "(delegated user must not leak to FEDORA_ALL_PRINCIPALS)",
-                principals.stream().anyMatch(x->"delegatedUserName".equals(x.getName())));
+                principals.stream().map(Principal::getName).anyMatch("delegatedUserName"::equals));
     }
 
     @Test


### PR DESCRIPTION

ServletContainerAuthenticationProvider already handles DelegateHeaderPrincipalProvider differently
from other providers in authenticate() and getDelegatedPrincipal(). The same pattern was added into
collectPrincipals() to prevent instances of this class from filling FEDORA_ALL_PRINCIPALS.

Resolves: https://jira.duraspace.org/browse/FCREPO-2065