### PR TITLE
Exclude internal (jcr, mode) prefixes from namespace map

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/NamespaceTools.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/NamespaceTools.java
@@ -17,11 +17,14 @@
  */
 package org.fcrepo.kernel.modeshape.utils;
 
+import static com.google.common.collect.ImmutableSet.of;
 import static java.util.Objects.requireNonNull;
 import static java.util.Arrays.stream;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.jcr.NamespaceException;
 import javax.jcr.NamespaceRegistry;
@@ -42,6 +45,9 @@ public final class NamespaceTools {
 
     private NamespaceTools() {
     }
+
+    // Internal namespaces defined in the modeshape CND file
+    private static final Set<String> INTERNAL_PREFIXES = of("jcr", "nt", "mode", "mix", "image", "sv");
 
     /**
      * Return the {@link NamespaceRegistry} associated with the arg session.
@@ -101,7 +107,7 @@ public final class NamespaceTools {
         final Map<String, String> namespaces = new HashMap<>();
 
         try {
-            stream(registry.getPrefixes()).filter(x -> !x.isEmpty()).forEach(x -> {
+            stream(registry.getPrefixes()).filter(internalPrefix.negate()).forEach(x -> {
                 try {
                     namespaces.put(x, registry.getURI(x));
                 } catch (final RepositoryException e) {
@@ -113,4 +119,6 @@ public final class NamespaceTools {
         }
         return namespaces;
     }
+
+    private static Predicate<String> internalPrefix = prefix -> prefix.isEmpty() || INTERNAL_PREFIXES.contains(prefix);
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/NamespaceTools.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/NamespaceTools.java
@@ -20,6 +20,10 @@ package org.fcrepo.kernel.modeshape.utils;
 import static com.google.common.collect.ImmutableSet.of;
 import static java.util.Objects.requireNonNull;
 import static java.util.Arrays.stream;
+import static javax.jcr.NamespaceRegistry.PREFIX_EMPTY;
+import static javax.jcr.NamespaceRegistry.PREFIX_JCR;
+import static javax.jcr.NamespaceRegistry.PREFIX_MIX;
+import static javax.jcr.NamespaceRegistry.PREFIX_NT;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +51,8 @@ public final class NamespaceTools {
     }
 
     // Internal namespaces defined in the modeshape CND file
-    private static final Set<String> INTERNAL_PREFIXES = of("jcr", "nt", "mode", "mix", "image", "sv");
+    private static final Set<String> INTERNAL_PREFIXES = of(PREFIX_EMPTY, PREFIX_JCR, PREFIX_MIX, PREFIX_NT,
+            "mode", "sv", "image");
 
     /**
      * Return the {@link NamespaceRegistry} associated with the arg session.
@@ -120,5 +125,5 @@ public final class NamespaceTools {
         return namespaces;
     }
 
-    private static Predicate<String> internalPrefix = prefix -> prefix.isEmpty() || INTERNAL_PREFIXES.contains(prefix);
+    private static Predicate<String> internalPrefix = INTERNAL_PREFIXES::contains;
 }


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2244