### PR TITLE
Prevents whitespace characters from being used in version labels.

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/VersionsRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/VersionsRdfContext.java
@@ -36,6 +36,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionHistory;
 import org.apache.jena.rdf.model.Resource;
+import org.modeshape.common.text.UrlEncoder;
 
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -60,6 +61,8 @@ public class VersionsRdfContext extends DefaultRdfStream {
     private final VersionHistory versionHistory;
 
     private static final Logger LOGGER = getLogger(VersionsRdfContext.class);
+
+    private static final UrlEncoder URL_ENCODER = new UrlEncoder();
 
     /**
      * Ordinary constructor.
@@ -95,7 +98,7 @@ public class VersionsRdfContext extends DefaultRdfStream {
             .flatMap(UncheckedFunction.uncheck((final Version v) -> {
                 final String[] labels = versionHistory.getVersionLabels(v);
                 final Node versionSubject
-                        = createProperty(topic() + "/" + FCR_VERSIONS + "/" + labels[0]).asNode();
+                        = createProperty(topic() + "/" + FCR_VERSIONS + "/" + urlEncode(labels[0])).asNode();
 
                 return Stream.concat(
                         Arrays.stream(labels).map(x -> create(versionSubject, HAS_VERSION_LABEL.asNode(),
@@ -105,5 +108,9 @@ public class VersionsRdfContext extends DefaultRdfStream {
                             create(versionSubject, CREATED_DATE.asNode(),
                                 createTypedLiteral(v.getCreated()).asNode())));
             }));
+    }
+
+    private String urlEncode(final String string) {
+        return URL_ENCODER.encode(string).replaceAll("[+]", "%20");
     }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -55,7 +55,7 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
 
     private static final Logger LOGGER = getLogger(VersionService.class);
 
-    private static final Pattern invalidLabelPattern = Pattern.compile("[~#@*+%{}<>\\[\\]|\"^]");
+    private static final Pattern invalidLabelPattern = Pattern.compile("[\\s~#@*+%{}<>\\[\\]|\"^]");
 
     @Override
     public String createVersion(final FedoraSession session, final String absPath, final String label) {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -21,6 +21,7 @@ import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.services.VersionService;
 import org.fcrepo.kernel.modeshape.FedoraBinaryImpl;
+
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -55,7 +56,9 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
 
     private static final Logger LOGGER = getLogger(VersionService.class);
 
-    private static final Pattern invalidLabelPattern = Pattern.compile("[\\s~#@*+%{}<>\\[\\]|\"^]");
+    private static final Pattern invalidLabelPattern = Pattern.compile("[~#@*+%{}<>\\[\\]|\"^]");
+
+    private static final Pattern invalidLabelEndsWithANumberPattern = Pattern.compile("^(.*[\\s]+)?[\\d]*$");
 
     @Override
     public String createVersion(final FedoraSession session, final String absPath, final String label) {
@@ -191,7 +194,11 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
 
     private static boolean validLabel(final String label) {
         final Matcher matcher = invalidLabelPattern.matcher(label);
-        return !matcher.find();
+        if (matcher.find()) {
+            return false;
+        }
+
+        return !invalidLabelEndsWithANumberPattern.matcher(label).find();
     }
 
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/VersionServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/VersionServiceImplTest.java
@@ -37,6 +37,8 @@ import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.services.VersionService;
 import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -178,6 +180,25 @@ public class VersionServiceImplTest {
         final Node unversionedNode = mockSession.getNode(EXAMPLE_UNVERSIONED_PATH);
         verify(unversionedNode).isNodeType(VERSIONABLE);
         verify(unversionedNode).addMixin(VERSIONABLE);
+    }
+
+    @Test
+    public void testCreateWithInvalidVersionLabels() throws RepositoryException {
+        // [\\s~#@*+%{}<>\\[\\]|\"^]
+        final String[] invalidChars = { " ", "~", "#", "@", "*", "+", "%", "{", "}",
+            "<", ">", "[", "]", "|", "\"", "^" };
+        for (String s : invalidChars) {
+            testLabel(s);
+        }
+    }
+
+    private void testLabel(final String label) {
+        try {
+            testObj.createVersion(testSession, EXAMPLE_UNVERSIONED_PATH, label);
+            Assert.fail("The previous call should have failed.");
+        } catch (Exception ex) {
+            Assert.assertTrue(ex.getMessage().contains("Invalid label"));
+        }
     }
 
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/VersionServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/VersionServiceImplTest.java
@@ -184,7 +184,11 @@ public class VersionServiceImplTest {
         testCreateWithValidLabel("version v1234");
     }
 
-
+    /**
+     * This test designed to be pass so long as no exception is thrown.
+     * @param label
+     * @throws RepositoryException
+     */
     private void testCreateWithValidLabel(final String label) throws RepositoryException {
         final VersionManager mockVersionManager = mock(VersionManager.class);
         final VersionHistory mockHistory = mock(VersionHistory.class);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/VersionServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/VersionServiceImplTest.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.modeshape.services;
 
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.VERSIONABLE;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -38,7 +39,6 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.services.VersionService;
 import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -171,11 +171,26 @@ public class VersionServiceImplTest {
 
     @Test
     public void testMixinCreationWhenExplicitlyVersioning() throws RepositoryException {
+        testCreateWithValidLabel("LABEL");
+    }
+
+    @Test
+    public void testCreateWithLabelv001() throws RepositoryException {
+        testCreateWithValidLabel("v0.0.1");
+    }
+
+    @Test
+    public void testCreateWithLabelWithSpace() throws RepositoryException {
+        testCreateWithValidLabel("version v1234");
+    }
+
+
+    private void testCreateWithValidLabel(final String label) throws RepositoryException {
         final VersionManager mockVersionManager = mock(VersionManager.class);
         final VersionHistory mockHistory = mock(VersionHistory.class);
         when(mockWorkspace.getVersionManager()).thenReturn(mockVersionManager);
         when(mockVersionManager.getVersionHistory(EXAMPLE_UNVERSIONED_PATH)).thenReturn(mockHistory);
-        testObj.createVersion(testSession, EXAMPLE_UNVERSIONED_PATH, "LABEL");
+        testObj.createVersion(testSession, EXAMPLE_UNVERSIONED_PATH, label);
 
         final Node unversionedNode = mockSession.getNode(EXAMPLE_UNVERSIONED_PATH);
         verify(unversionedNode).isNodeType(VERSIONABLE);
@@ -183,21 +198,26 @@ public class VersionServiceImplTest {
     }
 
     @Test
-    public void testCreateWithInvalidVersionLabels() throws RepositoryException {
-        // [\\s~#@*+%{}<>\\[\\]|\"^]
-        final String[] invalidChars = { " ", "~", "#", "@", "*", "+", "%", "{", "}",
-            "<", ">", "[", "]", "|", "\"", "^" };
-        for (String s : invalidChars) {
-            testLabel(s);
+    public void testCreateWithInvalidVersionCharacters() throws RepositoryException {
+        final String[] invalidLabels = { "~", "#", "@", "*", "+", "%", "{", "}",
+            "<", ">", "[", "]", "|", "\"", "^", "1234",
+            "label ending in whitespace followed by a number 123","label ending with space "};
+
+        for (String s : invalidLabels) {
+            testInvalidLabel(s);
         }
     }
 
-    private void testLabel(final String label) {
+    private void testInvalidLabel(final String label) {
         try {
             testObj.createVersion(testSession, EXAMPLE_UNVERSIONED_PATH, label);
-            Assert.fail("The previous call should have failed.");
+            fail("Expected failure on label \"" + label + "\" did not occur.");
         } catch (Exception ex) {
-            Assert.assertTrue(ex.getMessage().contains("Invalid label"));
+            final Throwable cause = ex.getCause();
+            if (!(cause instanceof VersionException)) {
+                fail("Expected VersionException on label \"" + label + "\": actual exception = " +
+                        cause);
+            }
         }
     }
 


### PR DESCRIPTION
Also adds test coverage for invalid version labels.

Resolves: https://jira.duraspace.org/browse/FCREPO-1984: