### PR TITLE
Updated integration test for LDPCv DELETE.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -90,8 +90,20 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testDeleteTimeMapForContainer() throws Exception {
         createVersionedContainer(id, subjectUri);
+
+        final String mementoUri = createMemento(subjectUri, null, null, null);
+        assertEquals(200, getStatus(new HttpGet(mementoUri)));
+
+        final String timeMapUri = subjectUri + "/" + FCR_VERSIONS;
+        assertEquals(200, getStatus(new HttpGet(timeMapUri)));
+
         // disabled versioning to delete TimeMap
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(serverAddress + id + "/" + FCR_VERSIONS)));
+
+        // validate that the memento version is gone
+        assertEquals(404, getStatus(new HttpGet(mementoUri)));
+        // validate that the LDPCv is gone
+        assertEquals(404, getStatus(new HttpGet(timeMapUri)));
     }
 
     @Test


### PR DESCRIPTION
Updated integration test for LDPCv DELETE.

https://jira.duraspace.org/browse/FCREPO-2684

# How should this be tested?
1. Create versioned resource with TimeMap and a Memento:
`curl -i -XPOST -H "Slug:versionedResource123" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest"`

`curl -i -XPOST -H "Memento-DateTime: Mon, 12 Mar 2018 13:29:06 GMT" -H "Content-Type: text/turtle" --data "<> <http://purl.org/dc/elements/1.1/title> \"The original title\" ." "http://localhost:8080/rest/versionedResource123/fcr:versions"`

2. Verify that the TimeMap and the Memento both are created:
`curl -i "http://localhost:8080/rest/versionedResource123/fcr:versions"`
`curl -i "http://localhost:8080/rest/versionedResource123/fedora:timemap/20180312132906"`

3. Delete the TimeMap:
`curl -i -XDELETE "http://localhost:8080/rest/versionedResource123/fcr:versions"`
HTTP/1.1 204 No Content
Date: Mon, 12 Mar 2018 20:43:33 GMT
Server: Jetty(9.2.3.v20140905)

4. Verify that the memento and the MimeMap both are gone:
`curl -i "http://localhost:8080/rest/versionedResource123/fedora:timemap/20180312132906"`
HTTP/1.1 404 Not Found
Date: Mon, 12 Mar 2018 20:46:53 GMT
Content-Type: text/html; charset=ISO-8859-1
Cache-Control: must-revalidate,no-cache,no-store
Content-Length: 339
Server: Jetty(9.2.3.v20140905)

`curl -i "http://localhost:8080/rest/versionedResource123/fcr:versions"`
HTTP/1.1 404 Not Found
Date: Mon, 12 Mar 2018 20:48:22 GMT
Content-Type: text/plain;charset=utf-8
Content-Length: 30
Server: Jetty(9.2.3.v20140905)
