### PR TITLE
PUT must fail with 409 if trying to change interaction model to non-subtype.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -57,6 +57,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_PAIRTREE;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_NAMESPACE_VALUE;
@@ -75,6 +76,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -109,11 +111,12 @@ import org.fcrepo.http.commons.domain.PATCH;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
+import org.fcrepo.kernel.api.exception.InsufficientStorageException;
+import org.fcrepo.kernel.api.exception.InteractionModelViolationException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
-import org.fcrepo.kernel.api.exception.ConstraintViolationException;
-import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
@@ -369,6 +372,13 @@ public class FedoraLdp extends ContentExposingResource {
 
             if (nodeService.exists(session.getFedoraSession(), path)) {
                 resource = resource();
+
+                final String resInteractionModel = getInteractionModel(resource);
+                if (StringUtils.isNoneBlank(interactionModel) && StringUtils.isNoneBlank(resInteractionModel)
+                        && !resInteractionModel.equals(interactionModel)) {
+                    throw new InteractionModelViolationException("Changing the interaction model " + resInteractionModel
+                                + " to " + interactionModel + " is not allowed!");
+                }
             } else {
                 final MediaType effectiveContentType
                         = requestBodyStream == null || requestContentType == null ? null : contentType;
@@ -793,12 +803,26 @@ public class FedoraLdp extends ContentExposingResource {
             result = binaryService.findOrCreate(session.getFedoraSession(), path);
         } else {
             result = containerService.findOrCreate(session.getFedoraSession(), path);
-            if (interactionModel != null && !interactionModel.equals("ldp:BasicContainer")) {
-                result.addType(interactionModel);
-            }
+        }
+
+        final String resInteractionModel = getInteractionModel(result);
+        if (StringUtils.isNoneBlank(interactionModel) && StringUtils.isNoneBlank(resInteractionModel)
+                && !resInteractionModel.equals(interactionModel)) {
+            throw new InteractionModelViolationException("Changing the interaction model " + resInteractionModel
+                        + " to " + interactionModel + " is not allowed!");
         }
 
         return result;
+    }
+
+    /*
+     * Get the interaction model from the Fedora Resource
+     * @param resource Fedora Resource
+     * @return String the Interaction Model
+     */
+    private String getInteractionModel(final FedoraResource resource) {
+        final Optional<String> result = INTERACTION_MODELS.stream().filter(x -> resource.hasType(x)).findFirst();
+        return result.isPresent() ? result.get() : null;
     }
 
     private String mintNewPid(final String slug) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2265,6 +2265,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         // attempt to change basic container to NonRdfSource
         final String ttl1 = "<> a <" + NON_RDF_SOURCE.getURI() + "> .";
         final HttpPut put1 = putObjMethod(pid + "/a", "text/turtle", ttl1);
+        put1.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         assertEquals("Changed the basic container ixn to NonRdfSource through PUT with RDF content!",
                 CONFLICT.getStatusCode(), getStatus(put1));
 
@@ -2272,6 +2273,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String ttl2 = "<> a <" + DIRECT_CONTAINER.getURI() + "> ; <" + MEMBERSHIP_RESOURCE.getURI() +
                 "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
         final HttpPut put2 = putObjMethod(pid + "/a", "text/turtle", ttl2);
+        put2.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         assertEquals("Changed the basic container ixn to Direct Container through PUT with RDF content!",
                 CONFLICT.getStatusCode(), getStatus(put2));
 
@@ -2283,19 +2285,29 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals(CREATED.getStatusCode(), getStatus(put));
         assertTrue(getLinkHeaders(getObjMethod(pid + "/b")).contains(DIRECT_CONTAINER_LINK_HEADER));
 
+        // successful update the properties with the interaction mode
+        final String ttla = "<> a <" + DIRECT_CONTAINER.getURI()
+                + "> ; <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
+                + "<" + HAS_MEMBER_RELATION + "> <info:some/relation> .\n";
+        final HttpPut puta = putObjMethod(pid + "/b", "text/turtle", ttla);
+        puta.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(puta));
+
         // attempt to change direct container to basic container
         final String ttl3 = "<> a <" + BASIC_CONTAINER.getURI() +
                 "> ; <http://purl.org/dc/elements/1.1/title> \"this is a title\".";
         final HttpPut put3 = putObjMethod(pid + "/b", "text/turtle", ttl3);
+        put3.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         assertEquals("Changed the direct container ixn to basic container through PUT with RDF content!",
                 CONFLICT.getStatusCode(), getStatus(put3));
 
         // attempt to change direct container to indirect container
