### PR TITLE
Create new versionFile nodeType with nt:folder inside

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1002,7 +1002,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore
     public void testCreateVersionedBinaryResource() throws IOException {
         final HttpPost method = postObjMethod();
         final String id = getRandomUniqueId();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -257,6 +257,8 @@ public final class RdfLexicon {
     public static final Predicate<Property> isManagedPredicate =
         hasFedoraNamespace.or(p -> managedProperties.contains(p));
 
+    public static final String NT_VERSION_FILE = "nt:versionFile";
+
     private RdfLexicon() {
 
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -257,6 +257,9 @@ public final class RdfLexicon {
     public static final Predicate<Property> isManagedPredicate =
         hasFedoraNamespace.or(p -> managedProperties.contains(p));
 
+    /**
+     * Fedora defined JCR node type with supertype of nt:file with a single nt:folder named fedora:timemap inside.
+     */
     public static final String NT_VERSION_FILE = "nt:versionFile";
 
     private RdfLexicon() {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -162,7 +162,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     private static final PropertyConverter propertyConverter = new PropertyConverter();
 
     @VisibleForTesting
-    public static final String LDPCV_TIME_MAP = "TimeMap";
+    public static final String LDPCV_TIME_MAP = "fedora:timemap";
 
     // A curried type accepting resource, translator, and "minimality", returning triples.
     private static interface RdfGenerator extends Function<FedoraResource,
@@ -229,7 +229,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
     /*
      * A terminating slash means ModeShape has trouble extracting the localName, e.g., for http://myurl.org/.
-     * 
+     *
      * @see <a href="https://jira.duraspace.org/browse/FCREPO-1409"> FCREPO-1409 </a> for details.
      */
     private static final Function<Quad, IllegalArgumentException> validatePredicateEndsWithSlash = uncheck(x -> {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/BinaryServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/BinaryServiceImpl.java
@@ -32,11 +32,11 @@ import javax.jcr.RepositoryException;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.NT_VERSION_FILE;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getContainingNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.touch;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.touchLdpMembershipResource;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
-import static org.modeshape.jcr.api.JcrConstants.NT_FILE;
 import static org.modeshape.jcr.api.JcrConstants.NT_RESOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -56,7 +56,7 @@ public class BinaryServiceImpl extends AbstractService implements BinaryService 
     @Override
     public FedoraBinary findOrCreate(final FedoraSession session, final String path) {
         try {
-            final Node dsNode = findOrCreateNode(session, path, NT_FILE);
+            final Node dsNode = findOrCreateNode(session, path, NT_VERSION_FILE);
 
             if (dsNode.isNew()) {
                 initializeNewDatastreamProperties(dsNode);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/ServiceHelpers.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/ServiceHelpers.java
@@ -21,10 +21,10 @@ import static javax.jcr.query.Query.JCR_SQL2;
 import static org.fcrepo.kernel.api.FedoraTypes.CONTENT_SIZE;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.NT_VERSION_FILE;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.modeshape.jcr.api.JcrConstants.JCR_DATA;
 import static org.modeshape.jcr.api.JcrConstants.JCR_PATH;
-import static org.modeshape.jcr.api.JcrConstants.NT_FILE;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -54,7 +54,7 @@ public class ServiceHelpers {
 
     /**
      * Get the total size of a Node's properties
-     * 
+     *
      * @param node the node
      * @return size in bytes
      * @throws RepositoryException if repository exception occurred
@@ -94,7 +94,7 @@ public class ServiceHelpers {
         Long size = 0L;
         for (final NodeIterator i = obj.getNodes(); i.hasNext();) {
             final Node node = i.nextNode();
-            if (node.isNodeType(NT_FILE)) {
+            if (node.isNodeType(NT_VERSION_FILE)) {
                 size += getDatastreamSize(node);
             }
         }
@@ -104,7 +104,7 @@ public class ServiceHelpers {
     /**
      * Get the size of a datastream by calculating the size of the properties
      * and the binary properties
-     * 
+     *
      * @param ds the node
      * @return size of the datastream's properties and binary properties
      * @throws RepositoryException if repository exception occurred
@@ -116,7 +116,7 @@ public class ServiceHelpers {
 
     /**
      * Get the size of the JCR content binary property
-     * 
+     *
      * @param ds the given node
      * @return size of the binary content property
      */

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -36,6 +36,9 @@
 
 <test = 'info:fedora/test/'>
 
+[nt:versionFile] > nt:file
++ fedora:timemap (nt:folder) =fedora:TimeMap
+
 /*
  * Any Fedora resource.
  */

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
@@ -23,6 +23,7 @@ import static java.util.UUID.randomUUID;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
+import static org.fcrepo.kernel.api.RdfLexicon.NT_VERSION_FILE;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
@@ -35,7 +36,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.modeshape.jcr.api.JcrConstants.JCR_DATA;
-import static org.modeshape.jcr.api.JcrConstants.NT_FILE;
 import static org.modeshape.jcr.api.JcrConstants.NT_RESOURCE;
 
 import java.io.ByteArrayInputStream;
@@ -372,7 +372,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
             final ValueFactory factory = jcrSession.getValueFactory();
             final Container object = containerService.findOrCreate(session, "/testLLObject");
 
-            final Node testRandomContentNode = getJcrNode(object).addNode("testRandomContent", NT_FILE);
+            final Node testRandomContentNode = getJcrNode(object).addNode("testRandomContent", NT_VERSION_FILE);
             testRandomContentNode.addMixin(FEDORA_NON_RDF_SOURCE_DESCRIPTION);
             final Node testRandomContent = testRandomContentNode.addNode(JCR_CONTENT, NT_RESOURCE);
             testRandomContent.addMixin(FEDORA_BINARY);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
@@ -25,6 +25,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.NT_VERSION_FILE;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
@@ -35,7 +36,6 @@ import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.junit.Assert.assertEquals;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
-import static org.modeshape.jcr.api.JcrConstants.NT_FILE;
 import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
 import static org.modeshape.jcr.api.JcrConstants.NT_RESOURCE;
 
@@ -123,7 +123,7 @@ public class SimpleObserverIT extends AbstractIT {
         final Session se = getJcrSession(session);
         final JcrTools jcrTools = new JcrTools();
 
-        final Node n = jcrTools.findOrCreateNode(se.getRootNode(), "/object3", NT_FOLDER, NT_FILE);
+        final Node n = jcrTools.findOrCreateNode(se.getRootNode(), "/object3", NT_FOLDER, NT_VERSION_FILE);
         n.addMixin(FEDORA_RESOURCE);
 
         final String content = "test content";


### PR DESCRIPTION
Enable Binary TimeMap test

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2644

# What does this Pull Request do?
Creates a new nodetype based on the nt:file but with an additional nt:folder child called fedora:timemap to hold the timemap and mementos.

# How should this be tested?

Integration and unit tests run. There are additional example actions, but with the resource called **TimeMap**, so change this to **fedora:timemap** now.

Example:
* Does this change require documentation to be updated? Hopefully not
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? Possibly

# Interested parties
SPRINTERS ASSEMBLE
@awoods
