### PR TITLE
Upgrade to Modeshape 5.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <jsonld.version>0.8.3</jsonld.version>
     <logback.version>1.1.7</logback.version>
     <metrics.version>3.1.2</metrics.version>
-    <modeshape.version>5.3.0.Final</modeshape.version>
+    <modeshape.version>5.4.0.Final</modeshape.version>
     <slf4j.version>1.7.21</slf4j.version>
     <snappy-java.version>1.1.2.6</snappy-java.version>
     <spring.version>4.3.3.RELEASE</spring.version>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2581

* [Modeshape 5.4.0.Final Release Notes](http://docs.jboss.org/modeshape/5.4.0.Final/release.html)
* [MODE-2670](https://issues.jboss.org/browse/MODE-2670)
* [Tomcat stuck thread issue on fedora-tech](https://groups.google.com/d/topic/fedora-tech/b8Eap28sL1M/discussion)

# What does this Pull Request do?
Upgrades to Modeshape 5.4.0.Final.

# What's new?
Updates the Modeshape dependency from 5.3.0.Final to 5.4.0.Final in the main pom.xml. UMD's interest in this is for the fix to [MODE-2670](https://issues.jboss.org/browse/MODE-2670), which we believe is responsible for some of our stuck thread issues.

# How should this be tested?
* Run all unit and integration tests

# Additional Notes:
This is a minor version upgrade of Modeshape, so it should not have any breaking changes or cause disruption to existing repositories.

# Interested parties
@awoods 
