### PR TITLE
Completes https://jira.duraspace.org/browse/FCREPO-2402

### DIFF
--- a/fcrepo-configs/src/main/resources/config/file-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/file-s3/repository.json
@@ -4,7 +4,8 @@
     "workspaces" : {
         "predefined" : ["default"],
         "default" : "default",
-        "allowCreation" : true
+        "allowCreation" : true,
+        "cacheSize" : 10000
     },
     "storage" : {
         "persistence": {

--- a/fcrepo-configs/src/main/resources/config/file-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/file-s3/repository.json
@@ -1,0 +1,31 @@
+{
+    "name" : "repo",
+    "jndiName" : "",
+    "workspaces" : {
+        "predefined" : ["default"],
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "storage" : {
+        "persistence": {
+            "type": "file",
+            "path" : "${fcrepo.object.directory:target/objects}"
+        },
+        "binaryStorage" : {
+            "type" : "s3",
+            "username" : "${aws.accessKeyId}",
+            "password" : "${aws.secretKey}",
+            "bucketName" : "${aws.bucket}"
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        },
+        "providers" : [
+            { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
+        ]
+    },
+    "node-types" : ["fedora-node-types.cnd"]
+}

--- a/fcrepo-configs/src/main/resources/config/file-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/file-s3/repository.json
@@ -27,5 +27,10 @@
             { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
         ]
     },
+    "garbageCollection" : {
+        "threadPool" : "modeshape-gc",
+        "initialTime" : "00:00",
+        "intervalInHours" : 24
+    },
     "node-types" : ["fedora-node-types.cnd"]
 }

--- a/fcrepo-configs/src/main/resources/config/jdbc-mysql-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/jdbc-mysql-s3/repository.json
@@ -4,7 +4,8 @@
     "workspaces" : {
         "predefined" : ["default"],
         "default" : "default",
-        "allowCreation" : true
+        "allowCreation" : true,
+        "cacheSize" : 10000
     },
     "storage" : {
         "persistence": {

--- a/fcrepo-configs/src/main/resources/config/jdbc-mysql-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/jdbc-mysql-s3/repository.json
@@ -1,0 +1,34 @@
+{
+    "name" : "repo",
+    "jndiName" : "",
+    "workspaces" : {
+        "predefined" : ["default"],
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "storage" : {
+        "persistence": {
+            "type" : "db",
+            "connectionUrl": "jdbc:mysql://${fcrepo.mysql.host:localhost}:${fcrepo.mysql.port:3306}/fcrepo?createDatabaseIfNotExist=true",
+            "driver" : "com.mysql.jdbc.Driver",
+            "username" : "${fcrepo.mysql.username}",
+            "password" : "${fcrepo.mysql.password}"
+        },
+        "binaryStorage" : {
+            "type" : "s3",
+            "username" : "${aws.accessKeyId}",
+            "password" : "${aws.secretKey}",
+            "bucketName" : "${aws.bucket}"
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        },
+        "providers" : [
+            { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
+        ]
+    },
+    "node-types" : ["fedora-node-types.cnd"]
+}

--- a/fcrepo-configs/src/main/resources/config/jdbc-mysql-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/jdbc-mysql-s3/repository.json
@@ -30,5 +30,10 @@
             { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
         ]
     },
+    "garbageCollection" : {
+        "threadPool" : "modeshape-gc",
+        "initialTime" : "00:00",
+        "intervalInHours" : 24
+    },
     "node-types" : ["fedora-node-types.cnd"]
 }

--- a/fcrepo-configs/src/main/resources/config/jdbc-postgresql-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/jdbc-postgresql-s3/repository.json
@@ -4,7 +4,8 @@
     "workspaces" : {
         "predefined" : ["default"],
         "default" : "default",
-        "allowCreation" : true
+        "allowCreation" : true,
+        "cacheSize" : 10000
     },
     "storage" : {
         "persistence": {

--- a/fcrepo-configs/src/main/resources/config/jdbc-postgresql-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/jdbc-postgresql-s3/repository.json
@@ -30,5 +30,10 @@
             { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
         ]
     },
+    "garbageCollection" : {
+        "threadPool" : "modeshape-gc",
+        "initialTime" : "00:00",
+        "intervalInHours" : 24
+    },
     "node-types" : ["fedora-node-types.cnd"]
 }

--- a/fcrepo-configs/src/main/resources/config/jdbc-postgresql-s3/repository.json
+++ b/fcrepo-configs/src/main/resources/config/jdbc-postgresql-s3/repository.json
@@ -1,0 +1,34 @@
+{
+    "name" : "repo",
+    "jndiName" : "",
+    "workspaces" : {
+        "predefined" : ["default"],
+        "default" : "default",
+        "allowCreation" : true
+    },
+    "storage" : {
+        "persistence": {
+            "type" : "db",
+            "connectionUrl": "jdbc:postgresql://${fcrepo.postgresql.host:localhost}:${fcrepo.postgresql.port:5432}/fcrepo",
+            "driver" : "org.postgresql.Driver",
+            "username" : "${fcrepo.postgresql.username}",
+            "password" : "${fcrepo.postgresql.password}"
+        },
+        "binaryStorage" : {
+            "type" : "s3",
+            "username" : "${aws.accessKeyId}",
+            "password" : "${aws.secretKey}",
+            "bucketName" : "${aws.bucket}"
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        },
+        "providers" : [
+            { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
+        ]
+    },
+    "node-types" : ["fedora-node-types.cnd"]
+}

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -144,6 +144,30 @@
       <artifactId>spring-web</artifactId>
     </dependency>
 
+    <!-- AWS S3 client dependencies -->
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>${aws.client.version}</version>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>${aws.client.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- test gear -->
     <dependency>
       <groupId>net.sourceforge.htmlunit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
     <!-- JCBC dependencies -->
     <postgresql.version>9.4.1211</postgresql.version>
     <mysql.version>5.1.38</mysql.version>
+    <!-- AWS S3 dependencies -->
+    <aws.client.version>1.11.95</aws.client.version>
     <!-- test gear -->
     <awaitility.version>1.7.0</awaitility.version>
     <grizzly.version>2.3.28</grizzly.version>


### PR DESCRIPTION
Adds new repository.json files to support binary storage in S3 along with object storage in mysql, postgresql, and as a file.

Performance of these configuration options have been tested and recorded (by Daniel Bernstein) here: https://wiki.duraspace.org/display/FF/Many+Members+Performance+Testing

Configuration to support binary storage in S3 is currently listed here: https://github.com/fcrepo4-labs/fcrepo-webapp-plus-cloud. In short, the additional parameters are as follows:

JAVA_OPTS="${JAVA_OPTS} -Daws.accessKeyId=<AWS Access ID>"
JAVA_OPTS="${JAVA_OPTS} -Daws.secretKey=<AWS Secret Key>"
JAVA_OPTS="${JAVA_OPTS} -Daws.bucket=<S3 Bucket Name>"