### PR TITLE
Check RDF mimetype in ebucore:hasMimeType triple

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.modeshape;
 
+import static com.google.common.net.MediaType.parse;
 import static java.time.Instant.ofEpochMilli;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
@@ -267,10 +268,26 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         return null;
     });
 
+    private static final Function<Quad, IllegalArgumentException> validateMimeTypeTriple = uncheck(x -> {
+
+        /* only look at the mime type if it's not a sparql variable */
+        if (x.getPredicate().toString().equals(RdfLexicon.HAS_MIME_TYPE.toString()) &&
+                !x.getObject().toString(false).startsWith("?")) {
+            try {
+                parse(x.getObject().toString(false));
+            } catch (Exception ex) {
+                return new IllegalArgumentException("Invalid value for '" + RdfLexicon.HAS_MIME_TYPE +
+                        "' encountered : " + x.getObject().toString());
+            }
+        }
+        return null;
+    });
+
     private static final List<Function<Quad, IllegalArgumentException>> quadValidators =
             ImmutableList.<Function<Quad, IllegalArgumentException>>builder()
                     .add(validatePredicateEndsWithSlash)
-                    .add(validateObjectUrl).build();
+                    .add(validateObjectUrl)
+                    .add(validateMimeTypeTriple).build();
 
     /**
      * Construct a {@link org.fcrepo.kernel.api.models.FedoraResource} from an existing JCR Node

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -104,10 +104,11 @@ import org.apache.commons.io.IOUtils;
 import org.fcrepo.kernel.api.FedoraRepository;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
-import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.InvalidPrefixException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.Container;
@@ -839,6 +840,34 @@ public class FedoraResourceImplIT extends AbstractIT {
         assertEquals(0, getJcrNode(object).getNode("#").getNodes().getSize());
     }
 
+    @Test (expected = ConstraintViolationException.class)
+    public void testReplacePropertyBadMimeType() {
+        final String pid = getRandomPid();
+        final Container object = containerService.findOrCreate(session, pid);
+
+        try (final RdfStream triples = object.getTriples(subjects, PROPERTIES)) {
+            final Model model = triples.collect(toModel());
+
+            final Resource resource = model.createResource();
+            final Resource subject = subjects.reverse().convert(object);
+            final Property predicate = model.createProperty(
+                    "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType");
+            model.add(subject, predicate, "--Total Junk Mime Type--");
+            model.add(resource, model.createProperty("http://purl.org/dc/elements/1.1/title"), "xyz");
+
+            object.replaceProperties(subjects, model, object.getTriples(subjects, PROPERTIES));
+        }
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testUpdatePropertyBadMimeType() {
+        final String pid = getRandomPid();
+        final FedoraResource object = containerService.findOrCreate(session, pid);
+        object.updateProperties(subjects,
+                "PREFIX ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#>\n" +
+                "INSERT { <> ebucore:hasMimeType \"-- Complete Junk --\"" + " . } WHERE { }",
+                object.getTriples(subjects, emptySet()));
+    }
     @Test
     public void testDeleteObject() throws RepositoryException {
         final String pid = getRandomPid();
@@ -1294,15 +1323,6 @@ public class FedoraResourceImplIT extends AbstractIT {
                 createResource("info:fedora/" + pid + "/c")));
     }
 
-    @Test (expected = IllegalArgumentException.class)
-    public void testMimeTypeValidation() {
-        final String pid = getRandomPid();
-        final FedoraResource object = containerService.findOrCreate(session, pid);
-        object.updateProperties(subjects,
-                "PREFIX ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#>\n" +
-                "INSERT { <> ebucore:hasMimeType \"-- Complete Junk --\"" + " . } WHERE { }",
-                object.getTriples(subjects, emptySet()));
-    }
 
     private void addVersionLabel(final String label, final FedoraResource r) throws RepositoryException {
         final Session jcrSession = getJcrSession(session);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -1294,6 +1294,16 @@ public class FedoraResourceImplIT extends AbstractIT {
                 createResource("info:fedora/" + pid + "/c")));
     }
 
+    @Test (expected = IllegalArgumentException.class)
+    public void testMimeTypeValidation() {
+        final String pid = getRandomPid();
+        final FedoraResource object = containerService.findOrCreate(session, pid);
+        object.updateProperties(subjects,
+                "PREFIX ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#>\n" +
+                "INSERT { <> ebucore:hasMimeType \"-- Complete Junk --\"" + " . } WHERE { }",
+                object.getTriples(subjects, emptySet()));
+    }
+
     private void addVersionLabel(final String label, final FedoraResource r) throws RepositoryException {
         final Session jcrSession = getJcrSession(session);
         addVersionLabel(label, jcrSession.getWorkspace().getVersionManager().getBaseVersion(r.getPath()));


### PR DESCRIPTION
**This is a continuation of the fix for FCREPO-2520. ebucore:hasMimeType triple will be syntatically validated on a sparql update or PUT request. 

***

JIRA Ticket: https://jira.duraspace.org/browse/FCREPO-2520

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Introduces code that will run through the triples and make sure an object of a ebucore:hasMimeType triple is syntactically valid. 

# What's new?
This code adds on to the triple validation that is done in the kernel-modeshape module. It adds a check for syntax on mime type. 

# How should this be tested?

You could test this change by sending in a sparql request with ebucore:hasMimeType set to something syntactically invalid - like "Junk Mime Type" - that should return a 400 error with a message about the mime type. 
Also, sending RDF via a PUT command with a syntactically invalid mime type would cause a 400 to be returned with a message about mime type. 




# Additional Notes:
I'm not sure if this would be considered a breaking change -- client software that sets the mime type could now (potentially) get a 400, whereas before it would have succeeded no matter what the value was.  This might cause them to have to re-write some code.  


# Interested parties
@awoods, @whikloj, @dbernstein 