### PR TITLE
Enable multiple user-provided content digests

### DIFF
--- a/fcrepo-connector-file/src/main/java/org/fcrepo/connector/file/FedoraFileSystemConnector.java
+++ b/fcrepo-connector-file/src/main/java/org/fcrepo/connector/file/FedoraFileSystemConnector.java
@@ -24,6 +24,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_RESOURCE;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATED;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_LASTMODIFIED;
@@ -220,7 +221,7 @@ public class FedoraFileSystemConnector extends FileSystemConnector {
         if (shouldCacheProperties()) {
             final Map<Name, Property> updateMap = new HashMap<>();
             final Property digestProperty = new BasicSingleValueProperty(nameFrom(CONTENT_DIGEST),
-                    asURI("SHA-1", sha1));
+                    asURI(SHA1.algorithm, sha1));
             final Property digestDateProperty = new BasicSingleValueProperty(nameFrom(JCR_CREATED),
                     factories().getDateFactory().create(file.lastModified()));
             updateMap.put(digestProperty.getName(), digestProperty);
@@ -256,7 +257,7 @@ public class FedoraFileSystemConnector extends FileSystemConnector {
                 || hasBeenModifiedSincePropertiesWereStored(file, docReader.getProperty(JCR_CREATED))) {
             final BinaryValue binaryValue = getBinaryValue(docReader);
             final String dsChecksum = binaryValue.getHexHash();
-            final String dsURI = asURI("SHA-1", dsChecksum).toString();
+            final String dsURI = asURI(SHA1.algorithm, dsChecksum).toString();
 
             LOGGER.trace("Adding {} property of {} to {}", CONTENT_DIGEST, dsURI, docReader.getDocumentId());
             docWriter.addProperty(CONTENT_DIGEST, dsURI);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -598,7 +598,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                                                    final ContentDisposition contentDisposition,
                                                    final MediaType contentType,
                                                    final Collection<String> checksums) throws InvalidChecksumException {
-        final Collection<URI> checksumURIs = null == checksums ?
+        final Collection<URI> checksumURIs = checksums == null ?
                 new HashSet<>() : checksums.stream().map(checksum -> checksumURI(checksum)).collect(Collectors.toSet());
         final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
         final String originalContentType = contentType != null ? contentType.toString() : "";

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -56,10 +56,13 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -594,14 +597,15 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                                                    final InputStream requestBodyStream,
                                                    final ContentDisposition contentDisposition,
                                                    final MediaType contentType,
-                                                   final String checksum) throws InvalidChecksumException {
-        final URI checksumURI = checksumURI(checksum);
+                                                   final Collection<String> checksums) throws InvalidChecksumException {
+        final Collection<URI> checksumURIs = null == checksums ?
+                new HashSet<>() : checksums.stream().map(checksum -> checksumURI(checksum)).collect(Collectors.toSet());
         final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
         final String originalContentType = contentType != null ? contentType.toString() : "";
 
         result.setContent(requestBodyStream,
                 originalContentType,
-                checksumURI,
+                checksumURIs,
                 originalFileName,
                 storagePolicyDecisionPoint);
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -722,11 +722,11 @@ public class FedoraLdp extends ContentExposingResource {
     private static Collection<String> parseDigestHeader(final String digest) throws InvalidChecksumException {
         try {
             final Map<String,String> digestPairs = RFC3230_SPLITTER.split(nullToEmpty(digest));
-            final boolean isSupportedAlgorithm = digestPairs.keySet().stream().anyMatch(
+            final boolean allSupportedAlgorithms = digestPairs.keySet().stream().allMatch(
                     ContentDigest.DIGEST_ALGORITHM::isSupportedAlgorithm);
 
-            // If you have one or more digests and one is sha1 or no digests.
-            if (digestPairs.isEmpty() || isSupportedAlgorithm) {
+            // If you have one or more digests that are all valid or no digests.
+            if (digestPairs.isEmpty() || allSupportedAlgorithms) {
                 return digestPairs.entrySet().stream()
                     .filter(entry -> ContentDigest.DIGEST_ALGORITHM.isSupportedAlgorithm(entry.getKey()))
                     .map(entry -> ContentDigest.asURI(entry.getKey(), entry.getValue()).toString())

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -60,8 +60,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.annotation.PostConstruct;
@@ -104,6 +106,7 @@ import org.fcrepo.kernel.api.RdfStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -313,7 +316,7 @@ public class FedoraLdp extends ContentExposingResource {
 
         final String path = toPath(translator(), externalPath);
 
-        final String checksum = parseDigestHeader(digest);
+        final Collection<String> checksums = parseDigestHeader(digest);
 
         final MediaType contentType = getSimpleContentType(requestContentType);
 
@@ -338,7 +341,7 @@ public class FedoraLdp extends ContentExposingResource {
             LOGGER.info("PUT resource '{}'", externalPath);
             if (resource instanceof FedoraBinary) {
                 replaceResourceBinaryWithStream((FedoraBinary) resource,
-                        requestBodyStream, contentDisposition, requestContentType, checksum);
+                        requestBodyStream, contentDisposition, requestContentType, checksums);
             } else if (isRdfContentType(contentType.toString())) {
                 replaceResourceWithStream(resource, requestBodyStream, contentType, resourceTriples);
             } else if (!created) {
@@ -468,7 +471,7 @@ public class FedoraLdp extends ContentExposingResource {
 
         final String newObjectPath = mintNewPid(slug);
 
-        final String checksum = parseDigestHeader(digest);
+        final Collection<String> checksum = parseDigestHeader(digest);
 
         LOGGER.info("Ingest with path: {}", newObjectPath);
 
@@ -716,20 +719,20 @@ public class FedoraLdp extends ContentExposingResource {
      * @return the sha1 checksum value
      * @throws InvalidChecksumException if an unsupported digest is used
      */
-    private static String parseDigestHeader(final String digest) throws InvalidChecksumException {
+    private static Collection<String> parseDigestHeader(final String digest) throws InvalidChecksumException {
         try {
             final Map<String,String> digestPairs = RFC3230_SPLITTER.split(nullToEmpty(digest));
-            final boolean checksumTypeIncludeSHA1 = digestPairs.keySet().stream().anyMatch("sha1"::equalsIgnoreCase);
+            final boolean isSupportedAlgorithm = digestPairs.keySet().stream().anyMatch(
+                    ContentDigest.DIGEST_ALGORITHM::isSupportedAlgorithm);
+
             // If you have one or more digests and one is sha1 or no digests.
-            if (digestPairs.isEmpty() || checksumTypeIncludeSHA1) {
+            if (digestPairs.isEmpty() || isSupportedAlgorithm) {
                 return digestPairs.entrySet().stream()
-                    .filter(s -> s.getKey().toLowerCase().equals("sha1"))
-                    .map(Map.Entry::getValue)
-                    .findFirst()
-                    .map("urn:sha1:"::concat)
-                    .orElse("");
+                    .filter(entry -> ContentDigest.DIGEST_ALGORITHM.isSupportedAlgorithm(entry.getKey()))
+                    .map(entry -> ContentDigest.asURI(entry.getKey(), entry.getValue()).toString())
+                    .collect(Collectors.toSet());
             } else {
-                throw new InvalidChecksumException(String.format("Unsupported Digest Algorithim: {}", digest));
+                throw new InvalidChecksumException(String.format("Unsupported Digest Algorithim: %1$s", digest));
             }
         } catch (final RuntimeException e) {
             if (e instanceof IllegalArgumentException) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1129,6 +1129,18 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testIngestWithBinaryAndValidAndInvalidDigestHeaders() {
+        final HttpPost method = postObjMethod();
+        final File img = new File("src/test/resources/test-objects/img.png");
+        method.addHeader("Content-Type", "application/octet-stream");
+        method.addHeader("Digest", "md5=6668675a91f39ca1afe46c084e8406ba," +
+                " sha99=7b115a72978fe138287c1a6dfe6cc1afce4720fb3610a81d32e4ad518700c923");
+        method.setEntity(new FileEntity(img));
+
+        assertEquals("Should be a 409 Conflict!", CONFLICT.getStatusCode(), getStatus(method));
+    }
+
+    @Test
     public void testIngestOnSubtree() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1106,6 +1106,29 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testIngestWithBinaryAndMD5DigestHeader() {
+        final HttpPost method = postObjMethod();
+        final File img = new File("src/test/resources/test-objects/img.png");
+        method.addHeader("Content-Type", "application/octet-stream");
+        method.addHeader("Digest", "md5=6668675a91f39ca1afe46c084e8406ba");
+        method.setEntity(new FileEntity(img));
+
+        assertEquals("Should be a 201 Created!", CREATED.getStatusCode(), getStatus(method));
+    }
+
+    @Test
+    public void testIngestWithBinaryAndTwoValidHeadersDigestHeaders() {
+        final HttpPost method = postObjMethod();
+        final File img = new File("src/test/resources/test-objects/img.png");
+        method.addHeader("Content-Type", "application/octet-stream");
+        method.addHeader("Digest", "md5=6668675a91f39ca1afe46c084e8406ba," +
+                " sha256=7b115a72978fe138287c1a6dfe6cc1afce4720fb3610a81d32e4ad518700c923");
+        method.setEntity(new FileEntity(img));
+
+        assertEquals("Should be a 201 Created!", CREATED.getStatusCode(), getStatus(method));
+    }
+
+    @Test
     public void testIngestOnSubtree() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
@@ -20,6 +20,7 @@ package org.fcrepo.http.commons.test.util;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static java.net.URI.create;
 import static javax.ws.rs.core.UriBuilder.fromUri;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.junit.Assert.assertNotNull;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
 import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
@@ -228,12 +229,12 @@ public abstract class TestHelpers {
         if (content != null) {
             final MessageDigest md;
             try {
-                md = MessageDigest.getInstance("SHA-1");
+                md = MessageDigest.getInstance(SHA1.algorithm);
             } catch (final NoSuchAlgorithmException e) {
                 throw new RuntimeException(e);
             }
             final byte[] digest = md.digest(content.getBytes());
-            final URI cd = asURI("SHA-1", digest);
+            final URI cd = asURI(SHA1.algorithm, digest);
             when(mockDs.getEtagValue()).thenReturn(cd.toString());
         }
         return mockDs;
@@ -249,12 +250,12 @@ public abstract class TestHelpers {
         if (content != null) {
             final MessageDigest md;
             try {
-                md = MessageDigest.getInstance("SHA-1");
+                md = MessageDigest.getInstance(SHA1.algorithm);
             } catch (final NoSuchAlgorithmException e) {
                 throw new RuntimeException(e);
             }
             final byte[] digest = md.digest(content.getBytes());
-            final URI cd = asURI("SHA-1", digest);
+            final URI cd = asURI(SHA1.algorithm, digest);
             when(mockBinary.getContent()).thenReturn(
                     IOUtils.toInputStream(content));
             when(mockBinary.getContentDigest()).thenReturn(cd);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
@@ -65,6 +65,8 @@ public interface FedoraTypes {
 
     String CONTENT_DIGEST = "premis:hasMessageDigest";
 
+    String DEFAULT_DIGEST_ALGORITHM = "fedoraconfig:defaultDigestAlgorithm";
+
     String FCR_METADATA = "fcr:metadata";
 
     String FCR_VERSIONS = "fcr:versions";

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraBinary.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraBinary.java
@@ -25,6 +25,7 @@ import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Collection;
 
 /**
  * @author cabeer
@@ -42,12 +43,12 @@ public interface FedoraBinary extends FedoraResource {
      *
      * @param content  InputStream of binary content to be stored
      * @param contentType MIME type of content (optional)
-     * @param checksum Checksum URI of the content (optional)
+     * @param checksums Collection of checksum URIs of the content (optional)
      * @param originalFileName Original file name of the content (optional)
      * @param storagePolicyDecisionPoint Policy decision point for storing the content (optional)
      * @throws org.fcrepo.kernel.api.exception.InvalidChecksumException if invalid checksum exception occurred
      */
-    void setContent(InputStream content, String contentType, URI checksum,
+    void setContent(InputStream content, String contentType, Collection<URI> checksums,
                     String originalFileName,
                     StoragePolicyDecisionPoint storagePolicyDecisionPoint)
             throws InvalidChecksumException;

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.api.utils;
 
 import static com.google.common.base.Throwables.propagate;
 import static org.apache.commons.codec.binary.Hex.encodeHexString;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
@@ -40,7 +41,7 @@ public final class ContentDigest {
     public enum DIGEST_ALGORITHM {
         SHA1("SHA-1", "urn:sha1"), SHA256("SHA-256", "urn:sha256"), MD5("MD5", "urn:md5"), MISSING("NONE", "missing");
 
-        final private String algorithm;
+        final public String algorithm;
         final private String scheme;
 
         DIGEST_ALGORITHM(final String alg, final String scheme) {
@@ -137,7 +138,7 @@ public final class ContentDigest {
      * @return URI
      */
     public static URI missingChecksum() {
-        return asURI("SHA-1", "missing");
+        return asURI(SHA1.algorithm, SHA1.scheme);
     }
 
 }

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.api.utils;
 
 import static java.net.URI.create;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.api.utils.ContentDigest.getAlgorithm;
 import static org.junit.Assert.assertEquals;
@@ -34,7 +35,7 @@ public class ContentDigestTest {
     @Test
     public void testSHA_1() {
         assertEquals("Failed to produce a proper content digest URI!",
-                create("urn:sha1:fake"), asURI("SHA-1", "fake"));
+                create("urn:sha1:fake"), asURI(SHA1.algorithm, "fake"));
     }
 
     @Test
@@ -45,7 +46,7 @@ public class ContentDigestTest {
 
     @Test
     public void testGetAlgorithm() {
-        assertEquals("Failed to produce a proper digest algorithm!", "SHA-1",
-                getAlgorithm(asURI("SHA-1", "fake")));
+        assertEquals("Failed to produce a proper digest algorithm!", SHA1.algorithm,
+                getAlgorithm(asURI(SHA1.algorithm, "fake")));
     }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
@@ -30,6 +30,7 @@ import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.utils.CacheEntry;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.fcrepo.kernel.api.utils.FixityResult;
 import org.fcrepo.kernel.modeshape.rdf.impl.FixityRdfContext;
@@ -43,16 +44,22 @@ import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
+import javax.jcr.Value;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionHistory;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FIELD_DELIMITER;
+import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.property2values;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isFedoraBinary;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.modeshape.jcr.api.JcrConstants.JCR_DATA;
@@ -91,7 +98,7 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
 
     private void initializeNewBinaryProperties() {
         try {
-            decorateContentNode(node);
+            decorateContentNode(node, new HashSet<>());
         } catch (final RepositoryException e) {
             LOGGER.warn("Count not decorate {} with FedoraBinary properties: {}", node, e);
         }
@@ -141,7 +148,7 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
      */
     @Override
     public void setContent(final InputStream content, final String contentType,
-                           final URI checksum, final String originalFileName,
+                           final Collection<URI> checksums, final String originalFileName,
                            final StoragePolicyDecisionPoint storagePolicyDecisionPoint)
             throws InvalidChecksumException {
 
@@ -186,16 +193,11 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
          */
             final Property dataProperty = contentNode.setProperty(JCR_DATA, binary);
 
-            final String dsChecksum = binary.getHexHash();
-            final URI uriChecksumString = ContentDigest.asURI("SHA-1", dsChecksum);
-            if (checksum != null &&
-                    !checksum.equals(uriChecksumString)) {
-                LOGGER.debug("Failed checksum test");
-                throw new InvalidChecksumException("Checksum Mismatch of " +
-                        uriChecksumString + " and " + checksum);
-            }
+            // Ensure provided checksums are valid
+            final Collection<URI> nonNullChecksums = (null == checksums) ? new HashSet<>() : checksums;
+            verifyChecksums(nonNullChecksums, dataProperty);
 
-            decorateContentNode(contentNode);
+            decorateContentNode(contentNode, nonNullChecksums);
             touch();
             ((FedoraResourceImpl) getDescription()).touch();
 
@@ -204,6 +206,61 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }
+    }
+
+    /**
+     * This method ensures that the arg checksums are valid against the binary associated with the arg dataProperty.
+     * If one or more of the checksums are invalid, an InvalidChecksumException is thrown.
+     *
+     * @param checksums that the user provided
+     * @param dataProperty containing the binary against which the checksums will be verified
+     * @throws InvalidChecksumException
+     * @throws RepositoryException
+     */
+    private void verifyChecksums(final Collection<URI> checksums, final Property dataProperty)
+            throws InvalidChecksumException, RepositoryException {
+
+        final Map<URI, URI> checksumErrors = new HashMap<>();
+
+        // Loop through provided checksums validating against computed values
+        checksums.forEach(checksum -> {
+            final String algorithm = ContentDigest.getAlgorithm(checksum);
+            try {
+                // The case internally supported by ModeShape
+                if (algorithm.equals("SHA-1")) {
+                    final String dsSHA1 = ((Binary) dataProperty.getBinary()).getHexHash();
+                    final URI dsSHA1Uri = ContentDigest.asURI("SHA-1", dsSHA1);
+
+                    if (!dsSHA1Uri.equals(checksum)) {
+                        LOGGER.debug("Failed checksum test");
+                        checksumErrors.put(checksum, dsSHA1Uri);
+                    }
+
+                // The case that requires re-computing the checksum
+                } else {
+                    final CacheEntry cacheEntry = CacheEntryFactory.forProperty(dataProperty);
+                    cacheEntry.checkFixity(algorithm).stream().findFirst().ifPresent(
+                            fixityResult -> {
+                                if (!fixityResult.matches(checksum)) {
+                                    LOGGER.debug("Failed checksum test");
+                                    checksumErrors.put(checksum, fixityResult.getComputedChecksum());
+                                }
+                            }
+                    );
+                }
+            } catch (RepositoryException e) {
+                throw new RepositoryRuntimeException(e);
+            }
+        });
+
+        // Throw an exception if any checksum errors occurred
+        if (!checksumErrors.isEmpty()) {
+            final String template = "Checksum Mismatch of %1$s and %2$s\n";
+            final StringBuilder error = new StringBuilder();
+            checksumErrors.forEach((key, value) -> error.append(String.format(template, key, value)));
+            throw new InvalidChecksumException(error.toString());
+        }
+
     }
 
     /*
@@ -230,11 +287,33 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
     @Override
     public URI getContentDigest() {
         try {
+            // Determine which digest algorithm to use
+            final String algorithm = hasProperty(DEFAULT_DIGEST_ALGORITHM) ?
+                    property2values.apply(getProperty(DEFAULT_DIGEST_ALGORITHM)).findFirst().get().getString() :
+                    ContentDigest.DEFAULT_ALGORITHM;
+            final String algorithmWithoutStringType = algorithm.replace(FIELD_DELIMITER + XSDstring.getURI(), "");
+
             if (hasProperty(CONTENT_DIGEST)) {
-                return new URI(getProperty(CONTENT_DIGEST).getString());
+                // Select the stored digest that matches the digest algorithm
+                Optional<Value> digestValue = property2values.apply(getProperty(CONTENT_DIGEST)).filter(digest -> {
+                    try {
+                        final URI digestUri = URI.create(digest.getString());
+                        return algorithmWithoutStringType.equalsIgnoreCase(ContentDigest.getAlgorithm(digestUri));
+
+                    } catch (RepositoryException e) {
+                        LOGGER.warn("Exception thrown when getting digest property {}, {}", digest, e.getMessage());
+                        return false;
+                    }
+                }).findFirst();
+
+                // Success, return the digest value
+                if (digestValue.isPresent()) {
+                    return URI.create(digestValue.get().getString());
+                }
             }
-        } catch (final RepositoryException | URISyntaxException e) {
-            LOGGER.info("Could not get content digest: {}", e.getMessage());
+            LOGGER.warn("No digest value was found to match the algorithm: {}", algorithmWithoutStringType);
+        } catch (final RepositoryException e) {
+            LOGGER.warn("Could not get content digest: {}", e.getMessage());
         }
 
         return ContentDigest.missingChecksum();
@@ -318,7 +397,8 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
         return getDescription().getBaseVersion();
     }
 
-    private static void decorateContentNode(final Node contentNode) throws RepositoryException {
+    private static void decorateContentNode(final Node contentNode, final Collection<URI> checksums)
+            throws RepositoryException {
         if (contentNode == null) {
             LOGGER.warn("{} node appears to be null!", JCR_CONTENT);
             return;
@@ -334,8 +414,13 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
 
             contentSizeHistogram.update(dataProperty.getLength());
 
+            checksums.add(ContentDigest.asURI("SHA-1", dsChecksum));
+
+            final String[] checksumArray = new String[checksums.size()];
+            checksums.stream().map(Object::toString).collect(Collectors.toSet()).toArray(checksumArray);
+
+            contentNode.setProperty(CONTENT_DIGEST, checksumArray);
             contentNode.setProperty(CONTENT_SIZE, dataProperty.getLength());
-            contentNode.setProperty(CONTENT_DIGEST, ContentDigest.asURI("SHA-1", dsChecksum).toString());
 
             LOGGER.debug("Decorated data property at path: {}", dataProperty.getPath());
         }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FIELD_DELIMITER;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.property2values;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isFedoraBinary;
@@ -227,9 +228,9 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
             final String algorithm = ContentDigest.getAlgorithm(checksum);
             try {
                 // The case internally supported by ModeShape
-                if (algorithm.equals("SHA-1")) {
+                if (algorithm.equals(SHA1.algorithm)) {
                     final String dsSHA1 = ((Binary) dataProperty.getBinary()).getHexHash();
-                    final URI dsSHA1Uri = ContentDigest.asURI("SHA-1", dsSHA1);
+                    final URI dsSHA1Uri = ContentDigest.asURI(SHA1.algorithm, dsSHA1);
 
                     if (!dsSHA1Uri.equals(checksum)) {
                         LOGGER.debug("Failed checksum test");
@@ -414,7 +415,7 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
 
             contentSizeHistogram.update(dataProperty.getLength());
 
-            checksums.add(ContentDigest.asURI("SHA-1", dsChecksum));
+            checksums.add(ContentDigest.asURI(SHA1.algorithm, dsChecksum));
 
             final String[] checksumArray = new String[checksums.size()];
             checksums.stream().map(Object::toString).collect(Collectors.toSet()).toArray(checksumArray);

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -71,7 +71,7 @@
   - ebucore:filename (STRING)
   - ebucore:hasMimeType (STRING)
   - premis:hasSize (LONG) COPY
-  - premis:hasMessageDigest (URI) COPY
+  - premis:hasMessageDigest (URI) COPY multiple
 
 [fedora:Skolem] > mix:referenceable mixin
   - fedora:lastModified (DATE)

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
@@ -25,6 +25,8 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTIO
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
+import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -57,7 +59,6 @@ import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.ContainerService;
-import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.fcrepo.kernel.modeshape.rdf.impl.DefaultIdentifierTranslator;
 
 import org.junit.Before;
@@ -232,7 +233,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
             binaryService.findOrCreate(session, "/testDatastreamObject/testDatastreamNode4").setContent(
                     new ByteArrayInputStream("asdf".getBytes()),
                     "application/octet-stream",
-                    new HashSet<>(asList(ContentDigest.asURI("SHA-1", "3da541559918a808c2402bba5012f6c60b27661c"))),
+                    new HashSet<>(asList(asURI(SHA1.algorithm, "3da541559918a808c2402bba5012f6c60b27661c"))),
                     null,
                     null
                     );

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.integration.kernel.modeshape;
 
+import static java.util.Arrays.asList;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static java.util.UUID.randomUUID;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
@@ -36,6 +37,7 @@ import static org.modeshape.jcr.api.JcrConstants.NT_RESOURCE;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.HashSet;
 import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.Repository;
@@ -230,7 +232,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
             binaryService.findOrCreate(session, "/testDatastreamObject/testDatastreamNode4").setContent(
                     new ByteArrayInputStream("asdf".getBytes()),
                     "application/octet-stream",
-                    ContentDigest.asURI("SHA-1", "3da541559918a808c2402bba5012f6c60b27661c"),
+                    new HashSet<>(asList(ContentDigest.asURI("SHA-1", "3da541559918a808c2402bba5012f6c60b27661c"))),
                     null,
                     null
                     );

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
@@ -30,6 +30,7 @@ import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_RELOCATION;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.junit.Assert.assertEquals;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
@@ -129,7 +130,7 @@ public class SimpleObserverIT extends AbstractIT {
         contentNode.addMixin(FEDORA_BINARY);
         final FedoraBinary binary = new FedoraBinaryImpl(contentNode);
         binary.setContent( new ByteArrayInputStream(content.getBytes()), "text/plain",
-                new HashSet<>(asList(asURI("SHA-1", checksum))), "text.txt", null);
+                new HashSet<>(asList(asURI(SHA1.algorithm, checksum))), "text.txt", null);
 
         try {
             se.save();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.integration.kernel.modeshape.observer;
 
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static com.jayway.awaitility.Awaitility.await;
 import static com.jayway.awaitility.Duration.ONE_HUNDRED_MILLISECONDS;
@@ -37,6 +38,7 @@ import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
 import static org.modeshape.jcr.api.JcrConstants.NT_RESOURCE;
 
 import java.io.ByteArrayInputStream;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -127,7 +129,7 @@ public class SimpleObserverIT extends AbstractIT {
         contentNode.addMixin(FEDORA_BINARY);
         final FedoraBinary binary = new FedoraBinaryImpl(contentNode);
         binary.setContent( new ByteArrayInputStream(content.getBytes()), "text/plain",
-                asURI("SHA-1", checksum), "text.txt", null);
+                new HashSet<>(asList(asURI("SHA-1", checksum))), "text.txt", null);
 
         try {
             se.save();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraBinaryImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraBinaryImplTest.java
@@ -42,6 +42,7 @@ import java.net.URISyntaxException;
 import java.util.Calendar;
 import java.util.Date;
 
+import static java.util.Collections.singleton;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
 import static org.fcrepo.kernel.modeshape.utils.TestHelpers.checksumString;
 import static org.fcrepo.kernel.modeshape.utils.TestHelpers.getContentNodeMock;
@@ -180,7 +181,7 @@ public class FedoraBinaryImplTest implements FedoraTypes {
         when(mockContent.setProperty(JCR_DATA, mockBin)).thenReturn(mockData);
         when(mockContent.getProperty(JCR_DATA)).thenReturn(mockData);
         when(mockData.getBinary()).thenReturn(mockBin);
-        testObj.setContent(mockStream, null, new URI("urn:sha1:xyz"), null, null);
+        testObj.setContent(mockStream, null, singleton(new URI("urn:sha1:xyz")), null, null);
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/FixityInputStreamTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/FixityInputStreamTest.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.modeshape.utils;
 import static org.apache.commons.codec.binary.Hex.encodeHexString;
 import static org.apache.commons.io.output.NullOutputStream.NULL_OUTPUT_STREAM;
 import static org.apache.tika.io.IOUtils.copy;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
@@ -40,7 +41,7 @@ public class FixityInputStreamTest {
     public void SimpleFixityInputStreamTest() throws NoSuchAlgorithmException, IOException {
         try (final FixityInputStream is =
                 new FixityInputStream(new ByteArrayInputStream("0123456789"
-                        .getBytes()), MessageDigest.getInstance("SHA-1"))) {
+                        .getBytes()), MessageDigest.getInstance(SHA1.algorithm))) {
             copy(is, NULL_OUTPUT_STREAM);
             assertEquals(10, is.getByteCount());
             assertEquals("87acec17cd9dcd20a716cc2cf67417b71c8a7016",

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/TestHelpers.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/TestHelpers.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.modeshape.utils;
 
 import static org.fcrepo.kernel.api.FedoraTypes.CONTENT_DIGEST;
 import static org.fcrepo.kernel.api.FedoraTypes.CONTENT_SIZE;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATEDBY;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -66,7 +67,7 @@ public abstract class TestHelpers {
         final String digest = checksumString(content);
         final Value digestValue = mock(Value.class);
         final Value[] digestArray = {digestValue};
-        final String digestType = "SHA-1";
+        final String digestType = SHA1.algorithm;
         final Property mockFedoraSize = mock(Property.class);
         final Property mockProp = mock(Property.class);
         final Property mockDigest = mock(Property.class);
@@ -107,9 +108,9 @@ public abstract class TestHelpers {
 
     public static String checksumString(final byte[] content) {
         try {
-            final MessageDigest d = MessageDigest.getInstance("SHA-1");
+            final MessageDigest d = MessageDigest.getInstance(SHA1.algorithm);
             final byte[] digest = d.digest(content);
-            return ContentDigest.asURI("SHA-1", digest).toString();
+            return ContentDigest.asURI(SHA1.algorithm, digest).toString();
         } catch (final NoSuchAlgorithmException e) {
             e.printStackTrace();
         }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/TestHelpers.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/TestHelpers.java
@@ -64,6 +64,8 @@ public abstract class TestHelpers {
     public static Node getContentNodeMock(final Node mock, final byte[] content) {
         final long size = content.length;
         final String digest = checksumString(content);
+        final Value digestValue = mock(Value.class);
+        final Value[] digestArray = {digestValue};
         final String digestType = "SHA-1";
         final Property mockFedoraSize = mock(Property.class);
         final Property mockProp = mock(Property.class);
@@ -82,7 +84,7 @@ public abstract class TestHelpers {
                 }
             });
             when(mockProp.getBinary()).thenReturn(mockBin);
-            when(mockDigest.getString()).thenReturn(digest);
+            when(mockDigest.getValues()).thenReturn(digestArray);
             when(mockDigestType.getString()).thenReturn(digestType);
             when(mock.hasProperty(JCR_DATA)).thenReturn(true);
             when(mock.hasProperty(CONTENT_SIZE)).thenReturn(true);
@@ -91,6 +93,8 @@ public abstract class TestHelpers {
             when(mock.getProperty(JCR_DATA)).thenReturn(mockProp);
             when(mock.getProperty(CONTENT_SIZE)).thenReturn(mockFedoraSize);
             when(mock.getProperty(CONTENT_DIGEST)).thenReturn(mockDigest);
+            when(mockDigest.isMultiple()).thenReturn(true);
+            when(digestValue.getString()).thenReturn(digest);
             when(mock.getProperty(JCR_CREATEDBY)).thenReturn(mockCreated);
         } catch (final RepositoryException e) {
         } // shhh


### PR DESCRIPTION
- Enable users to configure the default digest algorithm
** This is set with the property: fedoraconfig:defaultDigestAlgorithm
- Note: This update modifies the main CND:
** from: premis:hasMessageDigest (URI) COPY
** to: premis:hasMessageDigest (URI) COPY multiple

Resolves: https://jira.duraspace.org/browse/FCREPO-1842