### PR TITLE
Change groups from acl:agentClass to acl:agentGroup

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/URIConstants.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/URIConstants.java
@@ -101,6 +101,12 @@ final public class URIConstants {
     public static final URI WEBAC_AGENT_CLASS = URI.create(WEBAC_AGENT_CLASS_VALUE);
 
     /**
+     * WebAC agentGroup
+     */
+    public static final String WEBAC_AGENT_GROUP_VALUE = WEBAC_NAMESPACE_VALUE + "agentGroup";
+    public static final URI WEBAC_AGENT_GROUP = URI.create(WEBAC_AGENT_CLASS_VALUE);
+
+    /**
      * WebAC accessTo
      */
     public static final String WEBAC_ACCESSTO_VALUE = WEBAC_NAMESPACE_VALUE + "accessTo";
@@ -148,6 +154,23 @@ final public class URIConstants {
     public static final String FOAF_GROUP_VALUE = FOAF_NAMESPACE_VALUE + "Group";
     public static final URI FOAF_GROUP = URI.create(FOAF_GROUP_VALUE);
 
+    /**
+     * vCard Namespace
+     */
+    public static final String VCARD_NAMESPACE_VALUE = "http://www.w3.org/2006/vcard/ns#";
+    public static final URI VCARD_NAMESPACE = URI.create(VCARD_NAMESPACE_VALUE);
+
+    /**
+     * vCard Group
+     */
+    public static final String VCARD_GROUP_VALUE = VCARD_NAMESPACE_VALUE + "Group";
+    public static final URI VCARD_GROUP = URI.create(VCARD_GROUP_VALUE);
+
+    /**
+     * vCard member
+     */
+    public static final String VCARD_MEMBER_VALUE = VCARD_NAMESPACE_VALUE + "hasMember";
+    public static final URI VCARD_MEMBER = URI.create(VCARD_MEMBER_VALUE);
 
     /**
      * Fedora WebAC Namespace

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorization.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorization.java
@@ -39,6 +39,8 @@ public class WebACAuthorization {
 
     private final Set<String> accessToClass = new HashSet<>();
 
+    private final Set<String> agentGroups = new HashSet<>();
+
     /**
      * Constructor
      *
@@ -47,14 +49,17 @@ public class WebACAuthorization {
      * @param modes the acl:mode values
      * @param accessTo the acl:accessTo values
      * @param accessToClass the acl:accessToClass values
+     * @param agentGroups the acl:agentGroup values
      */
     public WebACAuthorization(final Collection<String> agents, final Collection<String> agentClasses,
-            final Collection<URI> modes, final Collection<String> accessTo, final Collection<String> accessToClass) {
+            final Collection<URI> modes, final Collection<String> accessTo, final Collection<String> accessToClass,
+            final Collection<String> agentGroups) {
         this.agents.addAll(agents);
         this.agentClasses.addAll(agentClasses);
         this.modes.addAll(modes);
         this.accessTo.addAll(accessTo);
         this.accessToClass.addAll(accessToClass);
+        this.agentGroups.addAll(agentGroups);
     }
 
     /**
@@ -100,5 +105,14 @@ public class WebACAuthorization {
      */
     public Set<String> getAccessToClassURIs() {
         return accessToClass;
+    }
+
+    /**
+     * Get the set of strings describing the agent groups for this ACL, empty set if none.
+     *
+     * @return set of Strings
+     */
+    public Set<String> getAgentGroups() {
+        return agentGroups;
     }
 }

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -29,12 +29,13 @@ import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.riot.Lang.TTL;
 import static org.fcrepo.auth.webac.URIConstants.FOAF_AGENT_VALUE;
-import static org.fcrepo.auth.webac.URIConstants.FOAF_GROUP;
-import static org.fcrepo.auth.webac.URIConstants.FOAF_MEMBER_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.VCARD_GROUP;
+import static org.fcrepo.auth.webac.URIConstants.VCARD_MEMBER_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESSTO_CLASS_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESSTO_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_AGENT_CLASS_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_AGENT_GROUP_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_AGENT_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_AUTHORIZATION;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_VALUE;
@@ -243,7 +244,7 @@ public class WebACRolesProvider implements AccessRolesProvider {
         authorizations.stream()
             .filter(checkAccessTo.or(checkAccessToClass))
             .forEach(auth -> {
-                concat(auth.getAgents().stream(), dereferenceAgentClasses(auth.getAgentClasses()).stream())
+                concat(auth.getAgents().stream(), dereferenceAgentGroups(auth.getAgentGroups()).stream())
                     .forEach(agent -> {
                         effectiveRoles.computeIfAbsent(agent, key -> new HashSet<>())
                             .addAll(auth.getModes().stream().map(URI::toString).collect(toSet()));
@@ -283,29 +284,29 @@ public class WebACRolesProvider implements AccessRolesProvider {
         uris.stream().anyMatch(uri -> auth.getAccessToURIs().contains(uri));
 
     /**
-     *  This maps a Collection of acl:agentClass values to a List of agents.
+     *  This maps a Collection of acl:agentGroup values to a List of agents.
      *  Any out-of-domain URIs are silently ignored.
      */
-    private List<String> dereferenceAgentClasses(final Collection<String> agentClasses) {
+    private List<String> dereferenceAgentGroups(final Collection<String> agentGroups) {
         final FedoraSession internalSession = sessionFactory.getInternalSession();
         final IdentifierConverter<Resource, FedoraResource> translator =
                 new DefaultIdentifierTranslator(getJcrSession(internalSession));
 
-        final List<String> members = agentClasses.stream().flatMap(agentClass -> {
-            if (agentClass.startsWith(FEDORA_INTERNAL_PREFIX)) {
+        final List<String> members = agentGroups.stream().flatMap(agentGroup -> {
+            if (agentGroup.startsWith(FEDORA_INTERNAL_PREFIX)) {
                 final FedoraResource resource = nodeService.find(
-                    internalSession, agentClass.substring(FEDORA_INTERNAL_PREFIX.length()));
+                    internalSession, agentGroup.substring(FEDORA_INTERNAL_PREFIX.length()));
                 return getAgentMembers(translator, resource);
-            } else if (agentClass.equals(FOAF_AGENT_VALUE)) {
-                return of(agentClass);
+            } else if (agentGroup.equals(FOAF_AGENT_VALUE)) {
+                return of(agentGroup);
             } else {
-                LOGGER.info("Ignoring agentClass: {}", agentClass);
+                LOGGER.info("Ignoring agentGroup: {}", agentGroup);
                 return empty();
             }
         }).collect(toList());
 
-        if (LOGGER.isDebugEnabled() && !agentClasses.isEmpty()) {
-            LOGGER.debug("Found {} members in {} agentClass resources", members.size(), agentClasses.size());
+        if (LOGGER.isDebugEnabled() && !agentGroups.isEmpty()) {
+            LOGGER.debug("Found {} members in {} agentGroups resources", members.size(), agentGroups.size());
         }
 
         return members;
@@ -335,10 +336,10 @@ public class WebACRolesProvider implements AccessRolesProvider {
     }
 
     /**
-     *  A simple predicate for filtering out any non-foaf:member properties
+     * A simple predicate for filtering out any non-vcard:hasMember properties
      */
-    private static final Function<List<URI>, Predicate<Triple>> memberTestFromTypes = types -> triple ->
-        types.contains(FOAF_GROUP) && triple.predicateMatches(createURI(FOAF_MEMBER_VALUE));
+    private static final Function<List<URI>, Predicate<Triple>> memberTestFromTypes = types -> triple -> types
+            .contains(VCARD_GROUP) && triple.predicateMatches(createURI(VCARD_MEMBER_VALUE));
 
     /**
      *  A simple predicate for filtering out any non-acl triples.
@@ -395,12 +396,13 @@ public class WebACRolesProvider implements AccessRolesProvider {
 
     private static WebACAuthorization createAuthorizationFromMap(final Map<String, List<String>> data) {
         return new WebACAuthorization(
-                    data.getOrDefault(WEBAC_AGENT_VALUE, emptyList()),
-                    data.getOrDefault(WEBAC_AGENT_CLASS_VALUE, emptyList()),
-                    data.getOrDefault(WEBAC_MODE_VALUE, emptyList()).stream()
-                                .map(URI::create).collect(toList()),
-                    data.getOrDefault(WEBAC_ACCESSTO_VALUE, emptyList()),
-                    data.getOrDefault(WEBAC_ACCESSTO_CLASS_VALUE, emptyList()));
+                data.getOrDefault(WEBAC_AGENT_VALUE, emptyList()),
+                data.getOrDefault(WEBAC_AGENT_CLASS_VALUE, emptyList()),
+                data.getOrDefault(WEBAC_MODE_VALUE, emptyList()).stream()
+                .map(URI::create).collect(toList()),
+                data.getOrDefault(WEBAC_ACCESSTO_VALUE, emptyList()),
+                data.getOrDefault(WEBAC_ACCESSTO_CLASS_VALUE, emptyList()),
+                data.getOrDefault(WEBAC_AGENT_GROUP_VALUE, emptyList()));
     }
 
     /**

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACAuthorizationTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACAuthorizationTest.java
@@ -45,6 +45,8 @@ public class WebACAuthorizationTest {
     private final String ACCESS_TO3 = "/baz";
     private final String ACCESS_TO_CLASS1 = "ex:Image";
     private final String ACCESS_TO_CLASS2 = "ex:Archive";
+    private final String ACCESS_GROUP1 = "/groupA";
+    private final String ACCESS_GROUP2 = "/groupB";
 
     @Test
     public void testLists() {
@@ -53,9 +55,10 @@ public class WebACAuthorizationTest {
         final List<URI> modes = Arrays.asList(WEBAC_MODE_READ, WEBAC_MODE_WRITE, WEBAC_MODE_READ);
         final List<String> accessTo = Arrays.asList(ACCESS_TO1, ACCESS_TO2, ACCESS_TO3);
         final List<String> accessToClass = Arrays.asList(ACCESS_TO_CLASS1, ACCESS_TO_CLASS2);
+        final List<String> accessGroups = Arrays.asList(ACCESS_GROUP1, ACCESS_GROUP2);
 
         final WebACAuthorization auth = new WebACAuthorization(agents, agentClasses,
-                modes, accessTo, accessToClass);
+                modes, accessTo, accessToClass, accessGroups);
 
         assertEquals(2, auth.getAgents().size());
         assertTrue(auth.getAgents().contains(AGENT1));
@@ -76,9 +79,10 @@ public class WebACAuthorizationTest {
         final Set<URI> modes = new HashSet<>(Arrays.asList(WEBAC_MODE_WRITE, WEBAC_MODE_READ));
         final Set<String> accessTo = new HashSet<>(Arrays.asList(ACCESS_TO1, ACCESS_TO2, ACCESS_TO3));
         final Set<String> accessToClass = new HashSet<>(Arrays.asList(ACCESS_TO_CLASS1, ACCESS_TO_CLASS2));
+        final Set<String> accessGroups = new HashSet<>(Arrays.asList(ACCESS_GROUP1, ACCESS_GROUP2));
 
         final WebACAuthorization auth = new WebACAuthorization(agents, agentClasses,
-                modes, accessTo, accessToClass);
+                modes, accessTo, accessToClass, accessGroups);
 
         assertEquals(2, auth.getAgents().size());
         assertTrue(auth.getAgents().contains(AGENT1));

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACAuthorizationTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACAuthorizationTest.java
@@ -70,6 +70,9 @@ public class WebACAuthorizationTest {
         assertTrue(auth.getAccessToURIs().contains(ACCESS_TO3));
         assertEquals(2, auth.getAccessToClassURIs().size());
         assertTrue(auth.getAccessToClassURIs().contains(ACCESS_TO_CLASS2));
+        assertEquals(2, auth.getAgentGroups().size());
+        assertTrue(auth.getAgentGroups().contains(ACCESS_GROUP1));
+        assertTrue(auth.getAgentGroups().contains(ACCESS_GROUP2));
     }
 
     @Test
@@ -94,6 +97,9 @@ public class WebACAuthorizationTest {
         assertTrue(auth.getAccessToURIs().contains(ACCESS_TO3));
         assertEquals(2, auth.getAccessToClassURIs().size());
         assertTrue(auth.getAccessToClassURIs().contains(ACCESS_TO_CLASS2));
+        assertEquals(2, auth.getAgentGroups().size());
+        assertTrue(auth.getAgentGroups().contains(ACCESS_GROUP1));
+        assertTrue(auth.getAgentGroups().contains(ACCESS_GROUP2));
     }
 
 

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -22,7 +22,7 @@ import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.graph.Triple.create;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.riot.Lang.TTL;
-import static org.fcrepo.auth.webac.URIConstants.FOAF_GROUP;
+import static org.fcrepo.auth.webac.URIConstants.VCARD_GROUP;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_AUTHORIZATION;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_READ_VALUE;
@@ -442,8 +442,8 @@ public class WebACRolesProviderTest {
     }
 
     /* (non-Javadoc)
-     * Test that an in-repository resource used as a target for acl:agentClass has
-     * the rdf:type of foaf:Group. This test mocks a foaf:Group resource and should
+     * Test that an in-repository resource used as a target for acl:agentGroup has
+     * the rdf:type of vcard:Group. This test mocks a vcard:Group resource and should
      * therefore retrieve two agents.
      */
     @Test
@@ -469,9 +469,9 @@ public class WebACRolesProviderTest {
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth);
         when(mockAuthorizationResource1.getTriples(anyObject(), eq(PROPERTIES)))
-                .thenReturn(getRdfStreamFromResource(auth, TTL));
+        .thenReturn(getRdfStreamFromResource(auth, TTL));
 
-        when(mockAgentClassResource.getTypes()).thenReturn(Arrays.asList(FOAF_GROUP));
+        when(mockAgentClassResource.getTypes()).thenReturn(Arrays.asList(VCARD_GROUP));
         when(mockAgentClassResource.getPath()).thenReturn(groupResource);
         when(mockAgentClassResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getRdfStreamFromResource(group, TTL));

--- a/fcrepo-auth-webac/src/test/resources/acls/09/authorization.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/09/authorization.ttl
@@ -1,6 +1,6 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 
 <> a acl:Authorization ;
-   acl:agentClass </rest/group/foo> ;
+   acl:agentGroup </rest/group/foo> ;
    acl:mode acl:Read, acl:Write ;
    acl:accessTo </rest/anotherCollection> .

--- a/fcrepo-auth-webac/src/test/resources/acls/09/group.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/09/group.ttl
@@ -1,4 +1,4 @@
-@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 
-<> a foaf:Group ;
-    foaf:member "person1" , "person2" .
+<> a vcard:Group ;
+    vcard:hasMember "person1" , "person2" .


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2633

# What does this Pull Request do?
Changes WebAC groups implementation from acl:agentClass to acl:agentGroup.

# What's new?
Implements the SOLID WebAC spec “Groups of Agents” section (https://github.com/solid/web-access-control-spec#groups-of-agents) by using acl:agentGroup / vcard:Group / vcard:hasMember to create lists of users. Use of acl:agentClass / foaf:Group / foaf:member is no longer supported.

# How should this be tested?
Standard `mvn clean test verify` in the fcrepo-auth-webac module.

# Additional Notes:
This will require updates to the wiki documentation on how to set up user groups for WebAC:
* https://wiki.duraspace.org/display/FEDORA5x/How+to+Use+WebAC+agentClass+Groups

# Interested parties
@dannylamb, @awoods 
