### PR TITLE
Fcrepo 2600 new

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -327,10 +327,14 @@ public class FedoraLdp extends ContentExposingResource {
     @Timed
     public Response deleteObject() {
 <<<<<<< HEAD
+<<<<<<< HEAD
         final FedoraResource resource = resource();
 =======
         FedoraResource resource = resource();
 >>>>>>> 406cd50... Adds support for depth header to DELETE action
+=======
+        final FedoraResource resource = resource();
+>>>>>>> d6882f6... corrects checkstyle errors
         if (resource instanceof ContainerImpl) {
             final String depth = headers.getHeaderString("Depth");
             System.out.println(depth);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -326,7 +326,11 @@ public class FedoraLdp extends ContentExposingResource {
     @DELETE
     @Timed
     public Response deleteObject() {
+<<<<<<< HEAD
         final FedoraResource resource = resource();
+=======
+        FedoraResource resource = resource();
+>>>>>>> 406cd50... Adds support for depth header to DELETE action
         if (resource instanceof ContainerImpl) {
             final String depth = headers.getHeaderString("Depth");
             System.out.println(depth);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -18,8 +18,8 @@
 package org.fcrepo.http.api;
 
 
-import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.nullToEmpty;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
@@ -102,11 +102,7 @@ import javax.ws.rs.core.Variant.VariantListBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.web.ContentType;
-<<<<<<< HEAD
 import org.apache.jena.rdf.model.Resource;
-
-=======
->>>>>>> b7a0011... Adds support for depth header to DELETE action
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.domain.ContentLocation;
 import org.fcrepo.http.commons.domain.PATCH;
@@ -126,11 +122,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
-<<<<<<< HEAD
-
-=======
 import org.fcrepo.kernel.modeshape.ContainerImpl;
->>>>>>> b7a0011... Adds support for depth header to DELETE action
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -326,15 +318,7 @@ public class FedoraLdp extends ContentExposingResource {
     @DELETE
     @Timed
     public Response deleteObject() {
-<<<<<<< HEAD
-<<<<<<< HEAD
         final FedoraResource resource = resource();
-=======
-        FedoraResource resource = resource();
->>>>>>> 406cd50... Adds support for depth header to DELETE action
-=======
-        final FedoraResource resource = resource();
->>>>>>> d6882f6... corrects checkstyle errors
         if (resource instanceof ContainerImpl) {
             final String depth = headers.getHeaderString("Depth");
             System.out.println(depth);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -122,7 +122,6 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
-import org.fcrepo.kernel.modeshape.ContainerImpl;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -318,24 +317,23 @@ public class FedoraLdp extends ContentExposingResource {
     @DELETE
     @Timed
     public Response deleteObject() {
-        final FedoraResource resource = resource();
-        if (resource instanceof ContainerImpl) {
+        if (resource() instanceof Container) {
             final String depth = headers.getHeaderString("Depth");
-            System.out.println(depth);
+            LOGGER.debug("Depth header value is: {}", depth);
             if (depth != null && !depth.equalsIgnoreCase("infinity")) {
                 throw new ClientErrorException("Depth header, if present, must be set to 'infinity' for containers",
                         SC_BAD_REQUEST);
             }
         }
 
-        evaluateRequestPreconditions(request, servletResponse, resource, session);
+        evaluateRequestPreconditions(request, servletResponse, resource(), session);
 
         LOGGER.info("Delete resource '{}'", externalPath);
 
-        final AcquiredLock lock = lockManager.lockForDelete(resource.getPath());
+        final AcquiredLock lock = lockManager.lockForDelete(resource().getPath());
 
         try {
-            resource.delete();
+            resource().delete();
             session.commit();
             return noContent().build();
         } finally {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -326,7 +326,7 @@ public class FedoraLdp extends ContentExposingResource {
     @DELETE
     @Timed
     public Response deleteObject() {
-        FedoraResource resource = resource();
+        final FedoraResource resource = resource();
         if (resource instanceof ContainerImpl) {
             final String depth = headers.getHeaderString("Depth");
             System.out.println(depth);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -102,8 +102,11 @@ import javax.ws.rs.core.Variant.VariantListBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.web.ContentType;
+<<<<<<< HEAD
 import org.apache.jena.rdf.model.Resource;
 
+=======
+>>>>>>> b7a0011... Adds support for depth header to DELETE action
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.domain.ContentLocation;
 import org.fcrepo.http.commons.domain.PATCH;
@@ -123,7 +126,11 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
+<<<<<<< HEAD
 
+=======
+import org.fcrepo.kernel.modeshape.ContainerImpl;
+>>>>>>> b7a0011... Adds support for depth header to DELETE action
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -319,14 +326,24 @@ public class FedoraLdp extends ContentExposingResource {
     @DELETE
     @Timed
     public Response deleteObject() {
-        evaluateRequestPreconditions(request, servletResponse, resource(), session);
+        FedoraResource resource = resource();
+        if (resource instanceof ContainerImpl) {
+            final String depth = headers.getHeaderString("Depth");
+            System.out.println(depth);
+            if (depth != null && !depth.equalsIgnoreCase("infinity")) {
+                throw new ClientErrorException("Depth header, if present, must be set to 'infinity' for containers",
+                        SC_BAD_REQUEST);
+            }
+        }
+
+        evaluateRequestPreconditions(request, servletResponse, resource, session);
 
         LOGGER.info("Delete resource '{}'", externalPath);
 
-        final AcquiredLock lock = lockManager.lockForDelete(resource().getPath());
+        final AcquiredLock lock = lockManager.lockForDelete(resource.getPath());
 
         try {
-            resource().delete();
+            resource.delete();
             session.commit();
             return noContent().build();
         } finally {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -50,8 +50,6 @@ import java.util.Collection;
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.DatatypeConverter;
 
-import org.fcrepo.http.commons.test.util.CloseableDataset;
-
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -76,6 +74,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -459,6 +458,12 @@ public abstract class AbstractResourceIT {
         final String location = serverAddress + id;
         assertThat("Expected object to be deleted", getStatus(new HttpHead(location)), is(GONE.getStatusCode()));
         assertThat("Expected object to be deleted", getStatus(new HttpGet(location)), is(GONE.getStatusCode()));
+    }
+
+    protected static void assertNotDeleted(final String id) {
+        final String location = serverAddress + id;
+        assertThat("Expected object not to be deleted", getStatus(new HttpHead(location)), is(OK.getStatusCode()));
+        assertThat("Expected object not to be deleted", getStatus(new HttpGet(location)), is(OK.getStatusCode()));
     }
 
     protected static String getTTLThatUpdatesServerManagedTriples(final String createdBy, final Calendar created,

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -687,15 +687,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testDeleteContainerWithDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
-<<<<<<< HEAD
-<<<<<<< HEAD
         final HttpDelete httpDelete = deleteObjMethod(id);
-=======
-        HttpDelete httpDelete = deleteObjMethod(id);
->>>>>>> 406cd50... Adds support for depth header to DELETE action
-=======
-        final HttpDelete httpDelete = deleteObjMethod(id);
->>>>>>> d6882f6... corrects checkstyle errors
         httpDelete.addHeader("Depth", "infinity");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpDelete));
         assertDeleted(id);
@@ -705,15 +697,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testDeleteContainerWithIncorrectDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
-<<<<<<< HEAD
-<<<<<<< HEAD
         final HttpDelete httpDelete = deleteObjMethod(id);
-=======
-        HttpDelete httpDelete = deleteObjMethod(id);
->>>>>>> 406cd50... Adds support for depth header to DELETE action
-=======
-        final HttpDelete httpDelete = deleteObjMethod(id);
->>>>>>> d6882f6... corrects checkstyle errors
         httpDelete.addHeader("Depth", "0");
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(httpDelete));
         assertNotDeleted(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -684,6 +684,26 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testDeleteContainerWithDepthHeaderSet() {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        HttpDelete httpDelete = deleteObjMethod(id);
+        httpDelete.addHeader("Depth", "infinity");
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpDelete));
+        assertDeleted(id);
+    }
+
+    @Test
+    public void testDeleteContainerWithIncorrectDepthHeaderSet() {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        HttpDelete httpDelete = deleteObjMethod(id);
+        httpDelete.addHeader("Depth", "0");
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(httpDelete));
+        assertNotDeleted(id);
+    }
+
+    @Test
     public void testDeleteHierarchy() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id + "/foo");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -687,7 +687,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testDeleteContainerWithDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
+<<<<<<< HEAD
         final HttpDelete httpDelete = deleteObjMethod(id);
+=======
+        HttpDelete httpDelete = deleteObjMethod(id);
+>>>>>>> 406cd50... Adds support for depth header to DELETE action
         httpDelete.addHeader("Depth", "infinity");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpDelete));
         assertDeleted(id);
@@ -697,7 +701,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testDeleteContainerWithIncorrectDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
+<<<<<<< HEAD
         final HttpDelete httpDelete = deleteObjMethod(id);
+=======
+        HttpDelete httpDelete = deleteObjMethod(id);
+>>>>>>> 406cd50... Adds support for depth header to DELETE action
         httpDelete.addHeader("Depth", "0");
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(httpDelete));
         assertNotDeleted(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -687,7 +687,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testDeleteContainerWithDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
-        HttpDelete httpDelete = deleteObjMethod(id);
+        final HttpDelete httpDelete = deleteObjMethod(id);
         httpDelete.addHeader("Depth", "infinity");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpDelete));
         assertDeleted(id);
@@ -697,7 +697,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testDeleteContainerWithIncorrectDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
-        HttpDelete httpDelete = deleteObjMethod(id);
+        final HttpDelete httpDelete = deleteObjMethod(id);
         httpDelete.addHeader("Depth", "0");
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(httpDelete));
         assertNotDeleted(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -688,10 +688,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
 <<<<<<< HEAD
+<<<<<<< HEAD
         final HttpDelete httpDelete = deleteObjMethod(id);
 =======
         HttpDelete httpDelete = deleteObjMethod(id);
 >>>>>>> 406cd50... Adds support for depth header to DELETE action
+=======
+        final HttpDelete httpDelete = deleteObjMethod(id);
+>>>>>>> d6882f6... corrects checkstyle errors
         httpDelete.addHeader("Depth", "infinity");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpDelete));
         assertDeleted(id);
@@ -702,10 +706,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
 <<<<<<< HEAD
+<<<<<<< HEAD
         final HttpDelete httpDelete = deleteObjMethod(id);
 =======
         HttpDelete httpDelete = deleteObjMethod(id);
 >>>>>>> 406cd50... Adds support for depth header to DELETE action
+=======
+        final HttpDelete httpDelete = deleteObjMethod(id);
+>>>>>>> d6882f6... corrects checkstyle errors
         httpDelete.addHeader("Depth", "0");
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(httpDelete));
         assertNotDeleted(id);


### PR DESCRIPTION
Adds support for depth headers to http DELETE method

- Adds logic to FedoraLdp.deleteObject() to check depth header for
containers
- Adds two new IT test cases
- Adds helper method to abstract IT class

Resolves: https://jira.duraspace.org/browse/FCREPO-2600