### PR TITLE
Use a new prefix definition for info:fedoraconfig/

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
@@ -93,7 +93,7 @@ public class FedoraFixityIT extends AbstractResourceIT {
         // Set default digest algorithm
         final HttpPatch patch = patchObjMethod(childId + "/fcr:metadata");
         patch.setHeader("Content-Type", "application/sparql-update");
-        final String updateString = "PREFIX fedoraconfig: <info:fedoraconfig/>\n" +
+        final String updateString = "PREFIX config: <info:fedoraconfig/>\n" +
                 "INSERT DATA { <> " + DEFAULT_DIGEST_ALGORITHM + " \"md5\" }";
         patch.setEntity(new StringEntity(updateString));
         assertEquals("Did not update successfully!", NO_CONTENT.getStatusCode(), getStatus(patch));

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
@@ -65,7 +65,7 @@ public interface FedoraTypes {
 
     String CONTENT_DIGEST = "premis:hasMessageDigest";
 
-    String DEFAULT_DIGEST_ALGORITHM = "fedoraconfig:defaultDigestAlgorithm";
+    String DEFAULT_DIGEST_ALGORITHM = "config:defaultDigestAlgorithm";
 
     String FCR_METADATA = "fcr:metadata";
 

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -47,7 +47,7 @@
  * An implementation-specific fedora namespace for properties a user may set on a node that may
  * enable or disable a fedora-specific behavior of that node.
  */
-<fedoraconfig = 'info:fedoraconfig/'>
+<config = 'info:fedoraconfig/'>
 
 /*
  * Any Fedora resource.

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -330,23 +330,23 @@ public class FedoraResourceImplIT extends AbstractIT {
         final NodeTypeManager mgr = jcrSession.getWorkspace().getNodeTypeManager();
         //create supertype mixin
         final NodeTypeTemplate type = mgr.createNodeTypeTemplate();
-        type.setName("fedoraconfig:aSupertype");
+        type.setName("config:aSupertype");
         type.setMixin(true);
         final NodeTypeDefinition[] nodeTypes = new NodeTypeDefinition[]{type};
         mgr.registerNodeTypes(nodeTypes, true);
 
         //create a type inheriting above supertype
         final NodeTypeTemplate type2 = mgr.createNodeTypeTemplate();
-        type2.setName("fedoraconfig:testInher");
+        type2.setName("config:testInher");
         type2.setMixin(true);
-        type2.setDeclaredSuperTypeNames(new String[]{"fedoraconfig:aSupertype"});
+        type2.setDeclaredSuperTypeNames(new String[]{"config:aSupertype"});
         final NodeTypeDefinition[] nodeTypes2 = new NodeTypeDefinition[]{type2};
         mgr.registerNodeTypes(nodeTypes2, true);
 
         //create object with inheriting type
         FedoraResource object = containerService.findOrCreate(session, "/testNTTnheritanceObject");
         final javax.jcr.Node node = getJcrNode(object);
-        node.addMixin("fedoraconfig:testInher");
+        node.addMixin("config:testInher");
 
         session.commit();
         session.expire();
@@ -358,7 +358,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         final Node s = createGraphSubjectNode(object);
         final Node p = createProperty(RDF_NAMESPACE + "type").asNode();
         final Node o = createProperty("info:fedoraconfig/aSupertype").asNode();
-        assertTrue("supertype fedoraconfig:aSupertype not found inherited in fedora:testInher!",
+        assertTrue("supertype config:aSupertype not found inherited in fedora:testInher!",
                 object.getTriples(subjects, PROPERTIES).collect(toModel()).getGraph().contains(s, p, o));
     }
 
@@ -1141,7 +1141,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     @Test
     public void testDeletePartOfMultiValueProperty() throws RepositoryException {
         final String pid = getRandomPid();
-        final String relation = "fedoraconfig:fakeRel";
+        final String relation = "config:fakeRel";
         containerService.findOrCreate(session, pid);
         final Container subject = containerService.findOrCreate(session, pid + "/a");
         final Container referent1 = containerService.findOrCreate(session, pid + "/b");

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/PropertiesRdfContextTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/PropertiesRdfContextTest.java
@@ -86,11 +86,11 @@ public class PropertiesRdfContextTest {
 
     private static final String RDF_PROPERTY_NAME = "rdf-property-name";
 
-    private static final String RDF_PROPERTY_VALUE = "fedoraconfig:rdf-value";
+    private static final String RDF_PROPERTY_VALUE = "config:rdf-value";
 
     private static final String BINARY_PROPERTY_NAME = "binary-property-name";
 
-    private static final String BINARY_PROPERTY_VALUE = "fedoraconfig:binary-value";
+    private static final String BINARY_PROPERTY_VALUE = "config:binary-value";
 
     private static final String RDF_PATH = "/resource/path";
 

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
@@ -221,7 +221,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
         final String updateSparql = "PREFIX dc: <http://purl.org/dc/elements/1.1/>\n" +
                 "PREFIX fedora: <" + REPOSITORY_NAMESPACE + ">\n" +
                 "\n" +
-                "INSERT DATA { <> fedoraconfig:versioningPolicy \"auto-version\" ; dc:title \"Object Title\". }";
+                "INSERT DATA { <> config:versioningPolicy \"auto-version\" ; dc:title \"Object Title\". }";
         postSparqlUpdateUsingHttpClient(updateSparql, pid);
 
         final HtmlPage objectPage = javascriptlessWebClient.getPage(serverAddress + pid);


### PR DESCRIPTION
Addresses: https://jira.duraspace.org/browse/FCREPO-2247

The goal here is to avoid making an [earlier change](https://github.com/fcrepo4/fcrepo4/commit/48010a20a13645977d4641cb987c939f6e2522b8) non-breaking for users who had previously made use of the `fedoraconfig` prefix.