### PR TITLE
Use Link header to determine interaction model, instead of mime type sniffing

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -148,7 +148,8 @@ public class FedoraLdpTest {
     private final String binaryDescriptionPath = "/some/other/path";
     private FedoraLdp testObj;
 
-    private final String nonRDFSourceLink = Link.fromUri(NON_RDF_SOURCE.toString()).rel("type").build().toString();
+    private final List<String> nonRDFSourceLink = Arrays.asList(
+            Link.fromUri(NON_RDF_SOURCE.toString()).rel("type").build().toString());
 
     @Mock
     private Request mockRequest;
@@ -762,7 +763,7 @@ public class FedoraLdpTest {
     @Test(expected = CannotCreateResourceException.class)
     public void testPutNewObjectLdpr() throws Exception {
         testObj.createOrReplaceObjectRdf(null, null, null, null,
-                "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\"", null);
+                asList("<http://www.w3.org/ns/ldp#Resource>; rel=\"type\""), null);
     }
 
     @Test
@@ -1031,15 +1032,19 @@ public class FedoraLdpTest {
     }
 
     @Test(expected = CannotCreateResourceException.class)
-    public void testLDPRNotImplemented() throws InvalidChecksumException,
-            IOException, MalformedRdfException, UnsupportedAlgorithmException {
-        testObj.createObject(null, null, null, null, "<http://www.w3.org/ns/ldp#Resource>; rel=\"type\"", null);
+    public void testLDPRNotImplemented() throws MalformedRdfException, InvalidChecksumException,
+            IOException, UnsupportedAlgorithmException {
+        setResource(Container.class);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/x")).thenReturn(mockContainer);
+        testObj.createObject(null, null, "x", null, asList("<http://www.w3.org/ns/ldp#Resource>; rel=\"type\""), null);
     }
 
     @Test(expected = ClientErrorException.class)
     public void testLDPRNotImplementedInvalidLink() throws MalformedRdfException, InvalidChecksumException,
-           IOException, UnsupportedAlgorithmException {
-        testObj.createObject(null, null, null, null, "Link: <http://www.w3.org/ns/ldp#Resource;rel=type", null);
+            IOException, UnsupportedAlgorithmException {
+        setResource(Container.class);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/x")).thenReturn(mockContainer);
+        testObj.createObject(null, null, "x", null, asList("<http://foo;rel=\"type\""), null);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -50,6 +50,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -85,6 +86,7 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
@@ -145,6 +147,8 @@ public class FedoraLdpTest {
     private final String binaryPath = "/some/binary/path";
     private final String binaryDescriptionPath = "/some/other/path";
     private FedoraLdp testObj;
+
+    private final String nonRDFSourceLink = Link.fromUri(NON_RDF_SOURCE.toString()).rel("type").build().toString();
 
     @Mock
     private Request mockRequest;
@@ -790,7 +794,7 @@ public class FedoraLdpTest {
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/some/path")).thenReturn(mockBinary);
 
         final Response actual = testObj.createOrReplaceObjectRdf(TEXT_PLAIN_TYPE,
-                toInputStream("xyz", UTF_8), null, null, null, null);
+                toInputStream("xyz", UTF_8), null, null, nonRDFSourceLink, null);
 
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
     }
@@ -912,7 +916,8 @@ public class FedoraLdpTest {
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {
-            final Response actual = testObj.createObject(null, APPLICATION_OCTET_STREAM_TYPE, "b", content, null, null);
+            final Response actual = testObj.createObject(null, APPLICATION_OCTET_STREAM_TYPE, "b", content,
+                nonRDFSourceLink, null);
             assertEquals(CREATED.getStatusCode(), actual.getStatus());
             verify(mockBinary).setContent(content, APPLICATION_OCTET_STREAM, Collections.emptySet(), "", null);
         }
@@ -932,9 +937,10 @@ public class FedoraLdpTest {
             doThrow(ex).when(mockBinary).setContent(content, APPLICATION_OCTET_STREAM_TYPE.toString(),
                     Collections
                     .emptySet(),
-                    "", null);
+                    "",
+                    null);
 
-            testObj.createObject(null, APPLICATION_OCTET_STREAM_TYPE, "b", content, null, null);
+            testObj.createObject(null, APPLICATION_OCTET_STREAM_TYPE, "b", content, nonRDFSourceLink, null);
         }
     }
 
@@ -946,7 +952,8 @@ public class FedoraLdpTest {
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {
             final MediaType requestContentType = MediaType.valueOf("some/mime-type; with=some; param=s");
-            final Response actual = testObj.createObject(null, requestContentType, "b", content, null, null);
+            final Response actual = testObj.createObject(null, requestContentType, "b", content, nonRDFSourceLink,
+                null);
             assertEquals(CREATED.getStatusCode(), actual.getStatus());
             verify(mockBinary).setContent(content, requestContentType.toString(), Collections.emptySet(), "", null);
         }
@@ -963,7 +970,8 @@ public class FedoraLdpTest {
             final String sha = "07a4d371f3b7b6283a8e1230b7ec6764f8287bf2";
             final String requestSHA = "sha1=" + sha;
             final Set<URI> shaURI = singleton(URI.create("urn:sha1:" + sha));
-            final Response actual = testObj.createObject(null, requestContentType, "b", content, null, requestSHA);
+            final Response actual = testObj.createObject(null, requestContentType, "b", content, nonRDFSourceLink,
+                requestSHA);
             assertEquals(CREATED.getStatusCode(), actual.getStatus());
             verify(mockBinary).setContent(content, requestContentType.toString(), shaURI, "", null);
         }
@@ -980,7 +988,8 @@ public class FedoraLdpTest {
             final String md5 = "HUXZLQLMuI/KZ5KDcJPcOA==";
             final String requestMD5 = "md5=" + md5;
             final Set<URI> md5URI = singleton(URI.create("urn:md5:" + md5));
-            final Response actual = testObj.createObject(null, requestContentType, "b", content, null, requestMD5);
+            final Response actual = testObj.createObject(null, requestContentType, "b", content, nonRDFSourceLink,
+                requestMD5);
             assertEquals(CREATED.getStatusCode(), actual.getStatus());
             verify(mockBinary).setContent(content, requestContentType.toString(), md5URI, "", null);
         }
@@ -1006,7 +1015,8 @@ public class FedoraLdpTest {
             final String requestChecksum = requestSHA + "," + requestMD5;
             final HashSet<URI> checksumURIs = new HashSet<>(asList(shaURI, md5URI));
 
-            final Response actual = testObj.createObject(null, requestContentType, "b", content, null, requestChecksum);
+            final Response actual = testObj.createObject(null, requestContentType, "b", content, nonRDFSourceLink,
+                requestChecksum);
             assertEquals(CREATED.getStatusCode(), actual.getStatus());
             verify(mockBinary).setContent(content, requestContentType.toString(), checksumURIs, "", null);
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -36,6 +36,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -92,6 +93,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public abstract class AbstractResourceIT {
 
     protected static Logger logger;
+    private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
 
     @Before
     public void setLogger() {
@@ -152,6 +154,15 @@ public abstract class AbstractResourceIT {
         final HttpPut put = new HttpPut(serverAddress + pid + "/" + ds);
         put.setEntity(new StringEntity(content == null ? "" : content));
         put.setHeader(CONTENT_TYPE, TEXT_PLAIN);
+        put.setHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        return put;
+    }
+
+    protected static HttpPut putObjMethod(final String pid, final String contentType, final String content)
+            throws UnsupportedEncodingException {
+        final HttpPut put = new HttpPut(serverAddress + pid);
+        put.setEntity(new StringEntity(content));
+        put.setHeader(CONTENT_TYPE, contentType);
         return put;
     }
 
@@ -289,6 +300,12 @@ public abstract class AbstractResourceIT {
 
     protected static Collection<String> getLinkHeaders(final HttpResponse response) {
         return getHeader(response, LINK);
+    }
+
+    protected Collection<String> getLinkHeaders(final HttpUriRequest method) throws IOException {
+        try (final CloseableHttpResponse response = execute(method)) {
+            return getLinkHeaders(response);
+        }
     }
 
     protected static Collection<String> getHeader(final HttpResponse response, final String header) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -282,10 +282,37 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testHeadDefaultRDF() throws IOException {
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id, "text/turtle", "<> a <http://example.com/Foo> .");
+        executeAndClose(put);
+
+        final HttpHead headObjMethod = headObjMethod(id);
+        try (final CloseableHttpResponse response = execute(headObjMethod)) {
+            final Collection<String> links = getLinkHeaders(response);
+            assertTrue("Didn't find LDP BasicContainer link header!", links.contains(BASIC_CONTAINER_LINK_HEADER));
+        }
+    }
+
+    @Test
+    public void testHeadDefaultNonRDF() throws IOException {
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id, "text/plain", "<> a <http://example.com/Foo> .");
+        executeAndClose(put);
+
+        final HttpHead headObjMethod = headObjMethod(id);
+        try (final CloseableHttpResponse response = execute(headObjMethod)) {
+            final Collection<String> links = getLinkHeaders(response);
+            assertTrue("Didn't find LDP NonRDFSource link header!", links.contains(NON_RDF_SOURCE_LINK_HEADER));
+        }
+    }
+
+    @Test
     public void testHeadDirectContainer() throws IOException {
         final String id = getRandomUniqueId();
-        createObjectAndClose(id);
-        addMixin(id, DIRECT_CONTAINER.getURI());
+        final HttpPut put = putObjMethod(id);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        executeAndClose(put);
 
         final HttpHead headObjMethod = headObjMethod(id);
         try (final CloseableHttpResponse response = execute(headObjMethod)) {
@@ -297,8 +324,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testHeadIndirectContainer() throws IOException {
         final String id = getRandomUniqueId();
-        createObjectAndClose(id);
-        addMixin(id, INDIRECT_CONTAINER.getURI());
+        final HttpPut put = putObjMethod(id);
+        put.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        executeAndClose(put);
 
         final HttpHead headObjMethod = headObjMethod(id);
         try (final CloseableHttpResponse response = execute(headObjMethod)) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
@@ -73,6 +73,7 @@ import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ModelFactory.createModelForGraph;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
@@ -442,6 +443,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         final HttpPost httpPost = new HttpPost(serverAddress);
         httpPost.addHeader("Slug", uri == null ? getRandomUniqueId() : uri.substring(serverAddress.length()));
         httpPost.addHeader(CONTENT_TYPE, "text/turtle");
+        httpPost.addHeader(LINK, "<" + BASIC_CONTAINER.toString() + ">; rel=\"type\"");
         httpPost.setEntity(new StringEntity(ttl));
         return execute(httpPost);
     }
@@ -451,6 +453,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         final HttpPut httpPut = new HttpPut(uri);
         httpPut.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         httpPut.addHeader(CONTENT_TYPE, "text/turtle");
+        httpPut.addHeader(LINK, "<" + BASIC_CONTAINER.toString() + ">; rel=\"type\"");
         httpPut.setEntity(new StringEntity(ttl));
         return execute(httpPut);
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
@@ -77,6 +77,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.SERVER_MANAGED_PROPERTIES_MODE;
 import static org.fcrepo.kernel.modeshape.utils.StreamUtils.iteratorToStream;
 import static org.junit.Assert.assertEquals;
@@ -429,6 +430,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
         post.setEntity(new StringEntity(content == null ? "" : content));
         post.setHeader(CONTENT_TYPE, TEXT_PLAIN);
+        post.setHeader(LINK, "<" + NON_RDF_SOURCE.toString() + ">; rel=\"type\"");
         return execute(post);
     }
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -118,6 +118,17 @@ public interface FedoraResource {
     List<URI> getTypes();
 
     /**
+     * Add an RDF:type value to the resource
+     *
+     * <p>Note: the type parameter should be in prefixed short form, so ldp:Container or ex:Image
+     * are both acceptable types. This method does not assume any jcr to fedora prefix mappings are
+     * managed by the implementation, so hasType("jcr:frozenNode") is a valid use of this method.</p>
+     *
+     * @param type the type to add
+     */
+    void addType(final String type);
+
+    /**
      * Update the provided properties with a SPARQL Update query. The updated
      * properties may be serialized to the persistence layer.
      *

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -1166,6 +1166,17 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         return getNode().toString();
     }
 
+    @Override
+    public void addType(final String type) {
+        try {
+            if (node.canAddMixin(type)) {
+                node.addMixin(type);
+            }
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
     protected Property getProperty(final String relPath) {
         try {
             return getNode().getProperty(relPath);

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -74,12 +74,14 @@
       const update_file = document.getElementById('binary_payload').files[0];
       const reader = new FileReader();
       headers.push(['Content-Disposition', 'attachment; filename=\"' + update_file.name + '\"']);
+      headers.push(['Link', '<http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\"']);
       headers.push(['Content-Type', update_file.type || 'application/octet-stream']);
       reader.onload = function(e) {
           fn(method, url, headers, e.target.result);
       };
       reader.readAsArrayBuffer(update_file);
     } else {
+      headers.push(['Link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"']);
       const turtle = document.getElementById('turtle_payload');
       if (turtle && turtle.value) {
         headers.push(['Content-Type', 'text/turtle']);


### PR DESCRIPTION
Use `Link rel="type"` header to determine interaction type, instead of checking the MIME type
and `Content-Disposition` headers.

Fixes https://jira.duraspace.org/browse/FCREPO-2584