### PR TITLE
Support versioning with versioned child ignored.

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -37,6 +37,12 @@
 <test = 'info:fedora/test/'>
 
 /*
+ * nt:folder node types: versioning with no child hierarchy.
+ */
+[nt:folder] > nt:hierarchyNode
+  + * (nt:hierarchyNode) ignore
+
+/*
  * Any Fedora resource.
  */
 [fedora:Resource] > mix:created, mix:lastModified, mix:referenceable mixin


### PR DESCRIPTION
Fixes https://jira.duraspace.org/browse/FCREPO-2636

Added support for versioning with versioned child ignored.

# What's new?
The versioned child will not be created for a versioned resource. The containment relationship to versioned child like "<>  ldp:contains <http://localhost:8080/rest/test/child1/fcr:versions>" is gone.

Example:
Current version support with versioned child (snapshot hierarchy):
$ curl http://localhost:8080/rest/test/fcr:versions/newVersionNam
@prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
@prefix test:  <info:fedora/test/> .
@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
@prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix xml:  <http://www.w3.org/XML/1998/namespace> .
@prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .
@prefix xs:  <http://www.w3.org/2001/XMLSchema> .
@prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@prefix dc:  <http://purl.org/dc/elements/1.1/> .

<http://localhost:8080/rest/test/fcr:versions/newVersionName>
        rdf:type               fedora:Version ;
        fedora:lastModifiedBy  "bypassAdmin" ;
        fedora:createdBy       "bypassAdmin" ;
        fedora:created         "2017-09-28T23:39:34.043Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2017-09-29T00:17:51.732Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        fedora:writable        true ;
        ldp:contains           <http://localhost:8080/rest/test/child1/fcr:versions> .

With the PR to ignore versioned child:
@prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
@prefix test:  <info:fedora/test/> .
@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
@prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix xml:  <http://www.w3.org/XML/1998/namespace> .
@prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .
@prefix xs:  <http://www.w3.org/2001/XMLSchema> .
@prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@prefix dc:  <http://purl.org/dc/elements/1.1/> .

<http://localhost:8080/rest/test/fcr:versions/newVersionName>
        rdf:type               fedora:Version ;
        fedora:lastModifiedBy  "bypassAdmin" ;
        fedora:createdBy       "bypassAdmin" ;
        fedora:created         "2017-09-28T23:39:34.043Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2017-09-29T00:17:51.732Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        fedora:writable        true  .