### PR TITLE
Insure 304 responses do not contain an entity body. (4.7.0-maint)

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -107,6 +107,7 @@ import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.jvnet.hk2.annotations.Optional;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * An abstract class that sits between AbstractResource and any resource that
@@ -528,7 +529,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         evaluateRequestPreconditions(request, servletResponse, resource, session, false);
     }
 
-    private static void evaluateRequestPreconditions(final Request request,
+    @VisibleForTesting
+    static void evaluateRequestPreconditions(final Request request,
                                                      final HttpServletResponse servletResponse,
                                                      final FedoraResource resource,
                                                      final Session session,
@@ -563,13 +565,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         Response.ResponseBuilder builder = request.evaluatePreconditions(etag);
-        if ( builder != null ) {
-            builder = builder.entity("ETag mismatch");
-        } else {
+        if ( builder == null ) {
             builder = request.evaluatePreconditions(roundedDate);
-            if ( builder != null ) {
-                builder = builder.entity("Date mismatch");
-            }
         }
 
         if (builder != null && cacheControl ) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -48,12 +48,14 @@ import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -64,6 +66,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.text.ParseException;
 import java.util.Collections;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -79,6 +82,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
@@ -496,6 +501,76 @@ public class FedoraLdpTest {
             assertFalse("Included non-minimal contexts", rdfNodes.contains("LDP_CONTAINMENT"));
         }
 
+    }
+
+    /**
+     * Emulates an 'If-None-Match' precondition failing for a GET request.  There should not be any entity body set
+     * on the response.
+     *
+     * @throws Exception if something exceptional happens
+     */
+    @Test
+    public void testGetWhenIfNoneMatchPreconditionFails() throws Exception {
+        setResource(FedoraResource.class);
+
+        // Set up the expectations for the ResponseBuilder
+        final Response.ResponseBuilder builder = mock(Response.ResponseBuilder.class);
+        when(builder.entity(any())).thenReturn(builder);
+        when(builder.cacheControl(any())).thenReturn(builder);
+        when(builder.lastModified((any()))).thenReturn(builder);
+        when(builder.tag(any(EntityTag.class))).thenReturn(builder);
+
+        // Set up expectations for the Request; returning a ResponseBuilder from evaluatePreconditions(...) indicates
+        // that satisfying the precondition fails, which is what we want to simulate in this test
+        when(mockRequest.evaluatePreconditions(any(EntityTag.class))).thenReturn(builder);
+
+        // Execute the method under test.  Preconditions should fail, resulting in an exception being thrown.
+        try {
+            ContentExposingResource.evaluateRequestPreconditions(mockRequest, mockResponse, testObj.resource(),
+                    mockSession, true);
+            fail("Expected " + WebApplicationException.class.getName() + " to be thrown.");
+        } catch (WebApplicationException e) {
+            // expected
+        }
+
+        // an entity body should _not_ be set under these conditions
+        verify(mockRequest).evaluatePreconditions(any(EntityTag.class));
+        verify(builder, times(0)).entity(any());
+    }
+
+    /**
+     * Emulates an 'If-Modified-Since' precondition failing for a GET request.  There should not be any entity body set
+     * on the response.
+     *
+     * @throws Exception if something exceptional happens
+     */
+    @Test
+    public void testGetWhenIfModifiedSincePreconditionFails() throws Exception {
+        setResource(FedoraResource.class);
+
+        // Set up the expectations for the ResponseBuilder
+        final Response.ResponseBuilder builder = mock(Response.ResponseBuilder.class);
+        when(builder.entity(any())).thenReturn(builder);
+        when(builder.cacheControl(any())).thenReturn(builder);
+        when(builder.lastModified((any()))).thenReturn(builder);
+        when(builder.tag(any(EntityTag.class))).thenReturn(builder);
+
+        // Set up expectations for the Request; returning a ResponseBuilder from evaluatePreconditions(...) indicates
+        // that satisfying the precondition fails, which is what we want to simulate in this test
+        when(mockRequest.evaluatePreconditions(any(Date.class))).thenReturn(builder);
+
+        // Execute the method under test.  Preconditions should fail, resulting in an exception being thrown.
+        try {
+            ContentExposingResource.evaluateRequestPreconditions(mockRequest, mockResponse, testObj.resource(),
+                    mockSession, true);
+            fail("Expected " + WebApplicationException.class.getName() + " to be thrown.");
+        } catch (WebApplicationException e) {
+            // expected
+        }
+
+        // an entity body should _not_ be set under these conditions
+        verify(mockRequest).evaluatePreconditions(any(Date.class));
+        verify(builder, times(0)).entity(any());
     }
 
     @Test


### PR DESCRIPTION
RFC 7232 explicitly states that 304 "Not Modified" responses to conditional requests MUST not contain an entity body: 

  "A 304 response cannot contain a message-body; it is always terminated 
   by the first empty line after the header fields." 

Responses from Fedora *do* have an entity body. When Fedora accessed via clients such as Apache Httpclient, this can cause apparent corruption of responses from Fedora. HttpClient does not consume entity bodies from requests that return a 304. The bytes from the errant entity body returned from Fedora can remain in internal HttpClient buffers, corrupting reads from subsequent responses. 

* Addresses https://jira.duraspace.org/browse/FCREPO-2313