### PR TITLE
Include Content-Location header in external content GET and HEAD responses.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -24,6 +24,7 @@ import static java.util.stream.Stream.empty;
 import static javax.ws.rs.core.HttpHeaders.CACHE_CONTROL;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_LOCATION;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
@@ -84,6 +85,7 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 
 import org.fcrepo.http.commons.api.HttpHeaderInjector;
 import org.fcrepo.http.commons.api.rdf.HttpTripleUtil;
@@ -190,7 +192,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             final MediaType mediaType = MediaType.valueOf(((FedoraBinary) resource()).getMimeType());
 
             if (isExternalBody(mediaType)) {
-                return temporaryRedirect(URI.create(mediaType.getParameters().get("URL"))).build();
+                return externalBodyRedirect(URI.create(mediaType.getParameters().get("URL"))).build();
             }
 
             return getBinaryContent(rangeValue);
@@ -213,6 +215,10 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 mediaType.getParameters().containsKey("access-type") &&
                 mediaType.getParameters().get("access-type").equals("URL") &&
                 mediaType.getParameters().containsKey("URL");
+    }
+
+    protected ResponseBuilder externalBodyRedirect(final URI resourceLocation) {
+        return temporaryRedirect(resourceLocation).header(CONTENT_LOCATION, resourceLocation);
     }
 
     protected RdfStream getResourceTriples() {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -32,7 +32,6 @@ import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.notAcceptable;
 import static javax.ws.rs.core.Response.ok;
-import static javax.ws.rs.core.Response.temporaryRedirect;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
@@ -205,7 +204,7 @@ public class FedoraLdp extends ContentExposingResource {
             final MediaType mediaType = MediaType.valueOf(((FedoraBinary) resource()).getMimeType());
 
             if (isExternalBody(mediaType)) {
-                builder = temporaryRedirect(URI.create(mediaType.getParameters().get("URL")));
+                builder = externalBodyRedirect(URI.create(mediaType.getParameters().get("URL")));
             }
 
             // we set the content-type explicitly to avoid content-negotiation from getting in the way


### PR DESCRIPTION
Fixes https://jira.duraspace.org/browse/FCREPO-2588

Added Content-Location header to GET and HEAD responses for external contents.