### PR TITLE
Replace outdated LDPRv link headers with Memento specified headers

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -444,6 +444,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (resource.isVersioned()) {
             final Link versionedResource = Link.fromUri(RdfLexicon.VERSIONED_RESOURCE.getURI()).rel("type").build();
             servletResponse.addHeader(LINK, versionedResource.toString());
+            final Link mementoTimeGate = Link.fromUri(RdfLexicon.VERSIONING_TIMEGATE_TYPE).rel("type").build();
+            servletResponse.addHeader(LINK, mementoTimeGate.toString());
             final Link timegate = Link.fromUri(getUri(resource.getDescribedResource())).rel("timegate").build();
             servletResponse.addHeader(LINK, timegate.toString());
             final Link timemap =

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -92,6 +92,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -1006,6 +1007,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final CloseableHttpResponse response) {
         assertEquals("Didn't get an OK (200) response!", OK.getStatusCode(), getStatus(response));
         checkForVersionedResourceLinkHeader(response);
+        checkForMementoTimeGateLinkHeader(response);
         checkForLinkHeader(response, subjectURI, "timegate");
         checkForLinkHeader(response, subjectURI + "/" + FCR_VERSIONS, "timemap");
         assertEquals(1, Arrays.asList(response.getHeaders("Vary")).stream().filter(x -> x.getValue().contains(
@@ -1030,6 +1032,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private void checkForVersionedResourceLinkHeader(final CloseableHttpResponse response) {
         checkForLinkHeader(response,VERSIONED_RESOURCE.getURI(), "type");
+    }
+
+    private void checkForMementoTimeGateLinkHeader(final CloseableHttpResponse response) {
+        checkForLinkHeader(response,VERSIONING_TIMEGATE_TYPE, "type");
     }
 
     @Test

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -266,9 +266,14 @@ public final class RdfLexicon {
 
     // VERSIONING
     /**
-     * This is a holder for an eventually Memento TimeMap RDF type.
+     * Memento TimeMap type.
      */
-    public static final String VERSIONING_TIMEMAP_TYPE = REPOSITORY_NAMESPACE + "TimeMap";
+    public static final String VERSIONING_TIMEMAP_TYPE = MEMENTO_NAMESPACE + "TimeMap";
+
+    /**
+     * Memento TimeGate type.
+     */
+    public static final String VERSIONING_TIMEGATE_TYPE = MEMENTO_NAMESPACE + "TimeGate";
 
     /**
      * This is an internal RDF type for versionable resources, this may be replaced by a Memento type.


### PR DESCRIPTION
Replace outdated LDPRv link headers with Memento specified headers http://mementoweb.org/ns#TimeGate and http://mementoweb.org/ns#TimeMap.

https://jira.duraspace.org/browse/FCREPO-2679

# How should this be tested?
1. Create LDPv versioned resource
`$ curl -i -XPUT -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest/versionedResource123"`

2. Verify the header links <http://mementoweb.org/ns#TimeGate&gt;, <http://mementoweb.org/ns#OriginalResource&gt;
`$ curl -i http://localhost:8080/rest/versionedResource123`
HTTP/1.1 200 OK
Date: Thu, 08 Mar 2018 17:30:51 GMT
ETag: W/"282640b6d95016247e7014ee34be960cd491bd09"
Last-Modified: Thu, 08 Mar 2018 17:29:06 GMT
Link: <http://www.w3.org/ns/ldp#Resource&gt;; rel="type"
Link: <http://www.w3.org/ns/ldp#Container&gt;; rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer&gt;; rel="type"
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Vary: Accept-Datetime
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://mementoweb.org/ns#OriginalResource&gt;; rel="type"
Link: <http://mementoweb.org/ns#TimeGate&gt;; rel="type"
Link: <http://localhost:8080/rest/versionedResource123&gt;; rel="timegate"
Link: <http://localhost:8080/rest/versionedResource123/fcr:versions&gt;; rel="timemap"
Accept-Patch: application/sparql-update
Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
Preference-Applied: return=representation
Vary: Prefer
Content-Type: text/turtle;charset=utf-8
Content-Length: 1415
Server: Jetty(9.2.3.v20140905)

3. Verify the Memento TimeMap header link <http://mementoweb.org/ns#TimeMap&gt;
`$ curl -i http://localhost:8080/rest/versionedResource123/fcr:versions`
HTTP/1.1 200 OK
Date: Thu, 08 Mar 2018 17:29:46 GMT
ETag: W/"8482d14110840e7c52143f5d03f7daf7cddd59f5"
Last-Modified: Thu, 08 Mar 2018 17:29:06 GMT
Link: <http://www.w3.org/ns/ldp#Resource&gt;; rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource&gt;; rel="type"
Link: <http://mementoweb.org/ns#TimeMap&gt;; rel="type"
Vary-Post: Memento-Datetime
Allow: POST,HEAD,GET,OPTIONS
Link: <http://www.w3.org/ns/ldp#Resource&gt;; rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource&gt;; rel="type"
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Preference-Applied: return=representation
Vary: Prefer
Content-Type: text/turtle;charset=utf-8
Content-Length: 1327
Server: Jetty(9.2.3.v20140905)

