### PR TITLE
Enable Versioning on a new LDPR

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -98,6 +98,7 @@ import org.fcrepo.http.commons.domain.ldp.LdpPreferTag;
 import org.fcrepo.http.commons.responses.RangeRequestInputStream;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.http.commons.session.HttpSession;
+import org.fcrepo.kernel.api.RdfLexicon;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
@@ -433,6 +434,12 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             servletResponse.addHeader(LINK,
                     Link.fromUri(constraintURI).rel(CONSTRAINED_BY.getURI()).build().toString());
         }
+
+        if (resource.isVersioned()) {
+            final Link link = Link.fromUri(RdfLexicon.VERSIONED_RESOURCE.getURI()).rel("type").build();
+            servletResponse.addHeader(LINK, link.toString());
+        }
+
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -63,6 +63,8 @@ import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
+
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -99,10 +101,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilderException;
 import javax.ws.rs.core.Variant.VariantListBuilder;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.atlas.web.ContentType;
-import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.domain.ContentLocation;
 import org.fcrepo.http.commons.domain.PATCH;
@@ -122,6 +120,12 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.atlas.web.ContentType;
+import org.apache.jena.rdf.model.Resource;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -399,7 +403,6 @@ public class FedoraLdp extends ContentExposingResource {
 
             try (final RdfStream resourceTriples =
                     created ? new DefaultRdfStream(asNode(resource())) : getResourceTriples()) {
-
                 LOGGER.info("PUT resource '{}'", externalPath);
                 if (resource instanceof FedoraBinary) {
                     replaceResourceBinaryWithStream((FedoraBinary) resource,
@@ -422,6 +425,10 @@ public class FedoraLdp extends ContentExposingResource {
                 }
             } catch (final Exception e) {
                 checkForInsufficientStorageException(e, e);
+            }
+
+            if (hasVersionedResourceLink(links)) {
+                resource.enableVersioning();
             }
 
             ensureInteractionType(resource, interactionModel,
@@ -596,6 +603,10 @@ public class FedoraLdp extends ContentExposingResource {
                     }
                 }
 
+                if (hasVersionedResourceLink(links)) {
+                    resource.enableVersioning();
+                }
+
                 ensureInteractionType(resource, interactionModel,
                         (requestBodyStream == null || requestContentType == null));
 
@@ -611,6 +622,35 @@ public class FedoraLdp extends ContentExposingResource {
         }
     }
 
+
+    /**
+     * Returns true if there is a link with a VERSIONED_RESOURCE type.
+     * @param links a list of link header values.
+     * @return True if there is a matching link header.
+     */
+    private boolean hasVersionedResourceLink(final List<String> links) {
+        if (!CollectionUtils.isEmpty(links)) {
+            try {
+                for (String link : links) {
+                    final Link linq = Link.valueOf(link);
+                    if ("type".equals(linq.getRel())) {
+                        final Resource type = createResource(linq.getUri().toString());
+                        if (type.equals(VERSIONED_RESOURCE)) {
+                            return true;
+                        }
+                    }
+                }
+            } catch (final RuntimeException e) {
+                if (e instanceof IllegalArgumentException | e instanceof UriBuilderException) {
+                    throw new ClientErrorException("Invalid link specified: " + String.join(", ", links),
+                            BAD_REQUEST);
+                }
+                throw e;
+            }
+        }
+
+        return false;
+    }
     /**
      * @param rootThrowable The original throwable
      * @param throwable The throwable under direct scrutiny.
@@ -845,8 +885,10 @@ public class FedoraLdp extends ContentExposingResource {
                             type.equals(DIRECT_CONTAINER) || type.equals(INDIRECT_CONTAINER)) {
                         return "ldp:" + type.getLocalName();
                     } else {
-                        LOGGER.info("Invalid interaction model: {}", type);
-                        throw new CannotCreateResourceException("Invalid interaction model: " + type);
+                        if (!type.equals(VERSIONED_RESOURCE)) {
+                            LOGGER.info("Invalid interaction model: {}", type);
+                            throw new CannotCreateResourceException("Invalid interaction model: " + type);
+                        }
                     }
                 }
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -884,11 +884,15 @@ public class FedoraLdp extends ContentExposingResource {
                     if (type.equals(NON_RDF_SOURCE) || type.equals(BASIC_CONTAINER) ||
                             type.equals(DIRECT_CONTAINER) || type.equals(INDIRECT_CONTAINER)) {
                         return "ldp:" + type.getLocalName();
+                    } else if (type.equals(VERSIONED_RESOURCE)) {
+                        // skip if versioned resource link header
+                        // NB: the versioned resource header is used for enabling
+                        // versioning on a resource and is thus orthogonal to
+                        // issue of interaction models. Nevertheless, it is
+                        // a possible link header and, therefore, must be ignored.
                     } else {
-                        if (!type.equals(VERSIONED_RESOURCE)) {
-                            LOGGER.info("Invalid interaction model: {}", type);
-                            throw new CannotCreateResourceException("Invalid interaction model: " + type);
-                        }
+                        LOGGER.info("Invalid interaction model: {}", type);
+                        throw new CannotCreateResourceException("Invalid interaction model: " + type);
                     }
                 }
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/url/HttpApiResources.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/url/HttpApiResources.java
@@ -19,7 +19,6 @@ package org.fcrepo.http.api.url;
 
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
-import static java.util.Collections.singletonMap;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_REPOSITORY_ROOT;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_FIXITY_SERVICE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_TRANSACTION_SERVICE;
@@ -36,8 +35,6 @@ import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.springframework.stereotype.Component;
 
 import javax.ws.rs.core.UriInfo;
-
-import java.util.Map;
 
 /**
  * Inject our HTTP API methods into the object graphs
@@ -57,8 +54,6 @@ public class HttpApiResources implements UriAwareResourceModelFactory {
 
         if (resource.hasType(FEDORA_REPOSITORY_ROOT)) {
             addRepositoryStatements(uriInfo, model, s);
-        } else {
-            addNodeStatements(resource, uriInfo, model, s);
         }
 
         if (resource.getDescribedResource() instanceof FedoraBinary) {
@@ -76,16 +71,6 @@ public class HttpApiResources implements UriAwareResourceModelFactory {
                 "/fcr:fixity"));
     }
 
-    private void addNodeStatements(final FedoraResource resource, final UriInfo uriInfo,
-        final Model model, final Resource s) {
-
-        final Map<String, String> pathMap = singletonMap("path", resource.getPath().substring(1));
-
-        // fcr:versions
-        if (resource.isVersioned()) {
-           throw new RuntimeException("Must implement with Memento!");
-        }
-    }
 
     private void addRepositoryStatements(final UriInfo uriInfo, final Model model,
         final Resource s) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -52,6 +52,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -910,6 +911,16 @@ public class FedoraLdpTest {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, null, "b", null, null, null);
+        assertEquals(CREATED.getStatusCode(), actual.getStatus());
+    }
+
+    @Test
+    public void testCreateNewObjectWithVersionedResource() throws MalformedRdfException, InvalidChecksumException,
+           IOException, UnsupportedAlgorithmException {
+        setResource(Container.class);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
+        final String versionedResourceLink = "<" + VERSIONED_RESOURCE.getURI() + ">;rel=\"type\"";
+        final Response actual = testObj.createObject(null, null, "b", null, Arrays.asList(versionedResourceLink), null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
     }
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -171,6 +171,9 @@ public final class RdfLexicon {
     public static final Property HAS_ACCESS_ROLES_SERVICE =
             createProperty(REPOSITORY_NAMESPACE + "hasAccessRoles");
 
+    public static final Property VERSIONED_RESOURCE =
+            createProperty("http://fedora.info/definitions/fcrepo#VersionedResource");
+
     public static final Set<Property> repositoryProperties = of(
             HAS_OBJECT_COUNT, HAS_OBJECT_SIZE, HAS_TRANSACTION_SERVICE);
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -91,9 +91,6 @@ import javax.jcr.Session;
 import javax.jcr.Value;
 import javax.jcr.nodetype.NodeType;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.FedoraVersion;
 import org.fcrepo.kernel.api.RdfLexicon;
@@ -134,6 +131,8 @@ import org.fcrepo.kernel.modeshape.utils.iterators.RdfRemover;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.modify.request.UpdateData;
 import org.apache.jena.sparql.modify.request.UpdateDeleteWhere;
@@ -142,6 +141,7 @@ import org.apache.jena.update.UpdateRequest;
 import org.modeshape.jcr.api.JcrTools;
 import org.slf4j.Logger;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Converter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -971,7 +971,9 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
   @Override
   public void enableVersioning() {
-      LOGGER.warn("Review if method (enableVersioning) can be removed after implementing Memento!");
+        if (!isVersioned()) {
+           getDescription().findOrCreateTimeMap();
+        }
   }
 
   @Override
@@ -981,8 +983,11 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
   @Override
   public boolean isVersioned() {
-      LOGGER.warn("Review if method (isVersioned) can be removed after implementing Memento!");
-    return false;
+      try {
+          return ((FedoraResourceImpl)getDescription()).getNode(getNode(), LDPCV_TIME_MAP, false) != null;
+      } catch (RepositoryException ex) {
+          throw new RepositoryRuntimeException(ex);
+      }
   }
 
   @Override

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -985,6 +985,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
   public boolean isVersioned() {
       try {
           return ((FedoraResourceImpl)getDescription()).getNode(getNode(), LDPCV_TIME_MAP, false) != null;
+          //@TODO This line should be changed to "return getDescription().getChild(LDPCV_TIME_MAP);"
+          //once the issues around https://jira.duraspace.org/browse/FCREPO-2644 have been landed.
       } catch (RepositoryException ex) {
           throw new RepositoryRuntimeException(ex);
       }


### PR DESCRIPTION
Note:  this is not currently working for binaries.  There is an integration test in this PR (FedoraLdpIT.testCreateVersionedBinaryResource) that covers binaries but is currently @Ignored until the https://jira.duraspace.org/browse/FCREPO-2644 is resolved.

Resolves: https://jira.duraspace.org/browse/FCREPO-2624


**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2624

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.

# What's new?
A in-depth description of the changes made by this PR. Technical details and possible side effects.

Example:
* Changes x feature to such that y
* Added x
* Removed y

# How should this be tested?

A description of what steps someone could take to:
1. mvn clean install -Pone-click
2. java -jar fcrepo-webapp-5.0.0-SNAPSHOT-console.jar
3. curl -v -XPOST  -H "Content-Type: text/n3" -H "Slug: test" "http://localhost:8080/rest/" -H "Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel=\"type\""
4.  Verify that the following link header exists: 
Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel="type"
# Additional Notes:
As per the commit message, I've opened an issue to resolve a bug related to binaries.  See above.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
