### PR TITLE
Add Link headers to fcr:fixity and integration test

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.http.api;
 
+import static javax.ws.rs.core.HttpHeaders.LINK;
 import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2_WITH_CHARSET;
@@ -26,6 +27,7 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
+import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.ws.rs.GET;
@@ -33,7 +35,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-
+import javax.ws.rs.core.Link;
 import com.google.common.annotations.VisibleForTesting;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
@@ -92,6 +94,11 @@ public class FedoraFixity extends ContentExposingResource {
         if (!(resource() instanceof FedoraBinary)) {
             throw new NotFoundException(resource() + " is not a binary");
         }
+
+        final Link.Builder resourceLink = Link.fromUri(LDP_NAMESPACE + "Resource").rel("type");
+        servletResponse.addHeader(LINK, resourceLink.build().toString());
+        final Link.Builder rdfSourceLink = Link.fromUri(LDP_NAMESPACE + "RDFSource").rel("type");
+        servletResponse.addHeader(LINK, rdfSourceLink.build().toString());
 
         LOGGER.info("Get fixity for '{}'", externalPath);
         return new RdfNamespacedStream(


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2526

Related to https://jira.duraspace.org/browse/FCREPO-1247 subsequent PR #1203 

# What does this Pull Request do?
Adds RDFSource and Resource Link headers as well as IT to test.
Copy of work in #1202 

# What's new?
2 new Link headers on /fcr:fixity results

# How should this be tested?
Same as #1202 for but for `/fcr:fixity`

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@awoods
