### PR TITLE
Adds support for depth header to DELETE action

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -326,7 +326,7 @@ public class FedoraLdp extends ContentExposingResource {
     @DELETE
     @Timed
     public Response deleteObject() {
-        FedoraResource resource = resource();
+        final FedoraResource resource = resource();
         if (resource instanceof ContainerImpl) {
             final String depth = headers.getHeaderString("Depth");
             System.out.println(depth);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -102,8 +102,11 @@ import javax.ws.rs.core.Variant.VariantListBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.web.ContentType;
+<<<<<<< HEAD
 import org.apache.jena.rdf.model.Resource;
 
+=======
+>>>>>>> b7a0011... Adds support for depth header to DELETE action
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.domain.ContentLocation;
 import org.fcrepo.http.commons.domain.PATCH;
@@ -123,7 +126,11 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
+<<<<<<< HEAD
 
+=======
+import org.fcrepo.kernel.modeshape.ContainerImpl;
+>>>>>>> b7a0011... Adds support for depth header to DELETE action
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -319,14 +326,24 @@ public class FedoraLdp extends ContentExposingResource {
     @DELETE
     @Timed
     public Response deleteObject() {
-        evaluateRequestPreconditions(request, servletResponse, resource(), session);
+        FedoraResource resource = resource();
+        if (resource instanceof ContainerImpl) {
+            final String depth = headers.getHeaderString("Depth");
+            System.out.println(depth);
+            if (depth != null && !depth.equalsIgnoreCase("infinity")) {
+                throw new ClientErrorException("Depth header, if present, must be set to 'infinity' for containers",
+                        SC_BAD_REQUEST);
+            }
+        }
+
+        evaluateRequestPreconditions(request, servletResponse, resource, session);
 
         LOGGER.info("Delete resource '{}'", externalPath);
 
-        final AcquiredLock lock = lockManager.lockForDelete(resource().getPath());
+        final AcquiredLock lock = lockManager.lockForDelete(resource.getPath());
 
         try {
-            resource().delete();
+            resource.delete();
             session.commit();
             return noContent().build();
         } finally {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -50,8 +50,6 @@ import java.util.Collection;
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.DatatypeConverter;
 
-import org.fcrepo.http.commons.test.util.CloseableDataset;
-
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -76,6 +74,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -459,6 +458,12 @@ public abstract class AbstractResourceIT {
         final String location = serverAddress + id;
         assertThat("Expected object to be deleted", getStatus(new HttpHead(location)), is(GONE.getStatusCode()));
         assertThat("Expected object to be deleted", getStatus(new HttpGet(location)), is(GONE.getStatusCode()));
+    }
+
+    protected static void assertNotDeleted(final String id) {
+        final String location = serverAddress + id;
+        assertThat("Expected object not to be deleted", getStatus(new HttpHead(location)), is(OK.getStatusCode()));
+        assertThat("Expected object not to be deleted", getStatus(new HttpGet(location)), is(OK.getStatusCode()));
     }
 
     protected static String getTTLThatUpdatesServerManagedTriples(final String createdBy, final Calendar created,

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -555,6 +555,40 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testGetRDFSourceWithPreferMinimal() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+
+        final HttpGet getMethod = new HttpGet(serverAddress + id);
+        final String preferHeader = "return=minimal";
+        getMethod.addHeader("Prefer", preferHeader);
+
+        try (final CloseableHttpResponse response = execute(getMethod)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't matched", preferenceApplied.contains(preferHeader));
+        }
+    }
+
+    @Test
+    public void testGetRDFSourceWithPreferRepresentation() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+
+        final HttpGet getMethod = new HttpGet(serverAddress + id);
+        final String preferHeader = "return=representation;"
+                + " include=\"http://fedora.info/definitions/v4/repository#InboundReferences\";"
+                + " omit=\"http://www.w3.org/ns/ldp#PreferMembership http://www.w3.org/ns/ldp#PreferContainment\"";
+        getMethod.addHeader("Prefer", preferHeader);
+
+        try (final CloseableHttpResponse response = execute(getMethod)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't matched", preferenceApplied.contains(preferHeader));
+        }
+    }
+
+    @Test
     public void testGetNonRDFSource() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", "some content");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -684,6 +684,26 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testDeleteContainerWithDepthHeaderSet() {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        HttpDelete httpDelete = deleteObjMethod(id);
+        httpDelete.addHeader("Depth", "infinity");
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpDelete));
+        assertDeleted(id);
+    }
+
+    @Test
+    public void testDeleteContainerWithIncorrectDepthHeaderSet() {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        HttpDelete httpDelete = deleteObjMethod(id);
+        httpDelete.addHeader("Depth", "0");
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(httpDelete));
+        assertNotDeleted(id);
+    }
+
+    @Test
     public void testDeleteHierarchy() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id + "/foo");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -687,7 +687,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testDeleteContainerWithDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
-        HttpDelete httpDelete = deleteObjMethod(id);
+        final HttpDelete httpDelete = deleteObjMethod(id);
         httpDelete.addHeader("Depth", "infinity");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpDelete));
         assertDeleted(id);
@@ -697,7 +697,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testDeleteContainerWithIncorrectDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
-        HttpDelete httpDelete = deleteObjMethod(id);
+        final HttpDelete httpDelete = deleteObjMethod(id);
         httpDelete.addHeader("Depth", "0");
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(httpDelete));
         assertNotDeleted(id);


### PR DESCRIPTION
- Adds logic to FedoraLdp.deleteObject() to check depth header for
containers
- Adds two new IT test cases
- Adds helper method to abstract IT class

Resolves: https://jira.duraspace.org/browse/FCREPO-2600