### PR TITLE
getDescribedResource to ensure timemap and timegate URIs are correct for binaries

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -444,9 +444,10 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (resource.isVersioned()) {
             final Link versionedResource = Link.fromUri(RdfLexicon.VERSIONED_RESOURCE.getURI()).rel("type").build();
             servletResponse.addHeader(LINK, versionedResource.toString());
-            final Link timegate = Link.fromUri(getUri(resource)).rel("timegate").build();
+            final Link timegate = Link.fromUri(getUri(resource.getDescribedResource())).rel("timegate").build();
             servletResponse.addHeader(LINK, timegate.toString());
-            final Link timemap = Link.fromUri(getUri(resource) + "/" + FCR_VERSIONS).rel("timemap").build();
+            final Link timemap =
+                Link.fromUri(getUri(resource.getDescribedResource()) + "/" + FCR_VERSIONS).rel("timemap").build();
             servletResponse.addHeader(LINK, timemap.toString());
         }
     }
@@ -701,7 +702,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      */
     private void ensureValidMemberRelation(final Model inputModel) throws BadRequestException {
         // check that ldp:hasMemberRelation value is not server managed predicate.
-        inputModel.listStatements().forEachRemaining((Statement s) -> {
+        inputModel.listStatements().forEachRemaining((final Statement s) -> {
             LOGGER.debug("statement: s={}, p={}, o={}", s.getSubject(), s.getPredicate(), s.getObject());
 
             if (s.getPredicate().equals(HAS_MEMBER_RELATION)) {
@@ -740,7 +741,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     /**
      * Calculate the max number of children to display at once.
-     * 
+     *
      * @return the limit of children to display.
      */
     protected int getChildrenLimit() {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2694

# What does this Pull Request do?
Uses `.getDescribedResource()` to ensure that when we are viewing the RdfSource tied to a NonRdfSource object, we want the timemap and the timegate URI to be relative to the NonRdfSource URI.

# What's new?


# How should this be tested?

Without this PR.
1. Make a versioned binary.
```
curl -v -XPUT -H "Content-Type: image/jpeg" -H "Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel=\"type\"" "http://localhost:8080/rest/binaryVersion" -u fedoraAdmin:fedoraAdmin
```

2. HEAD the binary and the `fcr:metadata` and notice the timemap and timegate Link headers.
```
[whikloj@MacBook-Pro.local 19:03 ] 
[/Users/whikloj] 
> curl -I http://localhost:8080/rest/binaryVersion
HTTP/1.1 200 OK
Date: Tue, 06 Mar 2018 01:14:38 GMT
ETag: "fe17af263d6a9bb04bff914eb3fd98d34dd501e4"
Last-Modified: Fri, 02 Mar 2018 20:09:34 GMT
Content-Type: image/jpeg
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Fri, 02 Mar 2018 20:09:34 GMT"; modification-date="Fri, 02 Mar 2018 20:09:34 GMT"; size=166613
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Vary: Accept-Datetime
Link: <http://localhost:8080/rest/binaryVersion/fcr:metadata>; rel="describedby"
Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel="type"
Link: <http://localhost:8080/rest/binaryVersion>; rel="timegate"
Link: <http://localhost:8080/rest/binaryVersion/fcr:versions>; rel="timemap"
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Content-Length: 166613
Server: Jetty(9.3.1.v20150714)

[whikloj@MacBook-Pro.local 19:03] 
[/Users/whikloj] 
> curl -I http://localhost:8080/rest/binaryVersion/fcr:metadata
HTTP/1.1 200 OK
Date: Tue, 06 Mar 2018 01:14:51 GMT
ETag: W/"fe17af263d6a9bb04bff914eb3fd98d34dd501e4"
Last-Modified: Fri, 02 Mar 2018 20:09:34 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>;rel="type"
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Vary: Accept-Datetime
Link: <http://localhost:8080/rest/binaryVersion>; rel="describes"
Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel="type"
Link: <http://localhost:8080/rest/binaryVersion/fcr:metadata>; rel="timegate"
Link: <http://localhost:8080/rest/binaryVersion/fcr:metadata/fcr:versions>; rel="timemap"
Accept-Patch: application/sparql-update
Allow: HEAD,GET,DELETE,PUT,PATCH,OPTIONS
Content-Type: text/turtle;charset=utf-8
Content-Length: 0
Server: Jetty(9.3.1.v20150714)
```

3. These are the wrong ones.
```
Link: <http://localhost:8080/rest/binaryVersion/fcr:metadata>; rel="timegate"
Link: <http://localhost:8080/rest/binaryVersion/fcr:metadata/fcr:versions>; rel="timemap"
```

4. Apply this PR and try again.
```
[whikloj@MacBook-Pro.local 19:14 ] 
[/Users/whikloj] 
> curl -I http://localhost:8080/rest/binaryVersion             
HTTP/1.1 200 OK
Date: Tue, 06 Mar 2018 01:04:04 GMT
ETag: "fe17af263d6a9bb04bff914eb3fd98d34dd501e4"
Last-Modified: Fri, 02 Mar 2018 20:09:34 GMT
Content-Type: image/jpeg
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Fri, 02 Mar 2018 20:09:34 GMT"; modification-date="Fri, 02 Mar 2018 20:09:34 GMT"; size=166613
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Vary: Accept-Datetime
Link: <http://localhost:8080/rest/binaryVersion/fcr:metadata>; rel="describedby"
Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel="type"
Link: <http://localhost:8080/rest/binaryVersion>; rel="timegate"
Link: <http://localhost:8080/rest/binaryVersion/fcr:versions>; rel="timemap"
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Content-Length: 166613
Server: Jetty(9.3.1.v20150714)

[whikloj@MacBook-Pro.local 19:14 ] 
[/Users/whikloj] 
> curl -I http://localhost:8080/rest/binaryVersion/fcr:metadata
HTTP/1.1 200 OK
Date: Tue, 06 Mar 2018 01:03:48 GMT
ETag: W/"fe17af263d6a9bb04bff914eb3fd98d34dd501e4"
Last-Modified: Fri, 02 Mar 2018 20:09:34 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>;rel="type"
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Vary: Accept-Datetime
Link: <http://localhost:8080/rest/binaryVersion>; rel="describes"
Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel="type"
Link: <http://localhost:8080/rest/binaryVersion>; rel="timegate"
Link: <http://localhost:8080/rest/binaryVersion/fcr:versions>; rel="timemap"
Accept-Patch: application/sparql-update
Allow: HEAD,GET,DELETE,PUT,PATCH,OPTIONS
Content-Type: text/turtle;charset=utf-8
Content-Length: 0
Server: Jetty(9.3.1.v20150714)
```


# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@dbernstein @awoods Sprint-1 participants
