### PR TITLE
update docs with new version of fcrepo-java-client

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,10 @@
           <h4>Fedora Java Client
             <a href="https://github.com/fcrepo4-exts/fcrepo-java-client" title="GitHub repository"><i class="fa fa-github"></i>GitHub</a></h4>
           <ul>
-            <li><a href="http://fcrepo4-exts.github.io/fcrepo-java-client/site/0.1.1/fcrepo-java-client/apidocs/">0.1.1</a></li>
+            <li><a href="http://fcrepo4-exts.github.io/fcrepo-java-client/site/0.2.0/fcrepo-java-client/apidocs/">0.2.0</a></li>
+            <li><a href="http://fcrepo4-exts.github.io/fcrepo-java-client/site/0.1.3/fcrepo-java-client/apidocs/">0.1.3</a></li>
             <li><a href="http://fcrepo4-exts.github.io/fcrepo-java-client/site/0.1.2/fcrepo-java-client/apidocs/">0.1.2</a></li>
+            <li><a href="http://fcrepo4-exts.github.io/fcrepo-java-client/site/0.1.1/fcrepo-java-client/apidocs/">0.1.1</a></li>
           </ul>
         </section>
       </section>


### PR DESCRIPTION
There is a new version of fcrepo-java-client: https://github.com/fcrepo4-exts/fcrepo-java-client/releases/tag/fcrepo-java-client-0.2.0