### PR TITLE
Fcrepo 2323

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/SkolemNodeRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/SkolemNodeRdfContext.java
@@ -26,6 +26,7 @@ import org.fcrepo.kernel.modeshape.rdf.impl.mappings.PropertyValueIterator;
 import org.slf4j.Logger;
 
 import javax.jcr.AccessDeniedException;
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
@@ -93,6 +94,11 @@ public class SkolemNodeRdfContext extends NodeRdfContext {
             return null;
 
         } catch (final RepositoryException e) {
+            if (e instanceof ItemNotFoundException) {
+                // Effectively skip resources that do not exist
+                LOGGER.warn("Reference to non-existent resource encounterd: {}", v);
+                return null;
+            }
             throw new RepositoryRuntimeException(e);
         }
     };

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/mappings/PropertyToTriple.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/mappings/PropertyToTriple.java
@@ -22,6 +22,7 @@ import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.Triple.create;
 import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.nodeToResource;
 import static org.fcrepo.kernel.modeshape.utils.StreamUtils.iteratorToStream;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -30,6 +31,8 @@ import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Value;
+
 import com.google.common.base.Converter;
 import org.apache.jena.graph.impl.LiteralLabel;
 import org.apache.jena.rdf.model.Resource;
@@ -40,6 +43,7 @@ import org.fcrepo.kernel.modeshape.rdf.converters.PropertyConverter;
 import org.fcrepo.kernel.modeshape.rdf.converters.ValueConverter;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.graph.Triple;
+import org.slf4j.Logger;
 
 /**
  * Utility for moving from JCR properties to RDF triples.
@@ -48,6 +52,8 @@ import org.apache.jena.graph.Triple;
  * @since Oct 10, 2013
  */
 public class PropertyToTriple implements Function<Property, Stream<Triple>> {
+
+    private static final Logger LOGGER = getLogger(PropertyToTriple.class);
 
     private static final PropertyConverter propertyConverter = new PropertyConverter();
     private final ValueConverter valueConverter;
@@ -71,7 +77,7 @@ public class PropertyToTriple implements Function<Property, Stream<Triple>> {
             final org.apache.jena.graph.Node propPredicate = propertyConverter.convert(p).asNode();
             final String propertyName = p.getName();
 
-            return iteratorToStream(new PropertyValueIterator(p)).map(v -> {
+            return iteratorToStream(new PropertyValueIterator(p)).filter(this::valueCanBeConverted).map(v -> {
                 final org.apache.jena.graph.Node object = valueConverter.convert(v).asNode();
                 if (object.isLiteral()) {
                     // unpack the name of the property for information about what kind of literal
@@ -94,4 +100,23 @@ public class PropertyToTriple implements Function<Property, Stream<Triple>> {
             throw new RepositoryRuntimeException(e);
         }
     }
+
+    /**
+     * This method tests if a given value can be converted.
+     * The scenario when this may not be true is for (weak)reference properties that target an non-existent resource.
+     * This scenario generally should not be possible, but the following bug introduced the possibility:
+     *   https://jira.duraspace.org/browse/FCREPO-2323
+     *
+     * @param value to be tested for whether it can be converted to an RDFNode or not
+     * @return true if value can be converted
+     */
+    private boolean valueCanBeConverted(final Value value) {
+        try {
+            valueConverter.convert(value);
+            return true;
+        } catch (final RepositoryRuntimeException e) {
+            LOGGER.warn("Reference to non-existent resource encounterd: {}", value);
+            return false;
+        }
+    };
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -804,6 +804,40 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test
+    public void testDeleteObjectWithInboundReferencesToChildren() throws RepositoryException {
+        // Set up resources
+        final String pid = getRandomPid();
+        final FedoraResource resourceA = containerService.findOrCreate(session, "/" + pid + "/a");
+        containerService.findOrCreate(session, "/" + pid + "/b");
+        final FedoraResource resourceX = containerService.findOrCreate(session, "/" + pid + "/b/x");
+        final Session jcrSession = getJcrSession(session);
+
+        // Create a Weak reference
+        final Value value = jcrSession.getValueFactory().createValue(getJcrNode(resourceX), true);
+        getJcrNode(resourceA).setProperty("fedora:hasMember", new Value[] { value });
+
+        session.commit();
+
+        // Verify that relationship exists
+        final Node s = subjects.reverse().convert(resourceA).asNode();
+        final Node hasMember = createProperty(REPOSITORY_NAMESPACE, "hasMember").asNode();
+
+        final Model rdf = resourceA.getTriples(subjects, PROPERTIES).collect(toModel());
+        assertTrue(rdf.toString(), rdf.getGraph().contains(s, hasMember, ANY));
+
+        // Delete parent of reference target
+        containerService.findOrCreate(session, "/" + pid + "/b").delete();
+
+        session.commit();
+
+        // Verify that relationship does NOT exist, and that the resource successfully loads.
+        containerService.find(session, "/" + pid + "/a");
+
+        final Model rdfAfter = resourceA.getTriples(subjects, PROPERTIES).collect(toModel());
+        assertFalse(rdfAfter.getGraph().contains(s, hasMember, ANY));
+    }
+
+    @Test
     public void testGetContainer() {
         final String pid = getRandomPid();
         final Container container = containerService.findOrCreate(session, "/" + pid);


### PR DESCRIPTION
The first commit recursively removes inbound references to child of deleted containers.
The second commit ignores non-existent referents.

Resolves: https://jira.duraspace.org/browse/FCREPO-2323

Note: These two commits should not be squashed.

