### PR TITLE
Disable output content buffering

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/FedoraApplication.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/FedoraApplication.java
@@ -31,6 +31,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import java.util.logging.Logger;
 
+import static org.glassfish.jersey.server.ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -56,6 +57,9 @@ public class FedoraApplication extends ResourceConfig {
         }
 
         register(new InstrumentedResourceMethodApplicationListener(new MetricRegistry()));
+
+        // Disable output buffering
+        property(OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
     }
 
     static class FactoryBinder extends AbstractBinder {


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2282

You will notice the difference in the lack of a `Content-Length` header for RdfSource responses. NonRdfSource documents continue to have the `Content-Length` header, since that value is set by the `fcrepo-http-api` code and not the JAX-RS runtime.

Note: ideally, HEAD requests for Containers would not have a `Content-Length` header, but that does not appear to be the case: they still contain a `Content-Length: 0` header.