### PR TITLE
Remove support for Slug header on POST to LDPCv.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -52,6 +52,7 @@ import java.util.List;
 
 import javax.jcr.ItemExistsException;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -161,6 +162,12 @@ public class FedoraVersioning extends ContentExposingResource {
 
         try {
             final MediaType contentType = getSimpleContentType(requestContentType);
+
+            final String slug = headers.getHeaderString("Slug");
+            if (slug != null) {
+                throw new BadRequestException("Slug header is no longer supported for versioning label. "
+                        + "Please use " + MEMENTO_DATETIME_HEADER + " header with RFC-1123 date-time.");
+            }
 
             final Instant mementoInstant;
             try {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,6 +75,7 @@ import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.LinkFormatStream;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryVersionRuntimeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
@@ -144,6 +146,7 @@ public class FedoraVersioning extends ContentExposingResource {
      * @param requestBodyStream request body stream
      * @return response
      * @throws InvalidChecksumException thrown if one of the provided digests does not match the content
+     * @throws MementoDatetimeFormatException if the header value of memento-datetime is not RFC-1123 format
      */
     @POST
     public Response addVersion(@HeaderParam(MEMENTO_DATETIME_HEADER) final String datetimeHeader,
@@ -151,7 +154,7 @@ public class FedoraVersioning extends ContentExposingResource {
             @HeaderParam(CONTENT_DISPOSITION) final ContentDisposition contentDisposition,
             @HeaderParam("Digest") final String digest,
             @ContentLocation final InputStream requestBodyStream)
-            throws InvalidChecksumException {
+            throws InvalidChecksumException, MementoDatetimeFormatException {
 
         final AcquiredLock lock = lockManager.lockForWrite(resource().findOrCreateTimeMap().getPath(),
             session.getFedoraSession(), nodeService);
@@ -159,8 +162,15 @@ public class FedoraVersioning extends ContentExposingResource {
         try {
             final MediaType contentType = getSimpleContentType(requestContentType);
 
-            final Instant mementoInstant = (isBlank(datetimeHeader) ? Instant.now()
+            final Instant mementoInstant;
+            try {
+                mementoInstant = (isBlank(datetimeHeader) ? Instant.now()
                     : Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(datetimeHeader)));
+            } catch (DateTimeParseException e) {
+                throw new MementoDatetimeFormatException("Invalid memento date-time value. "
+                        + "Please use RFC-1123 date-time format, such as 'Tue, 3 Jun 2008 11:05:30 GMT'", e);
+            }
+
             final boolean createFromExisting = isBlank(datetimeHeader);
 
             if (requestContentType == null && !createFromExisting) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -177,6 +177,24 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testCreateVersionWithSlugHeader() throws Exception {
+        createVersionedContainer(id, subjectUri);
+
+        // Bad request with Slug header to create memento
+        final String mementoDateTime = "Tue, 3 Jun 2008 11:05:30 GMT";
+        final String body = "<" + subjectUri + "> <info:test#label> \"bar\"";
+        final HttpPost post = postObjMethod(id + "/" + FCR_VERSIONS);
+
+        post.addHeader("Slug", "version_label");
+        post.addHeader(MEMENTO_DATETIME_HEADER, mementoDateTime);
+        post.addHeader(CONTENT_TYPE, "text/n3");
+        post.setEntity(new StringEntity(body));
+
+        assertEquals("Created memento with Slug!",
+                BAD_REQUEST.getStatusCode(), getStatus(post));
+    }
+
+    @Test
     public void testCreateVersionWithMementoDatetimeFromat() throws Exception {
         createVersionedContainer(id, subjectUri);
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MementoDatetimeFormatExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MementoDatetimeFormatExceptionMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
+import org.slf4j.Logger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.slf4j.LoggerFactory.getLogger;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static javax.ws.rs.core.Response.status;
+
+/**
+ * Handle MementoDatetimeFormatException with HTTP 400 Bad Request.
+ *
+ * @author lsitu
+ * @since 2018-03-12
+ */
+@Provider
+public class MementoDatetimeFormatExceptionMapper implements
+        ExceptionMapper<MementoDatetimeFormatException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(MementoDatetimeFormatExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final MementoDatetimeFormatException e) {
+        debugException(this, e, LOGGER);
+        return status(BAD_REQUEST).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET)
+                .build();
+    }
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/MementoDatetimeFormatException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/MementoDatetimeFormatException.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Indicates that the wrong format of the Memento-Datetime.
+ *
+ * @author lsitu
+ * @since 2018-03-12
+ */
+public class MementoDatetimeFormatException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     */
+    public MementoDatetimeFormatException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     * @param rootCause the root cause
+     */
+    public MementoDatetimeFormatException(final String msg, final Throwable rootCause) {
+        super(msg,rootCause);
+    }
+
+}


### PR DESCRIPTION
Remove support for Slug header on POST to LDPCv, and captured the memento DateTimeParseException to handle it with 400 bad request.

https://jira.duraspace.org/browse/FCREPO-2618

# How should this be tested?
1. Create versioned resource with TimeMap and a Memento:
`curl -i -XPOST -H "Slug:versionedResource123" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest"`

2. Verify that create memento with Slug header failed with 409 bad request:
`curl -i -XPOST -H "Memento-DateTime: Mon, 12 Mar 2018 13:29:06 GMT" -H "Slug: label123" -H "Content-Type: text/turtle" --data "<> <http://purl.org/dc/elements/1.1/title> \"The original title\" ." "http://localhost:8080/rest/versionedResource123/fcr:versions"`
HTTP/1.1 400 Bad Request
Date: Tue, 13 Mar 2018 19:16:49 GMT
Content-Type: text/plain;charset=utf-8
Content-Length: 116
Server: Jetty(9.2.3.v20140905)
Slug header is no longer supported for versioning label. Please use Memento-Datetime header with RFC-1123 date-time.

3. Verify that create memento with invalid memento RFC-1123 date-time format failed with 409 bad request:
`curl -i -XPOST -H "Memento-DateTime: Mon, 12 Mar 2018 13:29:06 ANYTIMEZONE" -H "Content-Type: text/turtle" --data "<> <http://purl.org/dc/elements/1.1/title> \"The original title\" ." "http://localhost:8080/rest/versionedResource123/fcr:versions"`
HTTP/1.1 400 Bad Request
Date: Tue, 13 Mar 2018 19:18:12 GMT
Content-Type: text/plain;charset=utf-8
Content-Length: 109
Server: Jetty(9.2.3.v20140905)
Invalid memento date-time value. Please use RFC-1123 date-time format, such as 'Tue, 3 Jun 2008 11:05:30 GMT'

4. Verify that create memento with date-time format other than RFC-1123 failed with 409 bad request:
`curl -i -XPOST -H "Memento-DateTime: 2018-03-12T13:29:06Z" -H "Content-Type: text/turtle" --data "<> <http://purl.org/dc/elements/1.1/title> \"The original title\" ." "http://localhost:8080/rest/versionedResource123/fcr:versions"`
HTTP/1.1 400 Bad Request
Date: Tue, 13 Mar 2018 19:18:47 GMT
Content-Type: text/plain;charset=utf-8
Content-Length: 109
Server: Jetty(9.2.3.v20140905)
Invalid memento date-time value. Please use RFC-1123 date-time format, such as 'Tue, 3 Jun 2008 11:05:30 GMT'

