### PR TITLE
Fixes parallel build (ie -Dfcrepo.streams.parallel=true) Integration …

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/GraphDifferencer.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/GraphDifferencer.java
@@ -69,11 +69,13 @@ public class GraphDifferencer {
         notCommon = replacement;
         common = createDefaultGraph();
         original.forEach(x -> {
-            if (notCommon.contains(x)) {
-                notCommon.remove(x.getSubject(), x.getPredicate(), x.getObject());
-                common.add(x);
-            } else if (!common.contains(x)) {
-                source.accept(x);
+            synchronized (this) {
+                if (notCommon.contains(x)) {
+                    notCommon.remove(x.getSubject(), x.getPredicate(), x.getObject());
+                    common.add(x);
+                } else if (!common.contains(x)) {
+                    source.accept(x);
+                }
             }
         });
     }


### PR DESCRIPTION
…test failures.  The problem stemmed from the fact that the GraphDifferencer wasn't taking into account the possibility of parallel RDF streams.

Resolves: https://jira.duraspace.org/browse/FCREPO-2466

