### PR TITLE
Disallowed PUT and PATCH on LDPCv

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -50,7 +50,6 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -101,19 +100,6 @@ public class FedoraVersioning extends ContentExposingResource {
     @VisibleForTesting
     public FedoraVersioning(final String externalPath) {
         this.externalPath = externalPath;
-    }
-
-
-    /**
-     * Enable versioning
-     * @return the response
-     */
-    @PUT
-    public Response enableVersioning() {
-        LOGGER.info("Enable versioning for '{}'", externalPath);
-        resource().enableVersioning();
-        session.commit();
-        return created(uriInfo.getRequestUri()).build();
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -42,6 +42,7 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.apache.jena.graph.Node;
@@ -128,5 +129,41 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             final Node subject = createURI(subjectURI + "/" + FCR_VERSIONS);
             assertTrue("Did not find correct subject", results.contains(ANY, subject, ANY, ANY));
         }
+    }
+
+    @Test
+    public void testPutOnTimeMapContainer() throws IOException {
+        final String id = getRandomUniqueId();
+
+        final String subjectURI = serverAddress + id;
+        final HttpPut createMethod = putObjMethod(id);
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
+        createMethod.addHeader(LINK, VERSIONED_RESOURCE_LINK_HEADER);
+        createMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
+
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+        }
+
+        // status 405: PUT On LPDCv is disallowed.
+        assertEquals(405, getStatus(new HttpPut(serverAddress + id + "/" + FCR_VERSIONS)));
+    }
+
+    @Test
+    public void testPatchOnTimeMapContainer() throws IOException {
+        final String id = getRandomUniqueId();
+
+        final String subjectURI = serverAddress + id;
+        final HttpPut createMethod = putObjMethod(id);
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
+        createMethod.addHeader(LINK, VERSIONED_RESOURCE_LINK_HEADER);
+        createMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
+
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+        }
+
+        // status 405: PATCH On LPDCv is disallowed.
+        assertEquals(405, getStatus(new HttpPatch(serverAddress + id + "/" + FCR_VERSIONS)));
     }
 }


### PR DESCRIPTION
Disallow PUT and PATCH on LDPCv.

https://jira.duraspace.org/browse/FCREPO-2686

# What does this Pull Request do?
Removed the PUT method, added integration test fro PUT and PATCH.

# Test
- Create versioned resource
$ curl -i -XPUT -H "Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel=\"type\"" "http://localhost:8080/rest/versionedResource123"
HTTP/1.1 201 Created
Date: Tue, 06 Mar 2018 22:34:27 GMT
ETag: W/"e762d7afd1d4e48bcb2c897ad2a5a7d8528747c0"
Last-Modified: Tue, 06 Mar 2018 22:34:27 GMT
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://fedora.info/definitions/fcrepo#VersionedResource>; rel="type"
Link: <http://localhost:8080/rest/versionedResource123>; rel="timegate"
Link: <http://localhost:8080/rest/versionedResource123/fcr:versions>; rel="timemap"
Location: http://localhost:8080/rest/versionedResource123
Content-Type: text/plain
Content-Length: 47
Server: Jetty(9.2.3.v20140905)

http://localhost:8080/rest/versionedResource123

- Test for PUT
$ curl -i -XPUT "http://localhost:8080/rest/versionedResource123/fcr:versions"
HTTP/1.1 405 Method Not Allowed
Date: Tue, 06 Mar 2018 22:35:20 GMT
Allow: DELETE,POST,GET,OPTIONS
Content-Type: text/plain;charset=utf-8
Content-Length: 27
Server: Jetty(9.2.3.v20140905)

- Test for PATCH
$ curl -i -XPATCH "http://localhost:8080/rest/versionedResource123/fcr:versions"
HTTP/1.1 405 Method Not Allowed
Date: Tue, 06 Mar 2018 22:35:57 GMT
Allow: DELETE,POST,GET,OPTIONS
Content-Type: text/plain;charset=utf-8
Content-Length: 27
Server: Jetty(9.2.3.v20140905)

