### PR TITLE
Adds ldp:constrainedBy header to creation of ldp:Resource

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -36,7 +36,6 @@ import static javax.ws.rs.core.Response.temporaryRedirect;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
-import static javax.ws.rs.core.Response.Status.NOT_IMPLEMENTED;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static javax.ws.rs.core.Variant.mediaTypes;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -86,7 +85,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
@@ -103,6 +101,7 @@ import org.fcrepo.http.commons.domain.PATCH;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
+import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
@@ -765,7 +764,7 @@ public class FedoraLdp extends ContentExposingResource {
                 final Link linq = Link.valueOf(link);
                 if ("type".equals(linq.getRel()) && (LDP_NAMESPACE + "Resource").equals(linq.getUri().toString())) {
                     LOGGER.info("Unimplemented LDPR creation requested with header link: {}", link);
-                    throw new ServerErrorException("LDPR creation not implemented", NOT_IMPLEMENTED);
+                    throw new CannotCreateResourceException("LDPR creation not implemented");
                 }
             } catch (final RuntimeException e) {
                 if (e instanceof IllegalArgumentException | e instanceof UriBuilderException) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -82,7 +82,6 @@ import java.util.Set;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.HttpHeaders;
@@ -106,6 +105,8 @@ import org.fcrepo.http.commons.session.HttpSession;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
+import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
@@ -742,7 +743,7 @@ public class FedoraLdpTest {
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
     }
 
-    @Test(expected = ServerErrorException.class)
+    @Test(expected = CannotCreateResourceException.class)
     public void testPutNewObjectLdpr() throws Exception {
         testObj.createOrReplaceObjectRdf(null, null, null, null,
                 "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\"", null);
@@ -1006,8 +1007,8 @@ public class FedoraLdpTest {
         testObj.createObject(null, null, null, null, null, null);
     }
 
-    @Test(expected = ServerErrorException.class)
-    public void testLDPRNotImplemented() throws MalformedRdfException, InvalidChecksumException,
+    @Test(expected = CannotCreateResourceException.class)
+    public void testLDPRNotImplemented() throws ConstraintViolationException, InvalidChecksumException,
             IOException {
         testObj.createObject(null, null, null, null, "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\"", null);
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/CannotCreateResourceExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/CannotCreateResourceExceptionMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
+
+import org.slf4j.Logger;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+/**
+ * @author bseeger
+ * @since 2017-04-07
+ */
+@Provider
+public class CannotCreateResourceExceptionMapper extends ConstraintExceptionMapper<CannotCreateResourceException>
+    implements ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(CannotCreateResourceExceptionMapper.class);
+
+    @Context
+    private ServletContext context; /* soon!! */
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Override
+    public Response toResponse(final CannotCreateResourceException e) {
+        debugException(this, e, LOGGER);
+        final Link link = buildConstraintLink(e, uriInfo);
+        final String msg = e.getMessage();
+        return status(BAD_REQUEST).entity(msg).links(link).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/CannotCreateResourceExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/CannotCreateResourceExceptionMapper.java
@@ -43,15 +43,15 @@ public class CannotCreateResourceExceptionMapper extends ConstraintExceptionMapp
     private static final Logger LOGGER = getLogger(CannotCreateResourceExceptionMapper.class);
 
     @Context
-    private ServletContext context; /* soon!! */
+    private UriInfo uriInfo;
 
     @Context
-    private UriInfo uriInfo;
+    private ServletContext context;
 
     @Override
     public Response toResponse(final CannotCreateResourceException e) {
         debugException(this, e, LOGGER);
-        final Link link = buildConstraintLink(e, uriInfo);
+        final Link link = buildConstraintLink(e, context, uriInfo);
         final String msg = e.getMessage();
         return status(BAD_REQUEST).entity(msg).links(link).type(TEXT_PLAIN_WITH_CHARSET).build();
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/CannotCreateResourceException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/CannotCreateResourceException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Request for object creation failed
+ *
+ * @author bseeger
+ * @since 2017-04-07
+ */
+public class CannotCreateResourceException extends ConstraintViolationException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     */
+    public CannotCreateResourceException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param rootCause the root cause
+     */
+    public CannotCreateResourceException(final Throwable rootCause) {
+        super(rootCause);
+    }
+
+}

--- a/fcrepo-webapp/src/main/webapp/static/constraints/CannotCreateResourceException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/CannotCreateResourceException.rdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="owl2html.xsl"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+]>
+
+
+<rdf:RDF
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="static/constraints/ConstraintNotImplementedException">
+        <rdfs:label xml:lang="en">Cannot Create Resource</rdfs:label>
+        <rdfs:comment xml:lang="en">Fedora is unable to create the requested resource.  Fedora will
+          not create a resource of type LDP Resource.  The type specified must be a subclass of
+          LDP Resource.
+        </rdfs:comment>
+    </owl:Ontology>
+</rdf:RDF>


### PR DESCRIPTION


**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2378

# What does this Pull Request do?
When a client requests creation of a ldp:Resource via link header they will get the usual error message and now will also get a ldp:constrainedBy link header in the response, pointing to a constraints file. 

# What's new?
This PR adds a new type of exception to cover this scenario. 

# How should this be tested?
Build the fcrepo.war file and deploy it. Then test this out via: 

      curl -i http://localhost:8080/fcrepo/rest -XPOST -H"Link: <http://www.w3.org/ns/ldp#Resource>; rel=\"type\""

This will fail and the message will have a pointer to a constraint file. Verify via curl that you can get that file. 

# Additional Notes:

# Interested parties
@awoods, @acoburn
