### PR TITLE
Replace want digest sha1 and with sha

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -848,7 +848,7 @@ public class FedoraLdp extends ContentExposingResource {
 
         final Collection<URI> checksumResults = binary.checkFixity(idTranslator, preferredDigests);
         final String digestValue = checksumResults.stream().map(uri -> uri.toString().replaceFirst("urn:", "")
-                .replaceFirst(":", "=")).collect(Collectors.joining(","));
+                .replaceFirst(":", "=").replaceFirst("sha1=", "sha=")).collect(Collectors.joining(","));
         return digestValue;
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -71,8 +71,6 @@ import static org.mockito.Mockito.when;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -84,8 +82,9 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.servlet.ServletContext;
+
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletContext;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.EntityTag;
@@ -97,6 +96,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
@@ -136,6 +136,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author cabeer
@@ -1005,6 +1008,24 @@ public class FedoraLdpTest {
             final String sha = "07a4d371f3b7b6283a8e1230b7ec6764f8287bf2";
             final String requestSHA = "sha=" + sha;
             final Set<URI> shaURI = singleton(URI.create("urn:sha1:" + sha));
+            final Response actual = testObj.createObject(null, requestContentType, "b", content, nonRDFSourceLink,
+                requestSHA);
+            assertEquals(CREATED.getStatusCode(), actual.getStatus());
+            verify(mockBinary).setContent(content, requestContentType.toString(), shaURI, "", null);
+        }
+    }
+
+    @Test
+    public void testCreateNewBinaryWithChecksumSHA256() throws MalformedRdfException,
+        InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+
+        setResource(Container.class);
+        when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
+        try (final InputStream content = toInputStream("x", UTF_8)) {
+            final MediaType requestContentType = MediaType.valueOf("some/mime-type; with=some; param=s");
+            final String sha = "73cb3858a687a8494ca3323053016282f3dad39d42cf62ca4e79dda2aac7d9ac";
+            final String requestSHA = "sha256=" + sha;
+            final Set<URI> shaURI = singleton(URI.create("urn:sha256:" + sha));
             final Response actual = testObj.createObject(null, requestContentType, "b", content, nonRDFSourceLink,
                 requestSHA);
             assertEquals(CREATED.getStatusCode(), actual.getStatus());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -71,6 +71,8 @@ import static org.mockito.Mockito.when;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -82,9 +84,8 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.EntityTag;
@@ -96,7 +97,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
@@ -136,9 +136,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.springframework.mock.web.MockHttpServletResponse;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * @author cabeer
@@ -589,7 +586,7 @@ public class FedoraLdpTest {
             testObj.evaluateRequestPreconditions(mockRequest, mockResponse, testObj.resource(),
                     mockSession, true);
             fail("Expected " + PreconditionException.class.getName() + " to be thrown.");
-        } catch (PreconditionException e) {
+        } catch (final PreconditionException e) {
             // expected
         }
 
@@ -629,7 +626,7 @@ public class FedoraLdpTest {
             testObj.evaluateRequestPreconditions(mockRequest, mockResponse, testObj.resource(),
                     mockSession, true);
             fail("Expected " + PreconditionException.class.getName() + " to be thrown.");
-        } catch (PreconditionException e) {
+        } catch (final PreconditionException e) {
             // expected
         }
 
@@ -1006,7 +1003,7 @@ public class FedoraLdpTest {
         try (final InputStream content = toInputStream("x", UTF_8)) {
             final MediaType requestContentType = MediaType.valueOf("some/mime-type; with=some; param=s");
             final String sha = "07a4d371f3b7b6283a8e1230b7ec6764f8287bf2";
-            final String requestSHA = "sha1=" + sha;
+            final String requestSHA = "sha=" + sha;
             final Set<URI> shaURI = singleton(URI.create("urn:sha1:" + sha));
             final Response actual = testObj.createObject(null, requestContentType, "b", content, nonRDFSourceLink,
                 requestSHA);
@@ -1043,7 +1040,7 @@ public class FedoraLdpTest {
             final MediaType requestContentType = MediaType.valueOf("some/mime-type; with=some; param=s");
 
             final String sha = "07a4d371f3b7b6283a8e1230b7ec6764f8287bf2";
-            final String requestSHA = "sha1=" + sha;
+            final String requestSHA = "sha=" + sha;
             final URI shaURI = URI.create("urn:sha1:" + sha);
 
             final String md5 = "HUXZLQLMuI/KZ5KDcJPcOA==";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -99,9 +99,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Iterators;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -120,11 +117,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.Variant;
-import nu.validator.htmlparser.sax.HtmlParser;
-import nu.validator.saxtree.TreeBuilder;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -165,6 +162,13 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterators;
+
+import nu.validator.htmlparser.sax.HtmlParser;
+import nu.validator.saxtree.TreeBuilder;
 
 /**
  * @author cabeer

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
@@ -39,7 +39,7 @@ public final class ContentDigest {
     private static final Logger LOGGER = getLogger(ContentDigest.class);
 
     public enum DIGEST_ALGORITHM {
-        SHA1("SHA-1", "urn:sha1"), SHA256("SHA-256", "urn:sha256"), MD5("MD5", "urn:md5"), MISSING("NONE", "missing");
+        SHA1("SHA", "urn:sha1"), SHA256("SHA-256", "urn:sha256"), MD5("MD5", "urn:md5"), MISSING("NONE", "missing");
 
         final public String algorithm;
         final private String scheme;

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
@@ -18,9 +18,9 @@
 package org.fcrepo.kernel.api.utils;
 
 import static java.net.URI.create;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.api.utils.ContentDigest.getAlgorithm;
-import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
@@ -18,9 +18,9 @@
 package org.fcrepo.kernel.api.utils;
 
 import static java.net.URI.create;
-import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.api.utils.ContentDigest.getAlgorithm;
+import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -41,12 +41,24 @@ public class ContentDigestTest {
     @Test
     public void testSHA1() {
         assertEquals("Failed to produce a proper content digest URI!",
-                create("urn:sha1:fake"), asURI("SHA1", "fake"));
+                create("urn:sha1:fake"), asURI("SHA", "fake"));
     }
 
     @Test
     public void testGetAlgorithm() {
         assertEquals("Failed to produce a proper digest algorithm!", SHA1.algorithm,
                 getAlgorithm(asURI(SHA1.algorithm, "fake")));
+    }
+
+    @Test
+    public void testSHA256() {
+        assertEquals("Failed to produce a proper content digest URI!",
+                create("urn:sha256:fake"), asURI("SHA-256", "fake"));
+    }
+
+    @Test
+    public void testMissingAlgorithm() {
+        assertEquals("Failed to produce a proper content digest URI!",
+                create("missing:fake"), asURI("SHA-819", "fake"));
     }
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
@@ -428,7 +428,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
     @Test
     public void testGetFixityWithWantDigest() throws RepositoryException, InvalidChecksumException,
             URISyntaxException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
-        final Collection<String> digestAlgs = Collections.singletonList("SHA-1");
+        final Collection<String> digestAlgs = Collections.singletonList("SHA");
         final String pid = "testFixityWithWantDigest-" + randomUUID();
         final FedoraSession session = repo.login();
         try {
@@ -463,7 +463,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
     @Test
     public void testGetFixityWithWantDigestMultuple() throws RepositoryException, InvalidChecksumException,
             URISyntaxException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
-        final String[] digestAlgValues = {"SHA-1", "md5"};
+        final String[] digestAlgValues = {"SHA", "md5"};
         final Collection<String> digestAlgs = Arrays.asList(digestAlgValues);
         final String pid = "testFixityWithWantDigestMultiple-" + randomUUID();
         final FedoraSession session = repo.login();


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/projects/FCREPO/issues/FCREPO-2651

# What does this Pull Request do?
Changes the algorithm accepted and returned in Want-Digest from **sha-1** to **sha**

# What's new?
A simple find and replace and a tonne of tests updated.

# How should this be tested?

```
> curl -i -G -H"Want-Digest: sha-1" http://localhost:8080/rest/louis -ufedoraAdmin:fedoraAdmin             
HTTP/1.1 400 Bad Request
Date: Thu, 02 Nov 2017 05:12:55 GMT
ETag: "810323d9c6f1ffce9984556f3da0f68f798f4ecf"
Last-Modified: Thu, 02 Nov 2017 05:07:27 GMT
Content-Type: text/plain;charset=utf-8
Content-Length: 68
Server: Jetty(9.3.1.v20150714)

Unsupported digest algorithm provided in 'Want-Digest' header: sha-1

> curl -i -I -H"Want-Digest: sha" http://localhost:8080/rest/louis -ufedoraAdmin:fedoraAdmin 
HTTP/1.1 200 OK
Date: Thu, 02 Nov 2017 05:13:46 GMT
ETag: "810323d9c6f1ffce9984556f3da0f68f798f4ecf"
Last-Modified: Thu, 02 Nov 2017 05:07:27 GMT
Content-Type: image/jpeg
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Thu, 02 Nov 2017 05:07:27 GMT"; modification-date="Thu, 02 Nov 2017 05:07:27 GMT"; size=751
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8080/rest/louis/fcr:metadata>; rel="describedby"
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Digest: sha=8e2d52a73c3f1a750d7e566534a6542d3fbb75ac
Content-Length: 751
Server: Jetty(9.3.1.v20150714)

> curl -i -XPOST -H"Slug: LargeLouis" -H"Digest: sha1=4deb37262cf584ecb9ca838c433e22042ab3dac8" -H"Content-type: image/jpeg" -d"@/Users/whikloj/Desktop/Louis_Riel.jpg" http://localhost:8080/rest -ufedoraAdmin:fedoraAdmin
HTTP/1.1 100 Continue

HTTP/1.1 400 Bad Request
Date: Thu, 02 Nov 2017 05:21:32 GMT
Content-Type: text/plain;charset=utf-8
Content-Length: 75
Server: Jetty(9.3.1.v20150714)

Unsupported Digest Algorithm: sha1=4deb37262cf584ecb9ca838c433e22042ab3dac8

> curl -i -XPOST -H"Slug: LargeLouis" -H"Digest: sha=4deb37262cf584ecb9ca838c433e22042ab3dac8" -H"Content-type: image/jpeg" -d"@/Users/whikloj/Desktop/Louis_Riel.jpg" http://localhost:8080/rest -ufedoraAdmin:fedoraAdmin 
HTTP/1.1 100 Continue

HTTP/1.1 201 Created
Date: Thu, 02 Nov 2017 05:22:13 GMT
ETag: "c3cb2594ea3a0c7ffec272e3561722d6aa93c130"
Last-Modified: Thu, 02 Nov 2017 05:22:13 GMT
Link: <http://localhost:8080/rest/LargeLouis/fcr:metadata>; rel="describedby"; anchor="http://localhost:8080/rest/LargeLouis"
Location: http://localhost:8080/rest/LargeLouis
Content-Type: text/plain
Content-Length: 37
Server: Jetty(9.3.1.v20150714)

http://localhost:8080/rest/LargeLouis
```

# Additional Notes:

* Does this change require documentation to be updated? yes
     * https://wiki.duraspace.org/display/FEDORA4x/Fixity+Checking
     * https://wiki.duraspace.org/display/FEDORA4x/RESTful+HTTP+API+-+Containers#RESTfulHTTPAPI-Containers-post-example4
     * https://wiki.duraspace.org/display/FEDORA4x/RESTful+HTTP+API+-+Containers#RESTfulHTTPAPI-Containers-post-example4b
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? possibly if someone is relying on SHA-1

# Interested parties
@fcrepo4/committers
