### PR TITLE
A fcrepo.jms.baseUrl with no port is unable to override the port in the request URL

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -52,6 +52,8 @@ abstract public class FedoraBaseResource extends AbstractResource {
 
     private static final Logger LOGGER = getLogger(FedoraBaseResource.class);
 
+    static final String JMS_BASEURL_PROP = "fcrepo.jms.baseUrl";
+
     @Inject
     protected HttpSession session;
 
@@ -103,7 +105,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
      **/
     protected void setUpJMSInfo(final UriInfo uriInfo, final HttpHeaders headers) {
         try {
-            String baseURL = getBaseUrlProperty();
+            String baseURL = getBaseUrlProperty(uriInfo);
             if (baseURL.length() == 0) {
                 baseURL = uriInfo.getBaseUri().toString();
             }
@@ -122,10 +124,23 @@ abstract public class FedoraBaseResource extends AbstractResource {
     /**
      * Produce a baseURL for JMS events using the system property fcrepo.jms.baseUrl of the form http[s]://host[:port],
      * if it exists.
-     *
+     * <p>
+     * Implementation note: forwards to {@link #getBaseUrlProperty(UriInfo)}, using the internal {@code UriInfo}.
+     * </p>
      * @return String the base Url
      */
     protected String getBaseUrlProperty() {
+        return getBaseUrlProperty(uriInfo);
+    }
+
+    /**
+     * Produce a baseURL for JMS events using the system property fcrepo.jms.baseUrl of the form http[s]://host[:port],
+     * if it exists.
+     *
+     * @param uriInfo used to build the base url
+     * @return String the base Url
+     */
+    protected String getBaseUrlProperty(final UriInfo uriInfo) {
         final String propBaseURL = System.getProperty("fcrepo.jms.baseUrl", "");
         if (propBaseURL.length() > 0 && propBaseURL.startsWith("http")) {
             return uriInfo.getBaseUriBuilder().uri(propBaseURL).toString();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -17,8 +17,6 @@
  */
 package org.fcrepo.http.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Resource;
@@ -33,6 +31,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.Tombstone;
 import org.slf4j.Logger;
 
+import java.net.URI;
 import java.security.Principal;
 import javax.inject.Inject;
 import javax.ws.rs.core.Context;
@@ -110,8 +109,6 @@ abstract public class FedoraBaseResource extends AbstractResource {
                 baseURL = uriInfo.getBaseUri().toString();
             }
             LOGGER.debug("setting baseURL = " + baseURL);
-            final ObjectMapper mapper = new ObjectMapper();
-            final ObjectNode json = mapper.createObjectNode();
             session.getFedoraSession().addSessionData(BASE_URL, baseURL);
             if (!StringUtils.isBlank(headers.getHeaderString("user-agent"))) {
                 session.getFedoraSession().addSessionData(USER_AGENT, headers.getHeaderString("user-agent"));
@@ -141,9 +138,13 @@ abstract public class FedoraBaseResource extends AbstractResource {
      * @return String the base Url
      */
     protected String getBaseUrlProperty(final UriInfo uriInfo) {
-        final String propBaseURL = System.getProperty("fcrepo.jms.baseUrl", "");
+        final String propBaseURL = System.getProperty(JMS_BASEURL_PROP, "");
         if (propBaseURL.length() > 0 && propBaseURL.startsWith("http")) {
-            return uriInfo.getBaseUriBuilder().uri(propBaseURL).toString();
+            final URI propBaseUri = URI.create(propBaseURL);
+            if (propBaseUri.getPort() < 0) {
+                return uriInfo.getBaseUriBuilder().port(-1).uri(propBaseUri).toString();
+            }
+            return uriInfo.getBaseUriBuilder().uri(propBaseUri).toString();
         }
         return "";
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -121,23 +121,11 @@ abstract public class FedoraBaseResource extends AbstractResource {
     /**
      * Produce a baseURL for JMS events using the system property fcrepo.jms.baseUrl of the form http[s]://host[:port],
      * if it exists.
-     * <p>
-     * Implementation note: forwards to {@link #getBaseUrlProperty(UriInfo)}, using the internal {@code UriInfo}.
-     * </p>
-     * @return String the base Url
-     */
-    protected String getBaseUrlProperty() {
-        return getBaseUrlProperty(uriInfo);
-    }
-
-    /**
-     * Produce a baseURL for JMS events using the system property fcrepo.jms.baseUrl of the form http[s]://host[:port],
-     * if it exists.
      *
      * @param uriInfo used to build the base url
      * @return String the base Url
      */
-    protected String getBaseUrlProperty(final UriInfo uriInfo) {
+    private String getBaseUrlProperty(final UriInfo uriInfo) {
         final String propBaseURL = System.getProperty(JMS_BASEURL_PROP, "");
         if (propBaseURL.length() > 0 && propBaseURL.startsWith("http")) {
             final URI propBaseUri = URI.create(propBaseURL);


### PR DESCRIPTION
The system property `fcrepo.jms.baseUrl` may be defined in order to override the URIs that are used by messages emitted from the repository. This is useful, for example, when URIs used by backend infrastructure are different from URIs used by external, user-facing services. 

By default, the `fcrepo.jms.baseUrl` is equal to the incoming request's base URL. 

The URI provided by `fcrepo.jms.baseUrl` must be an http(s) URL, but more importantly the implementation recognizes the URI as a template. This allows an administrator to override some or all of the request URL as local needs dictate. Example values for `fcrepo.jms.baseUrl` include: 

Host: `http://external.org` 
Host and port: `http://external.org:8080/` 
Host and path: `http://external.org/fcrepo/rest` 
etc. 

However, there is a bug in Fedora whereby a `fcrepo.jms.baseUrl` with no port (e.g. `http://external.org/fcrepo/rest`) cannot be used to override a request url that contains a port (e.g. `http://internal.org:8080/fcrepo/rest/foo`). 

When `fcrepo.jms.baseUrl` is set equal to `http://external.org/fcrepo/rest`, the expectation is that repository messages for `http://internal.org:8080/fcrepo/rest/foo` will be emitted as `http://external.org/fcrepo/rest/foo` (no port), but currently are emitted as `http://external.org:8080/fcrepo/rest/foo` (with a port).

Note that  447728c contains unit tests which verify the expected behavior and expose the bug.

Jira: https://jira.duraspace.org/browse/FCREPO-2395