### PR TITLE
Ensures correct response codes for creating LDP-NR

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -598,6 +598,7 @@ public class FedoraLdp extends ContentExposingResource {
      * @return 204 No Content (for updated resources), 201 Created (for created resources) including the resource
      *    URI or content depending on Prefer headers.
      */
+    @SuppressWarnings("resource")
     private Response createUpdateResponse(final FedoraResource resource, final boolean created) {
         addCacheControlHeaders(servletResponse, resource, session);
         addResourceLinkHeaders(resource, created);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -691,7 +691,7 @@ public class FedoraLdpTest {
 
 
     @Test
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({"resource", "unchecked"})
     public void testGetWithBinaryDescription() throws IOException {
 
         final NonRdfSourceDescription mockResource
@@ -838,7 +838,7 @@ public class FedoraLdpTest {
 
 
     @Test
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({"resource", "unchecked"})
     public void testPatchBinaryDescription() throws MalformedRdfException, IOException {
 
         final NonRdfSourceDescription mockObject = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -23,17 +23,16 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.stream.Stream.of;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
+import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
-import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NOT_MODIFIED;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.TEMPORARY_REDIRECT;
-import static javax.ws.rs.core.Response.Status.NOT_MODIFIED;
-
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
@@ -107,11 +106,11 @@ import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
-import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PreconditionException;
+import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
@@ -692,7 +691,7 @@ public class FedoraLdpTest {
 
 
     @Test
-    @SuppressWarnings({"resource", "unchecked"})
+    @SuppressWarnings({"unchecked"})
     public void testGetWithBinaryDescription() throws IOException {
 
         final NonRdfSourceDescription mockResource
@@ -839,7 +838,7 @@ public class FedoraLdpTest {
 
 
     @Test
-    @SuppressWarnings({"resource", "unchecked"})
+    @SuppressWarnings({"unchecked"})
     public void testPatchBinaryDescription() throws MalformedRdfException, IOException {
 
         final NonRdfSourceDescription mockObject = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);
@@ -876,7 +875,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObject() throws MalformedRdfException, InvalidChecksumException,
-           IOException {
+           IOException, UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, null, "b", null, null, null);
@@ -885,7 +884,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObjectWithSparql() throws MalformedRdfException,
-           InvalidChecksumException, IOException {
+           InvalidChecksumException, UnsupportedAlgorithmException, IOException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null,
@@ -896,7 +895,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObjectWithRdf() throws MalformedRdfException,
-           InvalidChecksumException, IOException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, NTRIPLES_TYPE, "b",
@@ -908,7 +907,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinary() throws MalformedRdfException, InvalidChecksumException,
-           IOException {
+           IOException, UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {
@@ -920,7 +919,7 @@ public class FedoraLdpTest {
 
     @Test(expected = InsufficientStorageException.class)
     public void testCreateNewBinaryWithInsufficientResources() throws MalformedRdfException,
-           InvalidChecksumException, IOException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
 
@@ -940,7 +939,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithContentTypeWithParams() throws MalformedRdfException,
-           InvalidChecksumException, IOException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -954,7 +953,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumSHA() throws MalformedRdfException,
-           InvalidChecksumException, IOException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -971,7 +970,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumMD5() throws MalformedRdfException,
-            InvalidChecksumException, IOException {
+            InvalidChecksumException, IOException, UnsupportedAlgorithmException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -988,7 +987,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumSHAandMD5() throws MalformedRdfException,
-           InvalidChecksumException, IOException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -1013,21 +1012,22 @@ public class FedoraLdpTest {
     }
 
     @Test(expected = ClientErrorException.class)
-    public void testPostToBinary() throws MalformedRdfException, InvalidChecksumException, IOException {
+    public void testPostToBinary() throws MalformedRdfException, InvalidChecksumException, IOException,
+            UnsupportedAlgorithmException {
         final FedoraBinary mockObject = (FedoraBinary)setResource(FedoraBinary.class);
         doReturn(mockObject).when(testObj).resource();
         testObj.createObject(null, null, null, null, null, null);
     }
 
     @Test(expected = CannotCreateResourceException.class)
-    public void testLDPRNotImplemented() throws ConstraintViolationException, InvalidChecksumException,
-            IOException {
+    public void testLDPRNotImplemented() throws InvalidChecksumException,
+            IOException, MalformedRdfException, UnsupportedAlgorithmException {
         testObj.createObject(null, null, null, null, "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\"", null);
     }
 
     @Test(expected = ClientErrorException.class)
     public void testLDPRNotImplementedInvalidLink() throws MalformedRdfException, InvalidChecksumException,
-           IOException {
+           IOException, UnsupportedAlgorithmException {
         testObj.createObject(null, null, null, null, "Link: <http://www.w3.org/ns/ldp#Resource;rel=type", null);
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -70,7 +70,6 @@ import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_VARIANTS;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
@@ -123,9 +122,6 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.Variant;
 
-import org.fcrepo.http.commons.domain.RDFMediaType;
-import org.fcrepo.http.commons.test.util.CloseableDataset;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -156,6 +152,8 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.DC_11;
+import org.fcrepo.http.commons.domain.RDFMediaType;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1358,7 +1356,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 " sha99=7b115a72978fe138287c1a6dfe6cc1afce4720fb3610a81d32e4ad518700c923");
         method.setEntity(new FileEntity(img));
 
-        assertEquals("Should be a 409 Conflict!", CONFLICT.getStatusCode(), getStatus(method));
+        assertEquals("Should be a 400 Bad Request!", BAD_REQUEST.getStatusCode(), getStatus(method));
     }
 
     @Test

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/UnsupportedAlgorithmExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/UnsupportedAlgorithmExceptionMapper.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
+import org.slf4j.Logger;
+
+/**
+ * Translate InvalidChecksumException errors into reasonable
+ * HTTP error codes
+ *
+ * @author harring
+ * @since 2017-09-12
+ */
+@Provider
+public class UnsupportedAlgorithmExceptionMapper implements
+        ExceptionMapper<UnsupportedAlgorithmException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER =
+            getLogger(UnsupportedAlgorithmExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final UnsupportedAlgorithmException e) {
+
+        LOGGER.error("InvalidChecksumException intercepted by UnsupportedAlgorithmExceptionMapper: {}\n",
+                e.getMessage());
+        debugException(this, e, LOGGER);
+
+        return status(BAD_REQUEST).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/UnsupportedAlgorithmExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/UnsupportedAlgorithmExceptionMapper.java
@@ -30,7 +30,7 @@ import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.slf4j.Logger;
 
 /**
- * Translate InvalidChecksumException errors into reasonable
+ * Translate UnsupportedAlgorithmException errors into reasonable
  * HTTP error codes
  *
  * @author harring
@@ -46,8 +46,6 @@ public class UnsupportedAlgorithmExceptionMapper implements
     @Override
     public Response toResponse(final UnsupportedAlgorithmException e) {
 
-        LOGGER.error("InvalidChecksumException intercepted by UnsupportedAlgorithmExceptionMapper: {}\n",
-                e.getMessage());
         debugException(this, e, LOGGER);
 
         return status(BAD_REQUEST).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/UnsupportedAlgorithmException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/UnsupportedAlgorithmException.java
@@ -18,6 +18,9 @@
 package org.fcrepo.kernel.api.exception;
 
 /**
+ * Thrown in circumstances where a client has used an unknown or unsupported hash algorithm
+ * in a request, e.g. with `Digest` or `Want-Digest`.
+ *
  * @author harring
  * @since 2017-09-12
  */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/UnsupportedAlgorithmException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/UnsupportedAlgorithmException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * @author harring
+ * @since 2017-09-12
+ */
+public class UnsupportedAlgorithmException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Exception with message
+     * @param message the message
+     */
+    public UnsupportedAlgorithmException(final String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
- Adds new UnsupportedAlgorithmException and mapper
- Updates FedoraLdp class to throw new exception appropriately
- Updates FedoraLdpTest and FedoraLdpIT

Resolves: https://jira.duraspace.org/browse/FCREPO-2593

This PR is a contribution toward the API Alignment sprint (9/11/17-9/22/17).