### PR TITLE
Skip fcr:versions handler for fcr:fixity requests

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
@@ -58,7 +58,7 @@ import com.google.common.annotations.VisibleForTesting;
  * @author ajs6f
  */
 @Scope("request")
-@Path("/{path: .*}/fcr:versions/{labelAndOptionalPathIntoVersion: .*}")
+@Path("/{path: .*}/fcr:versions/{labelAndOptionalPathIntoVersion: .*(?<!/fcr:fixity)$}")
 public class FedoraVersions extends ContentExposingResource {
 
     private static final Logger LOGGER = getLogger(FedoraVersions.class);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
@@ -636,6 +636,22 @@ public class FedoraVersionsIT extends AbstractResourceIT {
         }
     }
 
+    @Test
+    public void testFixityOnVersionedResource() throws IOException {
+        final String id = getRandomUniqueId();
+        final String childId = id + "/child1";
+        createObjectAndClose(id);
+        createDatastream(id, "child1", "foo");
+        enableVersioning(childId);
+        postObjectVersion(childId, "v0");
+
+        final HttpGet checkFixity = getObjMethod(childId + "/fcr:versions/v0/fcr:fixity");
+        try (final CloseableHttpResponse response = execute(checkFixity)) {
+            assertEquals("Did not get OK response", OK.getStatusCode(), getStatus(response));
+        }
+
+    }
+
     private static void patchLiteralProperty(final String url, final String predicate, final String literal)
             throws IOException {
         final HttpPatch updateObjectGraphMethod = new HttpPatch(url);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-1247

https://groups.google.com/forum/#!msg/fedora-tech/qw3GlptWBQw/CaGXHMuiRXIJ

Follow-on ticket: https://jira.duraspace.org/browse/FCREPO-2526 - 
To fix the HTML UI as it still fails to follow links on versions to their fixity results (see [FCREPO-2415](https://jira.duraspace.org/browse/FCREPO-2415)), but going direct in the browser to the URI now works.

# What does this Pull Request do?
Causes requests to `fcr:fixity` results of a `fcr:versions` to be handled by `FedoraFixity` instead of `FedoraVersions`.

This is the same as changing the URI `http://localhost:8080/rest/picture/fcr:versions/v0/fcr:fixity` to `http://localhost:8080/rest/picture/fcr%3Aversions/v0/fcr:fixity`

# What's new?
This was educational, it is a [negative lookbehind](http://www.rexegg.com/regex-disambiguation.html#negative-lookbehind) regular expression. Which essentially says match if the match does **not** end with `fcr:fixity`.

# How should this be tested?

Before PR a request of `curl -i -G "http://localhost:8080/rest/apple_box/carton_of_apples/cute/fcr:versions/v0/fcr:fixity"` should fail with a stack trace about `Error converting "fcr:fixity" from String to a Name`

After PR the same request should work.
```
> curl -i -G "http://localhost:8080/rest/apple_box/carton_of_apples/cute/fcr:versions/v0/fcr:fixity"
HTTP/1.1 200 OK
Date: Tue, 20 Jun 2017 20:20:32 GMT
Content-Type: text/turtle;charset=utf-8
Content-Length: 1803
Server: Jetty(9.3.1.v20150714)

@prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
@prefix test:  <info:fedora/test/> .
@prefix owl:  <http://www.w3.org/2002/07/owl#> .
@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
@prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
@prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix xml:  <http://www.w3.org/XML/1998/namespace> .
@prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .
@prefix dcterms:  <http://purl.org/dc/terms/> .
@prefix iana:  <http://www.iana.org/assignments/relation/> .
@prefix xs:  <http://www.w3.org/2001/XMLSchema> .
@prefix event:  <http://fedora.info/definitions/v4/event#> .
@prefix config:  <info:fedoraconfig/> .
@prefix prov:  <http://www.w3.org/ns/prov#> .
@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@prefix dc:  <http://purl.org/dc/elements/1.1/> .

<http://localhost:8080/rest/apple_box/carton_of_apples/cute/fcr:versions/v0>
        premis:hasFixity  <http://localhost:8080/rest/apple_box/carton_of_apples/cute/fcr:versions/v0#fixity/1497990032351> .

<http://localhost:8080/rest/apple_box/carton_of_apples/cute/fcr:versions/v0#fixity/1497990032351>
        rdf:type                 premis:Fixity ;
        rdf:type                 premis:EventOutcomeDetail ;
        premis:hasEventOutcome   "SUCCESS" ;
        premis:hasMessageDigestAlgorithm  "SHA-1" ;
        premis:hasMessageDigest  <urn:sha1:66f8fc38c87f1a52d95c3da7c1f59d34d2a065a0> ;
        premis:hasSize           "1375600"^^<http://www.w3.org/2001/XMLSchema#long> .
```

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@awoods
