### PR TITLE
Make response headers for HEAD requests match those for GET requests

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -215,7 +215,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (prefer != null) {
             prefer.getReturn().addResponseHeaders(servletResponse);
         }
-    servletResponse.addHeader("Vary", "Accept, Range, Accept-Encoding, Accept-Language");
+        servletResponse.addHeader("Vary", "Accept, Range, Accept-Encoding, Accept-Language");
 
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -205,13 +205,18 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                     new DefaultRdfStream(rdfStream.topic(), concat(rdfStream,
                         getResourceTriples(limit))),
                     session.getFedoraSession().getNamespaces());
-            if (prefer != null) {
-                prefer.getReturn().addResponseHeaders(servletResponse);
-            }
         }
-        servletResponse.addHeader("Vary", "Accept, Range, Accept-Encoding, Accept-Language");
-
+        setVaryAndPreferenceAppliedHeaders(servletResponse, prefer);
         return ok(outputStream).build();
+    }
+
+    protected void setVaryAndPreferenceAppliedHeaders(final HttpServletResponse servletResponse,
+            final MultiPrefer prefer) {
+        if (prefer != null) {
+            prefer.getReturn().addResponseHeaders(servletResponse);
+        }
+    servletResponse.addHeader("Vary", "Accept, Range, Accept-Encoding, Accept-Language");
+
     }
 
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -228,8 +228,9 @@ public class FedoraLdp extends ContentExposingResource {
             if (accept == null || "*/*".equals(accept)) {
                 builder.type(TURTLE_WITH_CHARSET);
             }
+            setVaryAndPreferenceAppliedHeaders(servletResponse, prefer);
         }
-        setVaryAndPreferenceAppliedHeaders(servletResponse, prefer);
+
 
         return builder.build();
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -229,6 +229,10 @@ public class FedoraLdp extends ContentExposingResource {
                 builder.type(TURTLE_WITH_CHARSET);
             }
         }
+        if (prefer != null) {
+            prefer.getReturn().addResponseHeaders(servletResponse);
+        }
+        servletResponse.addHeader("Vary", "Accept, Range, Accept-Encoding, Accept-Language");
 
         return builder.build();
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -229,10 +229,7 @@ public class FedoraLdp extends ContentExposingResource {
                 builder.type(TURTLE_WITH_CHARSET);
             }
         }
