### PR TITLE
Adds versioning response headers to LDPRv HEAD/GET responses w/o Acce…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -210,9 +210,18 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 prefer.getReturn().addResponseHeaders(servletResponse);
             }
         }
-        servletResponse.addHeader("Vary", "Accept, Range, Accept-Encoding, Accept-Language");
 
+        addVaryHeader(resource());
         return ok(outputStream).build();
+    }
+
+
+    protected void addVaryHeader(final FedoraResource resource) {
+        final StringBuilder varyValues = new StringBuilder("Accept, Range, Accept-Encoding, Accept-Language");
+        if (resource.isVersioned()) {
+            varyValues.append(", Accept-Datetime");
+        }
+        servletResponse.addHeader("Vary", varyValues.toString());
     }
 
     protected boolean isExternalBody(final MediaType mediaType) {
@@ -436,8 +445,13 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         if (resource.isVersioned()) {
-            final Link link = Link.fromUri(RdfLexicon.VERSIONED_RESOURCE.getURI()).rel("type").build();
-            servletResponse.addHeader(LINK, link.toString());
+            final Link versionedResource = Link.fromUri(RdfLexicon.VERSIONED_RESOURCE.getURI()).rel("type").build();
+            servletResponse.addHeader(LINK, versionedResource.toString());
+            final Link timegate = Link.fromUri(getUri(resource)).rel("timegate").build();
+            servletResponse.addHeader(LINK, timegate.toString());
+            final Link timemap = Link.fromUri(getUri(resource.findOrCreateTimeMap())).rel("timemap").build();
+            servletResponse.addHeader(LINK, timemap.toString());
+
         }
 
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -445,7 +445,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             servletResponse.addHeader(LINK, versionedResource.toString());
             final Link timegate = Link.fromUri(getUri(resource)).rel("timegate").build();
             servletResponse.addHeader(LINK, timegate.toString());
-            final Link timemap = Link.fromUri(getUri(resource.findOrCreateTimeMap())).rel("timemap").build();
+            final Link timemap = Link.fromUri(getUri(resource.getDescription().findOrCreateTimeMap())).rel("timemap")
+                    .build();
             servletResponse.addHeader(LINK, timemap.toString());
 
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -203,7 +203,6 @@ public class FedoraLdp extends ContentExposingResource {
         checkCacheControlHeaders(request, servletResponse, resource(), session);
 
         addResourceHttpHeaders(resource());
-        addVaryHeader(resource());
 
         Response.ResponseBuilder builder = ok();
 
@@ -709,7 +708,6 @@ public class FedoraLdp extends ContentExposingResource {
         } else if (prefer.getReturn().getValue().equals("minimal")) {
             return builder.build();
         } else {
-            addVaryHeader(resource);
             if (prefer != null) {
                 prefer.getReturn().addResponseHeaders(servletResponse);
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -203,6 +203,7 @@ public class FedoraLdp extends ContentExposingResource {
         checkCacheControlHeaders(request, servletResponse, resource(), session);
 
         addResourceHttpHeaders(resource());
+        addVaryHeader(resource());
 
         Response.ResponseBuilder builder = ok();
 
@@ -708,7 +709,7 @@ public class FedoraLdp extends ContentExposingResource {
         } else if (prefer.getReturn().getValue().equals("minimal")) {
             return builder.build();
         } else {
-            servletResponse.addHeader("Vary", "Accept, Range, Accept-Encoding, Accept-Language");
+            addVaryHeader(resource);
             if (prefer != null) {
                 prefer.getReturn().addResponseHeaders(servletResponse);
             }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -155,6 +155,8 @@ import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.DC_11;
 import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
+import org.fcrepo.kernel.modeshape.FedoraResourceImpl;
+
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1002,10 +1004,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private void verifyVersionedResourceResponseHeaders(final String subjectURI,
             final CloseableHttpResponse response) {
-        assertEquals("Didn't get a CREATED response!", OK.getStatusCode(), getStatus(response));
+        assertEquals("Didn't get an OK (200) response!", OK.getStatusCode(), getStatus(response));
         checkForVersionedResourceLinkHeader(response);
         checkForLinkHeader(response, subjectURI, "timegate");
-        checkForLinkHeader(response, subjectURI + "/TimeMap", "timemap");
+        checkForLinkHeader(response, subjectURI + "/" + FedoraResourceImpl.LDPCV_TIME_MAP, "timemap");
         assertEquals(1, Arrays.asList(response.getHeaders("Vary")).stream().filter(x -> x.getValue().contains(
                 "Accept-Datetime")).count());
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -106,7 +106,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
@@ -1011,7 +1010,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 "Accept-Datetime")).count());
     }
 
-    private String createVersionedRDFResource() throws UnsupportedEncodingException, IOException {
+    private String createVersionedRDFResource() throws IOException {
         final String id = getRandomUniqueId();
         final String subjectURI = serverAddress + id;
         final HttpPost createMethod = postObjMethod();
@@ -1032,9 +1031,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     private void checkForLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+        final Link linkA = Link.valueOf("<" + uri + ">; rel=" + rel);
         final int count = (int) Arrays.asList(response.getHeaders(LINK)).stream().filter(x -> {
-            final Link linq = Link.valueOf(x.getValue());
-            return linq.getRel().equals(rel) && linq.getUri().equals(URI.create(uri));
+            final Link linkB = Link.valueOf(x.getValue());
+            return linkB.equals(linkA);
         }).count();
         assertEquals(1, count);
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -106,6 +106,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
@@ -979,9 +980,38 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
     }
 
-
     @Test
     public void testCreateVersionedRDFResource() throws IOException {
+        createVersionedRDFResource();
+    }
+
+    @Test
+    public void testGetVersionedResourceHeaders() throws IOException {
+        final String subjectURI = createVersionedRDFResource();
+        try (final CloseableHttpResponse response = execute(new HttpGet(subjectURI))) {
+            verifyVersionedResourceResponseHeaders(subjectURI, response);
+        }
+    }
+
+    @Test
+    public void testHeadVersionedResourceHeaders() throws IOException {
+        final String subjectURI = createVersionedRDFResource();
+        try (final CloseableHttpResponse response = execute(new HttpHead(subjectURI))) {
+            verifyVersionedResourceResponseHeaders(subjectURI, response);
+        }
+    }
+
+    private void verifyVersionedResourceResponseHeaders(final String subjectURI,
+            final CloseableHttpResponse response) {
+        assertEquals("Didn't get a CREATED response!", OK.getStatusCode(), getStatus(response));
+        checkForVersionedResourceLinkHeader(response);
+        checkForLinkHeader(response, subjectURI, "timegate");
+        checkForLinkHeader(response, subjectURI + "/TimeMap", "timemap");
+        assertEquals(1, Arrays.asList(response.getHeaders("Vary")).stream().filter(x -> x.getValue().contains(
+                "Accept-Datetime")).count());
+    }
+
+    private String createVersionedRDFResource() throws UnsupportedEncodingException, IOException {
         final String id = getRandomUniqueId();
         final String subjectURI = serverAddress + id;
         final HttpPost createMethod = postObjMethod();
@@ -994,11 +1024,19 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
             checkForVersionedResourceLinkHeader(response);
         }
+        return subjectURI;
     }
 
     private void checkForVersionedResourceLinkHeader(final CloseableHttpResponse response) {
-        assertEquals(1, Arrays.asList(response.getHeaders(LINK)).stream().filter(x -> x.getValue().equals(
-                VERSIONED_RESOURCE_LINK_HEADER)).count());
+        checkForLinkHeader(response,VERSIONED_RESOURCE.getURI(), "type");
+    }
+
+    private void checkForLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+        final int count = (int) Arrays.asList(response.getHeaders(LINK)).stream().filter(x -> {
+            final Link linq = Link.valueOf(x.getValue());
+            return linq.getRel().equals(rel) && linq.getUri().equals(URI.create(uri));
+        }).count();
+        assertEquals(1, count);
     }
 
     @Test


### PR DESCRIPTION
…pt-Datetime

Includes:
     Vary: accept-datetime
     Link: <self>; rel="timegate"
     Link: <timemap-uri>; rel="timemap"

Resolves: https://jira.duraspace.org/browse/FCREPO-2612
# How should this be tested?

1. mvn jetty:run -pl fcrepo-webapp
2. curl -v -XPOST  -H "Content-Type: text/n3" -H "Link:  <http://fedora.info/definitions/fcrepo#VersionedResource>; rel=\"type\"" -H "Slug: test12345" "http://localhost:8080/rest/" -u fedoraAdmin:fedoraAdmin
3. curl -v -XGET  "http://localhost:8080/rest/test12345" -u fedoraAdmin:fedoraAdmin
4. verify that the response has these headers:

< Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel="type"
< Link: <http://localhost:8080/rest/test12345>; rel="timegate"
< Link: <http://localhost:8080/rest/test12345/TimeMap>; rel="timemap"
< Vary: Accept, Range, Accept-Encoding, Accept-Language, Accept-Datetime

5. curl -v -XHEAD  "http://localhost:8080/rest/tes12345" -u fedoraAdmin:fedoraAdmin
6. verify that  4 is still true.

# Additional Notes:

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
