### PR TITLE
Ensures that binary timemaps translate their paths correctly.

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
@@ -514,8 +514,15 @@ public abstract class FedoraTypesUtils implements FedoraTypes {
                 return empty();
             }
 
+            //check ancestors recursively only either of the following two cases applies:
+            // 1. the PARENT is a FEDORA_PAIRTREE
+            // 2. the PARENT is FEDORA_NON_RDF_SOURCE_DESCRIPTION AND the the NODE itself NOT a FEDORA_TIME_MAP.
+            //Time maps of Fedora binaries must be handled slightly differently due to the fact that
+            //the TimeMap is a child of the resource description rather than the resource itself as is the
+            //case for RDF sources.
             final Node parent = node.getParent();
-            if (parent.isNodeType(FEDORA_PAIRTREE) || parent.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION)) {
+            if (parent.isNodeType(FEDORA_PAIRTREE) ||
+                (parent.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION) && !node.isNodeType(FEDORA_TIME_MAP))) {
                 return getContainingNode(parent);
             }
             return Optional.of(parent);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtilsTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtilsTest.java
@@ -17,11 +17,14 @@
  */
 package org.fcrepo.kernel.modeshape.utils;
 
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_SKOLEM;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_TIME_MAP;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.ROOT;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.isBinaryContentProperty;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.property2values;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getClosestExistingAncestor;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getContainingNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getReferencePropertyName;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isSkolemNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isReferenceProperty;
@@ -151,6 +154,9 @@ public class FedoraTypesUtilsTest {
 
     @Mock
     private Node mockContainer;
+
+    @Mock
+    private Node mockParent;
 
     @Mock
     private JcrRepository mockJcrRepository;
@@ -382,4 +388,12 @@ public class FedoraTypesUtilsTest {
         assertFalse(isExternalNode.test(mockNode));
     }
 
+    @Test
+    public void testGetBinaryTimeMapShouldReturnDirectParent() throws RepositoryException {
+        when(mockNode.getDepth()).thenReturn(1);
+        when(mockNode.isNodeType(FEDORA_TIME_MAP)).thenReturn(true);
+        when(mockParent.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION)).thenReturn(true);
+        when(mockNode.getParent()).thenReturn(mockParent);
+        assertEquals(mockParent, getContainingNode(mockNode).get());
+    }
 }


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2690

**Ensures that binary timemaps translate their paths correctly.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2690

# What does this Pull Request do?
Ensures that binary timemaps translate their paths correctly.

# What's new?
FedoraTypes.getContainingNode(node) was modified to return the direct parent when the specified node is the TimeMap of a Non RDF Source Description.
 
# How should this be tested?
Start the one-click jar.

1. ``` curl -v -XPUT  -H "Content-Type: text/plain" -H "Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel=\"type\"" "http://localhost:8080/rest/test1234" -u fedoraAdmin:fedoraAdmin```

2. ```curl -v http://localhost:8080/rest/test2-1234/fedora:timemap```

3. Verify that subject URI is <http://localhost:8080/rest/test2-1234/fcr:versions> in the returned RDF.


# Interested parties
@whikloj 