### PR TITLE
Switch from JBoss JTA to Narayana JTA (#2649)

### DIFF
--- a/fcrepo-boms/fcrepo-jcr-bom/pom.xml
+++ b/fcrepo-boms/fcrepo-jcr-bom/pom.xml
@@ -52,9 +52,9 @@
         <version>${modeshape.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.jboss.jbossts</groupId>
-        <artifactId>jbossjta</artifactId>
-        <version>${jbossjta.version}</version>
+        <groupId>org.jboss.narayana.jta</groupId>
+        <artifactId>narayana-jta</artifactId>
+        <version>${narayana-jta.version}</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>

--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -82,8 +82,8 @@
           <artifactId>logback-classic</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.jboss.jbossts</groupId>
-          <artifactId>jbossjta</artifactId>
+          <groupId>org.jboss.narayana.jta</groupId>
+          <artifactId>narayana-jta</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.modeshape</groupId>

--- a/fcrepo-kernel-modeshape/pom.xml
+++ b/fcrepo-kernel-modeshape/pom.xml
@@ -62,8 +62,8 @@
       <artifactId>modeshape-jcr</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.jbossts</groupId>
-      <artifactId>jbossjta</artifactId>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>narayana-jta</artifactId>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <commons-codec.version>1.10</commons-codec.version>
     <commons-io.version>2.5</commons-io.version>
     <commons-lang.version>3.5</commons-lang.version>
-    <jbossjta.version>4.16.6.Final</jbossjta.version>
+    <narayana-jta.version>5.7.0.Final</narayana-jta.version>
     <jetty.version>9.3.1.v20150714</jetty.version>
     <guava.version>20.0</guava.version>
     <hk2.version>2.3.0</hk2.version>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2649

Fedora-tech thread where upgrading to Narayana was suggested by @birkland: https://groups.google.com/d/topic/fedora-tech/r4qR2mF4eGk/discussion

# What does this Pull Request do?
Switch from outdated JBoss JTA to up-to-date Narayana JTA.

# What's new?
The JBoss JTA library was at version 4.16.6.Final, which was approximately 5 years old. Switched to the Narayana JTA, which is actually the replacement for the old JBoss JTA. Using version 5.7.0.Final, which was released in September 2017.

# How should this be tested?
Run a standard `mvn clean install`

# Additional Notes:
* Adds a dependency on Narayana JTA
* Removes dependency on JBoss JTA

# Interested parties
@awoods 