-        if (prefer != null) {
-            prefer.getReturn().addResponseHeaders(servletResponse);
-        }
-        servletResponse.addHeader("Vary", "Accept, Range, Accept-Encoding, Accept-Language");
+        setVaryAndPreferenceAppliedHeaders(servletResponse, prefer);
 
         return builder.build();
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -287,6 +287,8 @@ public class FedoraLdpTest {
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should have a Link header", mockResponse.containsHeader(LINK));
         assertTrue("Should have an Allow header", mockResponse.containsHeader("Allow"));
+        assertTrue("Should have a Preference-Applied header", mockResponse.containsHeader("Preference-Applied"));
+        assertTrue("Should have a Vary header", mockResponse.containsHeader("Vary"));
         assertTrue("Should be an LDP Resource",
                 mockResponse.getHeaders(LINK).contains("<" + LDP_NAMESPACE + "Resource>;rel=\"type\""));
         assertShouldHaveConstraintsLink();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -61,6 +61,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -105,6 +106,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
 import org.fcrepo.http.commons.domain.MultiPrefer;
+import org.fcrepo.http.commons.domain.PreferTag;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.http.commons.session.HttpSession;
 import org.fcrepo.kernel.api.FedoraSession;
@@ -205,6 +207,12 @@ public class FedoraLdpTest {
     @Mock
     private AcquiredLock mockLock;
 
+    @Mock
+    private MultiPrefer prefer;
+
+    @Mock
+    private PreferTag preferTag;
+
     private static final Logger log = getLogger(FedoraLdpTest.class);
 
 
@@ -230,6 +238,7 @@ public class FedoraLdpTest {
         setField(testObj, "securityContext", mockSecurityContext);
         setField(testObj, "lockManager", mockLockManager);
         setField(testObj, "context", mockServletContext);
+        setField(testObj, "prefer", prefer);
 
         when(mockHttpConfiguration.putRequiresIfMatch()).thenReturn(false);
 
@@ -255,7 +264,12 @@ public class FedoraLdpTest {
         when(mockSession.getFedoraSession()).thenReturn(mockFedoraSession);
 
         when(mockServletContext.getContextPath()).thenReturn("/");
-    }
+
+        when(prefer.getReturn()).thenReturn(preferTag);
+        doAnswer((Answer<HttpServletResponse>) invocation -> {
+            mockResponse.addHeader("Preference-Applied", "return=representation");
+            return null;
+        }).when(preferTag).addResponseHeaders(mockResponse);    }
 
     private FedoraResource setResource(final Class<? extends FedoraResource> klass) {
         final FedoraResource mockResource = mock(klass);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -61,6 +61,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -105,6 +106,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
 import org.fcrepo.http.commons.domain.MultiPrefer;
+import org.fcrepo.http.commons.domain.PreferTag;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.http.commons.session.HttpSession;
 import org.fcrepo.kernel.api.FedoraSession;
@@ -205,6 +207,12 @@ public class FedoraLdpTest {
     @Mock
     private AcquiredLock mockLock;
 
+    @Mock
+    private MultiPrefer prefer;
+
+    @Mock
+    private PreferTag preferTag;
+
     private static final Logger log = getLogger(FedoraLdpTest.class);
 
 
@@ -230,6 +238,7 @@ public class FedoraLdpTest {
         setField(testObj, "securityContext", mockSecurityContext);
         setField(testObj, "lockManager", mockLockManager);
         setField(testObj, "context", mockServletContext);
+        setField(testObj, "prefer", prefer);
 
         when(mockHttpConfiguration.putRequiresIfMatch()).thenReturn(false);
 
@@ -255,6 +264,12 @@ public class FedoraLdpTest {
         when(mockSession.getFedoraSession()).thenReturn(mockFedoraSession);
 
         when(mockServletContext.getContextPath()).thenReturn("/");
+
+        when(prefer.getReturn()).thenReturn(preferTag);
+                doAnswer((Answer<HttpServletResponse>) invocation -> {
+                    mockResponse.addHeader("Preference-Applied", "return=representation");
+                    return null;
+                }).when(preferTag).addResponseHeaders(mockResponse);
     }
 
     private FedoraResource setResource(final Class<? extends FedoraResource> klass) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -61,7 +61,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -106,7 +105,6 @@ import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
 import org.fcrepo.http.commons.domain.MultiPrefer;
-import org.fcrepo.http.commons.domain.PreferTag;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.http.commons.session.HttpSession;
 import org.fcrepo.kernel.api.FedoraSession;
@@ -207,12 +205,6 @@ public class FedoraLdpTest {
     @Mock
     private AcquiredLock mockLock;
 
-    @Mock
-    private MultiPrefer prefer;
-
-    @Mock
-    private PreferTag preferTag;
-
     private static final Logger log = getLogger(FedoraLdpTest.class);
 
 
@@ -238,7 +230,6 @@ public class FedoraLdpTest {
         setField(testObj, "securityContext", mockSecurityContext);
         setField(testObj, "lockManager", mockLockManager);
         setField(testObj, "context", mockServletContext);
-        setField(testObj, "prefer", prefer);
 
         when(mockHttpConfiguration.putRequiresIfMatch()).thenReturn(false);
 
@@ -264,12 +255,7 @@ public class FedoraLdpTest {
         when(mockSession.getFedoraSession()).thenReturn(mockFedoraSession);
 
         when(mockServletContext.getContextPath()).thenReturn("/");
-
-        when(prefer.getReturn()).thenReturn(preferTag);
-        doAnswer((Answer<HttpServletResponse>) invocation -> {
-            mockResponse.addHeader("Preference-Applied", "return=representation");
-            return null;
-        }).when(preferTag).addResponseHeaders(mockResponse);    }
+    }
 
     private FedoraResource setResource(final Class<? extends FedoraResource> klass) {
         final FedoraResource mockResource = mock(klass);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -281,6 +281,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     "; expected result: " + mt, contentType.contains(mt));
         }
     }
+    
+    private void testHeadVaryAndPreferHeaders(final CloseableHttpResponse response) {
+    	final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+    	final Collection<String> vary = getHeader(response, "Vary");
+    	assertTrue("Didn't find valid Preference-Applied header", preferenceApplied.contains("return=representation"));
+    	assertTrue("Didn't find valid Vary Prefer header", vary.contains("Prefer"));
+    	assertTrue("Didn't find valid Vary Accept headers", vary.contains("Accept, Range, Accept-Encoding, Accept-Language"));
+    }
 
     @Test
     public void testHeadDefaultRDF() throws IOException {
@@ -292,6 +300,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(headObjMethod)) {
             final Collection<String> links = getLinkHeaders(response);
             assertTrue("Didn't find LDP BasicContainer link header!", links.contains(BASIC_CONTAINER_LINK_HEADER));
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -305,6 +314,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(headObjMethod)) {
             final Collection<String> links = getLinkHeaders(response);
             assertTrue("Didn't find LDP NonRDFSource link header!", links.contains(NON_RDF_SOURCE_LINK_HEADER));
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -319,6 +329,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(headObjMethod)) {
             final Collection<String> links = getLinkHeaders(response);
             assertTrue("Didn't find LDP container link header!", links.contains(DIRECT_CONTAINER_LINK_HEADER));
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -333,6 +344,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(headObjMethod)) {
             final Collection<String> links = getLinkHeaders(response);
             assertTrue("Didn't find LDP container link header!", links.contains(INDIRECT_CONTAINER_LINK_HEADER));
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -350,6 +362,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
             assertEquals("attachment", disposition.getType());
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -367,6 +380,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("Fixity Checksum doesn't match",
                     digesterHeaderValue.equals("sha=9578f951955d37f20b601c26591e260c1e5389bf"));
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -387,6 +401,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     digesterHeaderValue.indexOf("sha=9578f951955d37f20b601c26591e260c1e5389bf") >= 0);
             assertTrue("MD5 fixity checksum doesn't match",
                     digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -414,6 +429,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
             assertEquals("attachment", disposition.getType());
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -471,6 +487,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("Fixity Checksum doesn't match",
                     digesterHeaderValue.equals("sha=9578f951955d37f20b601c26591e260c1e5389bf"));
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 
@@ -506,6 +523,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     digesterHeaderValue.indexOf("sha=9578f951955d37f20b601c26591e260c1e5389bf") >= 0);
             assertTrue("MD5 fixity checksum doesn't match",
                     digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
+            testHeadVaryAndPreferHeaders(response);
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -281,13 +281,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     "; expected result: " + mt, contentType.contains(mt));
         }
     }
-    
+
     private void testHeadVaryAndPreferHeaders(final CloseableHttpResponse response) {
-    	final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
-    	final Collection<String> vary = getHeader(response, "Vary");
-    	assertTrue("Didn't find valid Preference-Applied header", preferenceApplied.contains("return=representation"));
-    	assertTrue("Didn't find valid Vary Prefer header", vary.contains("Prefer"));
-    	assertTrue("Didn't find valid Vary Accept headers", vary.contains("Accept, Range, Accept-Encoding, Accept-Language"));
+        final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+        final Collection<String> vary = getHeader(response, "Vary");
+        assertTrue("Didn't find valid Preference-Applied header", preferenceApplied.contains("return=representation"));
+        assertTrue("Didn't find valid Vary Prefer header", vary.contains("Prefer"));
+        assertTrue("Didn't find valid Vary Accept headers",
+                vary.contains("Accept, Range, Accept-Encoding, Accept-Language"));
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -281,14 +281,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     "; expected result: " + mt, contentType.contains(mt));
         }
     }
-
+    
     private void testHeadVaryAndPreferHeaders(final CloseableHttpResponse response) {
-        final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
-        final Collection<String> vary = getHeader(response, "Vary");
-        assertTrue("Didn't find valid Preference-Applied header", preferenceApplied.contains("return=representation"));
-        assertTrue("Didn't find valid Vary Prefer header", vary.contains("Prefer"));
-        assertTrue("Didn't find valid Vary Accept headers",
-                vary.contains("Accept, Range, Accept-Encoding, Accept-Language"));
+    	final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+    	final Collection<String> vary = getHeader(response, "Vary");
+    	assertTrue("Didn't find valid Preference-Applied header", preferenceApplied.contains("return=representation"));
+    	assertTrue("Didn't find valid Vary Prefer header", vary.contains("Prefer"));
+    	assertTrue("Didn't find valid Vary Accept headers", vary.contains("Accept, Range, Accept-Encoding, Accept-Language"));
     }
 
     @Test


### PR DESCRIPTION
This PR makes HEAD response headers match the non-payload headers returned by a GET request to the same resource. Specifically, this PR ensures the "Vary:" and "Preference-Applied” headers are present for HEAD.

Resolves: https://jira.duraspace.org/browse/FCREPO-2661