### PR TITLE
Ensures that CSV files are not considered RDF

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -758,7 +758,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             initialContent = EntityUtils.toString(subjectResponse.getEntity());
         }
         final HttpPut replaceMethod = putObjMethod(id);
-        replaceMethod.addHeader(CONTENT_TYPE, "application/n3");
+        replaceMethod.addHeader(CONTENT_TYPE, "text/n3");
         replaceMethod
                 .setEntity(new StringEntity(initialContent + "\n<" + subjectURI + "> <info:test#label> \"foo\""));
         try (final CloseableHttpResponse response = execute(replaceMethod)) {
@@ -777,7 +777,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testCreateGraph() throws IOException {
         final String subjectURI = serverAddress + getRandomUniqueId();
         final HttpPut createMethod = new HttpPut(subjectURI);
-        createMethod.addHeader(CONTENT_TYPE, "application/n3");
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
         createMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
         assertEquals(CREATED.getStatusCode(), getStatus(createMethod));
 
@@ -792,7 +792,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testCreateGraphWithBlanknodes() throws IOException {
         final String subjectURI = serverAddress + getRandomUniqueId();
         final HttpPut createMethod = new HttpPut(subjectURI);
-        createMethod.addHeader(CONTENT_TYPE, "application/n3");
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
         createMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:some-predicate> _:a ." +
                 "_:a <info:test#label> \"asdfg\""));
         assertEquals(CREATED.getStatusCode(), getStatus(createMethod));
@@ -1175,7 +1175,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testIngestWithNewAndGraph() throws IOException {
         final HttpPost method = postObjMethod();
-        method.addHeader(CONTENT_TYPE, "application/n3");
+        method.addHeader(CONTENT_TYPE, "text/n3");
         method.setEntity(new StringEntity("<> <http://purl.org/dc/elements/1.1/title> \"title\"."));
 
         try (final CloseableHttpResponse response = execute(method)) {
@@ -1440,7 +1440,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testIngestWithRDFLang() throws IOException {
         final HttpPost method = postObjMethod();
-        method.addHeader(CONTENT_TYPE, "application/n3");
+        method.addHeader(CONTENT_TYPE, "text/n3");
         method.setEntity(new StringEntity("<> <http://purl.org/dc/elements/1.1/title> \"french title\"@fr ."
                 + "<> <http://purl.org/dc/elements/1.1/title> \"english title\"@en ."));
 
@@ -1925,6 +1925,45 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testCreateBinaryUpperCaseMimeType() throws IOException {
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut createMethod = new HttpPut(subjectURI);
+        createMethod.addHeader(CONTENT_TYPE, "TEXT/PlAiN");
+        createMethod.setEntity(new StringEntity("Some text here."));
+
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+
+            final String receivedLocation = response.getFirstHeader("Location").getValue();
+            assertEquals("Got wrong URI in Location header for datastream creation!", subjectURI, receivedLocation);
+
+            final Link link = Link.valueOf(response.getFirstHeader(LINK).getValue());
+            // ensure it's a binary; if it doesn't have describedby, then it's not
+            assertEquals("No described by header!", "describedby", link.getRel());
+        }
+    }
+
+    @Test
+    public void testCreateBinaryCSV() throws IOException {
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut createMethod = new HttpPut(subjectURI);
+        createMethod.addHeader(CONTENT_TYPE, "text/csv");
+        createMethod.setEntity(new StringEntity("Header 1, Header 2, Header 3\r1,2,3\r1,2,3"));
+
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+
+            final String receivedLocation = response.getFirstHeader("Location").getValue();
+
+            assertEquals("Got wrong URI in Location header for datastream creation!", subjectURI, receivedLocation);
+
+            final Link link = Link.valueOf(response.getFirstHeader(LINK).getValue());
+            // ensure it's a binary; if it doesn't have describedby, then it's not
+            assertEquals("No described by header!", "describedby", link.getRel());
+        }
+    }
+
+    @Test
     public void testRoundTripReplaceGraphForDatastreamDescription() throws IOException {
         final String id = getRandomUniqueId();
         final String subjectURI = serverAddress + id + "/ds1";
@@ -2342,7 +2381,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testJsonLdProfileCompacted() throws IOException {
         // Create a resource
         final HttpPost method = postObjMethod();
-        method.addHeader(CONTENT_TYPE, "application/n3");
+        method.addHeader(CONTENT_TYPE, "text/n3");
         final BasicHttpEntity entity = new BasicHttpEntity();
         final String rdf = "<> <http://purl.org/dc/elements/1.1/title> \"ceci n'est pas un titre français\"@fr ." +
                 "<> <http://purl.org/dc/elements/1.1/title> \"this is an english title\"@en .";
@@ -2376,7 +2415,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testJsonLdProfileExpanded() throws IOException {
         // Create a resource
         final HttpPost method = postObjMethod();
-        method.addHeader(CONTENT_TYPE, "application/n3");
+        method.addHeader(CONTENT_TYPE, "text/n3");
         final BasicHttpEntity entity = new BasicHttpEntity();
         final String rdf = "<> <http://purl.org/dc/elements/1.1/title> \"ceci n'est pas un titre français\"@fr ." +
                 "<> <http://purl.org/dc/elements/1.1/title> \"this is an english title\"@en .";
@@ -2411,7 +2450,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testJsonLdProfileFlattened() throws IOException {
         // Create a resource
         final HttpPost method = postObjMethod();
-        method.addHeader(CONTENT_TYPE, "application/n3");
+        method.addHeader(CONTENT_TYPE, "text/n3");
         final BasicHttpEntity entity = new BasicHttpEntity();
         final String rdf = "<> <http://purl.org/dc/elements/1.1/title> \"ceci n'est pas un titre français\"@fr ." +
                 "<> <http://purl.org/dc/elements/1.1/title> \"this is an english title\"@en .";


### PR DESCRIPTION

#  Ensures that CSV files are not considered RDF
***

**JIRA Ticket**:  https://jira.duraspace.org/browse/FCREPO-2508

# What does this Pull Request do?
Adds a check for csv file type in the code that determines if something being PUT should be a binary or container. 

# What's new?
Along with that check described above, a few new tests are added.  One test specifically related to CSV files. and one test is for binaries created with mime type that's correct, but with capitol letters in the name. 

# How should this be tested?
Test by added a file with mime-type 'text/csv' to fedora. See that the binary is properly created and that you can retrieve it successfully. 

A description of what steps someone could take to:
* create a container
* upload a csv file as a binary in that container
* verify that you can retrieve it back successfully. 


# Additional Notes:
This partially addresses https://jira.duraspace.org/browse/FCREPO-2516  (nc files still fail, but for different reasons, I think). 
This will probably fix 


# Interested parties
@awoo