### PR TITLE
Improve mediatype validation on ingest

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -101,6 +101,7 @@ import org.fcrepo.http.commons.session.HttpSession;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PreconditionException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -641,7 +642,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                                                    final InputStream requestBodyStream,
                                                    final ContentDisposition contentDisposition,
                                                    final MediaType contentType,
-                                                   final Collection<String> checksums) throws InvalidChecksumException {
+                                                   final Collection<String> checksums)
+            throws InvalidChecksumException, InvalidMediaTypeException {
         final Collection<URI> checksumURIs = checksums == null ?
                 new HashSet<>() : checksums.stream().map(checksum -> checksumURI(checksum)).collect(Collectors.toSet());
         final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -113,6 +113,7 @@ import org.fcrepo.kernel.api.TripleCategory;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PreconditionException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
@@ -950,7 +951,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinary() throws MalformedRdfException, InvalidChecksumException,
-           IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException, InvalidMediaTypeException {
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {
@@ -963,7 +964,8 @@ public class FedoraLdpTest {
 
     @Test(expected = InsufficientStorageException.class)
     public void testCreateNewBinaryWithInsufficientResources() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException,
+            InvalidMediaTypeException {
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
 
@@ -984,7 +986,8 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithContentTypeWithParams() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException,
+            InvalidMediaTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -999,7 +1002,8 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumSHA() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException,
+            InvalidMediaTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -1017,7 +1021,8 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumSHA256() throws MalformedRdfException,
-        InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException,
+            InvalidMediaTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -1035,7 +1040,8 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumMD5() throws MalformedRdfException,
-            InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException,
+            InvalidMediaTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);
@@ -1053,7 +1059,8 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewBinaryWithChecksumSHAandMD5() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            InvalidChecksumException, IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException,
+            InvalidMediaTypeException {
 
         setResource(Container.class);
         when(mockBinaryService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockBinary);

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -55,6 +55,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.fcrepo.kernel.api.FedoraRepository;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.observer.EventType;
 import org.fcrepo.kernel.api.models.Container;
@@ -138,7 +139,7 @@ abstract class AbstractJmsIT implements MessageListener {
     }
 
     @Test(timeout = TIMEOUT)
-    public void testFileEvents() throws InvalidChecksumException, RepositoryException {
+    public void testFileEvents() throws InvalidChecksumException, RepositoryException, InvalidMediaTypeException {
 
         final FedoraSession session = repository.login();
         session.addSessionData(BASE_URL, TEST_BASE_URL);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InvalidMediaTypeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InvalidMediaTypeException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Exception to signal a received string is not a valid media type.
+ *
+ * @author claussni
+ */
+public class InvalidMediaTypeException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with the specified media type string.
+     * The exception message is going to be "Invalid media type ..."
+     *
+     * @param mediaTypeString the supposedly invalid media type string
+     */
+    public InvalidMediaTypeException(final String mediaTypeString) {
+        super(String.format("Invalid media type `%s`", mediaTypeString));
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraBinary.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraBinary.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.api.models;
 
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
@@ -49,11 +50,12 @@ public interface FedoraBinary extends FedoraResource {
      * @param originalFileName Original file name of the content (optional)
      * @param storagePolicyDecisionPoint Policy decision point for storing the content (optional)
      * @throws InvalidChecksumException if invalid checksum exception occurred
+     * @throws InvalidMediaTypeException if given content type is not a valid media type
      */
     void setContent(InputStream content, String contentType, Collection<URI> checksums,
                     String originalFileName,
                     StoragePolicyDecisionPoint storagePolicyDecisionPoint)
-            throws InvalidChecksumException;
+            throws InvalidChecksumException, InvalidMediaTypeException;
 
     /**
      * @return The size in bytes of content associated with this datastream.

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
@@ -60,6 +60,7 @@ import org.apache.commons.io.IOUtils;
 import org.fcrepo.kernel.api.FedoraRepository;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
@@ -104,7 +105,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
     }
 
     @Test
-    public void testCreatedDate() throws RepositoryException, InvalidChecksumException {
+    public void testCreatedDate() throws RepositoryException, InvalidChecksumException, InvalidMediaTypeException {
         FedoraSession session = repo.login();
         containerService.findOrCreate(session, "/testDatastreamObject");
 
@@ -128,7 +129,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
     @Test
     public void testDatastreamContent() throws IOException,
             RepositoryException,
-            InvalidChecksumException {
+            InvalidChecksumException, InvalidMediaTypeException {
         final FedoraSession session = repo.login();
         containerService.findOrCreate(session, "/testDatastreamObject");
 
@@ -151,7 +152,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
     }
 
     @Test
-    public void testDatastreamContentType() throws RepositoryException, InvalidChecksumException {
+    public void testDatastreamContentType() throws RepositoryException, InvalidChecksumException,
+            InvalidMediaTypeException {
         final FedoraSession session = repo.login();
         try {
             containerService.findOrCreate(session, "/testDatastreamObject");
@@ -178,7 +180,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
 
     @Test
     public void testDatastreamContentDigestAndLength() throws IOException, RepositoryException,
-    InvalidChecksumException {
+            InvalidChecksumException, InvalidMediaTypeException {
         final FedoraSession session = repo.login();
         try {
             containerService.findOrCreate(session, "/testDatastreamObject");
@@ -209,7 +211,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
 
     @Test
     public void
-    testModifyDatastreamContentDigestAndLength() throws IOException, RepositoryException, InvalidChecksumException {
+    testModifyDatastreamContentDigestAndLength() throws IOException, RepositoryException, InvalidChecksumException,
+            InvalidMediaTypeException {
         final FedoraSession session = repo.login();
         try {
             containerService.findOrCreate(session, "/testDatastreamObject");
@@ -238,7 +241,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
     }
 
     @Test
-    public void testDatastreamContentWithChecksum() throws IOException, RepositoryException, InvalidChecksumException {
+    public void testDatastreamContentWithChecksum() throws IOException, RepositoryException, InvalidChecksumException,
+            InvalidMediaTypeException {
         final FedoraSession session = repo.login();
         try {
             containerService.findOrCreate(session, "/testDatastreamObject");
@@ -267,7 +271,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
     }
 
     @Test
-    public void testDatastreamFileName() throws RepositoryException, InvalidChecksumException {
+    public void testDatastreamFileName() throws RepositoryException, InvalidChecksumException,
+            InvalidMediaTypeException {
         final FedoraSession session = repo.login();
         try {
             containerService.findOrCreate(session, "/testDatastreamObject");
@@ -293,7 +298,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
     }
 
     @Test
-    public void testChecksumBlobs() throws RepositoryException, InvalidChecksumException {
+    public void testChecksumBlobs() throws RepositoryException, InvalidChecksumException, InvalidMediaTypeException {
         final String pid = "testChecksumBlobs-" + randomUUID();
         final FedoraSession session = repo.login();
         try {
@@ -331,7 +336,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
     }
 
     @Test
-    public void testChecksumBlobsForInMemoryValues() throws RepositoryException, InvalidChecksumException {
+    public void testChecksumBlobsForInMemoryValues() throws RepositoryException, InvalidChecksumException,
+            InvalidMediaTypeException {
 
         final FedoraSession session = repo.login();
         try {
@@ -396,7 +402,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
 
     @Test
     public void testExceptionGetFixityWithWantDigest() throws RepositoryException, InvalidChecksumException,
-            UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            UnsupportedAlgorithmException, UnsupportedAccessTypeException, InvalidMediaTypeException {
         final Collection<String> digestAlgs = Collections.singletonList("sha256");
         final String pid = "testFixityWithWantDigest-" + randomUUID();
         final FedoraSession session = repo.login();
@@ -427,7 +433,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
 
     @Test
     public void testGetFixityWithWantDigest() throws RepositoryException, InvalidChecksumException,
-            URISyntaxException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            URISyntaxException, UnsupportedAlgorithmException, UnsupportedAccessTypeException,
+            InvalidMediaTypeException {
         final Collection<String> digestAlgs = Collections.singletonList("SHA");
         final String pid = "testFixityWithWantDigest-" + randomUUID();
         final FedoraSession session = repo.login();
@@ -462,7 +469,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
 
     @Test
     public void testGetFixityWithWantDigestMultuple() throws RepositoryException, InvalidChecksumException,
-            URISyntaxException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            URISyntaxException, UnsupportedAlgorithmException, UnsupportedAccessTypeException,
+            InvalidMediaTypeException {
         final String[] digestAlgValues = {"SHA", "md5"};
         final Collection<String> digestAlgs = Arrays.asList(digestAlgValues);
         final String pid = "testFixityWithWantDigestMultiple-" + randomUUID();
@@ -497,7 +505,8 @@ public class FedoraBinaryImplIT extends AbstractIT {
     }
 
     @Test
-    public void testModifyDatastreamDescriptionLastMod() throws RepositoryException, InvalidChecksumException {
+    public void testModifyDatastreamDescriptionLastMod() throws RepositoryException, InvalidChecksumException,
+            InvalidMediaTypeException {
         final FedoraSession session = repo.login();
         try {
             containerService.findOrCreate(session, "/testDatastreamObject");

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -104,6 +104,7 @@ import org.apache.commons.io.IOUtils;
 import org.fcrepo.kernel.api.FedoraRepository;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.InvalidPrefixException;
@@ -403,7 +404,7 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testDatastreamGraph() throws RepositoryException, InvalidChecksumException {
+    public void testDatastreamGraph() throws RepositoryException, InvalidChecksumException, InvalidMediaTypeException {
 
         final Container parentObject = containerService.findOrCreate(session, "/testDatastreamGraphParent");
         final Session jcrSession = getJcrSession(session);
@@ -1101,7 +1102,9 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testVersionedChildBinaryDeleted() throws RepositoryException, InvalidChecksumException, IOException {
+    public void testVersionedChildBinaryDeleted()
+            throws RepositoryException, InvalidChecksumException, IOException, InvalidMediaTypeException {
+
         final String pid = getRandomPid();
         final Container object = containerService.findOrCreate(session, "/" + pid);
         object.enableVersioning();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
@@ -53,6 +53,7 @@ import org.fcrepo.integration.kernel.modeshape.AbstractIT;
 import org.fcrepo.kernel.api.FedoraRepository;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.observer.EventType;
@@ -117,7 +118,8 @@ public class SimpleObserverIT extends AbstractIT {
     }
 
     @Test
-    public void contentEventCollapsing() throws RepositoryException, InvalidChecksumException {
+    public void contentEventCollapsing() throws RepositoryException, InvalidChecksumException,
+            InvalidMediaTypeException {
 
         final FedoraSession session = repository.login();
         final Session se = getJcrSession(session);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/RepositoryServiceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/RepositoryServiceImplIT.java
@@ -32,6 +32,7 @@ import org.fcrepo.integration.kernel.modeshape.AbstractIT;
 import org.fcrepo.kernel.api.FedoraRepository;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.RepositoryService;
 
@@ -57,7 +58,8 @@ public class RepositoryServiceImplIT extends AbstractIT {
     private BinaryService binaryService;
 
     @Test
-    public void testGetAllObjectsDatastreamSize() throws RepositoryException, InvalidChecksumException {
+    public void testGetAllObjectsDatastreamSize() throws RepositoryException, InvalidChecksumException,
+            InvalidMediaTypeException {
         final long originalSize;
         FedoraSession session = repository.login();
         try {

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraBinaryImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/FedoraBinaryImplTest.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.modeshape;
 
 import org.apache.tika.io.IOUtils;
 import org.fcrepo.kernel.api.FedoraTypes;
+import org.fcrepo.kernel.api.exception.InvalidMediaTypeException;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.junit.After;
@@ -127,7 +128,7 @@ public class FedoraBinaryImplTest implements FedoraTypes {
 
     @Test
     public void testSetContent() throws RepositoryException,
-            InvalidChecksumException {
+            InvalidChecksumException, InvalidMediaTypeException {
         final org.modeshape.jcr.api.Binary mockBin =
                 mock(org.modeshape.jcr.api.Binary.class);
         getContentNodeMock(mockContent, 8);
@@ -146,7 +147,7 @@ public class FedoraBinaryImplTest implements FedoraTypes {
 
     @Test
     public void testSetContentWithFilename() throws RepositoryException,
-            InvalidChecksumException {
+            InvalidChecksumException, InvalidMediaTypeException {
         final org.modeshape.jcr.api.Binary mockBin =
                 mock(org.modeshape.jcr.api.Binary.class);
         getContentNodeMock(mockContent, 8);
@@ -167,7 +168,7 @@ public class FedoraBinaryImplTest implements FedoraTypes {
     @Test(expected = InvalidChecksumException.class)
     public void testSetContentWithChecksumMismatch()
             throws RepositoryException, InvalidChecksumException,
-            URISyntaxException {
+            URISyntaxException, InvalidMediaTypeException {
         final org.modeshape.jcr.api.Binary mockBin =
                 mock(org.modeshape.jcr.api.Binary.class);
         getContentNodeMock(mockContent, 8);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2520

# What does this Pull Request do?
Add verification of client provided mediatype.

# What's new?
If a client provides an invalid mediatype (according to https://tools.ietf.org/html/rfc6838#section-4.2), the request is rejected with status code 400 BAD REQUEST

# How should this be tested?
See https://jira.duraspace.org/browse/FCREPO-2658