### PR TITLE
Fixes incorrect redirection of URIs ending /fcr:tx in HTML UI to /fcr…

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/common.js
+++ b/fcrepo-http-api/src/main/resources/views/common.js
@@ -101,7 +101,7 @@
           // (c.f. https://jira.duraspace.org/browse/FCREPO-2387)
           // WARNING: Fragile code relying on magic suffix '/fcr:metadata' and absence of 'Link' header 
           // on external resource.
-          if(!url.match(/.*fcr:metadata/)){
+          if(!url.match(/.*fcr:(metadata|tx)/)){
             newLocation = url + "/fcr:metadata";
           }
           location.href = newLocation ;


### PR DESCRIPTION
…:tx/fcr:metadata.


**JIRA Ticket**:  https://jira.duraspace.org/browse/FCREPO-2539


# How should this be tested?
See  https://jira.duraspace.org/browse/FCREPO-2539 for steps to reproduce original defect.