-        final String ttl4 = "<> a <" + DIRECT_CONTAINER.getURI()
+        final String ttl4 = "<> a <" + INDIRECT_CONTAINER.getURI()
                 + "> ; <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
                 + "<" + HAS_MEMBER_RELATION + "> <info:some/relation>;\n"
                 + "<" + LDP_NAMESPACE + "insertedContentRelation> <info:proxy/for> .\n";
         final HttpPut put4 = putObjMethod(pid + "/b", "text/turtle", ttl4);
+        put4.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         assertEquals("Changed the direct container ixn to indirect container through PUT with RDF content!",
                 CONFLICT.getStatusCode(), getStatus(put4));
     }
@@ -2314,6 +2326,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
         final HttpPut put1 = putObjMethod(pid + "/a", "text/turtle", ttl1);
         put1.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        put1.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         assertEquals("Changed the basic container ixn to direct container!",
                 CONFLICT.getStatusCode(), getStatus(put1));
 
@@ -2328,6 +2341,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String ttl2 = "<> <http://purl.org/dc/elements/1.1/title> \"this is a title\"";
         final HttpPut put2 = putObjMethod(pid + "/b", "text/turtle", ttl2);
         put2.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        put2.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         assertEquals("Changed the direct container ixn to basic container",
                 CONFLICT.getStatusCode(), getStatus(put2));
 
@@ -2336,6 +2350,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 + "<" + LDP_NAMESPACE + "insertedContentRelation> <info:proxy/for> .\n";
         final HttpPut put3 = putObjMethod(pid + "/b", "text/turtle", ttl3);
         put3.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        put3.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         assertEquals("Changed the direct container ixn to indirect container!",
                 CONFLICT.getStatusCode(), getStatus(put3));
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2189,15 +2189,15 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testGetObjectOmitContainment() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
-        final HttpPatch patch = patchObjMethod(id);
-        patch.setHeader(CONTENT_TYPE, "application/sparql-update");
-        final String updateString =
-                "INSERT DATA { <> a <" + DIRECT_CONTAINER.getURI() + "> ; <" + MEMBERSHIP_RESOURCE.getURI() +
-                        "> <> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .}";
-        patch.setEntity(new StringEntity(updateString));
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(patch));
+        final String location = serverAddress + id;
+        final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+        final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals(CREATED.getStatusCode(), getStatus(put));
+        assertTrue(getLinkHeaders(getObjMethod(id + "/a")).contains(DIRECT_CONTAINER_LINK_HEADER));
+        createObject(id + "/a/1");
 
-        createObjectAndClose(id + "/a");
         final HttpGet getObjMethod = getObjMethod(id);
         getObjMethod
                 .addHeader("Prefer", "return=representation; omit=\"http://www.w3.org/ns/ldp#PreferContainment\"");
@@ -2207,6 +2207,89 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
             assertFalse("Expected nothing contained", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
         }
