### PR TITLE
WebApplicationExceptionMapper adds entity bodies on 304 responses

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WebApplicationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WebApplicationExceptionMapper.java
@@ -46,6 +46,14 @@ public class WebApplicationExceptionMapper implements
                 "WebApplicationException intercepted by WebApplicationExceptionMapper: {}\n", e.getMessage());
         debugException(this, e, LOGGER);
         final String msg = null == e.getCause() ? e.getMessage() : e.getCause().getMessage();
-        return fromResponse(e.getResponse()).entity(msg).type(TEXT_PLAIN_WITH_CHARSET).build();
+        // 204, 205, 304 MUST NOT contain an entity body - RFC2616
+        switch (e.getResponse().getStatus()) {
+            case 204:
+            case 205:
+            case 304:
+                return fromResponse(e.getResponse()).entity(null).build();
+            default:
+                return fromResponse(e.getResponse()).entity(msg).type(TEXT_PLAIN_WITH_CHARSET).build();
+        }
     }
 }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/WebApplicationExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/WebApplicationExceptionMapperTest.java
@@ -18,12 +18,15 @@
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.stream.Stream;
 
 /**
  * <p>WebApplicationExceptionMapperTest class.</p>
@@ -45,5 +48,24 @@ public class WebApplicationExceptionMapperTest {
         final WebApplicationException input = new WebApplicationException();
         final Response actual = testObj.toResponse(input);
         assertEquals(input.getResponse().getStatus(), actual.getStatus());
+    }
+
+    /**
+     * Insures that the WebApplicationExceptionMapper does not provide an entity body to 204, 205, or 304 responses.
+     * Entity bodies on other responses are mapped appropriately.
+     */
+    @Test
+    public void testNoEntityBody() {
+        Stream.of(204, 205, 304).forEach(status -> {
+                    final WebApplicationException input = new WebApplicationException("Error message", status);
+                    final Response actual = testObj.toResponse(input);
+                    assertNull("Responses with a " + status + " status code MUST NOT carry an entity body.",
+                            actual.getEntity());
+                }
+        );
+
+        final WebApplicationException input = new WebApplicationException("Error message", 500);
+        final Response actual = testObj.toResponse(input);
+        assertEquals("Error message", actual.getEntity());
     }
 }


### PR DESCRIPTION
FCREPO-2313 addressed an issue where entity bodies were being included in responses that MUST NOT carry entity bodies, per RFC 2616. 

Unfortunately, the fix for FCREPO-2313 was incomplete. The WebApplicationExceptionMapper adds entity bodies to responses without regard for their status code. In particular ContentExposingResource#evaluateRequestPreconditions(...) may lead to an exception being thrown with a 304 response code. 

The consequences of this issue are the same as the consequences for FCREPO-2313- that is, application servers and clients get confused when processing responses that contain entity bodies when they otherwise shouldn't. 

In addition, the request logic is a bit unclear to me, but it seems that the intent is that if preconditions fail, an exception should be thrown by ContentExposingResource#evaluateRequestPreconditions(...). In that case shouldn't the response be a 412?

Jira issue: https://jira.duraspace.org/browse/FCREPO-2397