### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ as scientific data. Fedora has a worldwide installed user base that includes aca
 organizations, universities, research institutions, university libraries, national libraries, and government agencies.
 The Fedora community is supported by the stewardship of the [DuraSpace](http://www.duraspace.org) organization.
 
-##Technical goals:
+## Technical goals:
 * Improved scalability and performance
 * More flexible storage options
 * Improved reporting and metrics


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
