### PR TITLE
Replaces uses of java.util.Date/Cal with java.time options

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -414,13 +414,12 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (resource instanceof FedoraBinary) {
             final FedoraBinary binary = (FedoraBinary)resource;
             final Date createdDate = binary.getCreatedDate() != null ? Date.from(binary.getCreatedDate()) : null;
-            final Date modifiedDate =
-                binary.getLastModifiedDate() != null ? Date.from(binary.getCreatedDate()) : null;
+            final Date modDate = binary.getLastModifiedDate() != null ? Date.from(binary.getLastModifiedDate()) : null;
 
             final ContentDisposition contentDisposition = ContentDisposition.type("attachment")
                     .fileName(binary.getFilename())
                     .creationDate(createdDate)
-                    .modificationDate(modifiedDate)
+                    .modificationDate(modDate)
                     .size(binary.getContentSize())
                     .build();
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -52,10 +52,12 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.MINIMAL;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
 
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -410,12 +412,15 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      */
     protected void addResourceHttpHeaders(final FedoraResource resource) {
         if (resource instanceof FedoraBinary) {
-
             final FedoraBinary binary = (FedoraBinary)resource;
+            final Date createdDate = binary.getCreatedDate() != null ? Date.from(binary.getCreatedDate()) : null;
+            final Date modifiedDate =
+                binary.getLastModifiedDate() != null ? Date.from(binary.getCreatedDate()) : null;
+
             final ContentDisposition contentDisposition = ContentDisposition.type("attachment")
                     .fileName(binary.getFilename())
-                    .creationDate(binary.getCreatedDate())
-                    .modificationDate(binary.getLastModifiedDate())
+                    .creationDate(createdDate)
+                    .modificationDate(modifiedDate)
                     .size(binary.getContentSize())
                     .build();
 
@@ -492,7 +497,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         final EntityTag etag;
-        final Date date;
+        final Instant date;
 
         // See note about this code in the javadoc above.
         if (resource instanceof FedoraBinary) {
@@ -510,7 +515,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         if (date != null) {
-            servletResponse.addDateHeader("Last-Modified", date.getTime());
+            servletResponse.addDateHeader("Last-Modified", date.toEpochMilli());
         }
     }
 
@@ -542,8 +547,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         final EntityTag etag;
-        final Date date;
-        final Date roundedDate = new Date();
+        final Instant date;
+        Instant roundedDate = Instant.now();
 
         // See the related note about the next block of code in the
         // ContentExposingResource::addCacheControlHeaders method
@@ -558,14 +563,14 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         if (date != null) {
-            roundedDate.setTime(date.getTime() - date.getTime() % 1000);
+            roundedDate = date.minusMillis(date.toEpochMilli() % 1000);
         }
 
         Response.ResponseBuilder builder = request.evaluatePreconditions(etag);
         if ( builder != null ) {
             builder = builder.entity("ETag mismatch");
         } else {
-            builder = request.evaluatePreconditions(roundedDate);
+            builder = request.evaluatePreconditions(Date.from(roundedDate));
             if ( builder != null ) {
                 builder = builder.entity("Date mismatch");
             }
@@ -578,7 +583,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             // here we are implicitly emitting a 304
             // the exception is not an error, it's genuinely
             // an exceptional condition
-            builder = builder.cacheControl(cc).lastModified(date).tag(etag);
+            builder = builder.cacheControl(cc).lastModified(Date.from(date)).tag(etag);
         }
         if (builder != null) {
             throw new WebApplicationException(builder.build());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.net.URISyntaxException;
-import java.util.Date;
 import java.util.function.Supplier;
 
 import javax.jcr.ItemExistsException;
@@ -123,9 +122,6 @@ public class FedoraNodesTest {
     @Mock
     private Supplier<String> mockPidMinter;
 
-    @Mock
-    private Date mockDate;
-
     private UriInfo mockUriInfo;
 
     @Mock
@@ -160,7 +156,6 @@ public class FedoraNodesTest {
         when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
         final VersionManager mockVM = mock(VersionManager.class);
         when(mockWorkspace.getVersionManager()).thenReturn(mockVM);
-        when(mockDate.getTime()).thenReturn(0L);
         when(mockNode.getPath()).thenReturn(path);
         when(mockContainer.getPath()).thenReturn(path);
         when(mockContainer.getEtagValue()).thenReturn("XYZ");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2628,11 +2628,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String objURI = serverAddress + objid;
         final String binURI = objURI + "/binary1";
 
-        final long lastmod1;
+        final Instant lastmod1;
         try (final CloseableHttpResponse response = execute(putDSMethod(objid, "binary1", "some test content"))) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
-            lastmod1 = Instant.from(
-                headerFormat.parse(response.getFirstHeader("Last-Modified").getValue())).toEpochMilli();
+            lastmod1 = Instant.from(headerFormat.parse(response.getFirstHeader("Last-Modified").getValue()));
         }
 
         sleep(1000); // wait a second to make sure last-modified value will be different
@@ -2645,22 +2644,21 @@ public class FedoraLdpIT extends AbstractResourceIT {
         patchBinary.addHeader("Content-Type", "application/sparql-update");
         patchBinary.setEntity(new StringEntity("INSERT { <" + binURI + "> " +
                 "<http://www.w3.org/TR/rdf-schema/label> \"this is a label\" } WHERE {}"));
-        final long lastmod2;
+
+        final Instant lastmod2;
         try (final CloseableHttpResponse response = execute(patchBinary)) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
-            lastmod2 = Instant.from(
-                headerFormat.parse(response.getFirstHeader("Last-Modified").getValue())).toEpochMilli();
-            assertTrue(lastmod2 > lastmod1);
+            lastmod2 = Instant.from(headerFormat.parse(response.getFirstHeader("Last-Modified").getValue()));
+            assertTrue(lastmod2.isAfter(lastmod1));
         }
 
         sleep(1000); // wait a second to make sure last-modified value will be different
 
-        final long lastmod3;
+        final Instant lastmod3;
         try (final CloseableHttpResponse response = execute(putDSMethod(objid, "binary1", "new test content"))) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
-            lastmod3 = Instant.from(
-                headerFormat.parse(response.getFirstHeader("Last-Modified").getValue())).toEpochMilli();
-            assertTrue(lastmod3 > lastmod2);
+            lastmod3 = Instant.from(headerFormat.parse(response.getFirstHeader("Last-Modified").getValue()));
+            assertTrue(lastmod3.isAfter(lastmod2));
         }
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ViewHelpers.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ViewHelpers.java
@@ -26,6 +26,8 @@ import static org.apache.jena.vocabulary.DC.title;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.apache.jena.vocabulary.RDFS.label;
 import static org.apache.jena.vocabulary.SKOS.prefLabel;
+import static java.time.Instant.now;
+import static java.time.ZoneId.of;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyMap;
@@ -41,8 +43,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.WRITABLE;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -83,7 +84,8 @@ public class ViewHelpers {
 
     private static final List<Property>  TITLE_PROPERTIES = asList(label, title, DCTerms.title, prefLabel);
 
-    private static final String DEFAULT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(new Date());
+    private static final String DEFAULT =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(of("GMT")).format(now());
 
     private ViewHelpers() {
         // Exists only to defeat instantiation.

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
@@ -39,8 +39,9 @@ import static org.fcrepo.kernel.api.RdfLexicon.WRITABLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static java.time.Instant.now;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +80,7 @@ public class ViewHelpersTest {
     public void testGetVersions() {
         final Graph mem = createDefaultModel().getGraph();
         final Node version = createURI("http://localhost/fcrepo/abc/fcr:version/adcd");
-        final String date = new Date().toString();
+        final String date = Instant.now().toString();
         mem.add(new Triple(createURI("http://localhost/fcrepo/abc"), HAS_VERSION.asNode(),
                 version));
         mem.add(new Triple(version, CREATED_DATE.asNode(), createLiteral(date)));
@@ -93,9 +94,9 @@ public class ViewHelpersTest {
         final Node v1 = createURI("http://localhost/fcrepo/abc/fcr:version/1");
         final Node v2 = createURI("http://localhost/fcrepo/abc/fcr:version/2");
         final Node v3 = createURI("http://localhost/fcrepo/abc/fcr:version/3");
-        final Date now = new Date();
-        final Date later = new Date();
-        later.setTime(later.getTime() + 10000l);
+        final String date = Instant.now().toString();
+        final Instant now = Instant.now();
+        final Instant later = now.plusMillis(10000l);
 
         final Graph mem = createDefaultModel().getGraph();
         mem.add(new Triple(resource, HAS_VERSION.asNode(), v1));
@@ -213,7 +214,7 @@ public class ViewHelpersTest {
     @Test
     public void testGetVersionDate() {
         final Graph mem = createDefaultModel().getGraph();
-        final String date = new Date().toString();
+        final String date = Instant.now().toString();
         mem.add(new Triple(createURI("a/b/c"), CREATED_DATE.asNode(),
                 createLiteral(date)));
         assertEquals("Date should be available.", date, testObj.getVersionDate(mem, createURI("a/b/c")).get());

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
@@ -80,10 +80,9 @@ public class ViewHelpersTest {
     public void testGetVersions() {
         final Graph mem = createDefaultModel().getGraph();
         final Node version = createURI("http://localhost/fcrepo/abc/fcr:version/adcd");
-        final String date = Instant.now().toString();
         mem.add(new Triple(createURI("http://localhost/fcrepo/abc"), HAS_VERSION.asNode(),
                 version));
-        mem.add(new Triple(version, CREATED_DATE.asNode(), createLiteral(date)));
+        mem.add(new Triple(version, CREATED_DATE.asNode(), createLiteral(now().toString())));
         assertEquals("Version should be available.",
                      version, testObj.getVersions(mem, createURI("http://localhost/fcrepo/abc")).next());
     }
@@ -94,20 +93,16 @@ public class ViewHelpersTest {
         final Node v1 = createURI("http://localhost/fcrepo/abc/fcr:version/1");
         final Node v2 = createURI("http://localhost/fcrepo/abc/fcr:version/2");
         final Node v3 = createURI("http://localhost/fcrepo/abc/fcr:version/3");
-        final String date = Instant.now().toString();
-        final Instant now = Instant.now();
-        final Instant later = now.plusMillis(10000l);
+        final Instant date = now();
 
         final Graph mem = createDefaultModel().getGraph();
         mem.add(new Triple(resource, HAS_VERSION.asNode(), v1));
-        mem.add(new Triple(v1, CREATED_DATE.asNode(),
-                createLiteral(now.toString())));
+        mem.add(new Triple(v1, CREATED_DATE.asNode(), createLiteral(date.toString())));
         mem.add(new Triple(resource, HAS_VERSION.asNode(), v2));
-        mem.add(new Triple(v2, CREATED_DATE.asNode(),
-                createLiteral(now.toString())));
+        mem.add(new Triple(v2, CREATED_DATE.asNode(), createLiteral(date.toString())));
         mem.add(new Triple(resource, HAS_VERSION.asNode(), v3));
         mem.add(new Triple(v3, CREATED_DATE.asNode(),
-                createLiteral(later.toString())));
+                createLiteral(date.plusMillis(10000l).toString())));
 
         final Iterator<Node> versions = testObj.getOrderedVersions(mem, resource, HAS_VERSION);
         versions.next();
@@ -214,7 +209,7 @@ public class ViewHelpersTest {
     @Test
     public void testGetVersionDate() {
         final Graph mem = createDefaultModel().getGraph();
-        final String date = Instant.now().toString();
+        final String date = now().toString();
         mem.add(new Triple(createURI("a/b/c"), CREATED_DATE.asNode(),
                 createLiteral(date)));
         assertEquals("Date should be available.", date, testObj.getVersionDate(mem, createURI("a/b/c")).get());

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
@@ -36,9 +36,9 @@ import java.net.URI;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 
 import javax.jcr.LoginException;
 import javax.jcr.Node;
@@ -224,8 +224,8 @@ public abstract class TestHelpers {
         when(mockDs.getDescribedResource()).thenReturn(mockBinary);
         when(mockDs.getDescribedResource().getDescription()).thenReturn(mockDs);
         when(mockDs.getPath()).thenReturn("/" + pid + "/" + dsId);
-        when(mockDs.getCreatedDate()).thenReturn(new Date());
-        when(mockDs.getLastModifiedDate()).thenReturn(new Date());
+        when(mockDs.getCreatedDate()).thenReturn(Instant.now());
+        when(mockDs.getLastModifiedDate()).thenReturn(Instant.now());
         if (content != null) {
             final MessageDigest md;
             try {
@@ -245,8 +245,8 @@ public abstract class TestHelpers {
         final FedoraBinary mockBinary = mock(FedoraBinary.class);
         when(mockBinary.getPath()).thenReturn("/" + pid + "/" + dsId + "/jcr:content");
         when(mockBinary.getMimeType()).thenReturn("application/octet-stream");
-        when(mockBinary.getCreatedDate()).thenReturn(new Date());
-        when(mockBinary.getLastModifiedDate()).thenReturn(new Date());
+        when(mockBinary.getCreatedDate()).thenReturn(Instant.now());
+        when(mockBinary.getLastModifiedDate()).thenReturn(Instant.now());
         if (content != null) {
             final MessageDigest md;
             try {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -18,7 +18,7 @@
 package org.fcrepo.kernel.api.models;
 
 import java.net.URI;
-import java.util.Date;
+import java.time.Instant;
 
 import java.util.List;
 import java.util.Set;
@@ -93,13 +93,13 @@ public interface FedoraResource {
      * Get the date this resource was created
      * @return created date
      */
-    Date getCreatedDate();
+    Instant getCreatedDate();
 
     /**
      * Get the date this resource was last modified
      * @return last modified date
      */
-    Date getLastModifiedDate();
+    Instant getLastModifiedDate();
 
     /**
      * Check if this object uses a given RDF type

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.modeshape;
 import static org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral;
 import static org.apache.jena.update.UpdateAction.execute;
 import static org.apache.jena.update.UpdateFactory.create;
+import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.joining;
@@ -441,7 +442,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     public Instant getCreatedDate() {
         try {
             if (hasProperty(JCR_CREATED)) {
-                return Instant.ofEpochMilli(getTimestamp(JCR_CREATED, NO_TIME));
+                return ofEpochMilli(getTimestamp(JCR_CREATED, NO_TIME));
             }
         } catch (final PathNotFoundException e) {
             throw new PathNotFoundRuntimeException(e);
@@ -477,9 +478,9 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         try {
             final long created = createdDate == null ? NO_TIME : createdDate.toEpochMilli();
             if (hasProperty(FEDORA_LASTMODIFIED)) {
-                return Instant.ofEpochMilli(getTimestamp(FEDORA_LASTMODIFIED, created));
+                return ofEpochMilli(getTimestamp(FEDORA_LASTMODIFIED, created));
             } else if (hasProperty(JCR_LASTMODIFIED)) {
-                return Instant.ofEpochMilli(getTimestamp(JCR_LASTMODIFIED, created));
+                return ofEpochMilli(getTimestamp(JCR_LASTMODIFIED, created));
             }
         } catch (final PathNotFoundException e) {
             throw new PathNotFoundRuntimeException(e);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/FixityRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/FixityRdfContext.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.modeshape.rdf.impl;
 
+import static java.time.Instant.now;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.graph.Triple.create;
@@ -32,7 +33,6 @@ import static org.fcrepo.kernel.modeshape.utils.UncheckedFunction.uncheck;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
@@ -69,7 +69,7 @@ public class FixityRdfContext extends NodeRdfContext {
 
         concat(StreamSupport.stream(blobs.spliterator(), false).flatMap(uncheck(blob -> {
             final org.apache.jena.graph.Node resultSubject =
-                    createURI(subject().getURI() + "#fixity/" + Calendar.getInstance().getTimeInMillis());
+                    createURI(subject().getURI() + "#fixity/" + now().toEpochMilli());
             final List<Triple> b = new ArrayList<>();
 
             b.add(create(subject(), HAS_FIXITY_RESULT.asNode(), resultSubject));

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
@@ -206,7 +206,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
             final FedoraBinary orig = binaryService.findOrCreate(session, "/testDatastreamObject/testDatastreamNode3");
             orig.setContent(new ByteArrayInputStream("asdf".getBytes()), "application/octet-stream", null, null, null);
             session.commit();
-            final long origMod = orig.getLastModifiedDate().getTime();
+            final long origMod = orig.getLastModifiedDate().toEpochMilli();
 
             final FedoraBinary ds = binaryService.findOrCreate(session,
                     "/testDatastreamObject/testDatastreamNode3");
@@ -220,7 +220,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
             final String contentString = IOUtils.toString(ds.getContent(), "ASCII");
 
             assertEquals("0123456789", contentString);
-            assertTrue("Last-modified should be updated", ds.getLastModifiedDate().getTime() > origMod);
+            assertTrue("Last-modified should be updated", ds.getLastModifiedDate().toEpochMilli() > origMod);
         } finally {
             session.expire();
         }
@@ -392,10 +392,10 @@ public class FedoraBinaryImplIT extends AbstractIT {
             final FedoraBinary orig = binaryService.findOrCreate(session, "/testDatastreamObject/testDatastreamNode6");
             orig.setContent(new ByteArrayInputStream("asdf".getBytes()), "application/octet-stream", null, null, null);
             session.commit();
-            final long origMod = orig.getLastModifiedDate().getTime();
+            final long origMod = orig.getLastModifiedDate().toEpochMilli();
 
             final FedoraResource description = orig.getDescription();
-            final long origDescriptionMod = description.getLastModifiedDate().getTime();
+            final long origDescriptionMod = description.getLastModifiedDate().toEpochMilli();
 
             description.updateProperties(idTranslator, "INSERT { <> <info:fcrepo/foo> \"b\" } WHERE {}",
                     description.getTriples(idTranslator, PROPERTIES));
@@ -403,8 +403,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
 
             final FedoraBinary ds = binaryService.findOrCreate(session, "/testDatastreamObject/testDatastreamNode6");
 
-            final long modMod = ds.getLastModifiedDate().getTime();
-            final long modDescMod = ds.getDescription().getLastModifiedDate().getTime();
+            final long modMod = ds.getLastModifiedDate().toEpochMilli();
+            final long modDescMod = ds.getDescription().getLastModifiedDate().toEpochMilli();
 
             assertEquals("Last-modified on the binary should be the same", modMod,  origMod);
             assertNotEquals("Last-modified on the description should not be the same", modDescMod, origDescriptionMod);
@@ -412,9 +412,9 @@ public class FedoraBinaryImplIT extends AbstractIT {
             ds.setContent(new ByteArrayInputStream("0123456789".getBytes()), null, null, null, null);
 
             assertNotEquals("Last-modified on the binary should have changed",
-                    ds.getLastModifiedDate().getTime(), modMod);
+                    ds.getLastModifiedDate().toEpochMilli(), modMod);
             assertNotEquals("Last-modified on the description should have changed",
-                    ds.getDescription().getLastModifiedDate().getTime(), modDescMod);
+                    ds.getDescription().getLastModifiedDate().toEpochMilli(), modDescMod);
 
         } finally {
             session.expire();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -69,9 +69,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.time.Instant;
 
 import javax.inject.Inject;
 import javax.jcr.Value;
@@ -206,9 +206,9 @@ public class FedoraResourceImplIT extends AbstractIT {
         session = repo.login();
 
         final Container obj2 = containerService.findOrCreate(session, "/" + pid);
-        final Date created = roundDate(obj2.getCreatedDate());
-        final Date modified = roundDate(obj2.getLastModifiedDate());
-        assertFalse(modified + " should not be before " + created, modified.before(created));
+        final Instant created = roundDate(obj2.getCreatedDate());
+        final Instant modified = roundDate(obj2.getLastModifiedDate());
+        assertFalse(modified + " should not be before " + created, modified.isBefore(created));
 
         final Graph graph = obj2.getTriples(subjects, PROPERTIES).collect(toModel()).getGraph();
         final Node s = createGraphSubjectNode(obj2);
@@ -231,9 +231,9 @@ public class FedoraResourceImplIT extends AbstractIT {
 
         final Container obj2 = containerService.findOrCreate(session, "/" + pid);
         final FedoraResourceImpl impl = new FedoraResourceImpl(getJcrNode(obj2));
-        final Date oldMod = impl.getLastModifiedDate();
+        final Instant oldMod = impl.getLastModifiedDate();
         impl.touch();
-        assertTrue( oldMod.before(obj2.getLastModifiedDate()) );
+        assertTrue( oldMod.isBefore(obj2.getLastModifiedDate()) );
     }
 
     @Test
@@ -1186,7 +1186,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         v.getContainingHistory().addVersionLabel(v.getName(), label, false);
     }
 
-    private static Date roundDate(final Date date) {
-        return new Date(date.getTime() - date.getTime() % 1000);
+    private static Instant roundDate(final Instant date) {
+        return date.minusMillis(date.toEpochMilli() % 1000);
     }
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraBinaryImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraBinaryImplTest.java
@@ -40,7 +40,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
 
 import static java.util.Collections.singleton;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
@@ -235,28 +235,24 @@ public class FedoraBinaryImplTest implements FedoraTypes {
 
     @Test
     public void testGetCreatedDate() throws RepositoryException {
-        final Date expected = new Date();
         final Calendar cal = Calendar.getInstance();
-        cal.setTime(expected);
         final Property mockProp = mock(Property.class);
         when(mockProp.getDate()).thenReturn(cal);
         when(mockContent.hasProperty(JCR_CREATED)).thenReturn(true);
         when(mockContent.getProperty(JCR_CREATED)).thenReturn(mockProp);
-        final Date actual = testObj.getCreatedDate();
-        assertEquals(expected.getTime(), actual.getTime());
+        final Instant actual = testObj.getCreatedDate();
+        assertEquals(cal.getTimeInMillis(), actual.toEpochMilli());
     }
 
     @Test
     public void testGetLastModifiedDate() throws RepositoryException {
-        final Date expected = new Date();
         final Calendar cal = Calendar.getInstance();
-        cal.setTime(expected);
         final Property mockProp = mock(Property.class);
         when(mockProp.getDate()).thenReturn(cal);
         when(mockContent.hasProperty(JCR_LASTMODIFIED)).thenReturn(true);
         when(mockContent.getProperty(JCR_LASTMODIFIED)).thenReturn(mockProp);
-        final Date actual = testObj.getLastModifiedDate();
-        assertEquals(expected.getTime(), actual.getTime());
+        final Instant actual = testObj.getLastModifiedDate();
+        assertEquals(cal.getTimeInMillis(), actual.toEpochMilli());
     }
 
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraResourceImplTest.java
@@ -47,10 +47,10 @@ import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 
 import java.net.URI;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import java.time.Instant;
 
 import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
@@ -140,8 +140,7 @@ public class FedoraResourceImplTest {
         when(mockProp.getDate()).thenReturn(someDate);
         when(mockNode.hasProperty(JCR_CREATED)).thenReturn(true);
         when(mockNode.getProperty(JCR_CREATED)).thenReturn(mockProp);
-        assertEquals(someDate.getTimeInMillis(), testObj.getCreatedDate()
-                .getTime());
+        assertEquals(someDate.getTimeInMillis(), testObj.getCreatedDate().toEpochMilli());
     }
 
     @Test
@@ -201,8 +200,8 @@ public class FedoraResourceImplTest {
         } catch (final RepositoryException e) {
             e.printStackTrace();
         }
-        final Date actual = testObj.getLastModifiedDate();
-        assertEquals(someDate.getTimeInMillis(), actual.getTime());
+        final Instant actual = testObj.getLastModifiedDate();
+        assertEquals(someDate.getTimeInMillis(), actual.toEpochMilli());
         // this is a read operation, it must not persist the session
         verify(mockSession, never()).save();
     }
@@ -230,8 +229,8 @@ public class FedoraResourceImplTest {
             System.err.println("What are we doing in the second test?");
             e.printStackTrace();
         }
-        final Date actual = testObj.getLastModifiedDate();
-        assertEquals(modDate.getTimeInMillis(), actual.getTime());
+        final Instant actual = testObj.getLastModifiedDate();
+        assertEquals(modDate.getTimeInMillis(), actual.toEpochMilli());
     }
 
     @Test
@@ -248,8 +247,8 @@ public class FedoraResourceImplTest {
         when(mockNode.hasProperty(JCR_LASTMODIFIED)).thenReturn(true);
         when(mockNode.getProperty(JCR_LASTMODIFIED)).thenReturn(mockMod);
         when(mockMod.getDate()).thenReturn(modDate);
-        final Date actual = testObj.getLastModifiedDate();
-        assertEquals(modDate.getTimeInMillis(), actual.getTime());
+        final Instant actual = testObj.getLastModifiedDate();
+        assertEquals(modDate.getTimeInMillis(), actual.toEpochMilli());
     }
 
     @Test
@@ -337,7 +336,7 @@ public class FedoraResourceImplTest {
         when(mockMod.getDate()).thenReturn(modDate);
 
         assertEquals(shaHex("some-path"
-                + testObj.getLastModifiedDate().getTime()), testObj
+                + testObj.getLastModifiedDate().toEpochMilli()), testObj
                 .getEtagValue());
     }
 

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImplTest.java
@@ -35,7 +35,7 @@ import javax.jcr.nodetype.NodeType;
 
 import java.io.InputStream;
 import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
 
 import static org.fcrepo.kernel.modeshape.NonRdfSourceDescriptionImpl.hasMixin;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATED;
@@ -108,28 +108,24 @@ public class NonRdfSourceDescriptionImplTest implements FedoraTypes {
 
     @Test
     public void testGetCreatedDate() throws RepositoryException {
-        final Date expected = new Date();
         final Calendar cal = Calendar.getInstance();
-        cal.setTime(expected);
         final Property mockProp = mock(Property.class);
         when(mockProp.getDate()).thenReturn(cal);
         when(mockDsNode.hasProperty(JCR_CREATED)).thenReturn(true);
         when(mockDsNode.getProperty(JCR_CREATED)).thenReturn(mockProp);
-        final Date actual = testObj.getCreatedDate();
-        assertEquals(expected.getTime(), actual.getTime());
+        final Instant actual = testObj.getCreatedDate();
+        assertEquals(cal.getTimeInMillis(), actual.toEpochMilli());
     }
 
     @Test
     public void testGetLastModifiedDate() throws RepositoryException {
-        final Date expected = new Date();
         final Calendar cal = Calendar.getInstance();
-        cal.setTime(expected);
         final Property mockProp = mock(Property.class);
         when(mockProp.getDate()).thenReturn(cal);
         when(mockDsNode.hasProperty(JCR_LASTMODIFIED)).thenReturn(true);
         when(mockDsNode.getProperty(JCR_LASTMODIFIED)).thenReturn(mockProp);
-        final Date actual = testObj.getLastModifiedDate();
-        assertEquals(expected.getTime(), actual.getTime());
+        final Instant actual = testObj.getLastModifiedDate();
+        assertEquals(cal.getTimeInMillis(), actual.toEpochMilli());
     }
 
     @Test


### PR DESCRIPTION
- Wherever possible java.util.Date and Calendar have been replaced

Resolves: https://jira.duraspace.org/browse/FCREPO-1995
