### PR TITLE
Correctly parse 'described-by' Link header. (FCREPO-2341)

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/common.js
+++ b/fcrepo-http-api/src/main/resources/views/common.js
@@ -55,10 +55,10 @@
       http(method, url, headers, data, function(res) {
         if (res.status == 201) {
           const loc = res.getResponseHeader('Location');
-          const link = res.getResponseHeader('Link');
-          if (link != null && link.match('rel="describedby"')) {
-            const str = link.match(/<[^>]+>/)[0];
-            window.location = str.slice(1, str.length - 1);
+          const linkheaders = (res.getResponseHeader('Link') != null) ? res.getResponseHeader('Link').split(", ") : null;
+          const link = (linkheaders != null) ? linkheaders.filter(function(h) { return h.match(/rel="describedby"/)}) : "";
+          if (linkheaders != null && link.length > 0) {
+            window.location = link[0].substr(1, link[0].indexOf('>') - 1);
           } else if (loc != null) {
             window.location = loc;
           } else {


### PR DESCRIPTION
@whikloj's [patch](https://jira.duraspace.org/browse/FCREPO-2341?focusedCommentId=53173&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-53173) for [FCREPO-2341](https://jira.duraspace.org/browse/FCREPO-2341) seems to work.

This PR corrects the parsing of HTTP `Link` headers in the Fedora HTML UI to be more rigorous when multiple `Link` headers are present in the response (as is the case when API-X is set up as a proxy to the Fedora repository).  The `describedBy` link header will always be used, even in the presence of multiple link headers in the response.

When multiple `Link` headers are present in the response, the browser seems to pick one of them at random.  This is problematic, for example, when API-X adds additional `Link` headers, such as a link to a service document.  Users may be randomly redirected to an API-X service discovery document after uploading a binary via (an API-X proxied) Fedora HTML UI.