### PR TITLE
Remove fcrepo-kernel-api dependency on javax.servlet.http package

### DIFF
--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <osgi.import.packages>
       javax.jcr.*,
-      javax.servlet.http,
 
       com.google.common.*,
       com.hp.hpl.jena.*,
@@ -64,10 +63,6 @@
     <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
     </dependency>
 
     <!-- test gear -->

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CredentialsService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CredentialsService.java
@@ -16,7 +16,6 @@
 package org.fcrepo.kernel.api.services;
 
 import javax.jcr.Credentials;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author acoburn
@@ -25,11 +24,11 @@ import javax.servlet.http.HttpServletRequest;
 public interface CredentialsService {
 
     /**
-     * Get the credentials for the given servlet request
+     * Get the credentials for the given request
      *
-     * @param request the servlet request
+     * @param request the request
      * @return the JCR credentials for the given request
      */
-    Credentials getCredentials(final HttpServletRequest request);
+    Credentials getCredentials(final Object request);
 
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/CredentialsServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/CredentialsServiceImpl.java
@@ -31,7 +31,10 @@ import org.springframework.stereotype.Component;
 public class CredentialsServiceImpl implements CredentialsService {
 
     @Override
-    public Credentials getCredentials(final HttpServletRequest request) {
-        return new ServletCredentials(request);
+    public Credentials getCredentials(final Object request) {
+        if (request instanceof HttpServletRequest) {
+            return new ServletCredentials((HttpServletRequest)request);
+        }
+        throw new IllegalArgumentException("Request object is of the wrong type");
     }
 }


### PR DESCRIPTION
Addresses: https://jira.duraspace.org/browse/FCREPO-1664

`javax.jcr.Credentials` is just a marker class, and as such it there is no need for it to make `fcrepo-kernel-api` depend on `javax.servlet.http`. (Modeshape _does_ require a dependency on `javax.servlet.http`, but this PR isolates that dependency in the `fcrepo-kernel-modeshape` module).