### PR TITLE
Adds PreconditionException type to replace WebapplicationException.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -77,7 +77,6 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.BeanParam;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.EntityTag;
@@ -99,6 +98,7 @@ import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.exception.PreconditionException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.models.Container;
@@ -591,8 +591,12 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             // an exceptional condition
             builder = builder.cacheControl(cc).lastModified(Date.from(roundedDate)).tag(etag);
         }
+
         if (builder != null) {
-            throw new WebApplicationException(builder.build());
+            final Response response = builder.build();
+            final Object message = response.getEntity();
+            throw new PreconditionException(message != null ? message.toString()
+                    : "Request failed due to unspecified failed precondition.", response.getStatus());
         }
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PreconditionExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PreconditionExceptionMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.fcrepo.kernel.api.exception.PreconditionException;
+
+import org.slf4j.Logger;
+
+/**
+ * Maps PreconditionException to an appropriate http response.
+ * @author Daniel Bernstein
+ * @since Jun 22, 2017
+ */
+@Provider
+public class PreconditionExceptionMapper implements
+        ExceptionMapper<PreconditionException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER =
+            getLogger(PreconditionExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final PreconditionException e) {
+        debugException(this, e, LOGGER);
+        return status(e.getHttpStatus()).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+}

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/PreconditionExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/PreconditionExceptionMapperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.core.Response;
+
+import org.fcrepo.kernel.api.exception.PreconditionException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * PreconditionExceptionTest class.
+ *
+ * @author dbernstein
+ * @since Jun 22, 2017
+ */
+public class PreconditionExceptionMapperTest {
+
+    private PreconditionExceptionMapper testObj;
+
+    @Before
+    public void setUp() {
+        testObj = new PreconditionExceptionMapper();
+    }
+
+    @Test
+    public void testToResponse() {
+        final String message = "error message";
+        final PreconditionException input = new PreconditionException(message, PRECONDITION_FAILED.getStatusCode());
+        final Response actual = testObj.toResponse(input);
+        assertEquals(PRECONDITION_FAILED.getStatusCode(), actual.getStatus());
+        assertEquals(message, actual.getEntity().toString());
+
+    }
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PreconditionException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PreconditionException.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.exception;
+
+import static org.apache.http.HttpStatus.SC_PRECONDITION_FAILED;
+import static org.apache.http.HttpStatus.SC_NOT_MODIFIED;
+
+/**
+ * @author dbernstein
+ * @since Jun 22, 2017
+ */
+public class PreconditionException extends RepositoryRuntimeException {
+
+    private int httpStatus;
+
+    /**
+     * Ordinary constructor
+     * 
+     * @param msg error message
+     * @param httpStatus
+     */
+    public PreconditionException(final String msg, final int httpStatus) {
+        super(msg);
+        if (httpStatus != SC_PRECONDITION_FAILED && httpStatus != SC_NOT_MODIFIED) {
+            throw new IllegalArgumentException("Invalid httpStatus (" + httpStatus +
+                    "). The http status for PreconditionExceptions must be " +
+                    SC_PRECONDITION_FAILED + " or " + SC_NOT_MODIFIED);
+        }
+        this.httpStatus = httpStatus;
+    }
+
+    /**
+     * @return the httpStatus
+     */
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+}


### PR DESCRIPTION
Resolves https://jira.duraspace.org/browse/FCREPO-2386

**Adds PreconditionException for handling precondition failures.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2386

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Mostly housecleaning.  No functionality changes or bug fixes.
# What's new?
A in-depth description of the changes made by this PR. Technical details and possible side effects.
This PR does a bit of housecleaning by ensuring that precondition exceptions follow the same exception handling pattern used by similar api exceptions and adds assurance that precondition exceptions will only return appropriate http codes.

# How should this be tested?

Not necessary.  Unit and integration tests already cover the functionality.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

# Interested parties
@awoods 