### PR TITLE
Adds code to handle invalid mime-type

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -209,7 +209,7 @@ public class FedoraLdp extends ContentExposingResource {
         Response.ResponseBuilder builder = ok();
 
         if (resource() instanceof FedoraBinary) {
-            final MediaType mediaType = MediaType.valueOf(((FedoraBinary) resource()).getMimeType());
+            final MediaType mediaType = getBinaryResourceMediaType();
 
             if (isExternalBody(mediaType)) {
                 builder = externalBodyRedirect(getExternalResourceLocation(mediaType));
@@ -274,7 +274,8 @@ public class FedoraLdp extends ContentExposingResource {
                     .getAcceptableMediaTypes());
 
             if (resource() instanceof FedoraBinary && acceptableMediaTypes.size() > 0) {
-                final MediaType mediaType = MediaType.valueOf(((FedoraBinary) resource()).getMimeType());
+
+                final MediaType mediaType = getBinaryResourceMediaType();
 
                 // Respect the Want-Digest header for fixity check
                 final String wantDigest = headers.getHeaderString(WANT_DIGEST);


### PR DESCRIPTION
- Allows binary to be retrieved even if mime-type is invalid

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2520

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR will allow a client to still be able to retrieve a binary, should the mime type field become syntactically incorrect.  This is possible solution (or a step in the right direction) for the above JIRA ticket. 

Another solution is to ensure that ebucore:hasMimeType field is not set to something invalid.  Not sure how hard that would be to implement. 

# What's new?
This change wraps up the MediaType.valueOf() call and catches an exception it might throw.  If it throws one, the exception gets logged and the code keeps going as if the mime type were 'application/octet-stream', versus returning a 500 error. 

# How should this be tested?
Start up a fcrepo4 server.  Add a binary file with a correct mime type.  Change the technical metadata triple:  ebucore:hasMimeType to something syntactically invalid - like "== invalid==".  Then try to GET the binary again.  It should allow you to retrieve the binary, which will show the content type of 'application/octet-stream'

# Interested parties
@fcrepo4/committers 