### PR TITLE
Adjust to get the timemap from the binary correctly.

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -103,6 +103,7 @@ import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.GraphDifferencer;
@@ -246,7 +247,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
             final String uri = x.getObject().toString();
             try {
                 new URI(uri);
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 return new IllegalArgumentException("Invalid object URI (" + uri + " ) : " + ex.getMessage());
             }
         }
@@ -375,9 +376,9 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     public FedoraResource getTimeMap() {
         try {
             return Optional.of(node.getNode(LDPCV_TIME_MAP)).map(nodeConverter::convert).orElse(null);
-        } catch (PathNotFoundException e) {
+        } catch (final PathNotFoundException e) {
             throw new PathNotFoundRuntimeException(e);
-        } catch (RepositoryException e) {
+        } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }
     }
@@ -386,7 +387,11 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     public FedoraResource findOrCreateTimeMap() {
         final Node ldpcvNode;
         try {
-            ldpcvNode = findOrCreateChild(getNode(), LDPCV_TIME_MAP, NT_FOLDER);
+            if (this instanceof FedoraBinary) {
+                ldpcvNode = findOrCreateChild(getNode().getParent(), LDPCV_TIME_MAP, NT_FOLDER);
+            } else {
+                ldpcvNode = findOrCreateChild(getNode(), LDPCV_TIME_MAP, NT_FOLDER);
+            }
 
             if (ldpcvNode.isNew()) {
                 LOGGER.debug("Created TimeMap LDPCv {}", ldpcvNode.getPath());
@@ -481,7 +486,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
                 final Iterator<Node> nodes = n.getNodes();
                 nodes.forEachRemaining(this::removeReferences);
             }
-        } catch (RepositoryException e) {
+        } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }
     }
@@ -706,7 +711,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         try {
             touch(propertyChanged.get(), listener.getAddedCreatedDate(), listener.getAddedCreatedBy(),
                     listener.getAddedModifiedDate(), listener.getAddedModifiedBy());
-        } catch (RepositoryException e) {
+        } catch (final RepositoryException e) {
             throw new RuntimeException(e);
         }
     }
@@ -804,7 +809,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
                         RelaxedPropertiesHelper.getCreatedBy(filteredStatements),
                         RelaxedPropertiesHelper.getModifiedDate(filteredStatements),
                         RelaxedPropertiesHelper.getModifiedBy(filteredStatements));
-            } catch (RepositoryException e) {
+            } catch (final RepositoryException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -997,7 +1002,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
           return ((FedoraResourceImpl)getDescription()).getNode(getNode(), LDPCV_TIME_MAP, false) != null;
           //@TODO This line should be changed to "return getDescription().getChild(LDPCV_TIME_MAP);"
           //once the issues around https://jira.duraspace.org/browse/FCREPO-2644 have been landed.
-      } catch (RepositoryException ex) {
+      } catch (final RepositoryException ex) {
           throw new RepositoryRuntimeException(ex);
       }
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2681

# What does this Pull Request do?
In the nt:file type there is jcr:content child, our new nt:versionedFile also has a fedora:timemap.

But because the jcr:content has the PRIMARY attribute it is returned when the getNode() function is accessed. So we need to go up to the containing resource (Description) and then access the timemap.

# What's new?

# How should this be tested?

Build a versionable binary. Before on a GET you would get a 500 error. Now you should get the correct(ish) response. The address of the timemap in the returned RDF is wrong. There is a new ticket for that (https://jira.duraspace.org/browse/FCREPO-2690)

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
@dbernstein 
