### PR TITLE
Insure 304 responses do not contain an entity body. (4.6.0-maint)

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -75,6 +75,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.jena.atlas.RuntimeIOException;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RiotException;
@@ -520,7 +521,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         evaluateRequestPreconditions(request, servletResponse, resource, session, false);
     }
 
-    private static void evaluateRequestPreconditions(final Request request,
+    @VisibleForTesting
+    static void evaluateRequestPreconditions(final Request request,
                                                      final HttpServletResponse servletResponse,
                                                      final FedoraResource resource,
                                                      final Session session,
@@ -555,13 +557,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         Response.ResponseBuilder builder = request.evaluatePreconditions(etag);
-        if ( builder != null ) {
-            builder = builder.entity("ETag mismatch");
-        } else {
+        if ( builder == null ) {
             builder = request.evaluatePreconditions(roundedDate);
-            if ( builder != null ) {
-                builder = builder.entity("Date mismatch");
-            }
         }
 
         if (builder != null && cacheControl ) {


### PR DESCRIPTION
RFC 7232 explicitly states that 304 "Not Modified" responses to conditional requests MUST not contain an entity body:

"A 304 response cannot contain a message-body; it is always terminated
by the first empty line after the header fields."

Responses from Fedora do have an entity body. When Fedora accessed via clients such as Apache Httpclient, this can cause apparent corruption of responses from Fedora. HttpClient does not consume entity bodies from requests that return a 304. The bytes from the errant entity body returned from Fedora can remain in internal HttpClient buffers, corrupting reads from subsequent responses.

Addresses https://jira.duraspace.org/browse/FCREPO-2313