### PR TITLE
Unsupported external-body access-types now result in 415 Unsupported …

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -138,9 +138,6 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public abstract class ContentExposingResource extends FedoraBaseResource {
 
-    /**
-     * 
-     */
     private static final String ACCESS_TYPE = "access-type";
     private static final String URL_ACCESS_TYPE = "URL";
     private static final Logger LOGGER = getLogger(ContentExposingResource.class);
@@ -231,7 +228,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * Throws a NotSupportedException if media type is an invalid message/external-body type. To be valid it must
      * contain the access-type parameter that equals a valid access type and a URL parameter that contains a URL.
      * 
-     * @param mediaType
+     * @param mediaType The media type to be validated
      * @throws NotSupportedException
      */
     protected void checkExternalBody(final MediaType mediaType) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -70,7 +70,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -219,15 +218,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     protected URI getExternalResourceLocation(final MediaType mediaType) throws UnsupportedAccessTypeException {
         return URI.create(MessageExternalBodyContentType.parse(mediaType.toString()).getResourceLocation());
-    }
-
-    protected String getAccessTypeValue(final Map<String, String> params, final String accessType) {
-        for (String key : params.keySet()) {
-            if (key.equalsIgnoreCase(accessType)) {
-                return params.get(key);
-            }
-        }
-        return null;
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -124,6 +124,8 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
+import org.fcrepo.kernel.api.utils.MessageExternalBodyContentType;
+
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -210,8 +212,7 @@ public class FedoraLdp extends ContentExposingResource {
             final MediaType mediaType = MediaType.valueOf(((FedoraBinary) resource()).getMimeType());
 
             if (isExternalBody(mediaType)) {
-                checkExternalBody(mediaType);
-                builder = externalBodyRedirect(getURLAccessType(mediaType));
+                builder = externalBodyRedirect(getExternalResourceLocation(mediaType));
             }
 
             // we set the content-type explicitly to avoid content-negotiation from getting in the way
@@ -372,12 +373,13 @@ public class FedoraLdp extends ContentExposingResource {
             @HeaderParam("If-Match") final String ifMatch,
             @HeaderParam(LINK) final List<String> links,
             @HeaderParam("Digest") final String digest)
-            throws InvalidChecksumException, MalformedRdfException, UnsupportedAlgorithmException {
+            throws InvalidChecksumException, MalformedRdfException, UnsupportedAlgorithmException,
+            UnsupportedAccessTypeException {
 
         final String interactionModel = checkInteractionModel(links);
 
         if (isExternalBody(requestContentType)) {
-            checkExternalBody(requestContentType);
+            checkMessageExternalBody(requestContentType);
         }
 
         final FedoraResource resource;
@@ -443,6 +445,10 @@ public class FedoraLdp extends ContentExposingResource {
         } finally {
             lock.release();
         }
+    }
+
+    private void checkMessageExternalBody(final MediaType requestContentType) throws UnsupportedAccessTypeException {
+        MessageExternalBodyContentType.parse(requestContentType.toString());
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -556,9 +556,14 @@ public class FedoraLdp extends ContentExposingResource {
                                  @ContentLocation final InputStream requestBodyStream,
                                  @HeaderParam(LINK) final List<String> links,
                                  @HeaderParam("Digest") final String digest)
-            throws InvalidChecksumException, IOException, MalformedRdfException, UnsupportedAlgorithmException {
+            throws InvalidChecksumException, IOException, MalformedRdfException, UnsupportedAlgorithmException,
+            UnsupportedAccessTypeException {
 
         final String interactionModel = checkInteractionModel(links);
+
+        if (isExternalBody(requestContentType)) {
+            checkMessageExternalBody(requestContentType);
+        }
 
         if (!(resource() instanceof Container)) {
             throw new ClientErrorException("Object cannot have child nodes", CONFLICT);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersions.java
@@ -46,6 +46,8 @@ import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
+
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
 
@@ -137,7 +139,8 @@ public class FedoraVersions extends ContentExposingResource {
     @Produces({TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8", N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET,
             RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET, TURTLE_X,
             TEXT_HTML_WITH_CHARSET, "*/*"})
-    public Response getVersion(@HeaderParam("Range") final String rangeValue) throws IOException {
+    public Response getVersion(@HeaderParam("Range") final String rangeValue) throws IOException,
+            UnsupportedAccessTypeException {
         LOGGER.trace("Getting version profile for: {} at version: {}", path,
                 label);
         checkCacheControlHeaders(request, servletResponse, resource(), session);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -918,7 +918,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObject() throws MalformedRdfException, InvalidChecksumException,
-           IOException, UnsupportedAlgorithmException {
+           IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, null, "b", null, null, null);
@@ -927,7 +927,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObjectWithSparql() throws MalformedRdfException,
-           InvalidChecksumException, UnsupportedAlgorithmException, IOException {
+           InvalidChecksumException, UnsupportedAlgorithmException, IOException, UnsupportedAccessTypeException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null,
@@ -938,7 +938,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObjectWithRdf() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, NTRIPLES_TYPE, "b",
@@ -950,7 +950,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinary() throws MalformedRdfException, InvalidChecksumException,
-           IOException, UnsupportedAlgorithmException {
+           IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {
@@ -963,7 +963,7 @@ public class FedoraLdpTest {
 
     @Test(expected = InsufficientStorageException.class)
     public void testCreateNewBinaryWithInsufficientResources() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
 
@@ -984,7 +984,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithContentTypeWithParams() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -999,7 +999,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumSHA() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -1017,7 +1017,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumMD5() throws MalformedRdfException,
-            InvalidChecksumException, IOException, UnsupportedAlgorithmException {
+            InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -1035,7 +1035,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumSHAandMD5() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
+           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -1062,7 +1062,7 @@ public class FedoraLdpTest {
 
     @Test(expected = ClientErrorException.class)
     public void testPostToBinary() throws MalformedRdfException, InvalidChecksumException, IOException,
-            UnsupportedAlgorithmException {
+            UnsupportedAlgorithmException, UnsupportedAccessTypeException {
         final FedoraBinary mockObject = (FedoraBinary)setResource(FedoraBinary.class);
         doReturn(mockObject).when(testObj).resource();
         testObj.createObject(null, null, null, null, null, null);
@@ -1070,7 +1070,7 @@ public class FedoraLdpTest {
 
     @Test(expected = CannotCreateResourceException.class)
     public void testLDPRNotImplemented() throws MalformedRdfException, InvalidChecksumException,
-            IOException, UnsupportedAlgorithmException {
+            IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/x")).thenReturn(mockContainer);
         testObj.createObject(null, null, "x", null, asList("<http://www.w3.org/ns/ldp#Resource>; rel=\"type\""), null);
@@ -1078,7 +1078,7 @@ public class FedoraLdpTest {
 
     @Test(expected = ClientErrorException.class)
     public void testLDPRNotImplementedInvalidLink() throws MalformedRdfException, InvalidChecksumException,
-            IOException, UnsupportedAlgorithmException {
+            IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/x")).thenReturn(mockContainer);
         testObj.createObject(null, null, "x", null, asList("<http://foo;rel=\"type\""), null);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -33,6 +33,7 @@ import static javax.ws.rs.core.Response.Status.NOT_MODIFIED;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.TEMPORARY_REDIRECT;
+import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
@@ -721,6 +722,15 @@ public class FedoraLdpTest {
         assertEquals(new URI("some:uri"), actual.getLocation());
     }
 
+    @Test(expected = UnsupportedAccessTypeException.class)
+    public void testGetWithExternalMessageMissingURLBinary() throws Exception {
+        final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
+        when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
+        when(mockResource.getMimeType()).thenReturn("message/external-body; access-type=URL;");
+        when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
+        final Response actual = testObj.getResource(null);
+        assertEquals(UNSUPPORTED_MEDIA_TYPE.getStatusCode(), actual.getStatus());
+    }
 
     @Test
     @SuppressWarnings({"resource", "unchecked"})

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2756,6 +2756,62 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testUnsupportedAccessTypeInExternalMessage() throws IOException {
+
+        // we need a client that won't automatically follow redirects
+        try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
+                .build()) {
+
+            final String id = getRandomUniqueId();
+            final HttpPut httpPut = putObjMethod(id);
+            httpPut.addHeader(CONTENT_TYPE, "message/external-body; access-type=ftp; " +
+                    "URL=\"ftp://www.example.com/file\"");
+
+            try (final CloseableHttpResponse response = execute(httpPut)) {
+                assertEquals("Didn't get an UNSUPPORTED_MEDIA_TYPE response!", UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
+                        getStatus(response));
+            }
+        }
+    }
+
+    @Test
+    public void testMissingAccessTypeInExternalMessage() throws IOException {
+
+        // we need a client that won't automatically follow redirects
+        try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
+                .build()) {
+
+            final String id = getRandomUniqueId();
+            final HttpPut httpPut = putObjMethod(id);
+            httpPut.addHeader(CONTENT_TYPE, "message/external-body; " +
+                    "URL=\"http://www.example.com/file\"");
+
+            try (final CloseableHttpResponse response = execute(httpPut)) {
+                assertEquals("Didn't get an UNSUPPORTED_MEDIA_TYPE response!", UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
+                        getStatus(response));
+            }
+        }
+    }
+
+    @Test
+    public void testInvalidExternalMessageBodyMissingURL() throws IOException {
+
+        // we need a client that won't automatically follow redirects
+        try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
+                .build()) {
+
+            final String id = getRandomUniqueId();
+            final HttpPut httpPut = putObjMethod(id);
+            httpPut.addHeader(CONTENT_TYPE, "message/external-body; access-type=URL; ");
+
+            try (final CloseableHttpResponse response = execute(httpPut)) {
+                assertEquals("Didn't get a UNSUPPORTED_MEDIA_TYPE response!", UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
+                        getStatus(response));
+            }
+        }
+    }
+
+    @Test
     public void testJsonLdProfileCompacted() throws IOException {
         // Create a resource
         final HttpPost method = postObjMethod();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2756,7 +2756,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testUnsupportedAccessTypeInExternalMessage() throws IOException {
+    public void testUnsupportedAccessTypeInExternalMessagePUT() throws IOException {
 
         // we need a client that won't automatically follow redirects
         try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
@@ -2768,6 +2768,25 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     "URL=\"ftp://www.example.com/file\"");
 
             try (final CloseableHttpResponse response = execute(httpPut)) {
+                assertEquals("Didn't get an UNSUPPORTED_MEDIA_TYPE response!", UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
+                        getStatus(response));
+            }
+        }
+    }
+
+    @Test
+    public void testUnsupportedAccessTypeInExternalMessagePOST() throws IOException {
+
+        // we need a client that won't automatically follow redirects
+        try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
+                .build()) {
+
+            final String id = getRandomUniqueId();
+            final HttpPost httpPost = postObjMethod(id);
+            httpPost.addHeader(CONTENT_TYPE, "message/external-body; access-type=ftp; " +
+                    "URL=\"ftp://www.example.com/file\"");
+
+            try (final CloseableHttpResponse response = execute(httpPost)) {
                 assertEquals("Didn't get an UNSUPPORTED_MEDIA_TYPE response!", UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
                         getStatus(response));
             }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2783,18 +2783,18 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String id = getRandomUniqueId();
             final HttpPut httpPut = putObjMethod(id);
-            httpPut.addHeader(CONTENT_TYPE, "message/external-body; " +
+            httpPut.addHeader(CONTENT_TYPE, "message/external-body; accept-type;" +
                     "URL=\"http://www.example.com/file\"");
 
             try (final CloseableHttpResponse response = execute(httpPut)) {
-                assertEquals("Didn't get an UNSUPPORTED_MEDIA_TYPE response!", UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
+                assertEquals("Didn't get an BAD REQUEST response!", BAD_REQUEST.getStatusCode(),
                         getStatus(response));
             }
         }
     }
 
     @Test
-    public void testInvalidExternalMessageBodyMissingURL() throws IOException {
+    public void testInvalidExternalMessageBodyMissingURLParam() throws IOException {
 
         // we need a client that won't automatically follow redirects
         try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
@@ -2805,7 +2805,42 @@ public class FedoraLdpIT extends AbstractResourceIT {
             httpPut.addHeader(CONTENT_TYPE, "message/external-body; access-type=URL; ");
 
             try (final CloseableHttpResponse response = execute(httpPut)) {
-                assertEquals("Didn't get a UNSUPPORTED_MEDIA_TYPE response!", UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
+                assertEquals("Didn't get a BAD REQUEST response!", BAD_REQUEST.getStatusCode(),
+                        getStatus(response));
+            }
+        }
+    }
+
+    @Test
+    public void testInvalidExternalMessageBodyMissingURLValue() throws IOException {
+
+        // we need a client that won't automatically follow redirects
+        try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
+                .build()) {
+
+            final String id = getRandomUniqueId();
+            final HttpPut httpPut = putObjMethod(id);
+            httpPut.addHeader(CONTENT_TYPE, "message/external-body; access-type=URL; URL");
+
+            try (final CloseableHttpResponse response = execute(httpPut)) {
+                assertEquals("Didn't get an UNSUPPORTED_MEDIA_TYPE response!", BAD_REQUEST.getStatusCode(),
+                        getStatus(response));
+            }
+        }
+    }
+
+    @Test
+    public void testWildcardExternalMessageBodyWithValidAccessType() throws IOException {
+        // we need a client that won't automatically follow redirects
+        try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
+                .build()) {
+
+            final String id = getRandomUniqueId();
+            final HttpPut httpPut = putObjMethod(id);
+            httpPut.addHeader(CONTENT_TYPE, "*/*; access-type=url; url=\"some://url\"");
+
+            try (final CloseableHttpResponse response = execute(httpPut)) {
+                assertEquals("wasn't successful", CREATED.getStatusCode(),
                         getStatus(response));
             }
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2787,7 +2787,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     "URL=\"http://www.example.com/file\"");
 
             try (final CloseableHttpResponse response = execute(httpPut)) {
-                assertEquals("Didn't get an BAD REQUEST response!", BAD_REQUEST.getStatusCode(),
+                assertEquals("Didn't get a BAD_REQUEST response!", BAD_REQUEST.getStatusCode(),
                         getStatus(response));
             }
         }
@@ -2805,7 +2805,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             httpPut.addHeader(CONTENT_TYPE, "message/external-body; access-type=URL; ");
 
             try (final CloseableHttpResponse response = execute(httpPut)) {
-                assertEquals("Didn't get a BAD REQUEST response!", BAD_REQUEST.getStatusCode(),
+                assertEquals("Didn't get an UNSUPPORTED_MEDIA_TYPE response!", UNSUPPORTED_MEDIA_TYPE.getStatusCode(),
                         getStatus(response));
             }
         }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/UnsupportedAccessTypeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/UnsupportedAccessTypeExceptionMapper.java
@@ -18,7 +18,7 @@
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -47,7 +47,7 @@ public class UnsupportedAccessTypeExceptionMapper implements
 
         debugException(this, e, LOGGER);
 
-        return status(CONFLICT).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
+        return status(UNSUPPORTED_MEDIA_TYPE).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 
 }

--- a/fcrepo-integration-ldp/src/test/java/org/fcrepo/integration/ldp/LdpTestSuiteIT.java
+++ b/fcrepo-integration-ldp/src/test/java/org/fcrepo/integration/ldp/LdpTestSuiteIT.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentType.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentType.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Splitter;
+
+/**
+ * @author lsitu
+ * @author Daniel Bernstein
+ */
+public class MessageExternalBodyContentType {
+
+    public final static String MEDIA_TYPE = "message/external-body";
+
+    private final static String MIME_TYPE_FIELD = "mime-type";
+
+    /**
+     * Utility method to parse the external body content in format: message/external-body; access-type=URL;
+     * url="http://www.example.com/file"
+     * 
+     * @param mimeType the MimeType value for external resource
+     * @return MessageExternalBodyContentType value
+     * @throws UnsupportedAccessTypeException if mimeType param is not a valid message/external-body content type.
+     */
+    public static MessageExternalBodyContentType parse(final String mimeType) throws UnsupportedAccessTypeException {
+        final Map<String, String> map = new HashMap<String, String>();
+        Splitter.on(';').omitEmptyStrings().trimResults()
+                .withKeyValueSeparator(Splitter.on('=').limit(2)).split(MIME_TYPE_FIELD + "=" + mimeType.trim())
+                // use lower case for keys, unwrap the quoted values (double quotes at the beginning and the end)
+                .forEach((k, v) -> map.put(k.toLowerCase(), v.replaceAll("^\"|\"$", "")));
+
+        final String accessType = map.get("access-type").toLowerCase();
+        final String resourceLocation = map.get(accessType);
+        if (MEDIA_TYPE.equals(map.get(MIME_TYPE_FIELD)) &&
+                "url".equals(accessType) &&
+                !StringUtils.isBlank(resourceLocation)) {
+            return new MessageExternalBodyContentType(accessType, resourceLocation);
+        }
+
+        throw new UnsupportedAccessTypeException(
+                "The specified type is not a valid message/external body content type: value=" + mimeType);
+
+    }
+
+    private String accessType;
+
+    private String resourceLocation;
+
+    private MessageExternalBodyContentType(final String accessType, final String resourceLocation) {
+        this.accessType = accessType;
+        this.resourceLocation = resourceLocation;
+    }
+
+    /**
+     * @return
+     */
+    public String getResourceLocation() {
+        return this.resourceLocation;
+    }
+
+    /**
+     * @return the accessType
+     */
+    public String getAccessType() {
+        return accessType;
+    }
+}

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentTypeTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentTypeTest.java
@@ -30,10 +30,9 @@ import org.junit.Test;
  */
 public class MessageExternalBodyContentTypeTest {
 
-    public static String RESOURCE_URL = "http://www.example.com/file";
+    private static String RESOURCE_URL = "http://www.example.com/file";
 
-    private static String EXTERNAL_RESOURCE = "message/external-body;" + " access-type=URL; URL=\"" + RESOURCE_URL +
-            "\"";
+    private static String EXTERNAL_RESOURCE = "message/external-body; access-type=URL; URL=\"" + RESOURCE_URL + "\"";
 
     @Test
     public void testParseExternalBody() throws UnsupportedAccessTypeException {
@@ -45,25 +44,39 @@ public class MessageExternalBodyContentTypeTest {
     @Test(expected = UnsupportedAccessTypeException.class)
     public void testParseExternalBodyInvalidAccessType() throws UnsupportedAccessTypeException {
         MessageExternalBodyContentType.parse(
-                "message/external-body;" + " access-type=ftp; URL=\"" + RESOURCE_URL + "\"");
+                "message/external-body; access-type=ftp; URL=\"" + RESOURCE_URL + "\"");
     }
 
     @Test(expected = UnsupportedAccessTypeException.class)
     public void testParseExternalBodyInvalidAccessTypeBlankURL() throws UnsupportedAccessTypeException {
         MessageExternalBodyContentType.parse(
-                "message/external-body;" + " access-type=ftp; URL=\"\"");
+                "message/external-body; access-type=ftp; URL=\"\"");
+    }
+
+    public void testParseExternalBodyAccessTypeCaseInsensitive() throws UnsupportedAccessTypeException {
+        final MessageExternalBodyContentType contentType = MessageExternalBodyContentType.parse(
+                "invalid/mimetype; access-type=url; URL=\"" + RESOURCE_URL + "\"");
+        assertEquals("Access-type doesn't match.", "url", contentType.getAccessType());
+        assertEquals("URL doesn't match.", RESOURCE_URL, contentType.getResourceLocation());
+    }
+
+    public void testParseExternalBodyLocationKeyCaseInsensitive() throws UnsupportedAccessTypeException {
+        final MessageExternalBodyContentType contentType = MessageExternalBodyContentType.parse(
+                "invalid/mimetype; access-type=URL; url=\"" + RESOURCE_URL + "\"");
+        assertEquals("Access-type doesn't match.", "url", contentType.getAccessType());
+        assertEquals("URL doesn't match.", RESOURCE_URL, contentType.getResourceLocation());
     }
 
     @Test(expected = UnsupportedAccessTypeException.class)
     public void testParseExternalBodyInvalidMimeType() throws UnsupportedAccessTypeException {
         MessageExternalBodyContentType.parse(
-                "invalid/mimetype;" + " access-type=url; URL=\"\"");
+                "invalid/mimetype; access-type=url; URL=\"\"");
     }
 
     @Test(expected = UnsupportedAccessTypeException.class)
     public void testParseExternalBodyMissingURL() throws UnsupportedAccessTypeException {
         MessageExternalBodyContentType.parse(
-                "invalid/mimetype;" + " access-type=url;");
+                "message/mimetype; access-type=url;");
     }
 
 }

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentTypeTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentTypeTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
+
+import org.junit.Test;
+
+/**
+ * @author lsitu
+ * @author dbernstein
+ */
+public class MessageExternalBodyContentTypeTest {
+
+    public static String RESOURCE_URL = "http://www.example.com/file";
+
+    private static String EXTERNAL_RESOURCE = "message/external-body;" + " access-type=URL; URL=\"" + RESOURCE_URL +
+            "\"";
+
+    @Test
+    public void testParseExternalBody() throws UnsupportedAccessTypeException {
+        final MessageExternalBodyContentType contentType = MessageExternalBodyContentType.parse(EXTERNAL_RESOURCE);
+        assertEquals("Access-type doesn't match.", "url", contentType.getAccessType());
+        assertEquals("URL doesn't match.", RESOURCE_URL, contentType.getResourceLocation());
+    }
+
+    @Test(expected = UnsupportedAccessTypeException.class)
+    public void testParseExternalBodyInvalidAccessType() throws UnsupportedAccessTypeException {
+        MessageExternalBodyContentType.parse(
+                "message/external-body;" + " access-type=ftp; URL=\"" + RESOURCE_URL + "\"");
+    }
+
+    @Test(expected = UnsupportedAccessTypeException.class)
+    public void testParseExternalBodyInvalidAccessTypeBlankURL() throws UnsupportedAccessTypeException {
+        MessageExternalBodyContentType.parse(
+                "message/external-body;" + " access-type=ftp; URL=\"\"");
+    }
+
+    @Test(expected = UnsupportedAccessTypeException.class)
+    public void testParseExternalBodyInvalidMimeType() throws UnsupportedAccessTypeException {
+        MessageExternalBodyContentType.parse(
+                "invalid/mimetype;" + " access-type=url; URL=\"\"");
+    }
+
+    @Test(expected = UnsupportedAccessTypeException.class)
+    public void testParseExternalBodyMissingURL() throws UnsupportedAccessTypeException {
+        MessageExternalBodyContentType.parse(
+                "invalid/mimetype;" + " access-type=url;");
+    }
+
+}

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentTypeTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentTypeTest.java
@@ -55,14 +55,14 @@ public class MessageExternalBodyContentTypeTest {
 
     public void testParseExternalBodyAccessTypeCaseInsensitive() throws UnsupportedAccessTypeException {
         final MessageExternalBodyContentType contentType = MessageExternalBodyContentType.parse(
-                "invalid/mimetype; access-type=url; URL=\"" + RESOURCE_URL + "\"");
+                "message/external-body; access-type=url; URL=\"" + RESOURCE_URL + "\"");
         assertEquals("Access-type doesn't match.", "url", contentType.getAccessType());
         assertEquals("URL doesn't match.", RESOURCE_URL, contentType.getResourceLocation());
     }
 
     public void testParseExternalBodyLocationKeyCaseInsensitive() throws UnsupportedAccessTypeException {
         final MessageExternalBodyContentType contentType = MessageExternalBodyContentType.parse(
-                "invalid/mimetype; access-type=URL; url=\"" + RESOURCE_URL + "\"");
+                "message/external-body; access-type=URL; url=\"" + RESOURCE_URL + "\"");
         assertEquals("Access-type doesn't match.", "url", contentType.getAccessType());
         assertEquals("URL doesn't match.", RESOURCE_URL, contentType.getResourceLocation());
     }
@@ -70,13 +70,13 @@ public class MessageExternalBodyContentTypeTest {
     @Test(expected = UnsupportedAccessTypeException.class)
     public void testParseExternalBodyInvalidMimeType() throws UnsupportedAccessTypeException {
         MessageExternalBodyContentType.parse(
-                "invalid/mimetype; access-type=url; URL=\"\"");
+                "invalid/mimetype; access-type=url; URL=\"" + RESOURCE_URL + "\"");
     }
 
     @Test(expected = UnsupportedAccessTypeException.class)
     public void testParseExternalBodyMissingURL() throws UnsupportedAccessTypeException {
         MessageExternalBodyContentType.parse(
-                "message/mimetype; access-type=url;");
+                "message/external-body; access-type=url;");
     }
 
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
@@ -394,7 +394,7 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
         try (final Timer.Context context = timer.time()) {
 
             final String mimeType = getMimeType();
-            if (mimeType.contains(CacheEntryFactory.MESSAGE_EXTERNAL_BODY)) {
+            if (mimeType.contains(MessageExternalBodyContentType.MEDIA_TYPE)) {
                 final MessageExternalBodyContentType externalBody = MessageExternalBodyContentType.parse(mimeType);
                 final String resourceLocation = externalBody.getResourceLocation();
                 LOGGER.debug("Checking external resource: " + resourceLocation);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
@@ -36,6 +36,7 @@ import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.utils.CacheEntry;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.fcrepo.kernel.api.utils.FixityResult;
+import org.fcrepo.kernel.api.utils.MessageExternalBodyContentType;
 import org.fcrepo.kernel.modeshape.rdf.impl.FixityRdfContext;
 import org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils;
 import org.fcrepo.kernel.modeshape.utils.impl.CacheEntryFactory;
@@ -394,18 +395,10 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
 
             final String mimeType = getMimeType();
             if (mimeType.contains(CacheEntryFactory.MESSAGE_EXTERNAL_BODY)) {
-                final Map<String, String> params = CacheEntryFactory.parseExternalBody(mimeType);
-                final String accessType = params.get("access-type");
-                final String resourceLocation = params.get(accessType.toLowerCase());
-
-                if (accessType != null && accessType.equals("URL")) {
-                    LOGGER.debug("Checking external resource: " + resourceLocation);
-
-                    return CacheEntryFactory.forProperty(getProperty(HAS_MIME_TYPE)).checkFixity(algorithms);
-                } else {
-                    throw new UnsupportedAccessTypeException("Unsupported access-type " + accessType
-                            + " with external resource " + resourceLocation + ".");
-                }
+                final MessageExternalBodyContentType externalBody = MessageExternalBodyContentType.parse(mimeType);
+                final String resourceLocation = externalBody.getResourceLocation();
+                LOGGER.debug("Checking external resource: " + resourceLocation);
+                return CacheEntryFactory.forProperty(getProperty(HAS_MIME_TYPE)).checkFixity(algorithms);
             } else {
 
                 LOGGER.debug("Checking resource: " + getPath());

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/ExternalResourceCacheEntry.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/ExternalResourceCacheEntry.java
@@ -21,13 +21,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.util.Map;
 
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.modeshape.utils.impl.CacheEntryFactory;
+import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
+import org.fcrepo.kernel.api.utils.MessageExternalBodyContentType;
 
 /**
  * Cache entry that wraps a binary stream for External Resource
@@ -67,9 +67,8 @@ public class ExternalResourceCacheEntry extends BinaryCacheEntry {
     @Override
     public String getExternalIdentifier() {
         try {
-            final Map<String, String> params = CacheEntryFactory.parseExternalBody(property().getValue().getString());
-            return params.get(params.get("access-type").toLowerCase());
-        } catch (final RepositoryException e) {
+            return MessageExternalBodyContentType.parse(property().getValue().getString()).getResourceLocation();
+        } catch (final RepositoryException | UnsupportedAccessTypeException e) {
             throw new RepositoryRuntimeException(e);
         }
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/impl/CacheEntryFactory.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/impl/CacheEntryFactory.java
@@ -17,16 +17,11 @@
  */
 package org.fcrepo.kernel.modeshape.utils.impl;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.fcrepo.kernel.api.utils.CacheEntry;
 import org.fcrepo.kernel.modeshape.utils.BinaryCacheEntry;
 import org.fcrepo.kernel.modeshape.utils.ExternalResourceCacheEntry;
 import org.fcrepo.kernel.modeshape.utils.ProjectedCacheEntry;
 import org.modeshape.jcr.value.binary.ExternalBinaryValue;
-
-import com.google.common.base.Splitter;
 
 import javax.jcr.Binary;
 import javax.jcr.Property;
@@ -63,20 +58,5 @@ public final class CacheEntryFactory {
             }
             return new BinaryCacheEntry(property);
         }
-    }
-
-    /**
-     * Utility method to parse the external body content in format:
-     *   message/external-body; access-type=URL; url="http://www.example.com/file"
-     * @param mimeType the MimeType value for external resource
-     * @return Map with key mime-type for MimeType value.
-     */
-    public static Map<String, String> parseExternalBody(final String mimeType) {
-        final Map<String, String> params = new HashMap<String, String>();
-        Splitter.on(';').omitEmptyStrings().trimResults()
-            .withKeyValueSeparator(Splitter.on('=').limit(2)).split("mime-type=" + mimeType.trim())
-             // use lower case for keys, unwrap the quoted values (double quotes at the beginning and the end)
-            .forEach((k, v) -> params.put(k.toLowerCase(), v.replaceAll("^\"|\"$", "")));
-        return params;
     }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/impl/CacheEntryFactory.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/impl/CacheEntryFactory.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.modeshape.utils.impl;
 
 import org.fcrepo.kernel.api.utils.CacheEntry;
+import org.fcrepo.kernel.api.utils.MessageExternalBodyContentType;
 import org.fcrepo.kernel.modeshape.utils.BinaryCacheEntry;
 import org.fcrepo.kernel.modeshape.utils.ExternalResourceCacheEntry;
 import org.fcrepo.kernel.modeshape.utils.ProjectedCacheEntry;
@@ -33,8 +34,6 @@ import javax.jcr.RepositoryException;
  */
 public final class CacheEntryFactory {
 
-    public static String MESSAGE_EXTERNAL_BODY = "message/external-body";
-
     /**
      * No public constructor on utility class
      */
@@ -48,7 +47,7 @@ public final class CacheEntryFactory {
      * @throws RepositoryException if repository exception occurred
      */
     public static CacheEntry forProperty(final Property property) throws RepositoryException {
-        if (property.getValue().getString().indexOf((MESSAGE_EXTERNAL_BODY)) >= 0) {
+        if (property.getValue().getString().indexOf((MessageExternalBodyContentType.MEDIA_TYPE)) >= 0) {
             return new ExternalResourceCacheEntry(property);
         } else {
             final Binary binary = property.getBinary();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/impl/CacheEntryFactoryTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/impl/CacheEntryFactoryTest.java
@@ -17,11 +17,8 @@
  */
 package org.fcrepo.kernel.modeshape.utils.impl;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
-
-import java.util.Map;
 
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
@@ -62,13 +59,5 @@ public class CacheEntryFactoryTest {
     public void testForProperty() throws RepositoryException {
         final CacheEntry instance = CacheEntryFactory.forProperty(mockProperty);
         assertTrue("CacheEntry class isn't correct", instance instanceof ExternalResourceCacheEntry);
-    }
-
-    @Test
-    public void testParseExternalBody() {
-        final Map<String, String> params = CacheEntryFactory.parseExternalBody(EXTERNAL_RESOURCE);
-        assertEquals("Mime-type doesn't match.", "message/external-body", params.get("mime-type"));
-        assertEquals("Access-type doesn't match.", "URL", params.get("access-type"));
-        assertEquals("URL doesn't match.", RESOURCE_URL, params.get("url"));
     }
 }


### PR DESCRIPTION
…Media Type.

Resolves: https://jira.duraspace.org/browse/FCREPO-2586

**JIRA Ticket**: (link)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
It ensures that unsupported external-body access-types now result in 415 Unsupported Media Type.

# How should this be tested?
0. build and fire up fedora.
1. run `curl -XPUT -H"Content-Type: message/external-body; access-type=ftp; NAME=\"/some/file\"; site=\"example.com\"" -i localhost:8080/rest/external`
2. Verify that 415 http is returned.


# Additional Notes:
If a fedora binary has an invalid external-body content type associated with it,  a GET request for that resource will fail with a 415.  Previously GET requests would not fail.  

# Interested parties
@escowles 
