### PR TITLE
Skolemizing blank nodes with hash URIs

### DIFF
--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/AbstractIntegrationRdfIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/AbstractIntegrationRdfIT.java
@@ -125,7 +125,7 @@ public abstract class AbstractIntegrationRdfIT extends AbstractResourceIT {
 
             Triple replacement = next;
 
-            if (replacement.getSubject().toString().contains(".well-known")) {
+            if (replacement.getSubject().toString().contains("#genid")) {
                 if (!bnodeMap.containsKey(replacement.getSubject())) {
                     bnodeMap.put(replacement.getSubject(), createBlankNode());
                 }
@@ -135,7 +135,7 @@ public abstract class AbstractIntegrationRdfIT extends AbstractResourceIT {
                         replacement.getObject());
             }
 
-            if (replacement.getObject().toString().contains(".well-known")) {
+            if (replacement.getObject().toString().contains("#genid")) {
 
                 if (!bnodeMap.containsKey(replacement.getObject())) {
                     bnodeMap.put(replacement.getObject(), createBlankNode());

--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/AbstractIntegrationRdfIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/AbstractIntegrationRdfIT.java
@@ -39,6 +39,7 @@ import org.fcrepo.integration.http.api.AbstractResourceIT;
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -125,7 +126,7 @@ public abstract class AbstractIntegrationRdfIT extends AbstractResourceIT {
 
             Triple replacement = next;
 
-            if (replacement.getSubject().toString().contains("#genid")) {
+            if (isSkolemizedBnode(replacement.getSubject())) {
                 if (!bnodeMap.containsKey(replacement.getSubject())) {
                     bnodeMap.put(replacement.getSubject(), createBlankNode());
                 }
@@ -135,7 +136,7 @@ public abstract class AbstractIntegrationRdfIT extends AbstractResourceIT {
                         replacement.getObject());
             }
 
-            if (replacement.getObject().toString().contains("#genid")) {
+            if (isSkolemizedBnode(replacement.getObject())) {
 
                 if (!bnodeMap.containsKey(replacement.getObject())) {
                     bnodeMap.put(replacement.getObject(), createBlankNode());
@@ -157,6 +158,14 @@ public abstract class AbstractIntegrationRdfIT extends AbstractResourceIT {
             betterGraph.add(replacement);
         }
         return betterGraph;
+    }
+
+    private static boolean isSkolemizedBnode(final Node node) {
+        if (!node.isURI()) {
+            return false;
+        }
+        final URI uri = URI.create(node.toString());
+        return uri.getFragment() != null && uri.getFragment().startsWith("genid");
     }
 
     protected void checkResponse(final HttpResponse response, final Response.StatusType expected) {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/JcrPropertyStatementListener.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/JcrPropertyStatementListener.java
@@ -122,7 +122,7 @@ public class JcrPropertyStatementListener extends StatementListener {
             validateSubject(subject);
             LOGGER.debug(">> adding statement {}", input);
 
-            final Statement s = jcrRdfTools.skolemize(idTranslator, input);
+            final Statement s = jcrRdfTools.skolemize(idTranslator, input, topic.toString());
 
             final FedoraResource resource = idTranslator.convert(s.getSubject());
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/PersistingRdfStreamConsumer.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/PersistingRdfStreamConsumer.java
@@ -149,7 +149,7 @@ public abstract class PersistingRdfStreamConsumer implements RdfStreamConsumer {
     protected void operateOnTriple(final Statement input) throws MalformedRdfException {
         try {
 
-            final Statement t = jcrRdfTools.skolemize(idTranslator, input);
+            final Statement t = jcrRdfTools.skolemize(idTranslator, input, stream().topic().toString());
 
             final Resource subject = t.getSubject();
             final FedoraResource subjectNode = translator().convert(subject);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -756,7 +756,7 @@ public class FedoraResourceImplIT extends AbstractIT {
 
             final javax.jcr.Node skolemizedNode = jcrSession.getNodeByIdentifier(values[0].getString());
 
-            assertTrue(skolemizedNode.getPath().contains("/.well-known/genid/"));
+            assertTrue(skolemizedNode.getPath().contains("/#/"));
             assertEquals("xyz" + FIELD_DELIMITER + XSDstring.getURI(),
                     skolemizedNode.getProperty("dc:title").getValues()[0].getString());
         }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/JcrRdfToolsTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/JcrRdfToolsTest.java
@@ -34,6 +34,7 @@ import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FROZEN_NODE;
 import static org.fcrepo.kernel.modeshape.rdf.JcrRdfTools.getJcrNamespaceForRDFNamespace;
 import static org.fcrepo.kernel.modeshape.rdf.JcrRdfTools.getRDFNamespaceForJcrNamespace;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -283,7 +284,7 @@ public class JcrRdfToolsTest implements FedoraTypes {
         final Statement x = m.createStatement(testSubjects.toDomain("/"),
                 createProperty("info:x"),
                 createPlainLiteral("x"));
-        final Statement statement = testObj.skolemize(testSubjects, x);
+        final Statement statement = testObj.skolemize(testSubjects, x, "info:fedora/");
 
         assertEquals(x, statement);
     }
@@ -291,31 +292,42 @@ public class JcrRdfToolsTest implements FedoraTypes {
     @Test
     public void shouldSkolemizeBlankNodeSubjects() throws RepositoryException {
         final Model m = createDefaultModel();
-        final Statement x = m.createStatement(createResource(),
+        final Resource resource = createResource();
+        final Statement x = m.createStatement(resource,
                 createProperty("info:x"),
                 testSubjects.toDomain("/"));
         testObj.jcrTools = mock(JcrTools.class);
-        when(testObj.jcrTools.findOrCreateNode(eq(mockSession), anyString())).thenReturn(mockNode);
-        when(mockNode.getPath()).thenReturn("/.well-known/x");
-        final Statement statement = testObj.skolemize(testSubjects, x);
+        when(testObj.jcrTools.findOrCreateNode(eq(mockSession), anyString(), eq(NT_FOLDER))).thenReturn(mockNode);
+        when(mockNode.getPath()).thenReturn("/#/x");
+        when(mockNode.getParent()).thenReturn(mockHashNode);
+        when(mockHashNode.getParent()).thenReturn(mockChildNode);
+        when(mockHashNode.isNew()).thenReturn(true);
+        when(FedoraTypesUtils.getClosestExistingAncestor(mockSession, anyString())).thenReturn(mockHashNode);
+        final Statement statement = testObj.skolemize(testSubjects, x, "info:fedora/");
 
-
-        assertEquals("info:fedora/.well-known/x", statement.getSubject().toString());
+        assertTrue("Doesn't match: " + statement.getSubject().toString(),
+                statement.getSubject().toString().startsWith("info:fedora/#"));
+        verify(mockNode).addMixin(FEDORA_RESOURCE);
     }
 
     @Test
     public void shouldSkolemizeBlankNodeObjects() throws RepositoryException {
         final Model m = createDefaultModel();
-        final Statement x = m.createStatement(testSubjects.toDomain("/"),
+        final Statement x = m.createStatement(testSubjects.toDomain("/foo"),
                 createProperty("info:x"),
                 createResource());
         testObj.jcrTools = mock(JcrTools.class);
-        when(testObj.jcrTools.findOrCreateNode(eq(mockSession), anyString())).thenReturn(mockNode);
-        when(mockNode.getPath()).thenReturn("/.well-known/x");
-        final Statement statement = testObj.skolemize(testSubjects, x);
+        when(testObj.jcrTools.findOrCreateNode(eq(mockSession), anyString(), eq(NT_FOLDER))).thenReturn(mockNode);
+        when(mockNode.getPath()).thenReturn("/foo#abc");
+        when(mockNode.getParent()).thenReturn(mockHashNode);
+        when(mockHashNode.getParent()).thenReturn(mockChildNode);
+        when(mockHashNode.isNew()).thenReturn(true);
+        when(FedoraTypesUtils.getClosestExistingAncestor(mockSession, anyString())).thenReturn(mockHashNode);
+        final Statement statement = testObj.skolemize(testSubjects, x, x.getSubject().toString());
 
-
-        assertEquals("info:fedora/.well-known/x", statement.getObject().toString());
+        assertTrue(statement.getObject().toString().startsWith("info:fedora/foo#"));
+        verify(mockNode).addMixin(FEDORA_RESOURCE);
+        verify(mockNode.getParent()).addMixin(FEDORA_PAIRTREE);
     }
 
     @Test
@@ -326,13 +338,15 @@ public class JcrRdfToolsTest implements FedoraTypes {
                 createProperty("info:x"),
                 resource);
         testObj.jcrTools = mock(JcrTools.class);
-        when(testObj.jcrTools.findOrCreateNode(eq(mockSession), anyString())).thenReturn(mockNode);
-        when(mockNode.getPath()).thenReturn("/.well-known/x");
-        final Statement statement = testObj.skolemize(testSubjects, x);
+        when(testObj.jcrTools.findOrCreateNode(eq(mockSession), anyString(), eq(NT_FOLDER))).thenReturn(mockNode);
+        when(mockNode.getPath()).thenReturn("/#/x");
+        when(mockNode.getParent()).thenReturn(mockHashNode);
+        when(mockHashNode.getParent()).thenReturn(mockChildNode);
+        when(FedoraTypesUtils.getClosestExistingAncestor(mockSession, anyString())).thenReturn(mockHashNode);
+        final Statement statement = testObj.skolemize(testSubjects, x, "info:fedora/");
 
-
-        assertEquals("info:fedora/.well-known/x", statement.getSubject().toString());
-        assertEquals("info:fedora/.well-known/x", statement.getObject().toString());
+        assertTrue(statement.getSubject().toString().startsWith("info:fedora/#"));
+        assertTrue(statement.getObject().toString().startsWith("info:fedora/#"));
     }
 
     @Test
@@ -349,34 +363,11 @@ public class JcrRdfToolsTest implements FedoraTypes {
         when(mockChildNode.isNew()).thenReturn(false);
         when(testObj.jcrTools.findOrCreateNode(mockSession, "/some/#/abc", NT_FOLDER)).thenReturn(mockNode);
         when(mockHashNode.isNew()).thenReturn(true);
-        final Statement statement = testObj.skolemize(testSubjects, x);
+        final Statement statement = testObj.skolemize(testSubjects, x, "/some/#/abc");
         assertEquals(x, statement);
         verify(testObj.jcrTools).findOrCreateNode(mockSession, "/some/#/abc", NT_FOLDER);
         verify(mockNode).addMixin(FEDORA_RESOURCE);
         verify(mockHashNode).addMixin(FEDORA_PAIRTREE);
-    }
-
-    @Test
-    public void shouldAddBlankNodePairtreeMixin() throws RepositoryException {
-        final Model m = createDefaultModel();
-        final Resource resource = createResource();
-        final Statement x = m.createStatement(resource,
-                createProperty("info:x"),
-                resource);
-        testObj.jcrTools = mock(JcrTools.class);
-        when(testObj.jcrTools.findOrCreateNode(eq(mockSession), anyString())).thenReturn(mockNode);
-        when(mockNode.getPath()).thenReturn("/x");
-        when(mockNode.getParent()).thenReturn(mockHashNode);
-        when(mockHashNode.getParent()).thenReturn(mockChildNode);
-        when(mockHashNode.isNew()).thenReturn(true);
-        when(FedoraTypesUtils.getClosestExistingAncestor(mockSession,"/.well-known/genid/"))
-                .thenReturn(mockChildNode);
-        final Statement statement = testObj.skolemize(testSubjects, x);
-        assertEquals("info:fedora/x", statement.getSubject().toString());
-        assertEquals("info:fedora/x", statement.getObject().toString());
-        verify(testObj.jcrTools).findOrCreateNode(mockSession, "/.well-known/genid/");
-        verify(mockNode).addMixin(FEDORA_SKOLEM);
-        verify(mockNode.getParent()).addMixin(FEDORA_PAIRTREE);
     }
 
     @Test
@@ -395,7 +386,7 @@ public class JcrRdfToolsTest implements FedoraTypes {
         when(mockChildNode.getNode("#")).thenReturn(mockHashNode);
         when(mockHashNode.isNew()).thenReturn(false);
         when(testObj.jcrTools.findOrCreateNode(mockSession, "/some/#/abc", NT_FOLDER)).thenReturn(mockNode);
-        final Statement statement = testObj.skolemize(testSubjects, x);
+        final Statement statement = testObj.skolemize(testSubjects, x, "/some/#/abc");
         assertEquals(x, statement);
         verify(testObj.jcrTools).findOrCreateNode(mockSession, "/some/#/abc", NT_FOLDER);
         verify(mockNode).addMixin(FEDORA_RESOURCE);
@@ -412,7 +403,9 @@ public class JcrRdfToolsTest implements FedoraTypes {
         when(mockHashNode.getParent()).thenReturn(mockChildNode);
         when(mockSession.nodeExists("/some")).thenReturn(false);
         when(testObj.jcrTools.findOrCreateNode(mockSession, "/some/#/abc", NT_FOLDER)).thenReturn(mockNode);
-        testObj.skolemize(testSubjects, x);
+        when(FedoraTypesUtils.getClosestExistingAncestor(mockSession,"/some/#/abc"))
+                .thenReturn(mockNode);
+        testObj.skolemize(testSubjects, x, "/some");
     }
 
     @Test
@@ -428,7 +421,7 @@ public class JcrRdfToolsTest implements FedoraTypes {
         when(mockSession.nodeExists("/some")).thenReturn(true);
         when(mockSession.getNode("/some")).thenReturn(mockChildNode);
         when(testObj.jcrTools.findOrCreateNode(mockSession, "/some/#/abc", NT_FOLDER)).thenReturn(mockNode);
-        final Statement statement = testObj.skolemize(testSubjects, x);
+        final Statement statement = testObj.skolemize(testSubjects, x, "/");
         assertEquals(x, statement);
         verify(testObj.jcrTools).findOrCreateNode(mockSession, "/some/#/abc", NT_FOLDER);
         verify(mockNode).addMixin(FEDORA_RESOURCE);
@@ -442,7 +435,7 @@ public class JcrRdfToolsTest implements FedoraTypes {
                 testSubjects.toDomain("/"),
                 createProperty("info:x"),
                 createResource("info:x#abc"));
-        final Statement statement = testObj.skolemize(testSubjects, x);
+        final Statement statement = testObj.skolemize(testSubjects, x, "/");
         assertEquals(x, statement);
     }
 

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/JcrPropertyStatementListenerTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/JcrPropertyStatementListenerTest.java
@@ -22,6 +22,7 @@ import static org.apache.jena.vocabulary.RDF.type;
 import static javax.jcr.PropertyType.URI;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getPropertyType;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -147,7 +148,7 @@ public class JcrPropertyStatementListenerTest {
 
         when(mockModel.getNsPrefixMap()).thenReturn(mockNsMapping);
         resource = idTranslator.convert(mockResource);
-        when(mockJcrRdfTools.skolemize(idTranslator, mockStatement)).thenReturn(mockStatement);
+        when(mockJcrRdfTools.skolemize(idTranslator, mockStatement, anyString())).thenReturn(mockStatement);
     }
 
     @Test
@@ -215,7 +216,7 @@ public class JcrPropertyStatementListenerTest {
                 + "object");
         final Statement statement = model.createStatement(mockResource, RDF.type, type);
         when(mockSubjectNode.canAddMixin("fedora:object")).thenReturn(true);
-        when(mockJcrRdfTools.skolemize(idTranslator, statement)).thenReturn(statement);
+        when(mockJcrRdfTools.skolemize(idTranslator, statement, anyString())).thenReturn(statement);
         testObj.addedStatement(statement);
         verify(mockJcrRdfTools).addMixin(resource, type, mockNsMapping);
     }
@@ -254,7 +255,7 @@ public class JcrPropertyStatementListenerTest {
                 type,
                 model.createResource(REPOSITORY_NAMESPACE + "Container"));
         when(mockSubjectNode.canAddMixin("fedora:object")).thenReturn(true);
-        when(mockJcrRdfTools.skolemize(idTranslator, statement)).thenReturn(statement);
+        when(mockJcrRdfTools.skolemize(idTranslator, statement, anyString())).thenReturn(statement);
         testObj.addedStatement(statement);
         verify(mockSubjectNode, never()).addMixin("fedora:object");
     }


### PR DESCRIPTION
Skolemizing blank nodes to hash URI resources (prefixed with "#genid") instead of external nodes prefixed with "/.well-known/genid/".

Fixes https://jira.duraspace.org/browse/FCREPO-2108
See also https://github.com/fcrepo/fcrepo-specification/issues/82