### PR TITLE
Make user identities available as URIs in kernel API.

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraSession.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraSession.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.api;
 
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -64,6 +65,12 @@ public interface FedoraSession {
      * @return the session id
      */
     String getId();
+
+    /**
+     * Get the user agent
+     * @return URI
+     */
+    URI getUserAgent();
 
     /**
      * Get the user identifier associated with this session

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraSessionImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraSessionImpl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.modeshape;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.Long.parseLong;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofMinutes;
@@ -25,6 +26,7 @@ import static java.util.Collections.singleton;
 import static java.util.Optional.of;
 import static java.util.UUID.randomUUID;
 
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -42,6 +44,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
+import org.fcrepo.kernel.api.exception.RepositoryConfigurationException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.modeshape.utils.NamespaceTools;
 
@@ -57,6 +60,9 @@ public class FedoraSessionImpl implements FedoraSession {
 
     @VisibleForTesting
     public static final String TIMEOUT_SYSTEM_PROPERTY = "fcrepo.session.timeout";
+
+    @VisibleForTesting
+    public static final String USER_AGENT_BASE_URI_PROPERTY = "fcrepo.auth.webac.userAgent.baseUri";
 
     private final Session jcrSession;
     private final String id;
@@ -138,6 +144,23 @@ public class FedoraSessionImpl implements FedoraSession {
     }
 
     @Override
+    public URI getUserAgent() {
+        // user id could be in format <anonymous>, remove < at the beginning and the > at the end in this case.
+        final String userId = getUserId().replaceAll("^<|>$", "");
+        try {
+            final URI uri = URI.create(userId);
+            // return useId if it's an absolute URI or an opaque URI
+            if (uri.isAbsolute() || uri.isOpaque()) {
+                return uri;
+            } else {
+                return buildDefaultURI(userId);
+            }
+        } catch (IllegalArgumentException e) {
+            return buildDefaultURI(userId);
+        }
+    }
+
+    @Override
     public String getUserId() {
         return jcrSession.getUserID();
     }
@@ -204,5 +227,20 @@ public class FedoraSessionImpl implements FedoraSession {
      */
     public static Duration operationTimeout() {
        return ofMillis(parseLong(System.getProperty(TIMEOUT_SYSTEM_PROPERTY, DEFAULT_TIMEOUT)));
+    }
+
+    /**
+     * Build default URI with the configured base uri for agent
+     * @param userId
+     * @return
+     */
+    private URI buildDefaultURI(final String userId) {
+        // Construct the default URI for the user ID that is not a URI.
+        final String userAgentBaseUri = System.getProperty(USER_AGENT_BASE_URI_PROPERTY);
+        if (isNullOrEmpty(userAgentBaseUri)) {
+            throw new RepositoryConfigurationException("User agent base URI prioperty is missing."
+                + " Please configure it with variable fcrepo.auth.webac.userAgent.baseUri.");
+        }
+        return URI.create(userAgentBaseUri + userId);
     }
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraSessionImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraSessionImplIT.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.kernel.modeshape;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+
+import javax.inject.Inject;
+import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.auth.BasicUserPrincipal;
+import org.fcrepo.kernel.api.FedoraRepository;
+import org.fcrepo.kernel.api.FedoraSession;
+import org.fcrepo.kernel.api.exception.RepositoryConfigurationException;
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.modeshape.jcr.api.ServletCredentials;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * <p>FedoraSessionImplIT class.</p>
+ *
+ * @author lsitu
+ */
+@ContextConfiguration({"/spring-test/repo.xml"})
+public class FedoraSessionImplIT extends AbstractIT {
+
+    private static final String TEST_USER_AGENT_BASE_URI = "http://example.com/person#";
+
+    private static final String FEDORA_USER = "fedoraUser";
+
+    @Inject
+    FedoraRepository repo;
+
+    private HttpServletRequest request;
+
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() throws RepositoryException {
+        request = mock(HttpServletRequest.class);
+    }
+
+    @After
+    public void tearDown() throws RepositoryException {
+        System.setProperty(FedoraSessionImpl.USER_AGENT_BASE_URI_PROPERTY, "");
+    }
+
+    @Test
+    public void testGetIdExceptionWithUserIdNonURI() throws RepositoryException {
+        when(request.getRemoteUser()).thenReturn(FEDORA_USER);
+        when(request.getUserPrincipal()).thenReturn(new BasicUserPrincipal(FEDORA_USER));
+        when(request.isUserInRole(eq("admin"))).thenReturn(true);
+
+        final ServletCredentials credentials = new ServletCredentials(request);
+        final FedoraSession session = repo.login(credentials);
+
+        // should thrown for unsupported digest algorithm sha256
+        thrown.expect(RepositoryConfigurationException.class);
+
+        session.getUserAgent();
+    }
+
+    @Test
+    public void testGetIdWithUserIdNonURI() throws RepositoryException {
+        // Set basic URI for user agent with environment variable: fcrepo.auth.webac.userAgent.baseUri
+        System.setProperty(FedoraSessionImpl.USER_AGENT_BASE_URI_PROPERTY, TEST_USER_AGENT_BASE_URI);
+
+        when(request.getRemoteUser()).thenReturn(FEDORA_USER);
+        when(request.getUserPrincipal()).thenReturn(new BasicUserPrincipal(FEDORA_USER));
+        when(request.isUserInRole(eq("admin"))).thenReturn(true);
+
+        final ServletCredentials credentials = new ServletCredentials(request);
+        final FedoraSession session = repo.login(credentials);
+
+        assertEquals("User agent URI invalid.",
+                URI.create(TEST_USER_AGENT_BASE_URI + FEDORA_USER), session.getUserAgent());
+    }
+
+    @Test
+    public void testGetIdWithUserIdURI() throws RepositoryException {
+
+        // test with an absolute user uri
+        final String userUri = TEST_USER_AGENT_BASE_URI + FEDORA_USER;
+        when(request.getRemoteUser()).thenReturn(userUri);
+        when(request.getUserPrincipal()).thenReturn(new BasicUserPrincipal(userUri));
+        when(request.isUserInRole(eq("admin"))).thenReturn(true);
+
+        ServletCredentials credentials = new ServletCredentials(request);
+        FedoraSession session = repo.login(credentials);
+
+        assertEquals("User agent URI invalid.", URI.create(userUri), session.getUserAgent());
+
+        // test with an Opaque user uri
+        final String opaqueUserUri = "user:info:" + FEDORA_USER;
+        when(request.getRemoteUser()).thenReturn(opaqueUserUri);
+        when(request.getUserPrincipal()).thenReturn(new BasicUserPrincipal(opaqueUserUri));
+        when(request.isUserInRole(eq("admin"))).thenReturn(true);
+
+        credentials = new ServletCredentials(request);
+        session = repo.login(credentials);
+
+        assertEquals("User agent URI invalid.", URI.create(opaqueUserUri), session.getUserAgent());
+    }
+}

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraSessionImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraSessionImplIT.java
@@ -31,7 +31,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.http.auth.BasicUserPrincipal;
 import org.fcrepo.kernel.api.FedoraRepository;
 import org.fcrepo.kernel.api.FedoraSession;
-import org.fcrepo.kernel.api.exception.RepositoryConfigurationException;
 import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 import org.junit.After;
 import org.junit.Before;
@@ -81,10 +80,9 @@ public class FedoraSessionImplIT extends AbstractIT {
         final ServletCredentials credentials = new ServletCredentials(request);
         final FedoraSession session = repo.login(credentials);
 
-        // should thrown for unsupported digest algorithm sha256
-        thrown.expect(RepositoryConfigurationException.class);
-
-        session.getUserAgent();
+        // should be the default local user agent URI
+        assertEquals("User agent URI invalid.",
+                URI.create(FedoraSessionImpl.DEFAULT_USER_AGENT_BASE_URI + FEDORA_USER), session.getUserAgent());
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/resources/config/testing/repository.json
+++ b/fcrepo-kernel-modeshape/src/test/resources/config/testing/repository.json
@@ -16,7 +16,13 @@
         "anonymous" : {
             "roles" : ["readonly","readwrite","admin"],
             "useOnFailedLogin" : true
-        }
+        },
+        "providers" : [
+            {
+                "name" : "Servlet Provider",
+                "classname" : "org.modeshape.jcr.security.ServletProvider",
+            },
+        ]
     },
     "node-types" : ["fedora-node-types.cnd"]
 }


### PR DESCRIPTION
Fixes #https://jira.duraspace.org/browse/FCREPO-2608

Make user identities available as URIs in kernel API through method getUserAgent().