### PR TITLE
Ensures that the error content type matches the media type of the ret…

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/AccessControlExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/AccessControlExceptionMapper.java
@@ -17,16 +17,10 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
-import static org.slf4j.LoggerFactory.getLogger;
-
 import javax.jcr.security.AccessControlException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
 
 /**
  * Translate JCR AccessControlExceptions into HTTP 403 Forbidden errors
@@ -36,15 +30,15 @@ import org.slf4j.Logger;
  * @author gregjan
  */
 @Provider
-public class AccessControlExceptionMapper implements
-        ExceptionMapper<AccessControlException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-        getLogger(AccessControlExceptionMapper.class);
+public class AccessControlExceptionMapper extends FedoraExceptionMapper<AccessControlException> {
 
     @Override
-    public Response toResponse(final AccessControlException e) {
-        debugException(this, e, LOGGER);
-        return status(FORBIDDEN).build();
+    protected ResponseBuilder status(final AccessControlException e) {
+        return super.status(Status.FORBIDDEN);
+    }
+
+    @Override
+    protected ResponseBuilder entity(final ResponseBuilder builder, final AccessControlException e) {
+        return builder.entity("This resource is forbidden.");
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/AccessControlJavaSecurityExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/AccessControlJavaSecurityExceptionMapper.java
@@ -15,19 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
-import static org.slf4j.LoggerFactory.getLogger;
+package org.fcrepo.http.commons.exceptionhandlers;
 
 import java.security.AccessControlException;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
 
 /**
  * Translate Java Security AccessControlExceptions into HTTP 403 Forbidden errors
@@ -37,16 +32,16 @@ import org.slf4j.Logger;
  * @author gregjan
  */
 @Provider
-public class AccessControlJavaSecurityExceptionMapper implements
-        ExceptionMapper<AccessControlException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-        getLogger(AccessControlJavaSecurityExceptionMapper.class);
+public class AccessControlJavaSecurityExceptionMapper extends FedoraExceptionMapper<AccessControlException> {
 
     @Override
-    public Response toResponse(final AccessControlException e) {
-        debugException(this, e, LOGGER);
-        return status(FORBIDDEN).build();
+    protected ResponseBuilder status(final AccessControlException e) {
+        return super.status(Status.FORBIDDEN);
+    }
+
+    @Override
+    protected ResponseBuilder entity(final ResponseBuilder builder, final AccessControlException e) {
+        return builder.entity("This resource is forbidden..");
     }
 
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/AccessDeniedExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/AccessDeniedExceptionMapper.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author fasseg
  */
 @Provider
-public class AccessDeniedExceptionMapper implements
-        ExceptionMapper<AccessDeniedException>, ExceptionDebugLogging {
+public class AccessDeniedExceptionMapper extends FedoraExceptionMapper<AccessDeniedException> {
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(AccessDeniedExceptionMapper.class);
-
-    /*
-     * (non-Javadoc)
-     * @see javax.ws.rs.ext.ExceptionMapper#toResponse(java.lang.Throwable)
-     */
     @Override
-    public Response toResponse(final AccessDeniedException e) {
-        debugException(this, e, LOGGER);
-        return status(FORBIDDEN).build();
+    protected ResponseBuilder status(final AccessDeniedException e) {
+        return super.status(Status.FORBIDDEN);
     }
+
+    @Override
+    protected ResponseBuilder entity(final ResponseBuilder builder, final AccessDeniedException e) {
+        return builder.entity("Access denied.");
+    }
+
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/BadRequestExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/BadRequestExceptionMapper.java
@@ -15,18 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.slf4j.Logger;
-
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.status;
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * For generic BadRequestExceptions.
@@ -35,16 +28,5 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @since November 18, 2014
  */
 @Provider
-public class BadRequestExceptionMapper implements
-        ExceptionMapper<BadRequestException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(BadRequestExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final BadRequestException e) {
-        LOGGER.error("BadRequestExceptionMapper caught an exception: {}", e.getMessage());
-        debugException(this, e, LOGGER);
-        return status(BAD_REQUEST).entity(e.getMessage()).build();
-    }
-
+public class BadRequestExceptionMapper extends FedoraExceptionMapper<BadRequestException> {
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ClientErrorExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ClientErrorExceptionMapper.java
@@ -15,31 +15,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
-
 import static javax.ws.rs.core.Response.fromResponse;
-import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.ext.Provider;
 
 /**
  * @author awoods
  * @since 11/20/14
  */
 @Provider
-public class ClientErrorExceptionMapper implements
-        ExceptionMapper<ClientErrorException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(ClientErrorExceptionMapper.class);
+public class ClientErrorExceptionMapper extends FedoraExceptionMapper<ClientErrorException> {
 
     @Override
-    public Response toResponse(final ClientErrorException e) {
-        debugException(this, e, LOGGER);
-        return fromResponse(e.getResponse()).entity(e.getMessage()).build();
+    protected ResponseBuilder status(final ClientErrorException e) {
+        return fromResponse(e.getResponse());
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConstraintExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConstraintExceptionMapper.java
@@ -15,13 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.ExceptionMapper;
 
 import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 
@@ -32,7 +34,11 @@ import org.fcrepo.kernel.api.exception.ConstraintViolationException;
  * @since 2015-06-24
  * @param <T> Throwable subclass of ConstraintViolationException
  */
-public abstract class ConstraintExceptionMapper<T extends ConstraintViolationException> implements ExceptionMapper<T> {
+public abstract class ConstraintExceptionMapper<T extends ConstraintViolationException>
+        extends FedoraExceptionMapper<T> {
+
+    @Context
+    private UriInfo uriInfo;
 
     /**
      * Where the RDF exception files sit.
@@ -51,6 +57,11 @@ public abstract class ConstraintExceptionMapper<T extends ConstraintViolationExc
                 uriInfo.getBaseUri().getScheme(), uriInfo.getBaseUri().getAuthority(),
                 CONSTRAINT_DIR, e.getClass().toString().substring(e.getClass().toString().lastIndexOf('.') + 1));
         return Link.fromUri(constraintURI).rel(CONSTRAINED_BY.getURI()).build();
+    }
+
+    @Override
+    protected ResponseBuilder links(final ResponseBuilder builder, final T e) {
+        return builder.links(buildConstraintLink(e, uriInfo));
     }
 
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConstraintViolationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConstraintViolationExceptionMapper.java
@@ -15,41 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
+import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.ConstraintViolationException;
-
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
 
 /**
  * @author whikloj
  * @since 2015-06-01
  */
 @Provider
-public class ConstraintViolationExceptionMapper extends ConstraintExceptionMapper<ConstraintViolationException>
-    implements ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(ConstraintViolationExceptionMapper.class);
-
-    @Context
-    private UriInfo uriInfo;
-
-    @Override
-    public Response toResponse(final ConstraintViolationException e) {
-        debugException(this, e, LOGGER);
-        final Link link = buildConstraintLink(e, uriInfo);
-        final String msg = e.getMessage();
-        return status(BAD_REQUEST).entity(msg).links(link).build();
-    }
-
+public class ConstraintViolationExceptionMapper extends ConstraintExceptionMapper<ConstraintViolationException> {
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/FedoraExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/FedoraExceptionMapper.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.ext.ExceptionMapper;
+
+
+import org.slf4j.Logger;
+
+/**
+ * @author dbernstein
+ * @since Jan 13, 2017
+ */
+public abstract class FedoraExceptionMapper<T extends Throwable> implements
+        ExceptionMapper<T>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(FedoraExceptionMapper.class);
+
+    private static final String DEFAULT_CONTENT_TYPE = TEXT_PLAIN;
+
+    private static final Response.Status DEFAULT_STATUS = BAD_REQUEST;
+
+    private String contentType;
+
+    private Response.Status status;
+
+    /**
+     * Default constructor
+     */
+    public FedoraExceptionMapper() {
+        this(DEFAULT_STATUS, DEFAULT_CONTENT_TYPE);
+    }
+
+    /**
+     * Alternate constructor to be used by subclasses that wish to override the default status only.
+     * 
+     * @param status http status
+     */
+    protected FedoraExceptionMapper(final Response.Status status) {
+        this(status, DEFAULT_CONTENT_TYPE);
+    }
+
+    /**
+     * Alternate constructor to be used by subclasses that wish to override the default status and contentType.
+     * 
+     * @param status http status
+     * @param contentType the content type
+     */
+    protected FedoraExceptionMapper(final Response.Status status, final String contentType) {
+        this.status = status;
+        this.contentType = contentType;
+    }
+
+    @Override
+    public Response toResponse(final T e) {
+        logError(e);
+        debugException(this, e, LOGGER);
+        ResponseBuilder builder = status(e);
+        builder = entity(builder, e);
+        builder = contentType(builder, e);
+        builder = links(builder,e);
+        return builder.build();
+    }
+
+    /**
+     * Sets the content on the builder. Subclasses can override this method in order to define custom logic for
+     * resolving the appropriate contentType.
+     * 
+     * @param builder The response builder.
+     * @param e The exception passed into the mapper.
+     * @return response builder
+     */
+    protected ResponseBuilder contentType(final ResponseBuilder builder, final T e) {
+        return builder.type(contentType);
+    }
+
+    /**
+     * Sets the entity on the builder. Subclasses can override this method in order to define custom logic for
+     * generating the appropriate entity.
+     * 
+     * @param builder The response builder.
+     * @param e The exception passed into the mapper.
+     * @return response builder
+     */
+    protected ResponseBuilder entity(final ResponseBuilder builder, final T e) {
+        return builder.entity(e.getMessage());
+    }
+
+    /**
+     * Set any links the entity on the builder. By default no links are set. Subclasses can override this method in
+     * order to define custom logic for generating the appropriate links.
+     * 
+     * @param builder The response builder.
+     * @param e The exception passed into the mapper.
+     * @return response builder
+     */
+    protected ResponseBuilder links(final ResponseBuilder builder, final T e) {
+        return builder;
+    }
+
+    /**
+     * Logs an error with default formatting. Subclasses may override to provide custom error message formatting.
+     * 
+     * @param e The exception passed into the mapper.
+     */
+    protected void logError(final T e) {
+        LOGGER.error("{} caught an exception: {}", getClass().getSimpleName(), e.getMessage());
+    }
+
+    /**
+     * Creates a response builder with the status defined in the constructor (or the default value, ie BAD_REQUEST, if
+     * the default constructor was used). Subclasses may override to specify a custom status.
+     * 
+     * @param e The exception passed into the mapper.
+     * @return The response builder.
+     */
+    protected ResponseBuilder status(final T e) {
+        return status(status);
+    }
+
+    /**
+     * Creates a response builder with the specified status
+     * 
+     * @param status http status
+     * @return The response builder.
+     */
+    protected ResponseBuilder status(final Response.Status status) {
+        return status(status.getStatusCode());
+    }
+
+    /**
+     * Creates a response builder with the specified http status code
+     * 
+     * @param statusCode http status code
+     * @return response builder
+     */
+    protected ResponseBuilder status(final int statusCode) {
+        return Response.status(statusCode);
+    }
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/FedoraInvalidNamespaceExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/FedoraInvalidNamespaceExceptionMapper.java
@@ -17,17 +17,9 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.FedoraInvalidNamespaceException;
-
-import org.slf4j.Logger;
 
 /**
  * For invalid namespace exceptions on CRUD actions for nodes/datastreams
@@ -36,16 +28,5 @@ import org.slf4j.Logger;
  * @since September 12, 2014
  */
 @Provider
-public class FedoraInvalidNamespaceExceptionMapper implements
-        ExceptionMapper<FedoraInvalidNamespaceException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(FedoraInvalidNamespaceExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final FedoraInvalidNamespaceException e) {
-        LOGGER.error("NamespaceExceptionMapper caught an exception: {}", e.getMessage());
-        debugException(this, e, LOGGER);
-        return status(BAD_REQUEST).entity(e.getMessage()).build();
-    }
-
+public class FedoraInvalidNamespaceExceptionMapper extends FedoraExceptionMapper<FedoraInvalidNamespaceException> {
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/HeaderValueExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/HeaderValueExceptionMapper.java
@@ -15,18 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.glassfish.jersey.message.internal.HeaderValueException;
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
-import static javax.ws.rs.core.Response.status;
+import org.glassfish.jersey.message.internal.HeaderValueException;
 
 /**
  * If a client-provided header value fails to parse, return an HTTP 400 Bad Request.
@@ -35,14 +30,10 @@ import static javax.ws.rs.core.Response.status;
  * @since 2015-08-06
  */
 @Provider
-public class HeaderValueExceptionMapper implements
-        ExceptionMapper<HeaderValueException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(HeaderValueExceptionMapper.class);
+public class HeaderValueExceptionMapper extends FedoraExceptionMapper<HeaderValueException> {
 
     @Override
-    public Response toResponse(final HeaderValueException e) {
-        debugException(this, e, LOGGER);
-        return status(BAD_REQUEST).entity(e.getMessage() + " ...should value be quoted?").build();
+    protected ResponseBuilder entity(final ResponseBuilder builder, final HeaderValueException e) {
+        return builder.entity(e.getMessage() + " ...should value be quoted?");
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/IncorrectTripleSubjectExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/IncorrectTripleSubjectExceptionMapper.java
@@ -15,41 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 
-import org.fcrepo.kernel.api.exception.IncorrectTripleSubjectException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
+
+import org.fcrepo.kernel.api.exception.IncorrectTripleSubjectException;
 
 /**
  * @author ajs6f
  * @since 2015-07-15
  */
 @Provider
-public class IncorrectTripleSubjectExceptionMapper extends ConstraintExceptionMapper<IncorrectTripleSubjectException>
-    implements ExceptionDebugLogging {
-
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(IncorrectTripleSubjectExceptionMapper.class);
-
-    @Context
-    private UriInfo uriInfo;
+public class IncorrectTripleSubjectExceptionMapper extends
+        ConstraintExceptionMapper<IncorrectTripleSubjectException> {
 
     @Override
-    public Response toResponse(final IncorrectTripleSubjectException e) {
-        debugException(this, e, LOGGER);
-        final Link link = buildConstraintLink(e, uriInfo);
-        final String msg = e.getMessage();
-        return status(FORBIDDEN).entity(msg).links(link).build();
+    protected ResponseBuilder status(final IncorrectTripleSubjectException e) {
+        return status(FORBIDDEN);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InsufficientStorageExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InsufficientStorageExceptionMapper.java
@@ -18,16 +18,10 @@
 
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
-
-import org.slf4j.Logger;
 
 /**
  * Translate InsufficientStorageException errors into HTTP error codes
@@ -36,20 +30,12 @@ import org.slf4j.Logger;
  * @since Oct 7, 2016
  */
 @Provider
-public class InsufficientStorageExceptionMapper implements
-        ExceptionMapper<InsufficientStorageException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-            getLogger(InsufficientStorageException.class);
+public class InsufficientStorageExceptionMapper extends FedoraExceptionMapper<InsufficientStorageException> {
 
     public static final int INSUFFICIENT_STORAGE_HTTP_CODE = 507;
 
     @Override
-    public Response toResponse(final InsufficientStorageException e) {
-        LOGGER.error("InsufficientStorageException intercepted by {}: {}\n",
-                getClass().getSimpleName(),
-                e.getMessage());
-        debugException(this, e, LOGGER);
-        return status(INSUFFICIENT_STORAGE_HTTP_CODE).entity(e.getMessage()).build();
+    protected ResponseBuilder status(final InsufficientStorageException e) {
+        return status(InsufficientStorageExceptionMapper.INSUFFICIENT_STORAGE_HTTP_CODE);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InterruptedExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InterruptedExceptionMapper.java
@@ -15,18 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.fcrepo.kernel.api.exception.InterruptedRuntimeException;
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
-import static org.slf4j.LoggerFactory.getLogger;
-import static javax.ws.rs.core.Response.status;
+import org.fcrepo.kernel.api.exception.InterruptedRuntimeException;
 
 /**
  * If an HTTP request's processing is interrupted, return an HTTP 503 Service Unavailable.
@@ -34,14 +30,10 @@ import static javax.ws.rs.core.Response.status;
  * @author Mike Durbin
  */
 @Provider
-public class InterruptedExceptionMapper implements
-        ExceptionMapper<InterruptedRuntimeException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(InterruptedExceptionMapper.class);
+public class InterruptedExceptionMapper extends FedoraExceptionMapper<InterruptedRuntimeException> {
 
     @Override
-    public Response toResponse(final InterruptedRuntimeException e) {
-        debugException(this, e, LOGGER);
-        return status(SERVICE_UNAVAILABLE).entity(e.getMessage()).build();
+    protected ResponseBuilder status(final InterruptedRuntimeException e) {
+        return status(Status.SERVICE_UNAVAILABLE);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidChecksumExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidChecksumExceptionMapper.java
@@ -15,41 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
-import static org.slf4j.LoggerFactory.getLogger;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
-import org.slf4j.Logger;
 
 /**
- *  Translate InvalidChecksumException errors into reasonable
- *  HTTP error codes
+ * Translate InvalidChecksumException errors into reasonable HTTP error codes
  *
  * @author awoods
  * @author ajs6f
  * @author cbeer
  */
 @Provider
-public class InvalidChecksumExceptionMapper implements
-        ExceptionMapper<InvalidChecksumException>, ExceptionDebugLogging {
+public class InvalidChecksumExceptionMapper extends FedoraExceptionMapper<InvalidChecksumException> {
 
-    private static final Logger LOGGER =
-        getLogger(InvalidChecksumExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final InvalidChecksumException e) {
-
-        LOGGER.error("InvalidChecksumException intercepted by InvalidChecksumExceptionMapper: {}\n",
-                e.getMessage());
-        debugException(this, e, LOGGER);
-
-        return status(CONFLICT).entity(e.getMessage()).build();
+    /**
+     * Default constructor
+     */
+    public InvalidChecksumExceptionMapper() {
+        super(CONFLICT);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidPrefixExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidPrefixExceptionMapper.java
@@ -15,19 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.InvalidPrefixException;
-
-import org.slf4j.Logger;
 
 /**
  * For invalid namespace exceptions on CRUD actions for nodes/datastreams
@@ -36,16 +29,5 @@ import org.slf4j.Logger;
  * @since November 2, 2015
  */
 @Provider
-public class InvalidPrefixExceptionMapper implements
-        ExceptionMapper<InvalidPrefixException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(InvalidPrefixExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final InvalidPrefixException e) {
-        LOGGER.error("FedoraInvalidPrefixExceptionMapper caught an exception: {}", e.getMessage());
-        debugException(this, e, LOGGER);
-        return status(BAD_REQUEST).entity(e.getMessage()).build();
-    }
-
+public class InvalidPrefixExceptionMapper extends FedoraExceptionMapper<InvalidPrefixException> {
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidResourceIdentifierExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidResourceIdentifierExceptionMapper.java
@@ -15,18 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.status;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
 
 /**
  * The class translates {@link org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException}s to its proper
@@ -36,15 +30,6 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @since July 14, 2015.
  */
 @Provider
-public class InvalidResourceIdentifierExceptionMapper implements
-        ExceptionMapper<InvalidResourceIdentifierException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(InvalidResourceIdentifierExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final InvalidResourceIdentifierException e) {
-        LOGGER.error("InvalidResourceIdentifierExceptionMapper caught an exception: {}", e.getMessage());
-        debugException(this, e, LOGGER);
-        return status(BAD_REQUEST).entity(e.getMessage()).build();
-    }
+public class InvalidResourceIdentifierExceptionMapper extends
+        FedoraExceptionMapper<InvalidResourceIdentifierException> {
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapper.java
@@ -15,18 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.jcr.ItemNotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
 
 /**
  * Translate jcr ItemNotFoundException to HTTP 404 Not Found
@@ -34,15 +30,17 @@ import org.slf4j.Logger;
  * @author lsitu
  */
 @Provider
-public class ItemNotFoundExceptionMapper implements
-        ExceptionMapper<ItemNotFoundException>, ExceptionDebugLogging {
+public class ItemNotFoundExceptionMapper extends FedoraExceptionMapper<ItemNotFoundException> {
 
-    private static final Logger LOGGER =
-        getLogger(ItemNotFoundExceptionMapper.class);
+    /**
+     * Default constructor
+     */
+    public ItemNotFoundExceptionMapper() {
+        super(NOT_FOUND);
+    }
 
     @Override
-    public Response toResponse(final ItemNotFoundException e) {
-        debugException(this, e, LOGGER);
-        return status(NOT_FOUND).build();
+    protected ResponseBuilder entity(final ResponseBuilder builder, final ItemNotFoundException e) {
+        return builder.entity("Item not found.");
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/JsonParseExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/JsonParseExceptionMapper.java
@@ -15,17 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
 
 import com.fasterxml.jackson.core.JsonParseException;
 
@@ -36,14 +29,6 @@ import com.fasterxml.jackson.core.JsonParseException;
  * @since 2014-05-21
  */
 @Provider
-public class JsonParseExceptionMapper implements
-        ExceptionMapper<JsonParseException>, ExceptionDebugLogging {
+public class JsonParseExceptionMapper extends FedoraExceptionMapper<JsonParseException> {
 
-    private static final Logger LOGGER = getLogger(JsonParseExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final JsonParseException e) {
-        debugException(this, e, LOGGER);
-        return status(BAD_REQUEST).entity(e.getMessage()).build();
-    }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/LabelExistsVersionExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/LabelExistsVersionExceptionMapper.java
@@ -15,38 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.slf4j.Logger;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
 
 import javax.jcr.version.LabelExistsVersionException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.Response.Status.CONFLICT;
-import static javax.ws.rs.core.Response.status;
-import static org.slf4j.LoggerFactory.getLogger;
-
 /**
- *  Translate LabelExistsVersionException errors into reasonable
- *  HTTP error codes
+ * Translate LabelExistsVersionException errors into reasonable HTTP error codes
  *
  * @author md5wz
  * @since 11/21/14
  */
 @Provider
-public class LabelExistsVersionExceptionMapper implements
-        ExceptionMapper<LabelExistsVersionException>, ExceptionDebugLogging {
+public class LabelExistsVersionExceptionMapper extends FedoraExceptionMapper<LabelExistsVersionException> {
 
-    private static final Logger LOGGER =
-        getLogger(LabelExistsVersionExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final LabelExistsVersionException e) {
-        LOGGER.error("LabelExistsVersionException intercepted by LabelExistsVersionExceptionMapper: {}\n",
-                    e.getMessage());
-        debugException(this, e, LOGGER);
-        return status(CONFLICT).entity(e.getMessage()).build();
+    /**
+     * Default
+     */
+    public LabelExistsVersionExceptionMapper() {
+        super(CONFLICT);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/OutOfDomainSubjectExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/OutOfDomainSubjectExceptionMapper.java
@@ -15,43 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
+import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.OutOfDomainSubjectException;
-
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
-import javax.ws.rs.ext.Provider;
 
 /**
  * @author whikloj
  * @since 2015-05-29
  */
 @Provider
-public class OutOfDomainSubjectExceptionMapper extends ConstraintExceptionMapper<OutOfDomainSubjectException>
-    implements ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-            getLogger(OutOfDomainSubjectExceptionMapper.class);
-
-    @Context
-    private UriInfo uriInfo;
-
-    @Override
-    public Response toResponse(final OutOfDomainSubjectException e) {
-
-        debugException(this, e, LOGGER);
-        final Link link = buildConstraintLink(e, uriInfo);
-        final String msg = e.getMessage();
-        return status(BAD_REQUEST).entity(msg).links(link).build();
-    }
-
+public class OutOfDomainSubjectExceptionMapper extends ConstraintExceptionMapper<OutOfDomainSubjectException> {
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ParamExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ParamExceptionMapper.java
@@ -15,17 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.glassfish.jersey.server.ParamException;
-import org.slf4j.Logger;
+import static javax.ws.rs.core.Response.fromResponse;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.Response.fromResponse;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.glassfish.jersey.server.ParamException;
 
 /**
  * Handle Jersey ParamException
@@ -34,23 +32,20 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @since 2015-01-20
  */
 @Provider
-public class ParamExceptionMapper implements
-        ExceptionMapper<ParamException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(ParamExceptionMapper.class);
+public class ParamExceptionMapper extends FedoraExceptionMapper<ParamException> {
 
     @Override
-    public Response toResponse(final ParamException e) {
+    protected ResponseBuilder status(final ParamException e) {
+        return fromResponse(e.getResponse());
+    }
 
-        LOGGER.error("ParamException intercepted by ParamExceptionMapper: {}\n", e.getMessage());
-        debugException(this, e, LOGGER);
-
+    @Override
+    protected ResponseBuilder entity(final ResponseBuilder builder, final ParamException e) {
         final StringBuilder msg = new StringBuilder("Error parsing parameter: ");
         msg.append(e.getParameterName());
         msg.append(", of type: ");
         msg.append(e.getParameterType().getSimpleName());
-
-        return fromResponse(e.getResponse()).entity(msg.toString()).build();
+        return builder.entity(msg);
     }
 
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapper.java
@@ -15,18 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.jcr.PathNotFoundException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
 
 /**
  * Translate PathNotFound exceptions into HTTP 404 errors
@@ -35,16 +31,17 @@ import org.slf4j.Logger;
  * @author cbeer
  */
 @Provider
-public class PathNotFoundExceptionMapper implements
-        ExceptionMapper<PathNotFoundException>, ExceptionDebugLogging {
+public class PathNotFoundExceptionMapper extends FedoraExceptionMapper<PathNotFoundException> {
 
-    private static final Logger LOGGER =
-        getLogger(PathNotFoundExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final PathNotFoundException e) {
-        debugException(this, e, LOGGER);
-        return status(NOT_FOUND).build();
+    /**
+     * Default
+     */
+    public PathNotFoundExceptionMapper() {
+        super(NOT_FOUND);
     }
 
+    @Override
+    protected ResponseBuilder entity(final ResponseBuilder builder, final PathNotFoundException e) {
+        return builder.entity("Path not found.");
+    }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/QueryParseExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/QueryParseExceptionMapper.java
@@ -17,18 +17,11 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
 
 import org.apache.jena.query.QueryParseException;
 
@@ -40,16 +33,10 @@ import org.apache.jena.query.QueryParseException;
  * @since September 9, 2014
  */
 @Provider
-public class QueryParseExceptionMapper implements
-        ExceptionMapper<QueryParseException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER = getLogger(QueryParseExceptionMapper.class);
+public class QueryParseExceptionMapper extends FedoraExceptionMapper<QueryParseException> {
 
     @Override
-    public Response toResponse(final QueryParseException e) {
-
-        LOGGER.error("Captured a query parse exception {}", e.getMessage());
-        debugException(this, e, LOGGER);
+    protected ResponseBuilder entity(final ResponseBuilder builder, final QueryParseException e) {
         if (e.getMessage().matches(".* Unresolved prefixed name: .*")) {
             final Pattern namespacePattern =
                 Pattern.compile("Unresolved prefixed name: (\\w+:\\w+)");
@@ -59,13 +46,13 @@ public class QueryParseExceptionMapper implements
                 final String msg =
                     String.format(
                         "There are one or more undefined namespace(s) in your request [ %s ], " +
-                        "please define them before retrying",
-                        namespaceMatch.group(1));
-                return status(BAD_REQUEST).entity(msg).build();
+                                        "please define them before retrying",
+                                namespaceMatch.group(1));
+                return builder.entity(msg);
             }
         }
 
-        return status(BAD_REQUEST).entity(e.getMessage()).build();
-    }
+        return builder.entity(e.getMessage());
 
+    }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapper.java
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-
-import org.slf4j.Logger;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static javax.ws.rs.core.Response.serverError;
 
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -27,9 +27,7 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
-import static com.google.common.base.Throwables.getStackTraceAsString;
-import static javax.ws.rs.core.Response.serverError;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 
 /**
  * @author cabeer
@@ -44,13 +42,12 @@ public class RepositoryRuntimeExceptionMapper implements
 
     /**
      * Get the context Providers so we can rethrow the cause to an appropriate handler
+     * 
      * @param providers the providers
      */
     public RepositoryRuntimeExceptionMapper(@Context final Providers providers) {
         this.providers = providers;
     }
-
-    private static final Logger LOGGER = getLogger(RepositoryExceptionMapper.class);
 
     @Override
     public Response toResponse(final RepositoryRuntimeException e) {
@@ -61,8 +58,6 @@ public class RepositoryRuntimeExceptionMapper implements
         if (exceptionMapper != null) {
             return exceptionMapper.toResponse(cause);
         }
-        LOGGER.error("Caught a repository exception: {}", e.getMessage());
-        debugException(this, cause, LOGGER);
         return serverError().entity(getStackTraceAsString(e)).build();
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryVersionRuntimeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryVersionRuntimeExceptionMapper.java
@@ -15,34 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.fcrepo.kernel.api.exception.RepositoryVersionRuntimeException;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static org.slf4j.LoggerFactory.getLogger;
-import static javax.ws.rs.core.Response.status;
+import org.fcrepo.kernel.api.exception.RepositoryVersionRuntimeException;
 
 /**
  * @author cabeer
  * @since 9/15/14
  */
 @Provider
-public class RepositoryVersionRuntimeExceptionMapper implements
-        ExceptionMapper<RepositoryVersionRuntimeException>, ExceptionDebugLogging {
+public class RepositoryVersionRuntimeExceptionMapper extends
+        FedoraExceptionMapper<RepositoryVersionRuntimeException> {
 
-    private static final Logger LOGGER =
-            getLogger(RepositoryVersionRuntimeExceptionMapper.class);
+    /**
+     * Default
+     */
+    public RepositoryVersionRuntimeExceptionMapper() {
+        super(NOT_FOUND);
+    }
 
     @Override
-    public Response toResponse(final RepositoryVersionRuntimeException e) {
-        debugException(this, e, LOGGER);
-        return status(NOT_FOUND).entity("This resource is not versioned").build();
+    protected ResponseBuilder entity(final ResponseBuilder builder, final RepositoryVersionRuntimeException e) {
+        return builder.entity("This resource is not versioned");
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ResourceTypeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ResourceTypeExceptionMapper.java
@@ -15,34 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.fcrepo.kernel.api.exception.ResourceTypeException;
-
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
-import static javax.ws.rs.core.Response.status;
+import org.fcrepo.kernel.api.exception.ResourceTypeException;
 
 /**
  * @author cabeer
  * @since 9/15/14
  */
 @Provider
-public class ResourceTypeExceptionMapper implements
-        ExceptionMapper<ResourceTypeException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-            getLogger(ResourceTypeExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final ResourceTypeException e) {
-        debugException(this, e, LOGGER);
-        return status(BAD_REQUEST).entity(null).build();
-    }
+public class ResourceTypeExceptionMapper extends FedoraExceptionMapper<ResourceTypeException> {
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ServerErrorExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ServerErrorExceptionMapper.java
@@ -17,30 +17,21 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import javax.ws.rs.ServerErrorException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
-
 import static javax.ws.rs.core.Response.fromResponse;
-import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.ext.Provider;
 
 /**
  * @author awoods
  * @since 11/20/14
  */
 @Provider
-public class ServerErrorExceptionMapper implements
-        ExceptionMapper<ServerErrorException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-            getLogger(ServerErrorExceptionMapper.class);
+public class ServerErrorExceptionMapper extends FedoraExceptionMapper<ServerErrorException> {
 
     @Override
-    public Response toResponse(final ServerErrorException e) {
-        debugException(this, e, LOGGER);
-        return fromResponse(e.getResponse()).entity(e.getMessage()).build();
+    protected ResponseBuilder status(final ServerErrorException e) {
+        return fromResponse(e.getResponse());
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ServerManagedPropertyExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ServerManagedPropertyExceptionMapper.java
@@ -15,21 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
 
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.Response.Status.CONFLICT;
-import static org.slf4j.LoggerFactory.getLogger;
-import static javax.ws.rs.core.Response.status;
+import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 
 /**
  * @author cabeer
@@ -37,20 +31,11 @@ import static javax.ws.rs.core.Response.status;
  * @since 10/1/14
  */
 @Provider
-public class ServerManagedPropertyExceptionMapper extends ConstraintExceptionMapper<ServerManagedPropertyException>
-    implements ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-            getLogger(ServerManagedPropertyExceptionMapper.class);
-
-    @Context
-    private UriInfo uriInfo;
+public class ServerManagedPropertyExceptionMapper extends ConstraintExceptionMapper<ServerManagedPropertyException> {
 
     @Override
-    public Response toResponse(final ServerManagedPropertyException e) {
-        debugException(this, e, LOGGER);
-        final Link link = buildConstraintLink(e, uriInfo);
-        final String msg = e.getMessage();
-        return status(CONFLICT).entity(msg).links(link).build();
+    protected ResponseBuilder status(final ServerManagedPropertyException e) {
+        return status(CONFLICT);
     }
+
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ServerManagedTypeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ServerManagedTypeExceptionMapper.java
@@ -15,41 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
-import static org.slf4j.LoggerFactory.getLogger;
 
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
-
-import org.slf4j.Logger;
 
 /**
  * @author whikloj
  * @since 2015-06-02
  */
 @Provider
-public class ServerManagedTypeExceptionMapper extends ConstraintExceptionMapper<ServerManagedTypeException>
-    implements ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-            getLogger(ServerManagedTypeExceptionMapper.class);
-
-    @Context
-    private UriInfo uriInfo;
+public class ServerManagedTypeExceptionMapper extends ConstraintExceptionMapper<ServerManagedTypeException> {
 
     @Override
-    public Response toResponse(final ServerManagedTypeException e) {
-        debugException(this, e, LOGGER);
-        final Link link = buildConstraintLink(e, uriInfo);
-        final String msg = e.getMessage();
-        return status(CONFLICT).entity(msg).links(link).build();
+    protected ResponseBuilder status(final ServerManagedTypeException e) {
+        return status(CONFLICT);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/SessionMissingExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/SessionMissingExceptionMapper.java
@@ -15,37 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.GONE;
-import static org.slf4j.LoggerFactory.getLogger;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.SessionMissingException;
 
-import org.slf4j.Logger;
-
 /**
- * If a session is requested that has been closed (or never existed), just
- * return an HTTP 410 Gone.
+ * If a session is requested that has been closed (or never existed), just return an HTTP 410 Gone.
  *
  * @author awoods
  */
 @Provider
-public class SessionMissingExceptionMapper implements
-        ExceptionMapper<SessionMissingException>, ExceptionDebugLogging {
+public class SessionMissingExceptionMapper extends FedoraExceptionMapper<SessionMissingException> {
 
-    private static final Logger LOGGER =
-            getLogger(SessionMissingExceptionMapper.class);
-
-
-    @Override
-    public Response toResponse(final SessionMissingException e) {
-        debugException(this, e, LOGGER);
-        return status(GONE).entity(e.getMessage()).build();
+    /**
+     * Default
+     */
+    public SessionMissingExceptionMapper() {
+        super(GONE);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapper.java
@@ -15,42 +15,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.fcrepo.kernel.api.exception.TombstoneException;
+import static javax.ws.rs.core.Response.Status.GONE;
 
-import org.slf4j.Logger;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
 
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static javax.ws.rs.core.Response.Status.GONE;
-import static javax.ws.rs.core.Response.status;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.fcrepo.kernel.api.exception.TombstoneException;
 
 /**
  * @author cabeer
  * @since 10/16/14
  */
 @Provider
-public class TombstoneExceptionMapper implements
-        ExceptionMapper<TombstoneException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-            getLogger(TombstoneExceptionMapper.class);
+public class TombstoneExceptionMapper extends FedoraExceptionMapper<TombstoneException> {
 
     @Override
-    public Response toResponse(final TombstoneException e) {
-        debugException(this, e, LOGGER);
-        final Response.ResponseBuilder response = status(GONE)
-                .entity(e.getMessage());
+    protected ResponseBuilder links(final ResponseBuilder builder, final TombstoneException e) {
+        return (e.getURI() != null) ? builder.link(e.getURI(), "hasTombstone") : builder;
+    }
 
-        if (e.getURI() != null) {
-            response.link(e.getURI(), "hasTombstone");
-        }
-
-        return response.type(TEXT_PLAIN_TYPE).build();
+    /*
+     * (non-Javadoc)
+     * @see org.fcrepo.http.commons.exceptionhandlers.FedoraExceptionMapper#status(java.lang.Throwable)
+     */
+    @Override
+    protected ResponseBuilder status(final TombstoneException e) {
+        return status(GONE);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/VersionExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/VersionExceptionMapper.java
@@ -15,33 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import javax.jcr.version.VersionException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
-
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.slf4j.LoggerFactory.getLogger;
-import static javax.ws.rs.core.Response.status;
 
 /**
  * @author cabeer
  * @since 10/9/14
  */
 @Provider
-public class VersionExceptionMapper implements
-        ExceptionMapper<VersionException>, ExceptionDebugLogging {
+public class VersionExceptionMapper extends FedoraExceptionMapper<VersionException> {
 
-    private static final Logger LOGGER =
-            getLogger(VersionExceptionMapper.class);
-
-    @Override
-    public Response toResponse(final VersionException e) {
-        debugException(this, e, LOGGER);
-        return status(BAD_REQUEST).entity(e.getMessage()).build();
-    }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WebApplicationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WebApplicationExceptionMapper.java
@@ -15,17 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import static javax.ws.rs.core.Response.fromResponse;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
 
 /**
  * Handle Jersey WebApplicationException
@@ -33,18 +30,16 @@ import org.slf4j.Logger;
  * @author lsitu
  */
 @Provider
-public class WebApplicationExceptionMapper implements
-        ExceptionMapper<WebApplicationException>, ExceptionDebugLogging {
-
-    private static final Logger LOGGER =
-        getLogger(WebApplicationExceptionMapper.class);
+public class WebApplicationExceptionMapper extends FedoraExceptionMapper<WebApplicationException> {
 
     @Override
-    public Response toResponse(final WebApplicationException e) {
-        LOGGER.error(
-                "WebApplicationException intercepted by WebApplicationExceptionMapper: {}\n", e.getMessage());
-        debugException(this, e, LOGGER);
+    protected ResponseBuilder entity(final ResponseBuilder builder, final WebApplicationException e) {
         final String msg = null == e.getCause() ? e.getMessage() : e.getCause().getMessage();
-        return fromResponse(e.getResponse()).entity(msg).build();
+        return builder.entity(msg);
+    }
+
+    @Override
+    protected ResponseBuilder status(final WebApplicationException e) {
+        return fromResponse(e.getResponse());
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapper.java
@@ -15,19 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static javax.ws.rs.core.Response.serverError;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.jcr.RepositoryException;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.kernel.api.exception.SessionMissingException;
-import org.slf4j.Logger;
 
 /**
  * Catch all the exceptions!
@@ -38,13 +37,9 @@ import org.slf4j.Logger;
  * @author fasseg
  */
 @Provider
-public class WildcardExceptionMapper implements
-        ExceptionMapper<Exception>, ExceptionDebugLogging {
+public class WildcardExceptionMapper extends FedoraExceptionMapper<Exception> {
 
     Boolean showStackTrace = true;
-
-    private static final Logger LOGGER =
-        getLogger(WildcardExceptionMapper.class);
 
     @Override
     public Response toResponse(final Exception e) {
@@ -53,21 +48,29 @@ public class WildcardExceptionMapper implements
                     .toResponse((SessionMissingException) e.getCause());
         }
 
-        if ( e.getCause() instanceof RepositoryException) {
+        if (e.getCause() instanceof RepositoryException) {
             return new RepositoryExceptionMapper()
-                    .toResponse((RepositoryException)e.getCause());
+                    .toResponse((RepositoryException) e.getCause());
         }
 
-        LOGGER.error("Exception intercepted by WildcardExceptionMapper: {}\n", e.getMessage());
-        debugException(this, e, LOGGER);
-        return serverError().entity(
-                showStackTrace ? getStackTraceAsString(e) : null).build();
+        return super.toResponse(e);
+    }
+
+    @Override
+    protected ResponseBuilder entity(final ResponseBuilder builder, final Exception e) {
+        return builder.entity(
+                showStackTrace ? getStackTraceAsString(e) : null);
+    }
+
+    @Override
+    protected ResponseBuilder status(final Exception e) {
+        return serverError();
     }
 
     /**
-     * Set whether the full stack trace should be returned as part of the
-     * error response. This may be a bad idea if the stack trace is exposed
-     * to the public.
+     * Set whether the full stack trace should be returned as part of the error response. This may be a bad idea if
+     * the stack trace is exposed to the public.
+     * 
      * @param showStackTrace the boolean value of showing stack trace
      */
     public void setShowStackTrace(final Boolean showStackTrace) {


### PR DESCRIPTION
…urned representation.

All the exception handlers have been refactored to
   1) reduce duplicate code
   2) ensure that there is only one place were the default content type for exceptions
   3) smooth the way for supporting rdf error responses.

Resolves https://jira.duraspace.org/browse/FCREPO-1888