### PR TITLE
Disallow interactions on paths with fedora: in it.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -66,7 +66,6 @@ import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -107,7 +106,6 @@ import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PreconditionException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
-import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -721,17 +719,5 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             return URI.create(checksum);
         }
         return null;
-    }
-
-    /**
-     * Check if a path has a segment prefixed with fedora:
-     *
-     * @param externalPath the path.
-     */
-    public static void hasRestrictedPath(final String externalPath) {
-        final String[] pathSegments = externalPath.split("/");
-        if (Arrays.asList(pathSegments).stream().anyMatch(p -> p.startsWith("fedora:"))) {
-            throw new ServerManagedTypeException("Path cannot contain a fedora: prefixed segment.");
-        }
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -66,6 +66,7 @@ import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -106,6 +107,7 @@ import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PreconditionException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
+import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -719,5 +721,17 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             return URI.create(checksum);
         }
         return null;
+    }
+
+    /**
+     * Check if a path has a segment prefixed with fedora:
+     *
+     * @param externalPath the path.
+     */
+    public static void hasRestrictedPath(final String externalPath) {
+        final String[] pathSegments = externalPath.split("/");
+        if (Arrays.asList(pathSegments).stream().anyMatch(p -> p.startsWith("fedora:"))) {
+            throw new ServerManagedTypeException("Path cannot contain a fedora: prefixed segment.");
+        }
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -65,6 +65,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 
+
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -199,6 +200,7 @@ public class FedoraLdp extends ContentExposingResource {
         TURTLE_X, TEXT_HTML_WITH_CHARSET })
     public Response head() throws UnsupportedAlgorithmException {
         LOGGER.info("HEAD for: {}", externalPath);
+        hasRestrictedPath(externalPath);
 
         checkCacheControlHeaders(request, servletResponse, resource(), session);
 
@@ -239,6 +241,7 @@ public class FedoraLdp extends ContentExposingResource {
     @Timed
     public Response options() {
         LOGGER.info("OPTIONS for '{}'", externalPath);
+        hasRestrictedPath(externalPath);
         addLinkAndOptionsHttpHeaders();
         return ok().build();
     }
@@ -257,6 +260,7 @@ public class FedoraLdp extends ContentExposingResource {
             TURTLE_X, TEXT_HTML_WITH_CHARSET})
     public Response getResource(@HeaderParam("Range") final String rangeValue)
             throws IOException, UnsupportedAlgorithmException {
+        hasRestrictedPath(externalPath);
         checkCacheControlHeaders(request, servletResponse, resource(), session);
 
         LOGGER.info("GET resource '{}'", externalPath);
@@ -321,6 +325,7 @@ public class FedoraLdp extends ContentExposingResource {
     @DELETE
     @Timed
     public Response deleteObject() {
+        hasRestrictedPath(externalPath);
         if (resource() instanceof Container) {
             final String depth = headers.getHeaderString("Depth");
             LOGGER.debug("Depth header value is: {}", depth);
@@ -370,7 +375,7 @@ public class FedoraLdp extends ContentExposingResource {
             @HeaderParam(LINK) final List<String> links,
             @HeaderParam("Digest") final String digest)
             throws InvalidChecksumException, MalformedRdfException, UnsupportedAlgorithmException {
-
+        hasRestrictedPath(externalPath);
         final String interactionModel = checkInteractionModel(links);
 
         final FedoraResource resource;
@@ -468,7 +473,7 @@ public class FedoraLdp extends ContentExposingResource {
     @Timed
     public Response updateSparql(@ContentLocation final InputStream requestBodyStream)
             throws IOException {
-
+        hasRestrictedPath(externalPath);
         if (null == requestBodyStream) {
             throw new BadRequestException("SPARQL-UPDATE requests must have content!");
         }
@@ -562,6 +567,7 @@ public class FedoraLdp extends ContentExposingResource {
         final String contentTypeString = contentType.toString();
 
         final String newObjectPath = mintNewPid(slug);
+        hasRestrictedPath(newObjectPath);
 
         final AcquiredLock lock = lockManager.lockForWrite(newObjectPath, session.getFedoraSession(), nodeService);
 
@@ -631,7 +637,7 @@ public class FedoraLdp extends ContentExposingResource {
     private boolean hasVersionedResourceLink(final List<String> links) {
         if (!CollectionUtils.isEmpty(links)) {
             try {
-                for (String link : links) {
+                for (final String link : links) {
                     final Link linq = Link.valueOf(link);
                     if ("type".equals(linq.getRel())) {
                         final Resource type = createResource(linq.getUri().toString());
@@ -877,7 +883,7 @@ public class FedoraLdp extends ContentExposingResource {
         }
 
         try {
-            for (String link : links) {
+            for (final String link : links) {
                 final Link linq = Link.valueOf(link);
                 if ("type".equals(linq.getRel())) {
                     final Resource type = createResource(linq.getUri().toString());
@@ -944,11 +950,11 @@ public class FedoraLdp extends ContentExposingResource {
      * @return Digest algorithms that are supported
      */
     private static Collection<String> parseWantDigestHeader(final String wantDigest) {
-        final Map<String, Double> digestPairs = new HashMap<String,Double>();
+        final Map<String, Double> digestPairs = new HashMap<String, Double>();
         try {
             final List<String> algs = Splitter.on(',').omitEmptyStrings().trimResults().splitToList(wantDigest);
             // Parse the optional q value with default 1.0, and 0 ignore. Format could be: SHA-1;qvalue=0.1
-            for (String alg : algs) {
+            for (final String alg : algs) {
                 final String[] tokens = alg.split(";", 2);
                 final double qValue = tokens.length == 1 || tokens[1].indexOf("=") < 0 ?
                         1.0 : Double.parseDouble(tokens[1].split("=", 2)[1]);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -3395,4 +3395,64 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue(response.getHeaders(DIGEST).length == 0);
         }
     }
+
+    @Test
+    public void testFedoraUri() throws Exception {
+        final String id = "fedora:" + getRandomUniqueId();
+
+        final HttpPost httpPost = postObjMethod("/");
+        httpPost.addHeader("Slug", id);
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals("Must not be able to POST to fedora: URI!", CONFLICT.getStatusCode(), getStatus(response));
+        }
+
+    }
+
+    @Test
+    public void testPostFedoraSlug() throws IOException {
+        final HttpPost httpPost = postObjMethod("/");
+        httpPost.addHeader("Slug", "fedora:path");
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals("Must not be able to POST with fedora namespaced Slug!", CONFLICT.getStatusCode(),
+                getStatus(response));
+        }
+    }
+
+    @Test
+    public void testPutFedoraPath() throws IOException {
+        final HttpPut httpPut = putObjMethod("/fedora:path");
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals("Must not be able to PUT with fedora namespaced path!", CONFLICT.getStatusCode(),
+                getStatus(response));
+        }
+    }
+
+    @Test
+    public void testGetFedoraPath() throws IOException {
+        final HttpGet httpGet = getObjMethod("/test/path/fedora:path");
+        try (final CloseableHttpResponse response = execute(httpGet)) {
+            assertEquals("Must not be able to GET with fedora namespaced path!", CONFLICT.getStatusCode(),
+                getStatus(response));
+        }
+    }
+
+    @Test
+    public void testOptionsFedoraPath() throws IOException {
+        final HttpOptions httpOptions = new HttpOptions(serverAddress + "/testing/fedora:path/test");
+        try (final CloseableHttpResponse response = execute(httpOptions)) {
+            assertEquals("Must not be able to OPTIONS with fedora namespaced path!", CONFLICT.getStatusCode(),
+                getStatus(response));
+        }
+    }
+
+    @Test
+    public void testDeleteWithFedoraPath() throws IOException {
+        final String id = getRandomUniqueId() + "/fedora:delete";
+        final HttpDelete httpDelete = deleteObjMethod(id);
+        httpDelete.addHeader("Depth", "infinity");
+        try (final CloseableHttpResponse response = execute(httpDelete)) {
+            assertEquals("Must not be able to DELETE with fedora namespaced path!", CONFLICT.getStatusCode(),
+                getStatus(response));
+        }
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -3397,18 +3397,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testFedoraUri() throws Exception {
-        final String id = "fedora:" + getRandomUniqueId();
-
-        final HttpPost httpPost = postObjMethod("/");
-        httpPost.addHeader("Slug", id);
-        try (final CloseableHttpResponse response = execute(httpPost)) {
-            assertEquals("Must not be able to POST to fedora: URI!", CONFLICT.getStatusCode(), getStatus(response));
-        }
-
-    }
-
-    @Test
     public void testPostFedoraSlug() throws IOException {
         final HttpPost httpPost = postObjMethod("/");
         httpPost.addHeader("Slug", "fedora:path");
@@ -3423,24 +3411,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpPut httpPut = putObjMethod("/fedora:path");
         try (final CloseableHttpResponse response = execute(httpPut)) {
             assertEquals("Must not be able to PUT with fedora namespaced path!", CONFLICT.getStatusCode(),
-                getStatus(response));
-        }
-    }
-
-    @Test
-    public void testGetFedoraPath() throws IOException {
-        final HttpGet httpGet = getObjMethod("/test/path/fedora:path");
-        try (final CloseableHttpResponse response = execute(httpGet)) {
-            assertEquals("Must not be able to GET with fedora namespaced path!", CONFLICT.getStatusCode(),
-                getStatus(response));
-        }
-    }
-
-    @Test
-    public void testOptionsFedoraPath() throws IOException {
-        final HttpOptions httpOptions = new HttpOptions(serverAddress + "/testing/fedora:path/test");
-        try (final CloseableHttpResponse response = execute(httpOptions)) {
-            assertEquals("Must not be able to OPTIONS with fedora namespaced path!", CONFLICT.getStatusCode(),
                 getStatus(response));
         }
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2645

# What does this Pull Request do?
Disallows any interaction if any part of the path (or Slug) uses a fedora: namespace prefix.

# How should this be tested?

Spin up a Fedora
Try to PUT a resource to http://localhost:8080/rest/fedora:resource, it should succeed
Pull in this PR
Try to PUT a resource to http://localhost:8080/rest/fedora:resource, it should fail.

Same for GET, POST, DELETE, HEAD or OPTIONS.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@awoods 
