### PR TITLE
Implements ACL linking on resource creation as defined in

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/URIConstants.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/URIConstants.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.auth.webac;
 
+import org.fcrepo.kernel.api.RdfLexicon;
+
 import java.net.URI;
 
 /**
@@ -35,7 +37,7 @@ final public class URIConstants {
     /**
      * Namespace for the W3C WebAC vocabulary.
      */
-    public static final String WEBAC_NAMESPACE_VALUE = "http://www.w3.org/ns/auth/acl#";
+    public static final String WEBAC_NAMESPACE_VALUE = RdfLexicon.WEBAC_NAMESPACE_VALUE;
 
     /**
      * Namespace for the W3C WebAC vocabulary.
@@ -121,8 +123,8 @@ final public class URIConstants {
     /**
      * WebAC accessControl
      */
-    public static final String WEBAC_ACCESS_CONTROL_VALUE = WEBAC_NAMESPACE_VALUE + "accessControl";
-    public static final URI WEBAC_ACCESS_CONTROL = URI.create(WEBAC_ACCESS_CONTROL_VALUE);
+    public static final String WEBAC_ACCESS_CONTROL_VALUE = RdfLexicon.WEBAC_ACCESS_CONTROL_VALUE;
+    public static final URI WEBAC_ACCESS_CONTROL = RdfLexicon.WEBAC_ACCESS_CONTROL;
 
     /**
      * WebAC mode

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -63,6 +63,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_NAMESPACE_VALUE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -111,6 +112,7 @@ import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
@@ -383,6 +385,8 @@ public class FedoraLdp extends ContentExposingResource {
             checkMessageExternalBody(requestContentType);
         }
 
+        final URI resourceAcl = checkForAclLink(links);
+
         final FedoraResource resource;
 
         final String path = toPath(translator(), externalPath);
@@ -439,6 +443,8 @@ public class FedoraLdp extends ContentExposingResource {
 
             ensureInteractionType(resource, interactionModel,
                     (requestBodyStream == null || requestContentType == null));
+
+            addResourceAcl(resourceAcl);
 
             session.commit();
             return createUpdateResponse(resource, created);
@@ -566,6 +572,8 @@ public class FedoraLdp extends ContentExposingResource {
             checkMessageExternalBody(requestContentType);
         }
 
+        final URI resourceAcl = checkForAclLink(links);
+
         if (!(resource() instanceof Container)) {
             throw new ClientErrorException("Object cannot have child nodes", CONFLICT);
         } else if (resource().hasType(FEDORA_PAIRTREE)) {
@@ -592,7 +600,7 @@ public class FedoraLdp extends ContentExposingResource {
                     !(requestBodyStream == null || requestContentType == null));
 
             try (final RdfStream resourceTriples =
-                    resource.isNew() ? new DefaultRdfStream(asNode(resource())) : getResourceTriples()) {
+                     resource.isNew() ? new DefaultRdfStream(asNode(resource())) : getResourceTriples()) {
 
                 if (requestBodyStream == null) {
                     LOGGER.trace("No request body detected");
@@ -621,6 +629,8 @@ public class FedoraLdp extends ContentExposingResource {
                 ensureInteractionType(resource, interactionModel,
                         (requestBodyStream == null || requestContentType == null));
 
+                addResourceAcl(resourceAcl);
+
                 session.commit();
             } catch (final Exception e) {
                 checkForInsufficientStorageException(e, e);
@@ -630,6 +640,49 @@ public class FedoraLdp extends ContentExposingResource {
             return createUpdateResponse(resource, true);
         } finally {
             lock.release();
+        }
+    }
+
+    private void addResourceAcl(final URI resourceAcl) {
+        if (resourceAcl != null) {
+            final String sparql =
+                    "PREFIX acl: <" + WEBAC_NAMESPACE_VALUE + ">\n" +
+                    "INSERT { \n" +
+                    "<> acl:accessControl <" + resourceAcl.toString() + "> \n" +
+                    "} WHERE {}";
+            patchResourcewithSparql(resource(), sparql, getResourceTriples());
+        }
+    }
+
+    /**
+     * Returns the URI of rel=acl link if there is one in the list.
+     *
+     * @param links the links to be checked.
+     * @return The URI portion of acl link header or null if no rel=acl links are present.
+     * @throws ConstraintViolationException if any of the links are syntactically invalid, if there is more than
+     *                                      one link where rel='acl', or if the acl link is cross domain.
+     */
+    private URI checkForAclLink(final List<String> links) throws ConstraintViolationException {
+        if (links == null) {
+            return null;
+        }
+
+        try {
+            Link aclLink = null;
+            for (String linkStr : links) {
+                final Link link = Link.valueOf(linkStr);
+                if (link.getRel().equals("acl")) {
+                    //throw constraint exception if there is a more than one rel='acl' link
+                    if (aclLink != null) {
+                        throw new ConstraintViolationException(
+                            "You may specify only one rel=acl Link header in your request.");
+                    }
+                    aclLink = link;
+                }
+            }
+            return (aclLink != null) ? aclLink.getUri() : null;
+        } catch (Exception ex) {
+            throw new ConstraintViolationException(ex.getMessage());
         }
     }
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableSet.of;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 
+import java.net.URI;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -51,6 +52,11 @@ public final class RdfLexicon {
     public static final String PROV_NAMESPACE = "http://www.w3.org/ns/prov#";
 
     public static final String PREMIS_NAMESPACE = "http://www.loc.gov/premis/rdf/v1#";
+
+    /**
+     * Namespace for the W3C WebAC vocabulary.
+     */
+    public static final String WEBAC_NAMESPACE_VALUE = "http://www.w3.org/ns/auth/acl#";
 
     /**
      * Fedora configuration namespace "fedora-config", used for user-settable
@@ -238,6 +244,12 @@ public final class RdfLexicon {
     public static final Property SERVER_MANAGED = createProperty(REPOSITORY_NAMESPACE + "ServerManaged");
 
     public static final Property EMBED_CONTAINED = createProperty(OA_NAMESPACE + "PreferContainedDescriptions");
+
+
+    // WEBAC
+    public static final String WEBAC_ACCESS_CONTROL_VALUE = WEBAC_NAMESPACE_VALUE + "accessControl";
+    public static final URI WEBAC_ACCESS_CONTROL = URI.create(WEBAC_ACCESS_CONTROL_VALUE);
+
 
     public static final Set<Property> managedProperties;
 

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -26,6 +26,8 @@
 <rdfs = 'http://www.w3.org/2000/01/rdf-schema#'>
 <premis = 'http://www.loc.gov/premis/rdf/v1#'>
 <ldp = 'http://www.w3.org/ns/ldp#'>
+<acl = 'http://www.w3.org/ns/auth/acl#'>
+
 <ebucore = 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#'>
 
 /*


### PR DESCRIPTION
 https://fcrepo.github.io/fcrepo-specification/#link-acl-on-create for PUTs and POSTs.

Adds the following five tests to FedoraLdpIT.
* testPostCreateNonRDFSourceWithAcl
* testPutCreateNonRDFSourceWithAcl
* testPostCreateRDFSourceWithAcl
* testPutCreateRDFSourceWithAcl
* testPutCreateRDFSourceWithNonExistentAcl


**JIRA Ticket**: Resolves: https://jira.duraspace.org/browse/FCREPO-2688


# What does this Pull Request do?

Implements acl assignment on new resources using PUT and POST according to  https://fcrepo.github.io/fcrepo-specification/#link-acl-on-create

# How should this be tested?
```
# create acl
curl -v -XPUT  "http://localhost:8080/rest/acl1" -u fedoraAdmin:fedoraAdmin

# create binary resource with acl on POST
curl -v -XPOST  -H "ContentType: text/plain" -H "Link: <http://localhost:8080/rest/acl1>; rel=\"acl\"" "http://localhost:8080/rest/" -H "Slug: test1" -u fedoraAdmin:fedoraAdmin --data-binary "test"
# ensure the acl triple  is present in the fcr:metadata
curl -v http://localhost:8080/rest/test1/fcr:metadata

# create binary resource with acl on PUT
curl -v -XPUT -H "ContentType: text/plain"  -H "Link: <http://localhost:8080/rest/acl1>; rel=\"acl\"" "http://localhost:8080/rest/test2" --data-binary "test" -u fedoraAdmin:fedoraAdmin 

# ensure the acl triple  is present in fcr:metatata response
curl -v http://localhost:8080/rest/test2/fcr:metadata

# create rdf resource with acl on POST
curl -v -XPOST  -H "Link: <http://localhost:8080/rest/acl1>; rel=\"acl\"" "http://localhost:8080/rest/" -H "Slug: test3" -u fedoraAdmin:fedoraAdmin 
# ensure the acl triple and link header is present response
curl -v http://localhost:8080/rest/test3

# create rdf resource with acl on PUT
curl -v -XPUT   -H "Link: <http://localhost:8080/rest/acl1>; rel=\"acl\"" "http://localhost:8080/rest/test4" -u fedoraAdmin:fedoraAdmin 

# ensure the acl triple and link header is present in response
curl -v http://localhost:8080/rest/test4

# return 400 if  acl does not exist on PUT
curl -v -XPUT   -H "Link: <http://localhost:8080/rest/aclx>; rel=\"acl\"" "http://localhost:8080/rest/test5" -u fedoraAdmin:fedoraAdmin 
```

# Additional Notes:
There is a follow on ticket to flesh out the error handling for this issue.
 * https://jira.duraspace.org/browse/FCREPO-2705 - ensures that constrainedBy links are returned when the acl link does not exist or is not properly typed.

This bug addresses a gap in existing GET / HEAD responses for acl controlled resources.
 * https://jira.duraspace.org/browse/FCREPO-2704 - Identifies the lack of an acl link in the HEAD and GET response on a binary with an acl set in the fcr:metadata.