+    }
+
+    @Test
+    public void testPatchToCreateDirectContainerInSparqlUpdate() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final HttpPatch patch = patchObjMethod(id);
+        patch.setHeader(CONTENT_TYPE, "application/sparql-update");
+        final String updateString =
+                "INSERT DATA { <> a <" + DIRECT_CONTAINER.getURI() + "> ; <" + MEMBERSHIP_RESOURCE.getURI() +
+                        "> <> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .}";
+        patch.setEntity(new StringEntity(updateString));
+        assertEquals("Patch with sparql update created direct container from basic container!",
+                CONFLICT.getStatusCode(), getStatus(patch));
+    }
+
+    @Test
+    public void testPatchToDeleteNonRdfSourceInteractionModel() throws IOException {
+        final String pid = getRandomUniqueId();
+
+        createDatastream(pid, "x", "some content");
+
+        final String location = serverAddress + pid + "/x/fcr:metadata";
+        final HttpPatch patchDeleteMethod = new HttpPatch(location);
+        patchDeleteMethod.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patchDeleteMethod.setEntity(new StringEntity("PREFIX ldp: <http://www.w3.org/ns/ldp#> " +
+                "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> DELETE { " +
+                "<> rdf:type  ldp:NonRDFSource .} WHERE {}"));
+        assertEquals("Delete interaction model got status 409!\n",
+                CONFLICT.getStatusCode(), getStatus(patchDeleteMethod));
+    }
+
+    @Test
+    public void testPutToChangeNonRdfSourceToRdfSource() throws IOException {
+        final String pid = getRandomUniqueId();
+
+        createDatastream(pid, "x", "some content");
+
+        final String ttl = "<> <http://purl.org/dc/elements/1.1/title> \"this is a title\" .";
+        final HttpPut put = putObjMethod(pid + "/x/fcr:metadata", "text/turtle", ttl);
+        put.setHeader(LINK, BASIC_CONTAINER_LINK_HEADER);
+        assertEquals("Changed the NonRdfSource ixn to basic container",
+                CONFLICT.getStatusCode(), getStatus(put));
+    }
+
+    @Test
+    public void testChangeInteractionModelWithPut() throws IOException {
+        final String pid = getRandomUniqueId();
+        final String resource = serverAddress + pid;
+        final String container = serverAddress + pid + "/c";
+
+        createObjectAndClose(pid);
+        createObjectAndClose(pid + "/a");
+        createObjectAndClose(pid + "/c");
+
+        final String ttl1 = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+        final HttpPut put1 = putObjMethod(pid + "/a", "text/turtle", ttl1);
+        put1.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals("Changed the basic container ixn to direct container!",
+                CONFLICT.getStatusCode(), getStatus(put1));
+
+        // create direct container
+        final String ttl = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+        final HttpPut put = putObjMethod(pid + "/b", "text/turtle", ttl);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals(CREATED.getStatusCode(), getStatus(put));
+        assertTrue(getLinkHeaders(getObjMethod(pid + "/b")).contains(DIRECT_CONTAINER_LINK_HEADER));
+
+        final String ttl2 = "<> <http://purl.org/dc/elements/1.1/title> \"this is a title\"";
+        final HttpPut put2 = putObjMethod(pid + "/b", "text/turtle", ttl2);
+        put2.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        assertEquals("Changed the direct container ixn to basic container",
+                CONFLICT.getStatusCode(), getStatus(put2));
+
+        final String ttl3 = "<> <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
+                + "<" + HAS_MEMBER_RELATION + "> <info:some/relation>;\n"
+                + "<" + LDP_NAMESPACE + "insertedContentRelation> <info:proxy/for> .\n";
+        final HttpPut put3 = putObjMethod(pid + "/b", "text/turtle", ttl3);
+        put3.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        assertEquals("Changed the direct container ixn to indirect container!",
+                CONFLICT.getStatusCode(), getStatus(put3));
     }
 
     @Test

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InteractionModelViolationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InteractionModelViolationExceptionMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.fcrepo.kernel.api.exception.InteractionModelViolationException;
+import org.slf4j.Logger;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author lsitu
+ * @since 2018-03-09
+ */
+@Provider
+public class InteractionModelViolationExceptionMapper extends
+        ConstraintExceptionMapper<InteractionModelViolationException> implements ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(InteractionModelViolationExceptionMapper.class);
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Context
+    private ServletContext context;
+
+    @Override
+    public Response toResponse(final InteractionModelViolationException e) {
+        debugException(this, e, LOGGER);
+        final Link link = buildConstraintLink(e, context, uriInfo);
+        final String msg = e.getMessage();
+        return status(CONFLICT).entity(msg).links(link).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -58,6 +58,8 @@ public final class RdfLexicon {
 
     public static final String MEMENTO_NAMESPACE = "http://mementoweb.org/ns#";
 
+    public static final String RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
     /**
      * Namespace for the W3C WebAC vocabulary.
      */
@@ -291,6 +293,15 @@ public final class RdfLexicon {
      */
     public static final Property VERSIONED_RESOURCE =
         createProperty(MEMENTO_NAMESPACE + "OriginalResource");
+
+    /*
+     * Interaction Models.
+     */
+    public static final Set<String>  INTERACTION_MODELS = of(
+            NON_RDF_SOURCE.getURI().replace(LDP_NAMESPACE, "ldp:"),
+            BASIC_CONTAINER.getURI().replace(LDP_NAMESPACE, "ldp:"),
+            DIRECT_CONTAINER.getURI().replace(LDP_NAMESPACE, "ldp:"),
+            INDIRECT_CONTAINER.getURI().replace(LDP_NAMESPACE, "ldp:"));
 
     private RdfLexicon() {
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InteractionModelViolationException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InteractionModelViolationException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * An Interaction Model constraint has been violated.
+ *
+ * @author lsitu
+ * @since 2018-03-09
+ */
+public class InteractionModelViolationException extends ConstraintViolationException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     */
+    public InteractionModelViolationException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param rootCause the root cause
+     */
+    public InteractionModelViolationException(final Throwable rootCause) {
+        super(rootCause);
+    }
+
+}

--- a/fcrepo-webapp/src/main/webapp/static/constraints/InteractionModelViolationException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/InteractionModelViolationException.rdf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="owl2html.xsl"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+]>
+
+
+<rdf:RDF
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="static/constraints/InteractionModelViolationException">
+        <rdfs:label xml:lang="en">Interaction Model Violation Exception</rdfs:label>
+        <rdfs:comment xml:lang="en">The RDF violated Fedora's internal constraints to change the interaction model.</rdfs:comment>
+    </owl:Ontology>
+</rdf:RDF>


### PR DESCRIPTION
PUT must fail with 409 if trying to change interaction model to non-subtype.

https://jira.duraspace.org/browse/FCREPO-2594,
https://jira.duraspace.org/browse/FCREPO-2591

# What does this Pull Request do?
When attempting to change/delete the interaction model with PUT or PATCH, it returns status 409 with the constrainedBy link header: <http://localhost:8080/static/constraints/InteractionModelViolationException.rdf&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy".

# How should this be tested?
1. Create NnRdfSource binary resource:
`curl -i -XPUT -H "Content-Type: text/plain" "http://localhost:8080/rest/mytest" --data "binary"`

2. Verify PATCH to delete interation model failed with 409:
`curl -i -XPATCH -H "Content-Type: application/sparql-update" "http://localhost:8080/rest/mytest/fcr:metadata" --data "PREFIX ldp: <http://www.w3.org/ns/ldp#> \
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \
DELETE { \
   <http://localhost:8080/rest/mytest> rdf:type ldp:NonRDFSource . \
} WHERE {}"`

HTTP/1.1 409 Conflict
Date: Fri, 09 Mar 2018 22:54:24 GMT
Link: <http://localhost:8080/static/constraints/InteractionModelViolationException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 61
Server: Jetty(9.2.3.v20140905)

3. Verify PUT to change the interation model failed with 409:
`curl -i -XPUT -H "Link: <http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"" -H "Content-Type: text/turtle" "http://localhost:8080/rest/mytest/fcr:metadata" --data "<> <http://purl.org/dc/elements/1.1/title> \"this is binary file\" ."`

HTTP/1.1 409 Conflict
Date: Fri, 09 Mar 2018 22:54:59 GMT
Link: <http://localhost:8080/static/constraints/ServerManagedTypeException.rdf&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 109
Server: Jetty(9.2.3.v20140905)

4. Create RDF Resource direct container:
`curl -i -XPOST -H "Slug: testRdfResource" "http://localhost:8080/rest"`
`curl -i -XPOST -H "Slug: a" "http://localhost:8080/rest/testRdfResource"`

5. Verify the old way to PATCH create Direct Container failed with 409:
`curl -i -XPATCH -H "Content-Type: application/sparql-update" "http://localhost:8080/rest/testRdfResource/a" --data "PREFIX ldp: <http://www.w3.org/ns/ldp#> \
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \
INSERT DATA { \
   <> a <http://www.w3.org/ns/ldp#DirectContainer> ; \
   ldp:membershipResource <http://localhost:8080/rest/testRdfResource> ; \
   ldp:hasMemberRelation ldp:member . \
}"`

HTTP/1.1 409 Conflict
Date: Fri, 09 Mar 2018 22:56:24 GMT
Link: <http://localhost:8080/static/constraints/InteractionModelViolationException.rdf&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 88
Server: Jetty(9.2.3.v20140905)

6. Verify it fails with PUT to change a basic container to direct container:
`curl -i -XPUT -H "Link: <http://www.w3.org/ns/ldp#DirectContainer>; rel=\"type\"" -H "Content-Type: text/turtle" "http://localhost:8080/rest/testRdfResource/a" --data "PREFIX ldp: <http://www.w3.org/ns/ldp#> \
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \
  <> ldp:membershipResource <http://localhost:8080/rest/testRdfResource> ; \
  ldp:hasMemberRelation ldp:member ."`

HTTP/1.1 409 Conflict
Date: Fri, 09 Mar 2018 22:57:19 GMT
Link: <http://localhost:8080/static/constraints/InteractionModelViolationException.rdf&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 88
Server: Jetty(9.2.3.v20140905)

7. Create direct container:
 `curl -i -XPUT -H "Link: <http://www.w3.org/ns/ldp#DirectContainer>; rel=\"type\"" -H "Content-Type: text/turtle" "http://localhost:8080/rest/testRdfResource/b" --data "PREFIX ldp: <http://www.w3.org/ns/ldp#> \
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \
  <> ldp:membershipResource <http://localhost:8080/rest/testRdfResource> ; \
  ldp:hasMemberRelation ldp:member ."`

8. Verify it fails with PUT to change the direct container to indirect container:
`curl -i -XPUT -H "Link: <http://www.w3.org/ns/ldp#IndirectContainer>; rel=\"type\"" -H "Content-Type: text/turtle" "http://localhost:8080/rest/testRdfResource/b" --data "PREFIX ldp: <http://www.w3.org/ns/ldp#> \
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \
  <> ldp:membershipResource <http://localhost:8080/rest/testRdfResource> ; \
  ldp:hasMemberRelation ldp:member ; \
  ldp:insertedContentRelation <info:proxyFor> ."`

HTTP/1.1 409 Conflict
Date: Fri, 09 Mar 2018 22:58:20 GMT
Link: <http://localhost:8080/static/constraints/InteractionModelViolationException.rdf&gt;; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 91
Server: Jetty(9.2.3.v20140905)
