### PR TITLE
Replace current Link type Header for LDPv  with Memento specified link.

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -55,6 +55,8 @@ public final class RdfLexicon {
 
     public static final String PREMIS_NAMESPACE = "http://www.loc.gov/premis/rdf/v1#";
 
+    public static final String MEMENTO_NAMESPACE = "http://mementoweb.org/ns#";
+
     /**
      * Fedora configuration namespace "fedora-config", used for user-settable
      * configuration properties.
@@ -272,7 +274,7 @@ public final class RdfLexicon {
      * This is an internal RDF type for versionable resources, this may be replaced by a Memento type.
      */
     public static final Property VERSIONED_RESOURCE =
-        createProperty(FCREPO_API_NAMESPACE + "VersionedResource");
+        createProperty(MEMENTO_NAMESPACE + "OriginalResource");
 
     private RdfLexicon() {
 


### PR DESCRIPTION
Replace current Link type Header for LDPv  with Memento specified link.

https://jira.duraspace.org/browse/FCREPO-2678

# How should this be tested?
- It failed to create versioned resource with the old Link type Header:
$ curl -i -XPUT -H "Link: <http://fedora.info/definitions/fcrepo#VersionedResource&gt; rel=\\"type\\"" "http://localhost:8080/rest/versionedResource123"
HTTP/1.1 400 Bad Request
Date: Wed, 07 Mar 2018 18:27:43 GMT
Link: <http://localhost:8080/static/constraints/CannotCreateResourceException.rdf&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 82
Server: Jetty(9.2.3.v20140905)

- It's able to create versioned resource with the memento specified link http://mementoweb.org/ns#OriginalResource:
$ curl -i -XPUT -H "Link: <http://mementoweb.org/ns#OriginalResource&gt;; rel=\\"type\\"" "http://localhost:8080/rest/mementoVersion123"
HTTP/1.1 201 Created
Date: Wed, 07 Mar 2018 18:01:51 GMT
ETag: W/"b17018aea3e08e0185bc6ca7532d56951fd022ed"
Last-Modified: Wed, 07 Mar 2018 18:01:51 GMT
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://mementoweb.org/ns#OriginalResource&gt;; rel="type"
Link: <http://localhost:8080/rest/mementoVersion123&gt;; rel="timegate"
Link: <http://localhost:8080/rest/mementoVersion123/fcr:versions&gt;; rel="timemap"
Location: http://localhost:8080/rest/mementoVersion123
Content-Type: text/plain
Content-Length: 44
Server: Jetty(9.2.3.v20140905)

http://localhost:8080/rest/mementoVersion123


