### PR TITLE
adds a config set for postgres only clustering.

### DIFF
--- a/fcrepo-configs/src/main/resources/config/clustered-postgesql/jgroups.xml.j2
+++ b/fcrepo-configs/src/main/resources/config/clustered-postgesql/jgroups.xml.j2
@@ -1,0 +1,79 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2010 Red Hat Inc. and/or its affiliates and other
+  ~ contributors as indicated by the @author tags. All rights reserved.
+  ~ See the copyright.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<!--See: https://docs.jboss.org/author/display/MODE50/ModeShape+in+Java+applications#ModeShapeinJavaapplications-Clustering-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:org:jgroups"
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
+
+    <TCP bind_port="${jgroups.tcp.port:7800}"
+         bind_addr="${jgroups.tcp.address:0.0.0.0}"
+         recv_buf_size="${tcp.recv_buf_size:5M}"
+         send_buf_size="${tcp.send_buf_size:5M}"
+         max_bundle_size="64K"
+         max_bundle_timeout="30"
+         sock_conn_timeout="3000"
+         timer_type="new3"
+         timer.min_threads="4"
+         timer.max_threads="10"
+         timer.keep_alive_time="3000"
+         timer.queue_max_size="500"
+         thread_pool.enabled="false"
+         oob_thread_pool.enabled="false"
+         port_range="0"/>
+    <JDBC_PING connection_url="jdbc:postgresql://${fcrepo.postgresql.host:localhost}:${fcrepo.postgresql.port:5432}/${fcrepo.postgresql.database:fedora}"
+               connection_username="${fcrepo.postgresql.username}"
+               connection_password="${fcrepo.postgresql.password}"
+               connection_driver="org.postgresql.Driver"
+               initialize_sql="CREATE TABLE IF NOT EXISTS JGROUPSPING (
+                   own_addr varchar(200) NOT NULL,
+                   bind_addr varchar(200) NOT NULL,
+                   created timestamp NOT NULL,
+                   cluster_name varchar(200) NOT NULL,
+                   ping_data BYTEA,
+                   constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name)
+                   )"
+               insert_single_sql="INSERT INTO JGROUPSPING (own_addr, bind_addr, created, cluster_name, ping_data) values (?,'${jgroups.tcp.address:127.0.0.1}',NOW(), ?, ?)"
+               delete_single_sql="DELETE FROM JGROUPSPING WHERE own_addr=? AND cluster_name=?"
+               select_all_pingdata_sql="SELECT ping_data FROM JGROUPSPING WHERE cluster_name=?" />
+
+    <MERGE3 min_interval="10000"
+            max_interval="30000"/>
+    <FD timeout="3000" max_tries="3" />
+    <VERIFY_SUSPECT timeout="1500" />
+    <BARRIER />
+    <pbcast.NAKACK2 use_mcast_xmit="false"
+                    xmit_interval="1000"
+                    xmit_table_num_rows="100"
+                    xmit_table_msgs_per_row="10000"
+                    xmit_table_max_compaction_time="10000"
+                    max_msg_batch_size="100"/>
+
+    <UNICAST3 />
+    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
+                   max_bytes="4M"/>
+    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+    <MFC max_credits="2M"
+         min_threshold="0.4"/>
+    <FRAG2 frag_size="60K" />
+    <pbcast.STATE_TRANSFER/>
+</config>

--- a/fcrepo-configs/src/main/resources/config/clustered-postgesql/postgres-cluster.json.j2
+++ b/fcrepo-configs/src/main/resources/config/clustered-postgesql/postgres-cluster.json.j2
@@ -1,0 +1,44 @@
+{
+    "name" : "repo",
+    "jndiName" : "",
+    "workspaces" : {
+        "predefined" : ["default"],
+        "default" : "default",
+        "allowCreation" : true,
+        "cacheSize" : 10000
+    },
+    "clustering" : {
+        "clusterName" : "fcrepo-cluster",
+        "configuration" : "${fcrepo.jgroups.configuration:config/jgroups-fcrepo-tcp.xml}"
+    },
+    "storage" : {
+        "persistence": {
+            "type" : "db",
+            "connectionUrl": "jdbc:postgresql://${fcrepo.postgresql.host:localhost}:${fcrepo.postgresql.port:5432}/${fcrepo.postgresql.database:fedora}",
+            "driver" : "org.postgresql.Driver",
+            "username" : "${fcrepo.postgresql.username}",
+            "password" : "${fcrepo.postgresql.password}",
+            "poolSize" : "20"
+        },
+        "binaryStorage" : {
+            "type" : "file",
+            "directory" : "${fcrepo.binary.directory:target/binaries}",
+            "minimumBinarySizeInBytes" : 4096
+        }
+    },
+    "security" : {
+        "anonymous" : {
+            "roles" : ["readonly","readwrite","admin"],
+            "useOnFailedLogin" : false
+        },
+        "providers" : [
+            { "classname" : "org.fcrepo.auth.common.BypassSecurityServletAuthenticationProvider" }
+        ]
+    },
+    "garbageCollection" : {
+        "threadPool" : "modeshape-gc",
+        "initialTime" : "00:00",
+        "intervalInHours" : 24
+    },
+    "node-types" : ["fedora-node-types.cnd"]
+}


### PR DESCRIPTION
currently assumes a network shared binary store instead of blob storage.

# What does this Pull Request do?
This PR adds a new cluster configuration option set.  It shows how to use jGroups with a database connection instead of having to set up an additional outside resource for sharing the state. It wasn't clear to me if upstream was accepting new configurations, if not feel free to close this PR. 

# What's new?

Adds a new postgres config with changeable database name and a jgroups file which uses the same database table as the repo.  This allows a single postgres target to be used in order to create a fully functioning Fedora cluster.

# Interested parties
@fcrepo4/committers