### PR TITLE
Add a patch to the RDF output framework to serialize RDF with their S…

### DIFF
--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -68,6 +68,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>jena-patch</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
       <version>${jetty.version}</version>

--- a/jena-patch/LICENSE.txt
+++ b/jena-patch/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/jena-patch/README.txt
+++ b/jena-patch/README.txt
@@ -1,0 +1,13 @@
+The RDF writers in this module are auto-injected into the "fcrepo-http-commons/RdfStreamStreamingOutput" framework
+via Spring's annotation-based instantiation of RdfWriterHelper.
+
+This module should be removed with the release of Fedora 4.8.0, at which point, standard RDF 1.1 output syntax
+should be used.
+
+The only other evidence of this patch that should also be removed is:
+1. jena-patch module definition in top-level pom.xml
+2. jena-patch dependency declaration in fcrepo-webapp/pom.xml
+
+Most of the classes in this module are exact or near copies of Jena classes. The differences from the original
+classes can be found by searching for comments prefixed with:
+"// NOTE, Fedora change"

--- a/jena-patch/pom.xml
+++ b/jena-patch/pom.xml
@@ -1,0 +1,209 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.fcrepo</groupId>
+    <artifactId>fcrepo</artifactId>
+    <version>4.7.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>jena-patch</artifactId>
+  <name>Jena Output Patch Module</name>
+  <description>The Fedora Commons Jena Patch module: Provides temporary patch for RDF 1.0 serialization.</description>
+  <packaging>jar</packaging>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>apache-jena-libs</artifactId>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!--Test Gear-->
+    <dependency>
+      <groupId>org.modeshape</groupId>
+      <artifactId>modeshape-jcr</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-http-commons</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-http-api</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-http-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-kernel-modeshape</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-kernel-modeshape</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-configs</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-http-commons</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-auth-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.grizzly</groupId>
+      <artifactId>grizzly-http-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.grizzly</groupId>
+      <artifactId>grizzly-http-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+      <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+      <version>${jersey.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.ext</groupId>
+      <artifactId>jersey-spring3</artifactId>
+      <scope>test</scope>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/jena-patch/src/main/java/org/fcrepo/jena/CopyOfBaseXMLWriter.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/CopyOfBaseXMLWriter.java
@@ -1,0 +1,908 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.jena;
+
+import java.io.OutputStream ;
+import java.io.OutputStreamWriter ;
+import java.io.PrintWriter ;
+import java.io.Writer ;
+import java.util.* ;
+import java.util.Map.Entry ;
+import java.util.regex.Pattern ;
+
+import org.apache.jena.JenaRuntime ;
+import org.apache.jena.iri.IRI ;
+import org.apache.jena.iri.IRIFactory ;
+import org.apache.jena.rdf.model.* ;
+import org.apache.jena.rdf.model.impl.RDFDefaultErrorHandler ;
+import org.apache.jena.rdf.model.impl.ResourceImpl ;
+import org.apache.jena.rdf.model.impl.Util ;
+import org.apache.jena.rdfxml.xmloutput.RDFXMLWriterI ;
+import org.apache.jena.rdfxml.xmloutput.impl.SimpleLogger;
+import org.apache.jena.shared.* ;
+import org.apache.jena.util.CharEncoding ;
+import org.apache.jena.util.FileUtils ;
+import org.apache.jena.vocabulary.* ;
+import org.apache.xerces.util.XMLChar ;
+import org.slf4j.Logger ;
+import org.slf4j.LoggerFactory ;
+
+/**
+ * This is not part of the public API.
+ * Base class for XML serializers.
+ * All methods with side-effects should be synchronized in this class and its
+ * subclasses. (i. e. XMLWriters assume that the world is not changing around
+ * them while they are writing).
+ *
+ * Functionality:
+ *
+ * <ul>
+ * <li>setProperty etc
+ * <li>namespace prefixes
+ * <li>xmlbase
+ * <li>relative URIs
+ * <li>encoding issues
+ * <li>anonymous node presentational
+ * <li>errorHandler
+ * </ul>
+ */
+abstract public class CopyOfBaseXMLWriter implements RDFXMLWriterI {
+
+    private static final String newline =
+            JenaRuntime.getSystemProperty( "line.separator" );
+    static private final String DEFAULT_NS_ENTITY_NAME = "this";
+    static private final String DEFAULT_NS_ENTITY_NAME_ALT = "here";
+    private String defaultNSEntityName = "UNSET" ;
+
+    public CopyOfBaseXMLWriter() {
+        setupMaps();
+    }
+
+    private static Logger xlogger = LoggerFactory.getLogger( CopyOfBaseXMLWriter.class );
+
+    protected static SimpleLogger logger = new SimpleLogger() {
+        @Override
+        public void warn(String s) {
+            xlogger.warn(s);
+        }
+        @Override
+        public void warn(String s, Exception e) {
+            xlogger.warn(s,e);
+        }
+    };
+
+    public static SimpleLogger setLogger(SimpleLogger lg) {
+        SimpleLogger old = logger;
+        logger= lg;
+        return old;
+    }
+
+    abstract protected void unblockAll();
+
+    abstract protected void blockRule(Resource r);
+
+    abstract protected void writeBody
+            ( Model mdl, PrintWriter pw, String baseUri, boolean inclXMLBase );
+
+    static private Set<String> badRDF = new HashSet<>();
+
+    /**
+     Counter used for allocating Jena transient namespace declarations.
+     */
+    private int jenaPrefixCount;
+
+    static String RDFNS = RDF.getURI();
+
+
+    static private Pattern jenaNamespace;
+
+    static {
+        jenaNamespace =
+                Pattern.compile("j\\.([1-9][0-9]*|cook\\.up)");
+
+        badRDF.add("RDF");
+        badRDF.add("Description");
+        badRDF.add("li");
+        badRDF.add("about");
+        badRDF.add("aboutEach");
+        badRDF.add("aboutEachPrefix");
+        badRDF.add("ID");
+        badRDF.add("nodeID");
+        badRDF.add("parseType");
+        badRDF.add("datatype");
+        badRDF.add("bagID");
+        badRDF.add("resource");
+    }
+
+    String xmlBase = null;
+
+    private IRI baseURI;
+
+    boolean longId = false;
+
+    private boolean demandGoodURIs = true;
+
+    int tabSize = 2;
+
+    int width = 60;
+
+    HashMap<AnonId, String> anonMap = new HashMap<>();
+
+    int anonCount = 0;
+
+    static private RDFDefaultErrorHandler defaultErrorHandler =
+            new RDFDefaultErrorHandler();
+
+    RDFErrorHandler errorHandler = defaultErrorHandler;
+
+    Boolean showXmlDeclaration = null;
+
+    protected Boolean showDoctypeDeclaration = Boolean.FALSE;
+
+	/*
+	 * There are two sorts of id's for anonymous resources.  Short id's are the
+	 * default, but require a mapping table.  The mapping table means that
+	 * serializing a large model could run out of memory.  Long id's require no
+	 * mapping table, but are less readable.
+	 */
+
+    String anonId(Resource r)  {
+        return longId ? longAnonId( r ) : shortAnonId( r );
+    }
+
+    /*
+     * A shortAnonId is computed by maintaining a mapping table from the internal
+     * id's of anon resources.  The short id is the index into the table of the
+     * internal id.
+     */
+    private String shortAnonId(Resource r)  {
+        String result = anonMap.get(r.getId());
+        if (result == null) {
+            result = "A" + Integer.toString(anonCount++);
+            anonMap.put(r.getId(), result);
+        }
+        return result;
+    }
+
+	/*
+	 * A longAnonId is the internal id of the anon resource expressed as a
+	 * character string.
+	 *
+	 * This code makes no assumptions about the characters used in the
+	 * implementation of an anon id.  It checks if they are valid namechar
+	 * characters and escapes the id if not.
+	 */
+
+    private String longAnonId(Resource r)  {
+        String rid = r.getId().toString();
+        return XMLChar.isValidNCName( rid ) ? rid : escapedId( rid );
+    }
+
+    /**
+     true means all namespaces defined in the model prefixes will be noted in xmlns
+     declarations; false means only "required" ones will be noted. Hook for configuration.
+     */
+    private boolean writingAllModelPrefixNamespaces = true;
+
+    private CopyOfRelation<String> nameSpaces = new CopyOfRelation<>();
+
+    private Map<String, String> ns;
+
+    private PrefixMapping modelPrefixMapping;
+
+    private Set<String> namespacesNeeded;
+
+    void addNameSpace(String uri) {
+        namespacesNeeded.add(uri);
+    }
+
+    boolean isDefaultNamespace( String uri ) {
+        return "".equals( ns.get( uri ) );
+    }
+
+    private void addNameSpaces( Model model )  {
+        NsIterator nsIter = model.listNameSpaces();
+        while (nsIter.hasNext()) this.addNameSpace( nsIter.nextNs() );
+    }
+
+    private void primeNamespace( Model model )
+    {
+        Map<String, String> m = model.getNsPrefixMap();
+        for ( Entry<String, String> e : m.entrySet() )
+        {
+            String value = e.getValue();
+            String already = this.getPrefixFor( value );
+            if ( already == null )
+            {
+                this.setNsPrefix( model.getNsURIPrefix( value ), value );
+                if ( writingAllModelPrefixNamespaces )
+                {
+                    this.addNameSpace( value );
+                }
+            }
+        }
+
+        if ( usesPrefix(model, "") )
+        {
+            // Doing "" prefix.  Ensure it is a non-clashing, non-empty entity name.
+            String entityForEmptyPrefix = DEFAULT_NS_ENTITY_NAME ;
+            if ( usesPrefix(model, entityForEmptyPrefix) )
+                entityForEmptyPrefix = DEFAULT_NS_ENTITY_NAME_ALT ;
+            int i = 0 ;
+            while ( usesPrefix(model,entityForEmptyPrefix) )
+            {
+                entityForEmptyPrefix = DEFAULT_NS_ENTITY_NAME_ALT+"."+i ;
+                i++ ;
+            }
+            defaultNSEntityName = entityForEmptyPrefix ;
+        }
+    }
+
+    void setupMaps() {
+        nameSpaces.set11(RDF.getURI(), "rdf");
+        nameSpaces.set11(RDFS.getURI(), "rdfs");
+        nameSpaces.set11(DC.getURI(), "dc");
+        nameSpaces.set11(RSS.getURI(), "rss");
+        nameSpaces.set11("http://www.daml.org/2001/03/daml+oil.daml#", "daml");
+        nameSpaces.set11(VCARD.getURI(), "vcard");
+        nameSpaces.set11("http://www.w3.org/2002/07/owl#", "owl");
+    }
+
+    void workOutNamespaces() {
+        if (ns == null) {
+            ns = new HashMap<>();
+            Set<String> prefixesUsed = new HashSet<>();
+            setFromWriterSystemProperties( ns, prefixesUsed );
+            setFromGivenNamespaces( ns, prefixesUsed );
+        }
+    }
+
+    private void setFromWriterSystemProperties( Map<String, String> ns, Set<String> prefixesUsed ) {
+        for ( String uri : namespacesNeeded )
+        {
+            String val = JenaRuntime.getSystemProperty( RDFWriter.NSPREFIXPROPBASE + uri );
+            if ( val != null && checkLegalPrefix( val ) && !prefixesUsed.contains( val ) )
+            {
+                ns.put( uri, val );
+                prefixesUsed.add( val );
+            }
+        }
+    }
+
+    private void setFromGivenNamespaces( Map<String, String> ns, Set<String> prefixesUsed ) {
+        for ( String uri : namespacesNeeded )
+        {
+            if ( ns.containsKey( uri ) )
+            {
+                continue;
+            }
+            String val = null;
+            Set<String> s = nameSpaces.forward( uri );
+            if ( s != null )
+            {
+                Iterator<String> it2 = s.iterator();
+                if ( it2.hasNext() )
+                {
+                    val = it2.next();
+                }
+                if ( prefixesUsed.contains( val ) )
+                {
+                    val = null;
+                }
+            }
+            if ( val == null )
+            {
+                // just in case the prefix has already been used, look for a free one.
+                // (the usual source of such prefixes is reading in a model we wrote out earlier)
+                do
+                {
+                    val = "j." + ( jenaPrefixCount++ );
+                }
+                while ( prefixesUsed.contains( val ) );
+            }
+            ns.put( uri, val );
+            prefixesUsed.add( val );
+        }
+    }
+
+    final synchronized public void setNsPrefix(String prefix, String ns) {
+        if (checkLegalPrefix(prefix)) {
+            nameSpaces.set11(ns, prefix);
+        }
+    }
+
+    final public String getPrefixFor( String uri )
+    {
+        // xml and xmlns namespaces are pre-bound
+        if ("http://www.w3.org/XML/1998/namespace".equals(uri)) return "xml";
+        if ("http://www.w3.org/2000/xmlns/".equals(uri)) return "xmlns";
+        Set<String> s = nameSpaces.backward( uri );
+        if (s != null && s.size() == 1) return s.iterator().next();
+        return null;
+    }
+
+    String xmlnsDecl() {
+        workOutNamespaces();
+        StringBuilder result = new StringBuilder();
+        Iterator<Entry<String, String>> it = ns.entrySet().iterator();
+        while (it.hasNext()) {
+            Entry<String, String> ent = it.next();
+            String prefix = ent.getValue();
+            String uri = ent.getKey();
+            result.append( newline ).append( "    xmlns" );
+            if (prefix.length() > 0) result.append( ':' ).append( prefix );
+            result.append( '=' ).append( substitutedAttribute( checkURI( uri ) ) );
+        }
+        return result.toString();
+    }
+
+    static final private int FAST = 1;
+    static final private int START = 2;
+    static final private int END = 3;
+    static final private int ATTR = 4;
+    static final private int FASTATTR = 5;
+
+    String rdfEl(String local) {
+        return tag(RDFNS, local, FAST, true);
+    }
+
+    String startElementTag(String uri, String local) {
+        return tag(uri, local, START, false);
+    }
+
+    protected String startElementTag(String uriref) {
+        return splitTag(uriref, START);
+    }
+
+    String attributeTag(String uriref) {
+        return splitTag(uriref, ATTR);
+    }
+
+    String attributeTag(String uri, String local) {
+        return tag(uri, local, ATTR, false);
+    }
+
+    String rdfAt(String local) {
+        return tag(RDFNS, local, FASTATTR, true);
+    }
+
+    String endElementTag(String uri, String local) {
+        return tag(uri, local, END, false);
+    }
+
+    protected String endElementTag(String uriref) {
+        return splitTag(uriref, END);
+    }
+
+    String splitTag(String uriref, int type) {
+        int split = Util.splitNamespaceXML( uriref );
+        if (split == uriref.length()) throw new InvalidPropertyURIException( uriref );
+        return tag( uriref.substring( 0, split ), uriref.substring( split ), type, true );
+    }
+
+    static public boolean dbg = false;
+
+    String tag( String namespace, String local, int type, boolean localIsQname)  {
+        if (dbg)
+            System.err.println(namespace + " - " + local);
+        String prefix = ns.get( namespace );
+        if (type != FAST && type != FASTATTR) {
+            if ((!localIsQname) && !XMLChar.isValidNCName(local))
+                return splitTag(namespace + local, type);
+            if (namespace.equals(RDFNS)) {
+                // Description, ID, nodeID, about, aboutEach, aboutEachPrefix, li
+                // bagID parseType resource datatype RDF
+                if (badRDF.contains(local)) {
+                    logger.warn(	"The URI rdf:" + local + " cannot be serialized in RDF/XML." );
+                    throw new InvalidPropertyURIException( "rdf:" + local );
+                }
+            }
+        }
+        boolean cookUp = false;
+        if (prefix == null) {
+            checkURI( namespace );
+            logger.warn(
+                    "Internal error: unexpected QName URI: <"
+                            + namespace
+                            + ">.  Fixing up with j.cook.up code.",
+                    new BrokenException( "unexpected QName URI " + namespace ));
+            cookUp = true;
+        } else if (prefix.length() == 0) {
+            if (type == ATTR || type == FASTATTR)
+                cookUp = true;
+            else
+                return local;
+        }
+        if (cookUp) return cookUpAttribution( type, namespace, local );
+        return prefix + ":" + local;
+    }
+
+    private String cookUpAttribution( int type, String namespace, String local )
+    {
+        String prefix = "j.cook.up";
+        switch (type) {
+            case FASTATTR :
+            case ATTR :
+                return "xmlns:" + prefix + "=" + substitutedAttribute( namespace ) + " " + prefix + ":" + local;
+            case START :
+                return prefix  + ":" + local + " xmlns:" + prefix+ "=" + substitutedAttribute( namespace );
+            default:
+            case END :
+                return prefix + ":" + local;
+            case FAST :
+                //  logger.error("Unreachable code - reached.");
+                throw new BrokenException( "cookup reached final FAST" );
+        }
+    }
+
+    /** Write out an XML serialization of a model.
+     * @param model the model to be serialized
+     * @param out the OutputStream to receive the serialization
+     * @param base The URL at which the file will be placed.
+     */
+    @Override
+    final public void write(Model model, OutputStream out, String base)
+    { write( model, FileUtils.asUTF8(out), base ); }
+
+    /** Serialize Model <code>model</code> to Writer <code>out</out>.
+     * @param model The model to be written.
+     * @param out The Writer to which the serialization should be sent.
+     * @param base the base URI for relative URI calculations.  <code>null</code> means use only absolute URI's.
+     */
+    @Override
+    synchronized public void write(Model model, Writer out, String base)
+    {
+        setupNamespaces( model );
+        PrintWriter pw = out instanceof PrintWriter ? (PrintWriter) out : new PrintWriter( out );
+        if (!Boolean.FALSE.equals(showXmlDeclaration)) writeXMLDeclaration( out, pw );
+        writeXMLBody( model, pw, base );
+        pw.flush();
+    }
+
+    /**
+     @param baseModel
+     @param model
+     */
+    private void setupNamespaces( Model model )
+    {
+        this.namespacesNeeded = new HashSet<>();
+        this.ns = null;
+        this.modelPrefixMapping = model;
+        primeNamespace( model );
+        addNameSpace( RDF.getURI() );
+        addNameSpaces(model);
+        jenaPrefixCount = 0;
+    }
+
+    @SuppressWarnings("deprecation")
+    static IRIFactory factory = IRIFactory.jenaImplementation();
+
+
+    private void writeXMLBody( Model model, PrintWriter pw, String base ) {
+        if (showDoctypeDeclaration.booleanValue()) generateDoctypeDeclaration( model, pw );
+//		try {
+        // errors?
+        if (xmlBase == null) {
+            baseURI = (base == null || base.length() == 0) ? null : factory.create(base);
+            writeBody(model, pw, base, false);
+        } else {
+            baseURI = xmlBase.length() == 0 ? null : factory.create(xmlBase);
+            writeBody(model, pw, xmlBase, true);
+        }
+//		} catch (MalformedURIException e) {
+//			throw new BadURIException( e.getMessage(), e);
+//		}
+    }
+
+    protected static final Pattern predefinedEntityNames = Pattern.compile( "amp|lt|gt|apos|quot" );
+
+    public boolean isPredefinedEntityName( String name )
+    { return predefinedEntityNames.matcher( name ).matches(); }
+
+    private String attributeQuoteChar ="\"";
+
+    protected String attributeQuoted( String s )
+    { return attributeQuoteChar + s + attributeQuoteChar; }
+
+    protected String substitutedAttribute( String s )
+    {
+        String substituted = Util.substituteStandardEntities( s );
+        if (!showDoctypeDeclaration.booleanValue())
+            return attributeQuoted( substituted );
+        else
+        {
+            int split = Util.splitNamespaceXML( substituted );
+            String namespace = substituted.substring(  0, split );
+            String prefix = modelPrefixMapping.getNsURIPrefix( namespace );
+            return prefix == null || isPredefinedEntityName( prefix )
+                    ? attributeQuoted( substituted )
+                    : attributeQuoted( "&" + strForPrefix(prefix) + ";" + substituted.substring( split ) )
+                    ;
+        }
+    }
+
+    private void generateDoctypeDeclaration( Model model, PrintWriter pw )
+    {
+        String rdfns = RDF.getURI();
+        String rdfRDF = model.qnameFor( rdfns + "RDF" );
+        if ( rdfRDF == null ) {
+            model.setNsPrefix("rdf",rdfns);
+            rdfRDF = "rdf:RDF";
+        }
+        Map<String, String> prefixes = model.getNsPrefixMap();
+        pw.print( "<!DOCTYPE " + rdfRDF +" [" );
+        for ( String prefix : prefixes.keySet() )
+        {
+            if ( isPredefinedEntityName( prefix ) )
+            {
+                continue;
+            }
+            pw.print(
+                    newline + "  <!ENTITY " + strForPrefix( prefix ) + " '" + Util.substituteEntitiesInEntityValue(
+                            prefixes.get( prefix ) ) + "'>" );
+        }
+        pw.print( "]>" + newline );
+    }
+
+    private String strForPrefix(String prefix)
+    {
+        if ( prefix.length() == 0 )
+            return defaultNSEntityName ;
+        return prefix ;
+    }
+
+    private static boolean usesPrefix(Model model, String prefix)
+    {
+        return model.getNsPrefixURI(prefix) != null ;
+    }
+
+    private void writeXMLDeclaration(Writer out, PrintWriter pw) {
+        String decl = null;
+        if (out instanceof OutputStreamWriter) {
+            String javaEnc = ((OutputStreamWriter) out).getEncoding();
+            // System.err.println(javaEnc);
+            if (!(javaEnc.equals("UTF8") || javaEnc.equals("UTF-16"))) {
+                CharEncoding encodingInfo = CharEncoding.create(javaEnc);
+
+                String ianaEnc = encodingInfo.name();
+                decl = "<?xml version="+attributeQuoted("1.0")+" encoding=" + attributeQuoted(ianaEnc) + "?>";
+                if (!encodingInfo.isIANA())
+                    logger.warn(encodingInfo.warningMessage()+"\n"+
+                            "   It is better to use a FileOutputStream, in place of a FileWriter.");
+
+            }
+        }
+        if (decl == null && showXmlDeclaration != null)
+            decl = "<?xml version="+attributeQuoted("1.0")+"?>";
+        if (decl != null) {
+            pw.println(decl);
+        }
+    }
+
+    /** Set an error handler.
+     * @param errHandler The new error handler to be used, or null for the default handler.
+     * @return the old error handler
+     */
+    @Override
+    synchronized public RDFErrorHandler setErrorHandler(RDFErrorHandler errHandler) {
+        // null means no user defined error handler.
+        // We implement this using defaultErrorHandler,
+        // but hide this fact from the user.
+        RDFErrorHandler rslt = errorHandler;
+        if (rslt == defaultErrorHandler) rslt = null;
+        errorHandler = errHandler == null ? defaultErrorHandler : errHandler;
+        return rslt;
+    }
+
+    static private final char ESCAPE = 'X';
+
+    static private String escapedId(String id) {
+        StringBuffer result = new StringBuffer();
+        for (int i = 0; i < id.length(); i++) {
+            char ch = id.charAt(i);
+            if (ch != ESCAPE
+                    && (i == 0 ? XMLChar.isNCNameStart(ch) : XMLChar.isNCName(ch))) {
+                result.append( ch );
+            } else {
+                escape( result, ch );
+            }
+        }
+        return result.toString();
+    }
+
+    static final char [] hexchar = "0123456789abcdef".toCharArray();
+
+    static private void escape( StringBuffer sb, char ch) {
+        sb.append( ESCAPE );
+        int charcode = ch;
+        do {
+            sb.append( hexchar[charcode & 15] );
+            charcode = charcode >> 4;
+        } while (charcode != 0);
+        sb.append( ESCAPE );
+    }
+
+    /**
+     Set the writer property propName to the value obtained from propValue. Return an
+     Object representation of the original value.
+
+     @see org.apache.jena.rdf.model.RDFWriter#setProperty(java.lang.String, java.lang.Object)
+     */
+    @Override
+    final synchronized public Object setProperty( String propName, Object propValue ) {
+        if (propName.equalsIgnoreCase("showXmlDeclaration")) {
+            return setShowXmlDeclaration(propValue);
+        } else if (propName.equalsIgnoreCase( "showDoctypeDeclaration" )) {
+            return setShowDoctypeDeclaration( propValue );
+        } else if (propName.equalsIgnoreCase( "minimalPrefixes" )) {
+            try { return new Boolean( !writingAllModelPrefixNamespaces ); }
+            finally { writingAllModelPrefixNamespaces = !getBoolean( propValue ); }
+        } else if (propName.equalsIgnoreCase("xmlbase")) {
+            String result = xmlBase;
+            xmlBase = (String) propValue;
+            return result;
+        } else if (propName.equalsIgnoreCase("tab")) {
+            return setTab( propValue );
+        } else if (propName.equalsIgnoreCase("width")) {
+            return setWidth(propValue);
+        } else if (propName.equalsIgnoreCase("longid")) {
+            Boolean result = new Boolean(longId);
+            longId = getBoolean(propValue);
+            return result;
+        } else if (propName.equalsIgnoreCase("attributeQuoteChar")) {
+            return setAttributeQuoteChar(propValue);
+        } else if (propName.equalsIgnoreCase( "allowBadURIs" )) {
+            Boolean result = new Boolean( !demandGoodURIs );
+            demandGoodURIs = !getBoolean(propValue);
+            return result;
+        } else if (propName.equalsIgnoreCase("prettyTypes")) {
+            return setTypes((Resource[]) propValue);
+        } else if (propName.equalsIgnoreCase("relativeURIs")) {
+            int old = relativeFlags;
+            relativeFlags = str2flags((String) propValue);
+            return flags2str(old);
+        } else if (propName.equalsIgnoreCase("blockRules")) {
+            return setBlockRules(propValue);
+        } else {
+            logger.warn("Unsupported property: " + propName);
+            return null;
+        }
+    }
+
+    private String setAttributeQuoteChar(Object propValue) {
+        String oldValue = attributeQuoteChar;
+        if ( "\"".equals(propValue) || "'".equals(propValue) )
+            attributeQuoteChar = (String)propValue;
+        else
+            logger.warn("attributeQutpeChar must be either \"\\\"\" or \', not \""+propValue+"\"" );
+        return oldValue;
+    }
+
+    private Integer setWidth(Object propValue) {
+        Integer oldValue = new Integer(width);
+        if (propValue instanceof Integer) {
+            width = ((Integer) propValue).intValue();
+        } else {
+            try {
+                width = Integer.parseInt((String) propValue);
+            } catch (Exception e) {
+                logger.warn(	"Bad value for width: '" + propValue + "' [" + e.getMessage() + "]" );
+            }
+        }
+        return oldValue;
+    }
+
+    private Integer setTab(Object propValue) {
+        Integer result = new Integer(tabSize);
+        if (propValue instanceof Integer) {
+            tabSize = ((Integer) propValue).intValue();
+        } else {
+            try {
+                tabSize = Integer.parseInt((String) propValue);
+            } catch (Exception e) {
+                logger.warn(	"Bad value for tab: '" + propValue + "' [" + e.getMessage() + "]" );
+            }
+        }
+        return result;
+    }
+
+    private String setShowDoctypeDeclaration( Object propValue )
+    {
+        String oldValue = showDoctypeDeclaration.toString();
+        showDoctypeDeclaration = getBooleanValue( propValue, Boolean.FALSE );
+        return oldValue;
+    }
+
+    private String setShowXmlDeclaration( Object propValue )
+    {
+        String oldValue = showXmlDeclaration == null ? null : showXmlDeclaration.toString();
+        showXmlDeclaration = getBooleanValue( propValue, null );
+        return oldValue;
+    }
+
+    /**
+     Answer the boolean value corresponding to o, which must either be a Boolean,
+     or a String parsable as a Boolean.
+     */
+    static private boolean getBoolean( Object o )
+    { return getBooleanValue( o, Boolean.FALSE ).booleanValue(); }
+
+    private static Boolean getBooleanValue( Object propValue, Boolean theDefault )
+    {
+        if (propValue == null)
+            return theDefault;
+        else if (propValue instanceof Boolean)
+            return (Boolean) propValue;
+        else if (propValue instanceof String)
+            return stringToBoolean( (String) propValue, theDefault );
+        else
+            throw new JenaException( "cannot treat as boolean: " + propValue );
+    }
+
+    private static Boolean stringToBoolean( String b, Boolean theDefault )
+    {
+        if (b.equals( "default" )) return theDefault;
+        if (b.equalsIgnoreCase( "true" )) return Boolean.TRUE;
+        if (b.equalsIgnoreCase( "false" )) return Boolean.FALSE;
+        throw new BadBooleanException( b );
+    }
+
+    Resource[] setTypes( Resource x[] ) {
+        logger.warn( "prettyTypes is not a property on the Basic RDF/XML writer." );
+        return null;
+    }
+
+    private Resource blockedRules[] = new Resource[]{RDFSyntax.propertyAttr};
+
+    Resource[] setBlockRules(Object o) {
+        Resource rslt[] = blockedRules;
+        unblockAll();
+        if (o instanceof Resource[]) {
+            blockedRules = (Resource[]) o;
+        } else {
+            StringTokenizer tkn = new StringTokenizer((String) o, ", ");
+            Vector<Resource> v = new Vector<>();
+            while (tkn.hasMoreElements()) {
+                String frag = tkn.nextToken();
+                //  System.err.println("Blocking " + frag);
+                v.add(new ResourceImpl(RDFSyntax.getURI() + frag));
+            }
+
+            blockedRules = new Resource[v.size()];
+            v.copyInto(blockedRules);
+        }
+        for ( Resource blockedRule : blockedRules )
+        {
+            blockRule( blockedRule );
+        }
+        return rslt;
+    }
+    /*
+    private boolean sameDocument = true;
+    private boolean network = false;
+    private boolean absolute = true;
+    private boolean relative = true;
+    private boolean parent = true;
+    private boolean grandparent = false;
+    */
+    private int relativeFlags =
+            IRI.SAMEDOCUMENT | IRI.ABSOLUTE | IRI.CHILD | IRI.PARENT;
+
+    /**
+     Answer the form of the URI after relativisation according to the relativeFlags set
+     by properties. If the flags are 0 or the base URI is null, answer the original URI.
+     Throw an exception if the URI is "bad" and we demandGoodURIs.
+     */
+    protected String relativize( String uri ) {
+        return relativeFlags != 0 && baseURI != null
+                ? relativize( baseURI, uri )
+                : checkURI( uri );
+    }
+
+    /**
+     Answer the relative form of the URI against the base, according to the relativeFlags.
+     */
+    private String relativize( IRI base, String uri )  {
+        // errors?
+        return base.relativize( uri, relativeFlags).toString();
+    }
+
+    /**
+     Answer the argument URI, but if we demandGoodURIs and it isn't good, throw
+     a JenaException that encapsulates a MalformedURIException. There doesn't
+     appear to be a convenient URI.checkGood() kind of method, alas.
+     */
+    private String checkURI( String uri ) {
+        if (demandGoodURIs) {
+            IRI iri = factory.create( uri );
+
+            if (iri.hasViolation(false) )
+                throw new BadURIException( "Only well-formed absolute URIrefs can be included in RDF/XML output: "
+                        + (iri.violations(false).next()).getShortMessage());
+        }
+
+
+        return uri;
+    }
+
+    /**
+     Answer true iff prefix is a "legal" prefix to use, ie, is empty [for the default namespace]
+     or an NCName that does not start with "xml" and does not match the reserved-to-Jena
+     pattern.
+     */
+    private boolean checkLegalPrefix( String prefix ) {
+        if (prefix.equals(""))
+            return true;
+        if (prefix.toLowerCase().startsWith( "xml" ))
+            logger.warn( "Namespace prefix '" + prefix + "' is reserved by XML." );
+        else if (!XMLChar.isValidNCName(prefix))
+            logger.warn( "'" + prefix + "' is not a legal namespace prefix." );
+        else if (jenaNamespace.matcher(prefix).matches())
+            logger.warn( "Namespace prefix '" + prefix + "' is reserved by Jena." );
+        else
+            return true;
+        return false;
+    }
+
+    static private String flags2str(int f) {
+        StringBuffer oldValue = new StringBuffer(64);
+        if ( (f&IRI.SAMEDOCUMENT)!=0 )
+            oldValue.append( "same-document, " );
+        if ( (f&IRI.NETWORK)!=0 )
+            oldValue.append( "network, ");
+        if ( (f&IRI.ABSOLUTE)!=0 )
+            oldValue.append("absolute, ");
+        if ( (f&IRI.CHILD)!=0 )
+            oldValue.append("relative, ");
+        if ((f&IRI.PARENT)!=0)
+            oldValue.append("parent, ");
+        if ((f&IRI.GRANDPARENT)!=0)
+            oldValue.append("grandparent, ");
+        if (oldValue.length() > 0)
+            oldValue.setLength(oldValue.length()-2);
+        return oldValue.toString();
+    }
+
+    public static int str2flags(String pv){
+        StringTokenizer tkn = new StringTokenizer(pv,", ");
+        int rslt = 0;
+        while ( tkn.hasMoreElements() ) {
+            String flag = tkn.nextToken();
+            if ( flag.equals("same-document") )
+                rslt |= IRI.SAMEDOCUMENT;
+            else if ( flag.equals("network") )
+                rslt |= IRI.NETWORK;
+            else if ( flag.equals("absolute") )
+                rslt |= IRI.ABSOLUTE;
+            else if ( flag.equals("relative") )
+                rslt |= IRI.CHILD;
+            else if ( flag.equals("parent") )
+                rslt |= IRI.PARENT;
+            else if ( flag.equals("grandparent") )
+                rslt |= IRI.GRANDPARENT;
+            else
+
+                logger.warn(
+                        "Incorrect property value for relativeURIs: " + flag
+                );
+        }
+        return rslt;
+    }
+
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/CopyOfBasic.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/CopyOfBasic.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.jena;
+
+import java.io.PrintWriter;
+
+import org.apache.jena.rdf.model.* ;
+import org.apache.jena.rdf.model.impl.Util ;
+import org.apache.jena.vocabulary.RDFSyntax ;
+
+/** Writes out an XML serialization of a model.
+ */
+public class CopyOfBasic extends CopyOfBaseXMLWriter
+{
+    public CopyOfBasic()
+    {}
+
+    private String space;
+
+    @Override protected void writeBody
+            ( Model model, PrintWriter pw, String base, boolean inclXMLBase )
+    {
+        setSpaceFromTabCount();
+        writeRDFHeader( model, pw );
+        writeRDFStatements( model, pw );
+        writeRDFTrailer( pw, base );
+        pw.flush();
+    }
+
+    private void setSpaceFromTabCount()
+    {
+        space = "";
+        for (int i=0; i < tabSize; i += 1) space += " ";
+    }
+
+    protected void writeSpace( PrintWriter writer )
+    { writer.print( space ); }
+
+    private void writeRDFHeader(Model model, PrintWriter writer)
+    {
+        String xmlns = xmlnsDecl();
+        writer.print( "<" + rdfEl( "RDF" ) + xmlns );
+        if (null != xmlBase && xmlBase.length() > 0)
+            writer.print( "\n  xml:base=" + substitutedAttribute( xmlBase ) );
+        writer.println( " > " );
+    }
+
+    protected void writeRDFStatements( Model model, PrintWriter writer )
+    {
+        ResIterator rIter = model.listSubjects();
+        while (rIter.hasNext()) writeRDFStatements( model, rIter.nextResource(), writer );
+    }
+
+    protected void writeRDFTrailer( PrintWriter writer, String base )
+    { writer.println( "</" + rdfEl( "RDF" ) + ">" ); }
+
+    protected void writeRDFStatements
+            ( Model model, Resource subject, PrintWriter writer )
+    {
+        StmtIterator sIter = model.listStatements( subject, null, (RDFNode) null );
+        writeDescriptionHeader( subject, writer );
+        while (sIter.hasNext()) writePredicate( sIter.nextStatement(), writer );
+        writeDescriptionTrailer( subject, writer );
+    }
+
+    protected void writeDescriptionHeader( Resource subject, PrintWriter writer)
+    {
+        writer.print( space + "<" + rdfEl( "Description" ) + " " );
+        writeResourceId( subject, writer );
+        writer.println( ">" );
+    }
+
+    protected void writePredicate(Statement stmt, final PrintWriter writer)
+    {
+        final Property predicate = stmt.getPredicate();
+        final RDFNode object = stmt.getObject();
+
+        writer.print(space+space+
+                "<"
+                + startElementTag(
+                predicate.getNameSpace(),
+                predicate.getLocalName()));
+
+        if (object instanceof Resource) {
+            writer.print(" ");
+            writeResourceReference(((Resource) object), writer);
+            writer.println("/>");
+        } else {
+            writeLiteral((Literal) object, writer);
+            writer.println(
+                    "</"
+                            + endElementTag(
+                            predicate.getNameSpace(),
+                            predicate.getLocalName())
+                            + ">");
+        }
+    }
+
+    @Override protected void unblockAll()
+    { blockLiterals = false; }
+
+    // NOTE, Fedora change: private -> protected
+    protected boolean blockLiterals = false;
+
+    @Override protected void blockRule( Resource r ) {
+        if (r.equals( RDFSyntax.parseTypeLiteralPropertyElt )) {
+            //       System.err.println("Blocking");
+            blockLiterals = true;
+        } else
+            logger.warn("Cannot block rule <"+r.getURI()+">");
+    }
+
+    protected void writeDescriptionTrailer( Resource subject, PrintWriter writer )
+    { writer.println( space + "</" + rdfEl( "Description" ) + ">" ); }
+
+
+    protected void writeResourceId( Resource r, PrintWriter writer )
+    {
+        if (r.isAnon()) {
+            writer.print(rdfAt("nodeID") + "=" + attributeQuoted(anonId(r)));
+        } else {
+            writer.print(
+                    rdfAt("about")
+                            + "="
+                            + substitutedAttribute(relativize(r.getURI())));
+        }
+    }
+
+    protected void writeResourceReference( Resource r, PrintWriter writer )
+    {
+        if (r.isAnon()) {
+            writer.print(rdfAt("nodeID") + "=" + attributeQuoted(anonId(r)));
+        } else {
+            writer.print(
+                    rdfAt("resource")
+                            + "="
+                            + substitutedAttribute(relativize(r.getURI())));
+        }
+    }
+
+    protected void writeLiteral( Literal l, PrintWriter writer ) {
+        String lang = l.getLanguage();
+        String form = l.getLexicalForm();
+        if (Util.isLangString(l)) {
+            writer.print(" xml:lang=" + attributeQuoted( lang ));
+        } else if (l.isWellFormedXML() && !blockLiterals) {
+            // RDF XML Literals inline.
+            writer.print(" " + rdfAt("parseType") + "=" + attributeQuoted( "Literal" )+">");
+            writer.print( form );
+            return ;
+        } else {
+            // Datatype (if not xsd:string and RDF 1.1)
+            String dt = l.getDatatypeURI();
+            if ( ! Util.isSimpleString(l) )
+                writer.print( " " + rdfAt( "datatype" ) + "=" + substitutedAttribute( dt ) );
+        }
+        // Content.
+        writer.print(">");
+        writer.print( Util.substituteEntitiesInElementContent( form ) );
+    }
+
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/CopyOfPairEntry.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/CopyOfPairEntry.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.jena;
+
+class CopyOfPairEntry<K,V>  implements java.util.Map.Entry<K,V>  {
+    K a;
+    V b;
+    @Override
+    public boolean equals(Object o) {
+        if (o != null && (o instanceof CopyOfPairEntry<?,?>)) {
+            CopyOfPairEntry<?,?> e = (CopyOfPairEntry<?,?>) o;
+            return e.a.equals(a) && e.b.equals(b);
+        }
+        return false;
+
+    }
+    @Override
+    public K getKey() {
+        return a;
+    }
+    @Override
+    public V getValue() {
+        return b;
+    }
+    @Override
+    public int hashCode() {
+        return a.hashCode() ^ b.hashCode();
+    }
+    @Override
+    public V setValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+    CopyOfPairEntry(K a, V b) {
+        this.a = a;
+        this.b = b;
+    }
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/CopyOfRelation.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/CopyOfRelation.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.jena;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.apache.jena.util.iterator.Map1Iterator ;
+import org.apache.jena.util.iterator.WrappedIterator ;
+
+/**
+ * A sparse 2 dimensional array of boolean indexed by Object.
+ *
+ * Complete with transitive closure algorithm.
+ */
+class CopyOfRelation<T> {
+    final private Map<T, Set<T>> rows;
+    final private Map<T, Set<T>> cols;
+    final private Set<T> index;
+    /** The empty Relation.
+     */
+    public CopyOfRelation() {
+        rows = new HashMap<>();
+        cols = new HashMap<>();
+        index = new HashSet<>();
+    }
+    /** <code>a</code> is now related to <code>b</code>
+     *
+     */
+    synchronized public void set(T a, T b) {
+        index.add(a);
+        index.add(b);
+        innerAdd(rows, a, b);
+        innerAdd(cols, b, a);
+    }
+    /** Uniquely <code>a</code> is now related to uniquely <code>b</code>.
+     *
+     *  When this is called any other <code>a</code> related to this <code>b</code> is removed.
+     *  When this is called any other <code>b</code> related to this <code>a</code> is removed.
+     *
+     */
+    synchronized public void set11(T a, T b) {
+        clearX(a, forward(a));
+        clearX(backward(b), b);
+        set(a, b);
+    }
+    /** Uniquely <code>a</code> is now related to <code>b</code>.
+     *  Many <code>b</code>'s can be related to each <code>a</code>.
+     *  When this is called any other <code>a</code> related to this <code>b</code> is removed.
+     */
+    synchronized public void set1N(T a, T b) {
+        clearX(backward(b), b);
+        set(a, b);
+    }
+    /** <code>a</code> is now related to uniquely <code>b</code>.
+     *  Many <code>a</code>'s can be related to each <code>b</code>.
+     *  When this is called any other <code>b</code> related to this <code>a</code> is removed.
+     */
+    synchronized public void setN1(T a, T b) {
+        clearX(a, forward(a));
+        set(a, b);
+    }
+    /** <code>a</code> is now related to <code>b</code>
+     *
+     */
+    synchronized public void setNN(T a, T b) {
+        set(a, b);
+    }
+    /** <code>a</code> is now <em>not</em> related to <code>b</code>
+     *
+     */
+    synchronized public void clear(T a, T b) {
+        innerClear(rows, a, b);
+        innerClear(cols, b, a);
+    }
+    private void clearX(Set<T> s, T b) {
+        if (s == null)
+            return;
+        for ( T value : s )
+        {
+            clear( value, b );
+        }
+    }
+    private void clearX(T a, Set<T> s) {
+        if (s == null)
+            return;
+        for ( T value : s )
+        {
+            clear( a, value );
+        }
+    }
+    static private <T> void innerAdd(Map<T, Set<T>> s, T a, T b) {
+        Set<T> vals = s.get(a);
+        if (vals == null) {
+            vals = new HashSet<>();
+            s.put(a, vals);
+        }
+        vals.add(b);
+    }
+    static private <T> void innerClear(Map<T, Set<T>> s, T a, T b) {
+        Set<T> vals = s.get(a);
+        if (vals != null) {
+            vals.remove(b);
+        }
+    }
+    /** Is <code>a</code> related to <code>b</code>?
+     *
+     */
+    public boolean get(T a, T b) {
+        Set <T> vals = rows.get(a);
+        return vals != null && vals.contains(b);
+    }
+    /**
+     * Takes this to its transitive closure.
+     See B. Roy. <b>Transitivit� et connexit�.</b> <i>C.R. Acad. Sci.</i> Paris <b>249</b>, 1959 pp 216-218.
+     or
+     S. Warshall, <b>A theorem on Boolean matrices</b>, <i>Journal of the ACM</i>, <b>9</b>(1), 1962, pp11-12
+
+
+     */
+    synchronized public void transitiveClosure() {
+        for ( T oj : index )
+        {
+            Set<T> si = cols.get( oj );
+            Set<T> sk = rows.get( oj );
+            if ( si != null && sk != null )
+            {
+                Iterator<T> i = si.iterator();
+                while ( i.hasNext() )
+                {
+                    T oi = i.next();
+                    if ( oi != oj )
+                    {
+                        Iterator<T> k = sk.iterator();
+                        while ( k.hasNext() )
+                        {
+                            T ok = k.next();
+                            if ( ok != oj )
+                            {
+                                set( oi, ok );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    /**
+     * The set of <code>a</code> such that <code>a</code> is related to <code>a</code>.
+     *
+     */
+    synchronized public Set<T> getDiagonal() {
+        Set<T> rslt = new HashSet<>();
+        for ( T o : index )
+        {
+            if ( get( o, o ) )
+            {
+                rslt.add( o );
+            }
+        }
+        return rslt;
+    }
+
+    synchronized public CopyOfRelation<T> copy() {
+        CopyOfRelation<T> rslt = new CopyOfRelation<>();
+        Iterator<CopyOfPairEntry<T, T>> it = iterator();
+        while ( it.hasNext() ) {
+            Map.Entry<T, T> e = it.next();
+            rslt.set(e.getKey(),e.getValue());
+        }
+        return rslt;
+    }
+
+    /**
+     * The set of <code>b</code> such that <code>a</code> is related to <code>b</code>.
+     *
+     */
+    public Set<T> forward(T a) {
+        return rows.get(a);
+    }
+    /**
+     * The set of <code>a</code> such that <code>a</code> is related to <code>b</code>.
+     *
+     */
+    public Set<T> backward(T b) {
+        return cols.get(b);
+    }
+
+    private static <T> Iterator<CopyOfPairEntry<T, T>> pairEntry(Map.Entry<T, Set<T>> pair)
+    {
+        final T a = pair.getKey() ;
+        Set<T> bs = pair.getValue() ;
+        return new Map1Iterator<>(b -> new CopyOfPairEntry<>(a, b), bs.iterator()) ;
+    }
+
+    /**
+     * An Iterator over the pairs of the Relation.
+     * Each pair is returned as a java.util.Map.Entry.
+     * The first element is accessed through <code>getKey()</code>,
+     * the second through <code>getValue()</code>.
+     *@see java.util.Map.Entry
+     */
+    public Iterator<CopyOfPairEntry<T, T>> iterator()
+    {
+        Map1Iterator<Map.Entry<T, Set<T>>,Iterator<CopyOfPairEntry<T, T>>> iter1 =
+                new Map1Iterator<>( entry -> pairEntry(entry) , rows.entrySet().iterator()) ;
+        // And now flatten it.
+        Iterator<CopyOfPairEntry<T, T>> iter2 = WrappedIterator.createIteratorIterator(iter1) ;
+        return iter2 ;
+    }
+}
+
+// Old version - exactly as original except with the generics.
+// Hard(er) to read.
+//        return new IteratorIterator<PairEntry<T, T>>(new Map1Iterator<Map.Entry<T, Set<T>>, Iterator<PairEntry<T, T>>>(new Map1<Map.Entry<T, Set<T>>, Iterator<PairEntry<T, T>>>() {
+//            // Convert a Map.Entry into an iterator over Map.Entry
+//            public Iterator<PairEntry<T, T>> map1(Map.Entry<T, Set<T>> pair)
+//            {
+//                final T a = pair.getKey() ;
+//                Set<T> bs = pair.getValue() ;
+//                return new Map1Iterator<T, PairEntry<T, T>>(
+//                // Converts a b into a Map.Entry pair.
+//                                                            new Map1<T, PairEntry<T, T>>() {
+//                                                                public PairEntry<T, T> map1(T b)
+//                                                                {
+//                                                                    return new PairEntry<T, T>(a, b) ;
+//                                                                }
+//                                                            }, bs.iterator()) ;
+//            }
+//            //Map<T, Set<T>>
+//        }

--- a/jena-patch/src/main/java/org/fcrepo/jena/CopyOfTurtleShell.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/CopyOfTurtleShell.java
@@ -1,0 +1,982 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for ad
+ * ditional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.jena;
+
+import static org.apache.jena.riot.writer.WriterConst.GAP_P_O ;
+import static org.apache.jena.riot.writer.WriterConst.GAP_S_P ;
+import static org.apache.jena.riot.writer.WriterConst.INDENT_OBJECT ;
+import static org.apache.jena.riot.writer.WriterConst.INDENT_PREDICATE ;
+import static org.apache.jena.riot.writer.WriterConst.LONG_PREDICATE ;
+import static org.apache.jena.riot.writer.WriterConst.LONG_SUBJECT ;
+import static org.apache.jena.riot.writer.WriterConst.MIN_PREDICATE ;
+import static org.apache.jena.riot.writer.WriterConst.OBJECT_LISTS ;
+import static org.apache.jena.riot.writer.WriterConst.RDF_First ;
+import static org.apache.jena.riot.writer.WriterConst.RDF_Nil ;
+import static org.apache.jena.riot.writer.WriterConst.RDF_Rest ;
+import static org.apache.jena.riot.writer.WriterConst.RDF_type ;
+import static org.apache.jena.riot.writer.WriterConst.rdfNS ;
+
+import java.util.* ;
+
+import org.apache.jena.atlas.io.IndentedWriter ;
+import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.atlas.lib.InternalErrorException ;
+import org.apache.jena.atlas.lib.Pair ;
+import org.apache.jena.atlas.lib.SetUtils ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.riot.RIOT ;
+import org.apache.jena.riot.other.GLib ;
+import org.apache.jena.riot.out.NodeFormatter ;
+import org.apache.jena.riot.out.NodeFormatterTTL ;
+import org.apache.jena.riot.out.NodeFormatterTTL_MultiLine ;
+import org.apache.jena.riot.out.NodeToLabel ;
+import org.apache.jena.riot.system.PrefixMap ;
+import org.apache.jena.riot.system.PrefixMapFactory ;
+import org.apache.jena.riot.system.RiotLib ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.util.Context ;
+import org.apache.jena.util.iterator.ExtendedIterator ;
+import org.apache.jena.vocabulary.RDF ;
+import org.apache.jena.vocabulary.RDFS ;
+
+/**
+ * Base class to support the pretty forms of Turtle-related languages (Turtle, TriG)
+ */
+public abstract class CopyOfTurtleShell {
+    protected final IndentedWriter out ;
+    protected final NodeFormatter  nodeFmt ;
+    protected final PrefixMap      prefixMap ;
+    protected final String         baseURI ;
+
+    protected CopyOfTurtleShell(IndentedWriter out, PrefixMap pmap, String baseURI, Context context) {
+        this.out = out ;
+        if ( pmap == null )
+            pmap = PrefixMapFactory.emptyPrefixMap() ;
+        this.prefixMap = pmap ;
+        this.baseURI = baseURI ;
+        if ( context != null && context.isTrue(RIOT.multilineLiterals) )
+            this.nodeFmt = new NodeFormatterTTL_MultiLine(baseURI, pmap, NodeToLabel.createScopeByDocument()) ;
+        else {
+            // NOTE, Fedora change: NodeFormatterTTL -> FedoraNodeFormatterTTL
+            this.nodeFmt = new FedoraNodeFormatterTTL(baseURI, pmap, NodeToLabel.createScopeByDocument()) ;
+        }
+    }
+
+    protected void writeBase(String base) {
+        RiotLib.writeBase(out, base) ;
+    }
+
+    protected void writePrefixes(PrefixMap prefixMap) {
+        RiotLib.writePrefixes(out, prefixMap) ;
+    }
+
+    /** Write graph in Turtle syntax (or part of TriG) */
+    protected void writeGraphTTL(Graph graph) {
+        ShellGraph x = new ShellGraph(graph, null, null) ;
+        x.writeGraph() ;
+    }
+
+    /** Write graph in Turtle syntax (or part of TriG). graphName is null for default graph. */
+    protected void writeGraphTTL(DatasetGraph dsg, Node graphName) {
+        Graph g = (graphName == null || Quad.isDefaultGraph(graphName))
+                ? dsg.getDefaultGraph()
+                : dsg.getGraph(graphName) ;
+        ShellGraph x = new ShellGraph(g, graphName, dsg) ;
+        x.writeGraph() ;
+    }
+
+    // Write one graph - using an inner object class to isolate
+    // the state variables for writing a single graph.
+    private final class ShellGraph {
+        // Dataset (for writing graphs indatasets) -- may be null
+        private final DatasetGraph          dsg ;
+        private final Collection<Node>      graphNames ;
+        private final Node                  graphName ;
+        private final Graph                 graph ;
+
+        // Blank nodes that have one incoming triple
+        private /*final*/ Set<Node>             nestedObjects ;
+        private final Set<Node>             nestedObjectsWritten ;
+
+        // Blank node subjects that are not referenced as objects or graph names
+        // excluding unlnked lists.
+        private final Set<Node>             freeBnodes ;
+
+        // The head node in each well-formed list -> list elements
+        private /*final*/ Map<Node, List<Node>> lists ;
+
+        // List that do not have any incoming triples
+        private final Map<Node, List<Node>> freeLists ;
+
+        // Lists that have more than one incoming triple
+        private final Map<Node, List<Node>> nLinkedLists ;
+
+        // All nodes that are part of list structures.
+        private final Collection<Node>      listElts ;
+
+        // Allow lists and nest bnode objects.
+        // This is true for the main pretty printing then
+        // false when we are clearing up unwritten triples.
+        private boolean allowDeepPretty = true ;
+
+        private ShellGraph(Graph graph, Node graphName, DatasetGraph dsg) {
+            this.dsg = dsg ;
+            this.graphName = graphName ;
+
+            this.graphNames = (dsg != null) ? Iter.toSet(dsg.listGraphNodes()) : null ;
+
+            this.graph = graph ;
+            this.nestedObjects = new HashSet<>() ;
+            this.nestedObjectsWritten = new HashSet<>() ;
+            this.freeBnodes = new HashSet<>() ;
+
+            this.lists = new HashMap<>() ;
+            this.freeLists = new HashMap<>() ;
+            this.nLinkedLists = new HashMap<>() ;
+            this.listElts = new HashSet<>() ;
+            this.allowDeepPretty = true ;
+
+            // Must be in this order.
+            findLists() ;
+            findBNodesSyntax1() ;
+            // Stop head of lists printed as triples going all the way to the
+            // good part.
+            nestedObjects.removeAll(listElts) ;
+
+            //printDetails() ;
+        }
+
+        // Debug
+        private void printDetails() {
+            printDetails("nestedObjects", nestedObjects) ;
+            //printDetails("nestedObjectsWritten", nestedObjectsWritten) ;
+            printDetails("freeBnodes", freeBnodes) ;
+
+            printDetails("lists", lists) ;
+            printDetails("freeLists", freeLists) ;
+            printDetails("nLinkedLists", nLinkedLists) ;
+            printDetails("listElts", listElts) ;
+        }
+
+        private void printDetails(String label, Map<Node, List<Node>> map) {
+            System.err.print("## ") ;
+            System.err.print(label) ;
+            System.err.print(" = ") ;
+            System.err.println(map) ;
+        }
+
+        private void printDetails(String label, Collection<Node> nodes) {
+            System.err.print("## ") ;
+            System.err.print(label) ;
+            System.err.print(" = ") ;
+            System.err.println(nodes) ;
+        }
+        // Debug
+
+        private ShellGraph(Graph graph) {
+            this(graph, null, null) ;
+        }
+
+        // ---- Data access
+        /** Get all the triples for the graph.find */
+        private List<Triple> triples(Node s, Node p, Node o) {
+            List<Triple> acc = new ArrayList<>() ;
+            RiotLib.accTriples(acc, graph, s, p, o) ;
+            return acc ;
+        }
+
+        /** Get exactly one triple or null for none or more than one. */
+        private Triple triple1(Node s, Node p, Node o) {
+            if ( dsg != null )
+                return RiotLib.triple1(dsg, s, p, o) ;
+            else
+                return RiotLib.triple1(graph, s, p, o) ;
+        }
+
+        /** Get exactly one triple, or null for none or more than one. */
+        private Triple triple1(DatasetGraph dsg, Node s, Node p, Node o) {
+            Iterator<Quad> iter = dsg.find(Node.ANY, s, p, o) ;
+            if ( !iter.hasNext() )
+                return null ;
+            Quad q = iter.next() ;
+            if ( iter.hasNext() )
+                return null ;
+            return q.asTriple() ;
+        }
+
+        private long countTriples(Node s, Node p, Node o) {
+            if ( dsg != null )
+                return RiotLib.countTriples(dsg, s, p, o) ;
+            else
+                return RiotLib.countTriples(graph, s, p, o) ;
+        }
+
+        private ExtendedIterator<Triple> find(Node s, Node p, Node o) {
+            return graph.find(s, p, o) ;
+        }
+
+        /** returns 0,1,2 (where 2 really means "more than 1") */
+        private int inLinks(Node obj) {
+            if ( dsg != null ) {
+                Iterator<Quad> iter = dsg.find(Node.ANY, Node.ANY, Node.ANY, obj) ;
+                return count012(iter) ;
+            } else {
+                ExtendedIterator<Triple> iter = graph.find(Node.ANY, Node.ANY, obj) ;
+                try { return count012(iter) ; }
+                finally { iter.close() ; }
+            }
+        }
+
+        /** returns 0,1,2 (where 2 really means "more than 1") */
+        private int occursAsSubject(Node subj) {
+            if ( dsg != null ) {
+                Iterator<Quad> iter = dsg.find(Node.ANY, subj, Node.ANY, Node.ANY) ;
+                return count012(iter) ;
+            } else {
+                ExtendedIterator<Triple> iter = graph.find(subj, Node.ANY, Node.ANY) ;
+                try { return count012(iter) ; }
+                finally { iter.close() ; }
+            }
+        }
+
+        private int count012(Iterator<? > iter) {
+            if ( !iter.hasNext() )
+                return 0 ;
+            iter.next() ;
+            if ( !iter.hasNext() )
+                return 1 ;
+            return 2 ;
+        }
+
+        /** Check whether a node is used only in the graph we're working on */
+        private boolean containedInOneGraph(Node node) {
+            if ( dsg == null )
+                // Single graph
+                return true ;
+
+            if ( graphNames.contains(node) )
+                // Used as a graph name.
+                return false ;
+
+            Iterator<Quad> iter = dsg.find(Node.ANY, node, Node.ANY, Node.ANY) ;
+            if ( ! quadsThisGraph(iter) )
+                return false ;
+
+            iter = dsg.find(Node.ANY, Node.ANY, node, Node.ANY) ;
+            if ( ! quadsThisGraph(iter) )
+                return false ;
+
+            iter = dsg.find(Node.ANY, Node.ANY, Node.ANY, node) ;
+            if ( ! quadsThisGraph(iter) )
+                return false ;
+            return true ;
+        }
+
+        /** Check whether an iterator of quads is all in the same graph (dataset assumed) */
+        private boolean quadsThisGraph(Iterator<Quad> iter) {
+            if ( ! iter.hasNext() )
+                // Empty iterator
+                return true ;
+            Quad q = iter.next() ;
+            Node gn = q.getGraph() ;
+
+            // Test first quad - both default graph (various forms) or same named graph
+            if ( isDefaultGraph(gn) ) {
+                if ( ! isDefaultGraph(graphName) )
+                    return false ;
+            } else {
+                if ( ! Objects.equals(gn, graphName) )
+                    // Not both same named graph
+                    return false ;
+            }
+            // Check rest of iterator.
+            for ( ; iter.hasNext() ; ) {
+                Quad q2 = iter.next() ;
+                if ( ! Objects.equals(gn, q2.getGraph()) )
+                    return false ;
+            }
+            return true ;
+        }
+
+        private boolean isDefaultGraph(Node node) {
+            return node == null || Quad.isDefaultGraph(node) ;
+        }
+
+        /** Get triples with the same subject */
+        private Collection<Triple> triplesOfSubject(Node subj) {
+            return RiotLib.triplesOfSubject(graph, subj) ;
+        }
+
+        private Iterator<Node> listSubjects() {
+            return GLib.listSubjects(graph) ;
+        }
+
+        // ---- Data access
+
+        /** Find Bnodes that can written as []
+         * Subject position (top level) - only used for subject position anywhere in the dataset
+         * Object position (any level) - only used as object once anywhere in the dataset
+         */
+        private void findBNodesSyntax1() {
+            Set<Node> rejects = new HashSet<>() ; // Nodes known not to meet the requirement.
+
+            ExtendedIterator<Triple> iter = find(Node.ANY, Node.ANY, Node.ANY) ;
+            try {
+                for ( ; iter.hasNext() ; ) {
+                    Triple t = iter.next() ;
+                    Node subj = t.getSubject() ;
+                    Node obj = t.getObject() ;
+
+                    if ( subj.isBlank() )
+                    {
+                        int sConn = inLinks(subj) ;
+                        if ( sConn == 0 && containedInOneGraph(subj) )
+                            // Not used as an object in this graph.
+                            freeBnodes.add(subj) ;
+                    }
+
+                    if ( ! obj.isBlank() )
+                        continue ;
+                    if ( rejects.contains(obj) )
+                        continue ;
+
+                    int connectivity = inLinks(obj) ;
+                    if ( connectivity == 1 && containedInOneGraph(obj) ) {
+                        // If not used in another graph (or as graph name)
+                        nestedObjects.add(obj) ;
+                    }
+                    else
+                        // Uninteresting object connected multiple times.
+                        rejects.add(obj) ;
+                }
+            } finally { iter.close() ; }
+        }
+
+        // --- Lists setup
+        /*
+         * Find all list heads and all nodes in well-formed lists. Return a
+         * (list head -> Elements map), list elements)
+         */
+        private void findLists() {
+            List<Triple> tails = triples(Node.ANY, RDF_Rest, RDF_Nil) ;
+            for ( Triple t : tails ) {
+                // Returns the elements, reversed.
+                Collection<Node> listElts2 = new HashSet<>() ;
+                Pair<Node, List<Node>> p = followTailToHead(t.getSubject(), listElts2) ;
+                if ( p != null ) {
+                    Node headElt = p.getLeft() ;
+                    // Free standing/private
+                    List<Node> elts = p.getRight() ;
+                    long numLinks = countTriples(null, null, headElt) ;
+                    if ( numLinks == 1 )
+                        lists.put(headElt, elts) ;
+                    else if ( numLinks == 0 )
+                        // 0 connected lists
+                        freeLists.put(headElt, elts) ;
+                    else
+                        // Two triples to this list.
+                        nLinkedLists.put(headElt, elts) ;
+                    listElts.addAll(listElts2) ;
+                }
+            }
+        }
+
+        // return head elt node, list of elements.
+        private Pair<Node, List<Node>> followTailToHead(Node lastListElt, Collection<Node> listElts) {
+            List<Node> listCells = new ArrayList<>() ;
+            List<Node> eltsReversed = new ArrayList<>() ;
+            List<Triple> acc = new ArrayList<>() ;
+            Node x = lastListElt ;
+
+            for ( ; ; ) {
+                if ( !validListElement(x, acc) ) {
+                    if ( listCells.size() == 0 )
+                        // No earlier valid list.
+                        return null ;
+                    // Fix up to previous valid list cell.
+                    x = listCells.remove(listCells.size() - 1) ;
+                    break ;
+                }
+
+                Triple t = triple1(x, RDF_First, null) ;
+                if ( t == null )
+                    return null ;
+                eltsReversed.add(t.getObject()) ;
+                listCells.add(x) ;
+
+                // Try to move up the list.
+                List<Triple> acc2 = triples(null, null, x) ;
+                long numRest = countTriples(null, RDF_Rest, x) ;
+                if ( numRest != 1 ) {
+                    // Head of well-formed list.
+                    // Classified by 0,1,more links later.
+                    listCells.add(x) ;
+                    break ;
+                }
+                // numRest == 1
+                int numLinks = acc2.size() ;
+                if ( numLinks > 1 )
+                    // Non-list links to x
+                    break ;
+                // Valid.
+                Triple tLink = acc2.get(0) ;
+                x = tLink.getSubject() ;
+            }
+            // Success.
+            listElts.addAll(listCells) ;
+            Collections.reverse(eltsReversed) ;
+            return Pair.create(x, eltsReversed) ;
+        }
+
+        /** Return the triples of the list element, or null if invalid list */
+        private boolean validListElement(Node x, List<Triple> acc) {
+            Triple t1 = triple1(x, RDF_Rest, null) ; // Which we came up to get
+            // here :-(
+            if ( t1 == null )
+                return false ;
+            Triple t2 = triple1(x, RDF_First, null) ;
+            if ( t2 == null )
+                return false ;
+            long N = countTriples(x, null, null) ;
+            if ( N != 2 )
+                return false ;
+            acc.add(t1) ;
+            acc.add(t2) ;
+            return true ;
+        }
+
+        // ----
+
+        private void writeGraph() {
+            Iterator<Node> subjects = listSubjects() ;
+            boolean somethingWritten = writeBySubject(subjects) ;
+            // Write remainders
+            // 1 - Shared lists
+            somethingWritten = writeRemainingNLinkedLists(somethingWritten) ;
+
+            // 2 - Free standing lists
+            somethingWritten = writeRemainingFreeLists(somethingWritten) ;
+
+            // 3 - Blank nodes that are unwrittern single objects.
+            //            System.err.println("## ## ##") ;
+            //            printDetails("nestedObjects", nestedObjects) ;
+            //            printDetails("nestedObjectsWritten", nestedObjectsWritten) ;
+            Set<Node> singleNodes = SetUtils.difference(nestedObjects, nestedObjectsWritten) ;
+            somethingWritten = writeRemainingNestedObjects(singleNodes, somethingWritten) ;
+        }
+
+        private boolean writeRemainingNLinkedLists(boolean somethingWritten) {
+            // Print carefully - need a label for the first cell.
+            // So we write out the first element of the list in triples, then
+            // put the remainer as a pretty list
+            for ( Node n : nLinkedLists.keySet() ) {
+                if ( somethingWritten )
+                    out.println() ;
+                somethingWritten = true ;
+
+                List<Node> x = nLinkedLists.get(n) ;
+                writeNode(n) ;
+
+                write_S_P_Gap();
+                out.pad() ;
+
+                writeNode(RDF_First) ;
+                print(" ") ;
+                writeNode(x.get(0)) ;
+                print(" ;") ;
+                println() ;
+                writeNode(RDF_Rest) ;
+                print("  ") ;
+                x = x.subList(1, x.size()) ;
+                writeList(x) ;
+                print(" .") ;
+                out.decIndent(INDENT_PREDICATE) ;
+                println() ;
+            }
+            return somethingWritten ;
+        }
+
+        // Write free standing lists - ones where the head is not an object of
+        // some other triple. Turtle does not allow free standing (... ) .
+        // so write as a predicateObjectList for one element.
+        private boolean writeRemainingFreeLists(boolean somethingWritten) {
+            for ( Node n : freeLists.keySet() ) {
+                if ( somethingWritten )
+                    out.println() ;
+                somethingWritten = true ;
+
+                List<Node> x = freeLists.get(n) ;
+                // Print first element for the [ ... ]
+                out.print("[ ") ;
+
+                writeNode(RDF_First) ;
+                print(" ") ;
+                writeNode(x.get(0)) ;
+                print(" ; ") ;
+                writeNode(RDF_Rest) ;
+                print(" ") ;
+                x = x.subList(1, x.size()) ;
+                // Print remainder.
+                writeList(x) ;
+                out.println(" ] .") ;
+            }
+            return somethingWritten ;
+        }
+
+        // Write any left over nested objects
+        // These come from blank node cycles : _:a <p> _:b . _b: <p> _:a .
+        // Also from from blank node cycles + tail: _:a <p> _:b . _:a <p> "" .  _b: <p> _:a .
+        private boolean writeRemainingNestedObjects(Set<Node> objects, boolean somethingWritten) {
+            for ( Node n : objects ) {
+                if ( somethingWritten )
+                    out.println() ;
+                somethingWritten = true ;
+
+                Triple t = triple1(null, null, n) ;
+                if ( t == null )
+                    throw new InternalErrorException("Expected exactly one triple") ;
+
+                Node subj = t.getSubject() ;
+                boolean b = allowDeepPretty ;
+                try {
+                    allowDeepPretty = false;
+                    Collection<Triple> triples = triples(subj, null, null) ;
+                    writeCluster(subj, triples);
+                } finally { allowDeepPretty = b ; }
+            }
+
+            return somethingWritten ;
+        }
+
+        // Write triples, flat and simply.
+        // Reset the state variables so "isPretty" return false.
+        private void writeTriples(Node subj, Iterator<Triple> iter) {
+            allowDeepPretty = false;
+            writeCluster(subj, Iter.toList(iter));
+        }
+
+        // return true if did write something.
+        private boolean writeBySubject(Iterator<Node> subjects) {
+            boolean first = true ;
+            for ( ; subjects.hasNext() ; ) {
+                Node subj = subjects.next() ;
+                if ( nestedObjects.contains(subj) )
+                    continue ;
+                if ( listElts.contains(subj) )
+                    continue ;
+                if ( !first )
+                    out.println() ;
+                first = false ;
+                if ( freeBnodes.contains(subj) ) {
+                    // Top level: write in "[....]" on "[] :p" form.
+                    writeNestedObjectTopLevel(subj) ;
+                    continue ;
+                }
+
+                Collection<Triple> cluster = triplesOfSubject(subj) ;
+                writeCluster(subj, cluster) ;
+            }
+            return !first ;
+        }
+
+        // A Cluster is a collection of triples with the same subject.
+        private void writeCluster(Node subject, Collection<Triple> cluster) {
+            if ( cluster.isEmpty() )
+                return ;
+            writeNode(subject) ;
+            writeClusterPredicateObjectList(INDENT_PREDICATE, cluster) ;
+        }
+
+        // Write the PredicateObjectList fora subject already output.
+        // The subject may have been a "[]" or a URI - the indentation is passed in.
+        private void writeClusterPredicateObjectList(int indent, Collection<Triple> cluster) {
+            write_S_P_Gap() ;
+            out.incIndent(indent) ;
+            out.pad() ;
+            writePredicateObjectList(cluster) ;
+            out.decIndent(indent) ;
+            print(" .") ;
+            println() ;
+        }
+
+        // Writing predicate-object lists.
+        // We group the cluster by predicate and within each group
+        // we print:
+        //    literals, then simple objects, then pretty objects
+
+        private void writePredicateObjectList(Collection<Triple> cluster) {
+            Map<Node, List<Node>> pGroups = groupByPredicates(cluster) ;
+            Collection<Node> predicates = pGroups.keySet() ;
+
+            // Find longest predicate URI
+            int predicateMaxWidth = RiotLib.calcWidth(prefixMap, baseURI, predicates, MIN_PREDICATE, LONG_PREDICATE) ;
+
+            boolean first = true ;
+
+            if ( !OBJECT_LISTS ) {
+                for ( Node p : predicates ) {
+                    for ( Node o : pGroups.get(p) ) {
+                        writePredicateObject(p, o, predicateMaxWidth, first) ;
+                        first = false ;
+                    }
+                }
+                return ;
+            }
+
+            for ( Node p : predicates ) {
+                // Literals in the group
+                List<Node> rdfLiterals = new ArrayList<>() ;
+                // Non-literals, printed
+                List<Node> rdfSimpleNodes = new ArrayList<>() ;
+                // Non-literals, printed (), or []-embedded
+                List<Node> rdfComplexNodes = new ArrayList<>() ;
+
+                for ( Node o : pGroups.get(p) ) {
+                    if ( o.isLiteral() ) {
+                        rdfLiterals.add(o) ;
+                        continue ;
+                    }
+                    if ( isPrettyNode(o) ) {
+                        rdfComplexNodes.add(o) ;
+                        continue ;
+                    }
+                    rdfSimpleNodes.add(o) ;
+                }
+
+                if ( ! rdfLiterals.isEmpty() ) {
+                    writePredicateObjectList(p, rdfLiterals, predicateMaxWidth, first) ;
+                    first = false ;
+                }
+                if ( ! rdfSimpleNodes.isEmpty() ) {
+                    writePredicateObjectList(p, rdfSimpleNodes, predicateMaxWidth, first) ;
+                    first = false ;
+                }
+
+                for ( Node o : rdfComplexNodes ) {
+                    writePredicateObject(p, o, predicateMaxWidth, first) ;
+                    first = false ;
+                }
+            }
+        }
+
+        private void writePredicateObject(Node p, Node obj, int predicateMaxWidth, boolean first) {
+            writePredicate(p, predicateMaxWidth, first) ;
+            out.incIndent(INDENT_OBJECT) ;
+            writeNodePretty(obj) ;
+            out.decIndent(INDENT_OBJECT) ;
+        }
+
+        private void writePredicateObjectList(Node p, List<Node> objects, int predicateMaxWidth, boolean first) {
+            writePredicate(p, predicateMaxWidth, first) ;
+            out.incIndent(INDENT_OBJECT) ;
+
+            boolean lastObjectMultiLine = false ;
+            boolean firstObject = true ;
+            for ( Node o : objects ) {
+                if ( !firstObject ) {
+                    if ( out.getCurrentOffset() > 0 )
+                        out.print(" , ") ;
+                    else
+                        // Before the current indent, due to a multiline literal being written raw.
+                        // We will pad spaces to indent on output spaces.  Don't add a first " "
+                        out.print(", ") ;
+                }
+                else
+                    firstObject = false ;
+                int row1 = out.getRow() ;
+                writeNode(o) ;
+                int row2 = out.getRow();
+                lastObjectMultiLine = (row2 > row1) ;
+            }
+            out.decIndent(INDENT_OBJECT) ;
+        }
+
+        /** Write a predicate - jump to next line if deemed long */
+        private void writePredicate(Node p, int predicateMaxWidth, boolean first) {
+            if ( first )
+                first = false ;
+            else {
+                print(" ;") ;
+                println() ;
+            }
+            int colPredicateStart = out.getAbsoluteIndent() ;
+
+            if ( !prefixMap.contains(rdfNS) && RDF_type.equals(p) )
+                print("a") ;
+            else
+                writeNode(p) ;
+            int colPredicateFinish = out.getCol() ;
+            int wPredicate = (colPredicateFinish - colPredicateStart) ;
+
+            if ( wPredicate > LONG_PREDICATE )
+                println() ;
+            else {
+                out.pad(predicateMaxWidth) ;
+                // out.print(' ', predicateMaxWidth-wPredicate) ;
+                gap(GAP_P_O) ;
+            }
+        }
+
+        private Map<Node, List<Node>> groupByPredicates(Collection<Triple> cluster) {
+            SortedMap<Node, List<Node>> x = new TreeMap<>(compPredicates) ;
+            for ( Triple t : cluster ) {
+                Node p = t.getPredicate() ;
+                if ( !x.containsKey(p) )
+                    x.put(p, new ArrayList<Node>()) ;
+                x.get(p).add(t.getObject()) ;
+            }
+
+            return x ;
+        }
+
+        private int countPredicates(Collection<Triple> cluster) {
+            Set<Node> x = new HashSet<>() ;
+            for ( Triple t : cluster ) {
+                Node p = t.getPredicate() ;
+                x.add(p) ;
+            }
+            return x.size() ;
+        }
+
+        // [ :p "abc" ] .  or    [] : "abc" .
+        private void writeNestedObjectTopLevel(Node subject) {
+            if ( true ) {
+                writeNestedObject(subject) ;
+                out.println(" .") ;
+            } else {
+                // Alternative.
+                Collection<Triple> cluster = triplesOfSubject(subject) ;
+                print("[]") ;
+                writeClusterPredicateObjectList(0, cluster) ;
+            }
+        }
+
+        private void writeNestedObject(Node node) {
+            Collection<Triple> x = triplesOfSubject(node) ;
+
+            if ( x.isEmpty() ) {
+                print("[] ") ;
+                return ;
+            }
+
+            int pCount = countPredicates(x) ;
+
+            if ( pCount == 1 ) {
+                print("[ ") ;
+                out.incIndent(2) ;
+                writePredicateObjectList(x) ;
+                out.decIndent(2) ;
+                print(" ]") ;
+                return ;
+            }
+
+            // Two or more.
+            int indent0 = out.getAbsoluteIndent() ;
+            int here = out.getCol() ;
+            out.setAbsoluteIndent(here) ;
+            print("[ ") ;
+            out.incIndent(2) ;
+            writePredicateObjectList(x) ;
+            out.decIndent(2) ;
+            if ( true ) {
+                println() ; // Newline for "]"
+                print("]") ;
+            } else { // Compact
+                print(" ]") ;
+            }
+            out.setAbsoluteIndent(indent0) ;
+        }
+
+        // Write a list
+        private void writeList(List<Node> elts) {
+            if ( elts.size() == 0 ) {
+                out.print("()") ;
+                return ;
+            }
+
+            if ( false ) {
+                out.print("(") ;
+                for ( Node n : elts ) {
+                    out.print(" ") ;
+                    writeNodePretty(n) ;
+                }
+                out.print(" )") ;
+            }
+
+            if ( true ) {
+                // "fresh line mode" means printed one on new line
+                // Multi line items are ones that can be multiple lines. Non-literals.
+                // Was the previous row a multiLine?
+                boolean lastItemFreshLine = false ;
+                // Have there been any items that causes "fresh line" mode?
+                boolean multiLineAny = false ;
+                boolean first = true ;
+
+                // Where we started.
+                int originalIndent = out.getAbsoluteIndent() ;
+                // Rebase indent here.
+                int x = out.getCol() ;
+                out.setAbsoluteIndent(x);
+
+                out.print("(") ;
+                out.incIndent(2);
+                for ( Node n : elts ) {
+
+                    // Print this item on a fresh line? (still to check: first line)
+                    boolean thisItemFreshLine = /* multiLineAny | */ n.isBlank() ;
+
+                    // Special case List in List.
+                    // Start on this line if last item was on this line.
+                    if ( lists.containsKey(n) )
+                        thisItemFreshLine = lastItemFreshLine ;
+
+                    // Starting point.
+                    if ( ! first ) {
+                        if ( lastItemFreshLine | thisItemFreshLine )
+                            out.println() ;
+                        else
+                            out.print(" ") ;
+                    }
+
+                    first = false ;
+                    //Literals with newlines: int x1 = out.getRow() ;
+                    // Adds INDENT_OBJECT even for a [ one triple ]
+                    // Special case [ one triple ]??
+                    writeNodePretty(n) ;
+                    //Literals with newlines:int x2 = out.getRow() ;
+                    //Literals with newlines: boolean multiLineAnyway = ( x1 != x2 ) ;
+                    lastItemFreshLine = thisItemFreshLine ;
+                    multiLineAny  = multiLineAny | thisItemFreshLine ;
+
+                }
+                if ( multiLineAny )
+                    out.println() ;
+                else
+                    out.print(" ") ;
+                out.decIndent(2);
+                out.setAbsoluteIndent(x);
+                out.print(")") ;
+                out.setAbsoluteIndent(originalIndent) ;
+            }
+        }
+
+        private boolean isPrettyNode(Node n) {
+            // Order matters? - one connected objects may include list elements.
+            if ( allowDeepPretty ) {
+                if ( lists.containsKey(n) )
+                    return true ;
+                if ( nestedObjects.contains(n) )
+                    return true ;
+            }
+            if ( RDF_Nil.equals(n) )
+                return true ;
+            return false ;
+        }
+
+        // --> write S or O??
+        private void writeNodePretty(Node obj) {
+            // Assumes "isPrettyNode" is true.
+            // Order matters? - one connected objects may include list elements.
+            if ( lists.containsKey(obj) )
+                writeList(lists.get(obj)) ;
+            else if ( nestedObjects.contains(obj) )
+                writeNestedObject(obj) ;
+            else if ( RDF_Nil.equals(obj) )
+                out.print("()") ;
+            else
+                writeNode(obj) ;
+            if ( nestedObjects.contains(obj) )
+                nestedObjectsWritten.add(obj) ;
+
+        }
+
+        // Order of properties.
+        // rdf:type ("a")
+        // RDF and RDFS
+        // Other.
+        // Sorted by URI.
+
+        private void write_S_P_Gap() {
+            if ( out.getCol() > LONG_SUBJECT )
+                out.println() ;
+            else
+                gap(GAP_S_P) ;
+        }
+    }
+
+    // Order of properties.
+    // rdf:type ("a")
+    // RDF and RDFS
+    // Other.
+    // Sorted by URI.
+
+    private static final class ComparePredicates implements Comparator<Node> {
+        private static int classification(Node p) {
+            if ( p.equals(RDF_type) )
+                return 0 ;
+
+            if ( p.getURI().startsWith(RDF.getURI()) || p.getURI().startsWith(RDFS.getURI()) )
+                return 1 ;
+
+            return 2 ;
+        }
+
+        @Override
+        public int compare(Node t1, Node t2) {
+            int class1 = classification(t1) ;
+            int class2 = classification(t2) ;
+            if ( class1 != class2 ) {
+                // Java 1.7
+                // return Integer.compare(class1, class2) ;
+                if ( class1 < class2 )
+                    return -1 ;
+                if ( class1 > class2 )
+                    return 1 ;
+                return 0 ;
+            }
+            String p1 = t1.getURI() ;
+            String p2 = t2.getURI() ;
+            return p1.compareTo(p2) ;
+        }
+    }
+
+    private static Comparator<Node> compPredicates = new ComparePredicates() ;
+
+    protected final void writeNode(Node node) {
+        nodeFmt.format(out, node) ;
+    }
+
+    private void print(String x) {
+        out.print(x) ;
+    }
+
+    private void gap(int gap) {
+        out.print(' ', gap) ;
+    }
+
+    // flush aggressively (debugging)
+    private void println() {
+        out.println() ;
+        // out.flush() ;
+    }
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/CopyOfWriterStreamRDFPlain.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/CopyOfWriterStreamRDFPlain.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.AWriter ;
+import org.apache.jena.atlas.io.IO ;
+import org.apache.jena.atlas.lib.CharSpace ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.riot.out.NodeFormatter ;
+import org.apache.jena.riot.out.NodeFormatterNT ;
+import org.apache.jena.riot.system.StreamRDF ;
+import org.apache.jena.riot.system.StreamRDFLib ;
+import org.apache.jena.sparql.core.Quad ;
+
+/**
+ * An output of triples / quads that is streaming. It writes N-triples/N-quads.
+ */
+
+public class CopyOfWriterStreamRDFPlain implements StreamRDF {
+    // This class is the overall structure - the NodeFormatter controls the
+    // appearance of the Nodes themselves.
+
+    // NOTE, Fedora change: remove 'final' on NodeFormatter
+    protected final AWriter       out ;
+    protected NodeFormatter nodeFmt ;
+
+    /**
+     * Output tuples, using UTF8 output See {@link StreamRDFLib#writer} for
+     * ways to create a AWriter object.
+     */
+    public CopyOfWriterStreamRDFPlain(AWriter w) {
+        this(w, CharSpace.UTF8) ;
+    }
+
+    /**
+     * Output tuples, choosing ASCII or UTF8 See
+     * {@link StreamRDFLib#writer} for ways to create a AWriter object.
+     */
+    public CopyOfWriterStreamRDFPlain(AWriter w, CharSpace charSpace) {
+        out = w ;
+        nodeFmt = new NodeFormatterNT(charSpace) ;
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void finish() {
+        IO.flush(out) ;
+    }
+
+    @Override
+    public void triple(Triple triple) {
+        Node s = triple.getSubject() ;
+        Node p = triple.getPredicate() ;
+        Node o = triple.getObject() ;
+
+        format(s) ;
+        out.print(" ") ;
+        format(p) ;
+        out.print(" ") ;
+        format(o) ;
+        out.print(" .\n") ;
+    }
+
+    @Override
+    public void quad(Quad quad) {
+        Node s = quad.getSubject() ;
+        Node p = quad.getPredicate() ;
+        Node o = quad.getObject() ;
+        Node g = quad.getGraph() ;
+
+        format(s) ;
+        out.print(" ") ;
+        format(p) ;
+        out.print(" ") ;
+        format(o) ;
+
+        if ( outputGraphSlot(g) ) {
+            out.print(" ") ;
+            format(g) ;
+        }
+        out.print(" .\n") ;
+    }
+
+    private void format(Node n) {
+        nodeFmt.format(out, n) ;
+    }
+
+    @Override
+    public void base(String base) {}
+
+    @Override
+    public void prefix(String prefix, String iri) {}
+
+    private static boolean outputGraphSlot(Node g) {
+        return (g != null && g != Quad.tripleInQuad && !Quad.isDefaultGraph(g)) ;
+    }
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraBasic.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraBasic.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import java.io.PrintWriter;
+
+import org.apache.jena.rdf.model.* ;
+import org.apache.jena.rdf.model.impl.Util;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraBasic extends CopyOfBasic {
+
+    protected void writeLiteral( Literal l, PrintWriter writer ) {
+        String lang = l.getLanguage();
+        String form = l.getLexicalForm();
+        if (Util.isLangString(l)) {
+            writer.print(" xml:lang=" + attributeQuoted( lang ));
+        } else if (l.isWellFormedXML() && !blockLiterals) {
+            // RDF XML Literals inline.
+            writer.print(" " + rdfAt("parseType") + "=" + attributeQuoted( "Literal" )+">");
+            writer.print( form );
+            return ;
+        } else {
+            // Datatype (if not xsd:string and RDF 1.1)
+            String dt = l.getDatatypeURI();
+            // NOTE, Fedora change: Remove condition
+//            if ( ! Util.isSimpleString(l) )
+                writer.print( " " + rdfAt( "datatype" ) + "=" + substitutedAttribute( dt ) );
+        }
+        // Content.
+        writer.print(">");
+        writer.print( Util.substituteEntitiesInElementContent( form ) );
+    }
+
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraNodeFormatterNT.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraNodeFormatterNT.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.AWriter;
+import org.apache.jena.atlas.lib.CharSpace;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.out.NodeFormatterNT;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraNodeFormatterNT extends NodeFormatterNT {
+
+    /**
+     *
+     * @param charSpace
+     */
+    public FedoraNodeFormatterNT(final CharSpace charSpace) {
+        super(charSpace);
+    }
+
+    /**
+     *
+     * @param w
+     * @param n
+     */
+    @Override
+    public void formatLiteral(final AWriter w, final Node n) {
+        final RDFDatatype dt = n.getLiteralDatatype();
+        final String lang = n.getLiteralLanguage();
+        final String lex = n.getLiteralLexicalForm();
+
+        if (lang != null && !lang.equals("")) {
+            formatLitLang(w, lex, lang);
+        } else if (dt == null) {
+            // RDF 1.0, simple literal.
+            formatLitString(w, lex);
+            // NOTE, Fedora: Remove condition
+//        } else if ( JenaRuntime.isRDF11 && dt.equals(XSDDatatype.XSDstring) ) {
+//            // RDF 1.1, xsd:string - output as short string.
+//            formatLitString(w, lex) ;
+        } else {
+            // Datatype, no language tag, not short string.
+            formatLitDT(w, lex, dt.getURI());
+        }
+    }
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraNodeFormatterTTL.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraNodeFormatterTTL.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.AWriter;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.out.NodeFormatterTTL;
+import org.apache.jena.riot.out.NodeToLabel;
+import org.apache.jena.riot.system.PrefixMap;
+import org.apache.jena.riot.system.RiotChars;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraNodeFormatterTTL extends NodeFormatterTTL {
+
+    /**
+     * @param baseIRI
+     * @param prefixMap
+     * @param nodeToLabel
+     */
+    public FedoraNodeFormatterTTL(final String baseIRI, final PrefixMap prefixMap, final NodeToLabel nodeToLabel) {
+        super(baseIRI, prefixMap, nodeToLabel);
+    }
+
+    /**
+     * @param w
+     * @param n
+     */
+    @Override
+    public void formatLiteral(final AWriter w, final Node n) {
+        final RDFDatatype dt = n.getLiteralDatatype();
+        final String lang = n.getLiteralLanguage();
+        final String lex = n.getLiteralLexicalForm();
+
+        if (lang != null && !lang.equals("")) {
+            formatLitLang(w, lex, lang);
+        } else if (dt == null) {
+            // RDF 1.0, simple literal.
+            formatLitString(w, lex);
+            // NOTE, Fedora change: remove condition
+//        } else if ( JenaRuntime.isRDF11 && dt.equals(XSDDatatype.XSDstring) ) {
+//            // RDF 1.1, xsd:string - output as short string.
+//            formatLitString(w, lex) ;
+        } else {
+            // Datatype, no language tag, not short string.
+            formatLitDT(w, lex, dt.getURI());
+        }
+    }
+
+    // NOTE, Fedora change: private -> protected
+    protected static final String dtDecimal = XSDDatatype.XSDdecimal.getURI() ;
+    protected static final String dtInteger = XSDDatatype.XSDinteger.getURI() ;
+    protected static final String dtDouble  = XSDDatatype.XSDdouble.getURI() ;
+
+    /**
+     * Write in a short form, e.g. integer.
+     *
+     * @return True if a short form was output else false.
+     */
+    protected boolean writeLiteralAbbreviated(final AWriter w, final String lex, final String datatypeURI) {
+        if (dtDecimal.equals(datatypeURI)) {
+            if (validDecimal(lex)) {
+                w.print(lex);
+                return true;
+            }
+        } else if (dtInteger.equals(datatypeURI)) {
+            if (validInteger(lex)) {
+                w.print(lex);
+                return true;
+            }
+        } else if (dtDouble.equals(datatypeURI)) {
+            if (validDouble(lex)) {
+                w.print(lex);
+                return true;
+            }
+            // NOTE, Fedora change: Remove condition
+//        } else if ( dtBoolean.equals(datatypeURI) ) {
+//            // We leave "0" and "1" as-is assumign that if written like that,
+//            // there was a reason.
+//            if ( lex.equals("true") || lex.equals("false") ) {
+//                w.print(lex) ;
+//                return true ;
+//            }
+        }
+        return false;
+    }
+
+    //********************************************************************
+    // NOTE, Fedora: Below are added from NodeFormatterTTL without change.
+    //********************************************************************
+
+    private static boolean validInteger(String lex) {
+        int N = lex.length() ;
+        if ( N == 0 )
+            return false ;
+        int idx = 0 ;
+
+        idx = skipSign(lex, idx) ;
+        idx = skipDigits(lex, idx) ;
+        return (idx == N) ;
+    }
+
+    private static boolean validDecimal(String lex) {
+        // case : In N3, "." illegal, as is "+." and -." but legal in Turtle.
+        int N = lex.length() ;
+        if ( N <= 1 )
+            return false ;
+        int idx = 0 ;
+
+        idx = skipSign(lex, idx) ;
+        idx = skipDigits(lex, idx) ; // Maybe none.
+
+        // DOT required.
+        if ( idx >= N )
+            return false ;
+
+        char ch = lex.charAt(idx) ;
+        if ( ch != '.' )
+            return false ;
+        idx++ ;
+        // Digit required.
+        if ( idx >= N )
+            return false ;
+        idx = skipDigits(lex, idx) ;
+        return (idx == N) ;
+    }
+
+    private static boolean validDouble(String lex) {
+        int N = lex.length() ;
+        if ( N == 0 )
+            return false ;
+        int idx = 0 ;
+
+        // Decimal part (except 12. is legal)
+
+        idx = skipSign(lex, idx) ;
+
+        int idx2 = skipDigits(lex, idx) ;
+        boolean initialDigits = (idx != idx2) ;
+        idx = idx2 ;
+        // Exponent required.
+        if ( idx >= N )
+            return false ;
+        char ch = lex.charAt(idx) ;
+        if ( ch == '.' ) {
+            idx++ ;
+            if ( idx >= N )
+                return false ;
+            idx2 = skipDigits(lex, idx) ;
+            boolean trailingDigits = (idx != idx2) ;
+            idx = idx2 ;
+            if ( idx >= N )
+                return false ;
+            if ( !initialDigits && !trailingDigits )
+                return false ;
+        }
+        // "e" or "E"
+        ch = lex.charAt(idx) ;
+        if ( ch != 'e' && ch != 'E' )
+            return false ;
+        idx++ ;
+        if ( idx >= N )
+            return false ;
+        idx = skipSign(lex, idx) ;
+        if ( idx >= N )
+            return false ; // At least one digit.
+        idx = skipDigits(lex, idx) ;
+        return (idx == N) ;
+    }
+
+    /**
+     * Skip digits [0-9] and return the index just after the digits, which may
+     * be beyond the length of the string. May skip zero.
+     */
+    private static int skipDigits(String str, int start) {
+        int N = str.length() ;
+        for (int i = start; i < N; i++) {
+            char ch = str.charAt(i) ;
+            if ( !RiotChars.isDigit(ch) )
+                return i ;
+        }
+        return N ;
+    }
+
+    /** Skip any plus or minus */
+    private static int skipSign(String str, int idx) {
+        int N = str.length() ;
+        char ch = str.charAt(idx) ;
+        if ( ch == '+' || ch == '-' )
+            return idx + 1 ;
+        return idx ;
+    }
+
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraRDFXMLPlainWriter.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraRDFXMLPlainWriter.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.riot.writer.RDFXMLPlainWriter;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraRDFXMLPlainWriter extends RDFXMLPlainWriter {
+
+    @Override
+    protected RDFWriter create() { return new FedoraBasic() ; }
+
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraTurtleWriter.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraTurtleWriter.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.system.PrefixMap;
+import org.apache.jena.riot.writer.TurtleWriter;
+import org.apache.jena.sparql.util.Context;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraTurtleWriter extends TurtleWriter {
+
+    @Override
+    protected void output(final IndentedWriter iOut,
+                          final Graph graph,
+                          final PrefixMap prefixMap,
+                          final String baseURI,
+                          final Context context) {
+        final FedoraTurtleWriter.TurtleWriter$ w =
+                new FedoraTurtleWriter.TurtleWriter$(iOut, prefixMap, baseURI, context) ;
+        w.write(graph) ;
+    }
+
+    private static class TurtleWriter$ extends CopyOfTurtleShell {
+
+        /**
+         *
+         * @param out
+         * @param prefixMap
+         * @param baseURI
+         * @param context
+         */
+        public TurtleWriter$(final IndentedWriter out,
+                             final PrefixMap prefixMap,
+                             final String baseURI,
+                             final Context context) {
+            super(out, prefixMap, baseURI, context) ;
+        }
+
+        private void write(final Graph graph) {
+            writeBase(baseURI) ;
+            writePrefixes(prefixMap) ;
+            if ( !prefixMap.isEmpty() && !graph.isEmpty() ) {
+                out.println();
+            }
+            writeGraphTTL(graph) ;
+        }
+    }
+
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraTurtleWriterBlocks.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraTurtleWriterBlocks.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.system.PrefixMap;
+import org.apache.jena.riot.system.StreamOps;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.riot.writer.TurtleWriterBase;
+import org.apache.jena.sparql.util.Context;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraTurtleWriterBlocks extends TurtleWriterBase {
+
+    @Override
+    protected void output(final IndentedWriter out,
+                          final Graph graph,
+                          final PrefixMap prefixMap,
+                          final String baseURI,
+                          final Context context) {
+        final StreamRDF dest = new FedoraWriterStreamRDFBlocks(out) ;
+        dest.start() ;
+        dest.base(baseURI) ;
+        StreamOps.sendGraphToStream(graph, dest, prefixMap) ;
+        dest.finish() ;
+    }
+
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraTurtleWriterFlat.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraTurtleWriterFlat.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.system.PrefixMap;
+import org.apache.jena.riot.system.StreamOps;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.riot.writer.TurtleWriterBase;
+import org.apache.jena.sparql.util.Context;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraTurtleWriterFlat extends TurtleWriterBase {
+
+    @Override
+    protected void output(final IndentedWriter out,
+                          final Graph graph,
+                          final PrefixMap prefixMap,
+                          final String baseURI,
+                          final Context context) {
+        final StreamRDF dest = new FedoraWriterStreamRDFFlat(out);
+        dest.start();
+        dest.base(baseURI);
+        StreamOps.sendGraphToStream(graph, dest, prefixMap);
+        dest.finish();
+    }
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraWriterStreamRDFBlocks.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraWriterStreamRDFBlocks.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.riot.writer.WriterStreamRDFBlocks;
+
+import java.io.OutputStream;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraWriterStreamRDFBlocks extends WriterStreamRDFBlocks {
+
+    /**
+     *
+     * @param output
+     */
+    public FedoraWriterStreamRDFBlocks(final OutputStream output) {
+        super(output);
+        setFormatter();
+    }
+
+    /**
+     *
+     * @param output
+     */
+    public FedoraWriterStreamRDFBlocks(final IndentedWriter output) {
+        super(output);
+        setFormatter();
+    }
+
+    private void setFormatter() {
+        fmt = new FedoraNodeFormatterTTL(baseURI, pMap, nodeToLabel) ;
+    }
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraWriterStreamRDFFlat.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraWriterStreamRDFFlat.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.riot.writer.WriterStreamRDFFlat;
+
+import java.io.OutputStream;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraWriterStreamRDFFlat extends WriterStreamRDFFlat {
+
+    /**
+     *
+     * @param output
+     */
+    public FedoraWriterStreamRDFFlat(final OutputStream output) {
+        super(output);
+        setFormatter();
+    }
+
+    /**
+     *
+     * @param output
+     */
+    public FedoraWriterStreamRDFFlat(final IndentedWriter output) {
+        super(output);
+        setFormatter();
+    }
+
+    private void setFormatter() {
+        fmt = new FedoraNodeFormatterTTL(baseURI, pMap, nodeToLabel) ;
+    }
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/FedoraWriterStreamRDFPlain.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/FedoraWriterStreamRDFPlain.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.AWriter;
+import org.apache.jena.atlas.lib.CharSpace;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+public class FedoraWriterStreamRDFPlain extends CopyOfWriterStreamRDFPlain {
+
+    public FedoraWriterStreamRDFPlain(final AWriter w, final CharSpace charSpace) {
+        super(w, charSpace);
+        nodeFmt = new FedoraNodeFormatterNT(charSpace) ;
+    }
+}

--- a/jena-patch/src/main/java/org/fcrepo/jena/RdfWriterHelper.java
+++ b/jena-patch/src/main/java/org/fcrepo/jena/RdfWriterHelper.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.jena;
+
+import org.apache.jena.atlas.io.AWriter;
+import org.apache.jena.atlas.io.IO;
+import org.apache.jena.atlas.lib.CharSpace;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFWriterRegistry;
+import org.apache.jena.riot.WriterGraphRIOTFactory;
+import org.apache.jena.riot.system.StreamRDFWriter;
+import org.apache.jena.riot.system.StreamRDFWriterFactory;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author awoods
+ * @since 2017/01/03
+ */
+@Component
+public class RdfWriterHelper {
+
+    private static final Logger LOGGER = getLogger(RdfWriterHelper.class);
+
+    private RdfWriterHelper() {
+        // prevent construction
+    }
+
+    private static StreamRDFWriterFactory streamWriterFactoryBlocks =
+            (output, format) -> new FedoraWriterStreamRDFBlocks(output);
+
+    private static StreamRDFWriterFactory streamWriterFactoryFlat =
+            (output, format) -> new FedoraWriterStreamRDFFlat(output);
+
+    private static StreamRDFWriterFactory streamWriterFactoryTriplesQuads =
+            (output, format) -> {
+                final AWriter w = IO.wrapUTF8(output);
+                return new FedoraWriterStreamRDFPlain(w, CharSpace.UTF8);     // N-Quads and N-Triples.
+            };
+
+    private static StreamRDFWriterFactory streamWriterFactoryTriplesQuadsAscii =
+            (output, format) -> {
+                final AWriter w = IO.wrapUTF8(output);
+                return new FedoraWriterStreamRDFPlain(w, CharSpace.ASCII);     // N-Quads and N-Triples.
+            };
+
+    private static WriterGraphRIOTFactory wgfactory = (serialization) ->
+        {
+            if ( Objects.equals(RDFFormat.TURTLE_PRETTY, serialization) ) {
+                return new FedoraTurtleWriter();
+            }
+            if ( Objects.equals(RDFFormat.TURTLE_BLOCKS, serialization) ) {
+                return new FedoraTurtleWriterBlocks();
+            }
+            if ( Objects.equals(RDFFormat.TURTLE_FLAT, serialization) ) {
+                return new FedoraTurtleWriterFlat();
+            }
+            if ( Objects.equals(RDFFormat.RDFXML_PLAIN, serialization) ) {
+                return new FedoraRDFXMLPlainWriter();
+            }
+
+            return null ;
+        };
+
+
+    static {
+        LOGGER.info("Loading JENA 3.1.1 Patched RDF Output Writers");
+        StreamRDFWriter.register(RDFFormat.TURTLE_BLOCKS, streamWriterFactoryBlocks);
+        StreamRDFWriter.register(RDFFormat.TURTLE_FLAT, streamWriterFactoryFlat);
+
+        StreamRDFWriter.register(RDFFormat.NTRIPLES, streamWriterFactoryTriplesQuads);
+        StreamRDFWriter.register(RDFFormat.NTRIPLES_UTF8, streamWriterFactoryTriplesQuads);
+        StreamRDFWriter.register(RDFFormat.NTRIPLES_ASCII, streamWriterFactoryTriplesQuadsAscii);
+
+        RDFWriterRegistry.register(RDFFormat.TURTLE_PRETTY,  wgfactory) ;
+        RDFWriterRegistry.register(RDFFormat.TURTLE_BLOCKS,  wgfactory) ;
+        RDFWriterRegistry.register(RDFFormat.TURTLE_FLAT,    wgfactory) ;
+
+        RDFWriterRegistry.register(RDFFormat.RDFXML_PLAIN,   wgfactory) ;
+    }
+}

--- a/jena-patch/src/test/java/org/fcrepo/integration/jena/FedoraRDFTypesIT.java
+++ b/jena-patch/src/test/java/org/fcrepo/integration/jena/FedoraRDFTypesIT.java
@@ -1,0 +1,86 @@
+package org.fcrepo.integration.jena;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.fcrepo.integration.http.api.AbstractResourceIT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author awoods
+ * @since 2017/01/04
+ */
+public class FedoraRDFTypesIT extends AbstractResourceIT {
+
+    private static Set<String> contentTypes;
+
+    private static final String STRING_XSD_TYPE = XSDDatatype.XSDstring.getURI();
+    private static final String BOOLEAN_XSD_TYPE = XSDDatatype.XSDboolean.getURI();
+
+    @BeforeClass
+    public static void setup() {
+        contentTypes = new HashSet<>();
+        contentTypes.add("application/ld+json");
+        contentTypes.add("application/n-triples");
+        contentTypes.add("application/rdf+xml");
+        contentTypes.add("application/x-turtle");
+        contentTypes.add("text/n3");
+        contentTypes.add("text/rdf+n3");
+        contentTypes.add("text/turtle");
+    }
+
+    @Test
+    public void testRDFTypes() throws IOException {
+        // Create a test resource with String and Boolean properties
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut createMethod = new HttpPut(subjectURI);
+        createMethod.addHeader(CONTENT_TYPE, "application/n3");
+        createMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\"; " +
+                "<info:test#flag> \"\"^^<" + BOOLEAN_XSD_TYPE + "> .", UTF_8));
+        assertEquals(CREATED.getStatusCode(), getStatus(createMethod));
+
+        contentTypes.forEach(contentType -> verifyResponse(subjectURI, contentType));
+    }
+
+    private void verifyResponse(final String subjectURI, final String contentType) {
+        final HttpGet method = new HttpGet(subjectURI);
+        method.addHeader(HttpHeaders.ACCEPT, contentType);
+        try (final CloseableHttpResponse response = execute(method)) {
+            final String body = EntityUtils.toString(response.getEntity());
+
+            // Verify String XSD Type is present
+            if (contentType.equals("application/ld+json")) {
+                // String XSD Type should not be present in JSON-LD
+                assertFalse("Did not find " + STRING_XSD_TYPE + " for " + contentType + " in " + body,
+                        body.contains(STRING_XSD_TYPE));
+            } else {
+                assertTrue("Did not find " + STRING_XSD_TYPE + " for " + contentType + " in " + body,
+                        body.contains(STRING_XSD_TYPE));
+            }
+            // Verify Boolean XSD Type is present
+            assertTrue("Did not find " + BOOLEAN_XSD_TYPE + " for " + contentType + " in " + body,
+                    body.contains(BOOLEAN_XSD_TYPE));
+
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+}

--- a/jena-patch/src/test/resources/logback-test.xml
+++ b/jena-patch/src/test/resources/logback-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%p %d{HH:mm:ss.SSS} \(%c{0}\) %m%n</pattern>
+        </encoder>
+    </appender>
+
+  <logger name="org.fcrepo.http.api" additivity="false" level="${fcrepo.log.http.api:-INFO}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.integration.jena" additivity="false" level="${fcrepo.log.integration.http:-INFO}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.glassfish" additivity="false" level="ERROR">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <root additivity="false" level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/jena-patch/src/test/resources/spring-test/eventing.xml
+++ b/jena-patch/src/test/resources/spring-test/eventing.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+    <!-- Context that suports event management, including the internal
+    event bus (fedoraInternalEventBus) -->
+
+    <context:annotation-config/>
+
+    <!-- listener that moves JCR Events to the Fedora internal event bus -->
+    <bean class="org.fcrepo.kernel.modeshape.observer.SimpleObserver"/>
+
+    <!-- used by bean above to filter which events get put on the bus -->
+    <bean name="fedoraEventFilter" class="org.fcrepo.kernel.modeshape.observer.DefaultFilter"/>
+
+    <!-- used by observer bean to map JCR events into Fedora events -->
+    <bean name="fedoraEventMapper" class="org.fcrepo.kernel.modeshape.observer.eventmappings.AllNodeEventsOneEvent"/>
+    
+    <!-- Fedora's lightweight internal event bus. Currently memory-resident.-->
+    <bean name="fedoraInternalEventBus" class="com.google.common.eventbus.EventBus"/>
+
+
+</beans>

--- a/jena-patch/src/test/resources/spring-test/master.xml
+++ b/jena-patch/src/test/resources/spring-test/master.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <!-- Master context for the test application. -->
+    
+    <import resource="classpath:/spring-test/repo.xml"/>
+    <import resource="classpath:/spring-test/rest.xml"/>
+    <import resource="classpath:/spring-test/eventing.xml"/>
+    <import resource="classpath:/spring-test/transactions.xml"/>
+    
+</beans>

--- a/jena-patch/src/test/resources/spring-test/repo.xml
+++ b/jena-patch/src/test/resources/spring-test/repo.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+    <!-- Context that supports the actual ModeShape JCR itself -->
+
+    <context:annotation-config/>
+
+    <bean name="modeshapeRepofactory"
+        class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
+        p:repositoryConfiguration="${fcrepo.modeshape.configuration:test_repository.json}"/>
+
+    <bean class="org.modeshape.jcr.ModeShapeEngine" init-method="start"/>
+
+    <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager"/>
+
+</beans>

--- a/jena-patch/src/test/resources/spring-test/rest.xml
+++ b/jena-patch/src/test/resources/spring-test/rest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:c="http://www.springframework.org/schema/c"
+  xmlns:util="http://www.springframework.org/schema/util"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+  <context:property-placeholder />
+
+  <bean class="org.fcrepo.http.commons.session.SessionFactory"/>
+
+  <!-- Identifier translation chain -->
+  <util:list id="translationChain" value-type="org.fcrepo.kernel.api.identifiers.InternalIdentifierConverter">
+    <bean class="org.fcrepo.kernel.modeshape.identifiers.HashConverter"/>
+    <bean class="org.fcrepo.kernel.modeshape.identifiers.NamespaceConverter"/>
+  </util:list>
+
+  <context:annotation-config/>
+
+  <context:component-scan base-package="org.fcrepo"/>
+
+</beans>

--- a/jena-patch/src/test/resources/spring-test/test-container.xml
+++ b/jena-patch/src/test/resources/spring-test/test-container.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:p="http://www.springframework.org/schema/p"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+  <context:property-placeholder/>
+
+  <bean id="containerWrapper"
+    class="org.fcrepo.http.commons.test.util.ContainerWrapper"
+    init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"
+    p:configLocation="classpath:web.xml"/>
+
+</beans>

--- a/jena-patch/src/test/resources/spring-test/transactions.xml
+++ b/jena-patch/src/test/resources/spring-test/transactions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+  xmlns:task="http://www.springframework.org/schema/task"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+  http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd">
+
+  <task:scheduler id="taskScheduler" />
+  <task:executor id="taskExecutor" pool-size="1" />
+  <task:annotation-driven executor="taskExecutor" scheduler="taskScheduler" />
+  
+</beans>

--- a/jena-patch/src/test/resources/test_repository.json
+++ b/jena-patch/src/test/resources/test_repository.json
@@ -1,0 +1,25 @@
+{
+  "name" : "repo",
+  "jndiName" : "",
+  "workspaces" : {
+    "predefined" : [],
+    "default" : "default",
+    "allowCreation" : true
+  },
+  "storage" : {
+    "persistence" : {
+      "type" : "file",
+      "path" : "target/fedora_repository/store"
+    }
+  },
+  "security" : {
+    "anonymous" : {
+      "roles" : ["readonly","readwrite","admin"],
+      "useOnFailedLogin" : false
+    },
+    "providers" : [
+      { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
+    ]
+  },
+  "node-types" : ["fedora-node-types.cnd"]
+}

--- a/jena-patch/src/test/resources/web.xml
+++ b/jena-patch/src/test/resources/web.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	 version="3.0" metadata-complete="false">
+    
+    <display-name>Fedora-on-ModeShape</display-name>
+    
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>classpath:spring-test/master.xml</param-value>
+    </context-param>
+
+    <listener>
+        <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+    </listener>
+    
+	<servlet>
+    <servlet-name>jersey-servlet</servlet-name>
+    <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+
+    <init-param>
+      <param-name>javax.ws.rs.Application</param-name>
+      <param-value>org.fcrepo.http.commons.FedoraApplication</param-value>
+    </init-param>
+
+    <load-on-startup>1</load-on-startup>
+	</servlet>
+ 
+	<servlet-mapping>
+		<servlet-name>jersey-servlet</servlet-name>
+		<url-pattern>/*</url-pattern>
+	</servlet-mapping>
+  
+    <!-- filter to add test auth to grizzly -->
+    <filter>
+      <filter-name>TestAuth</filter-name>
+      <filter-class>org.fcrepo.http.commons.test.util.TestAuthenticationRequestFilter</filter-class>
+    </filter>
+    
+    <filter-mapping>
+      <filter-name>TestAuth</filter-name>
+      <url-pattern>/*</url-pattern>
+    </filter-mapping>
+	
+</web-app>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <module>fcrepo-kernel-api</module>
     <module>fcrepo-kernel-modeshape</module>
     <module>fcrepo-webapp</module>
+    <module>jena-patch</module>
     <module>fcrepo-event-serialization</module>
     <module>fcrepo-jms</module>
     <module>fcrepo-http-commons</module>


### PR DESCRIPTION
…tring and Boolean type

information ala RDF 1.0.

Resolves: https://jira.duraspace.org/browse/FCREPO-2374

The RDF writers in this module are auto-injected into the "fcrepo-http-commons/RdfStreamStreamingOutput" framework
via Spring's annotation-based instantiation of RdfWriterHelper.

This module should be removed with the release of Fedora 4.8.0, at which point, standard RDF 1.1 output syntax
should be used.

The only other evidence of this patch that should also be removed is:
1. jena-patch module definition in top-level pom.xml
2. jena-patch dependency declaration in fcrepo-webapp/pom.xml

Most of the classes in this module are exact or near copies of Jena classes. The differences from the original
classes can be found by searching for comments prefixed with:
"// NOTE, Fedora change"