### PR TITLE
Each supported external content type is now advertised in

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -139,6 +139,7 @@ import com.google.common.annotations.VisibleForTesting;
 public abstract class ContentExposingResource extends FedoraBaseResource {
 
     private static final Logger LOGGER = getLogger(ContentExposingResource.class);
+    public static final String URL_ACCESS_TYPE = "URL";
 
     @Context protected Request request;
     @Context protected HttpServletResponse servletResponse;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -760,8 +760,9 @@ public class FedoraLdp extends ContentExposingResource {
 
             final String rdfTypes = TURTLE + "," + N3 + "," + N3_ALT2 + ","
                     + RDF_XML + "," + NTRIPLES + "," + JSON_LD;
-            servletResponse.addHeader("Accept-Post", rdfTypes + "," + MediaType.MULTIPART_FORM_DATA
-                    + "," + contentTypeSPARQLUpdate);
+            servletResponse.addHeader("Accept-Post", rdfTypes + "," + MediaType.MULTIPART_FORM_DATA + "," +
+                    contentTypeSPARQLUpdate + "," + MessageExternalBodyContentType.MEDIA_TYPE + "; access-type=" +
+                    URL_ACCESS_TYPE);
         } else {
             options = "";
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -572,6 +572,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertTrue("POST should support application/rdf+xml", postTypes.contains(contentTypeRDFXML));
         assertTrue("POST should support application/n-triples", postTypes.contains(contentTypeNTriples));
         assertTrue("POST should support multipart/form-data", postTypes.contains("multipart/form-data"));
+        assertTrue("POST should support message/external-body; access-type=URL", postTypes.contains(
+                "message/external-body; access-type=URL"));
+
     }
 
     private static void assertRdfOptionsHeaders(final HttpResponse httpResponse) {


### PR DESCRIPTION
Accept-Post response header.

Resolves: https://jira.duraspace.org/browse/FCREPO-2585

# To test this feature: 

1. Fire up the one-click
2. `curl -v -XOPTIONS http://localhost:8080/rest/`
3. Verify that the Accept-Post header containers the following option: 
message/external-body; access-type=URL

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
