### PR TITLE
Fcrepo 2707 - Provide separate timemap for binary and description

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -127,23 +127,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testGetTimeMapResponse() throws Exception {
         createVersionedContainer(id, subjectUri);
 
-        final List<Link> listLinks = new ArrayList<Link>();
-        listLinks.add(Link.fromUri(subjectUri).rel("original").build());
-        listLinks.add(Link.fromUri(subjectUri).rel("timegate").build());
-        listLinks
-            .add(Link.fromUri(subjectUri + "/" + FCR_VERSIONS).rel("self").type(APPLICATION_LINK_FORMAT).build());
-        final Link[] expectedLinks = listLinks.toArray(new Link[3]);
-
-        final HttpGet httpGet = getObjMethod(id + "/" + FCR_VERSIONS);
-        httpGet.setHeader("Accept", APPLICATION_LINK_FORMAT);
-        try (final CloseableHttpResponse response = execute(httpGet)) {
-            assertEquals("Didn't get a OK response!", OK.getStatusCode(), getStatus(response));
-            checkForLinkHeader(response, VERSIONING_TIMEMAP_TYPE, "type");
-            final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(","));
-            final Link[] bodyLinks = bodyList.stream().map(String::trim).filter(t -> !t.isEmpty())
-                .map(Link::valueOf).toArray(Link[]::new);
-            assertArrayEquals(expectedLinks, bodyLinks);
-        }
+        verifyTimemapResponse(subjectUri, id);
     }
 
     @Test
@@ -316,11 +300,26 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testGetTimeMapResponseForBinary() throws Exception {
         createVersionedBinary(id);
 
+        verifyTimemapResponse(subjectUri, id);
+    }
+
+    @Test
+    public void testGetTimeMapResponseForBinaryDescription() throws Exception {
+        createVersionedBinary(id);
+
+        final String descriptionUri = subjectUri + "/fcr:metadata";
+        final String descriptionId = id + "/fcr:metadata";
+
+        verifyTimemapResponse(descriptionUri, descriptionId);
+    }
+
+    private void verifyTimemapResponse(final String uri, final String id) throws Exception {
         final List<Link> listLinks = new ArrayList<Link>();
-        listLinks.add(Link.fromUri(subjectUri).rel("original").build());
-        listLinks.add(Link.fromUri(subjectUri).rel("timegate").build());
+        listLinks.add(Link.fromUri(uri).rel("original").build());
+        listLinks.add(Link.fromUri(uri).rel("timegate").build());
         listLinks
-                .add(Link.fromUri(subjectUri + "/" + FCR_VERSIONS).rel("self").type(APPLICATION_LINK_FORMAT).build());
+                .add(Link.fromUri(uri + "/" + FCR_VERSIONS).rel("self").type(APPLICATION_LINK_FORMAT)
+                        .build());
         final Link[] expectedLinks = listLinks.toArray(new Link[3]);
 
         final HttpGet httpGet = getObjMethod(id + "/" + FCR_VERSIONS);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -280,7 +280,8 @@ public final class RdfLexicon {
         hasFedoraNamespace.or(p -> managedProperties.contains(p));
 
     /**
-     * Fedora defined JCR node type with supertype of nt:file with a single nt:folder named fedora:timemap inside.
+     * Fedora defined JCR node type with supertype of nt:file with two nt:folder named fedora:timemap and
+     * fedora:binaryTimemap inside.
      */
     public static final String NT_VERSION_FILE = "nt:versionFile";
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -172,6 +172,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     @VisibleForTesting
     public static final String LDPCV_TIME_MAP = "fedora:timemap";
 
+    public static final String LDPCV_BINARY_TIME_MAP = "fedora:binaryTimemap";
+
     // A curried type accepting resource, translator, and "minimality", returning triples.
     private static interface RdfGenerator extends Function<FedoraResource,
     Function<IdentifierConverter<Resource, FedoraResource>, Function<Boolean, Stream<Triple>>>> {}
@@ -269,7 +271,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
                 !x.getObject().toString(false).startsWith("?")) {
             try {
                 parse(x.getObject().toString(false));
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 return new IllegalArgumentException("Invalid value for '" + RdfLexicon.HAS_MIME_TYPE +
                         "' encountered : " + x.getObject().toString());
             }
@@ -403,7 +405,13 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     @Override
     public FedoraResource getTimeMap() {
         try {
-            return Optional.of(node.getNode(LDPCV_TIME_MAP)).map(nodeConverter::convert).orElse(null);
+            final Node timeMapNode;
+            if (this instanceof FedoraBinary) {
+                timeMapNode = getNode().getParent().getNode(LDPCV_BINARY_TIME_MAP);
+            } else {
+                timeMapNode = node.getNode(LDPCV_TIME_MAP);
+            }
+            return Optional.of(timeMapNode).map(nodeConverter::convert).orElse(null);
         } catch (final PathNotFoundException e) {
             throw new PathNotFoundRuntimeException(e);
         } catch (final RepositoryException e) {
@@ -416,7 +424,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         final Node ldpcvNode;
         try {
             if (this instanceof FedoraBinary) {
-                ldpcvNode = findOrCreateChild(getNode().getParent(), LDPCV_TIME_MAP, NT_FOLDER);
+                ldpcvNode = findOrCreateChild(getNode().getParent(), LDPCV_BINARY_TIME_MAP, NT_FOLDER);
             } else {
                 ldpcvNode = findOrCreateChild(getNode(), LDPCV_TIME_MAP, NT_FOLDER);
             }

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -41,6 +41,7 @@
 
 [nt:versionFile] > nt:file
 + fedora:timemap (nt:folder) =fedora:TimeMap
++ fedora:binaryTimemap (nt:folder) =fedora:TimeMap
 
 /*
  * Any Fedora resource.


### PR DESCRIPTION
Provide separate timemap for binary and description so that they can be managed separately

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2707

# What does this Pull Request do?
Provides two timemaps for binaries:
http://localhost/binary/fcr:versions
http://localhost/binary/fcr:metadata/fcr:versions

# What's new?
* Two timemap nodes can be created as children of a binary, currently as outlined in the first example here:
  * https://gist.github.com/bbpennel/a3682a61fdd030c03a9a3f63fb3dc9fc
* nt:versionFile allows for two children, fedora:timemap and fedora:binaryTimemap
  * fedora:binaryTimemap is used for FedoraBinary resources
  * fedora:timemap is used for other resources (including binary description)
* Adds test to check uris of timemap response for binary and description

# How should this be tested?

```
# Create versioned binary
curl -XPOST -H "Slug: versioned_bin2" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" http://localhost:8080/ -H "Content-Type: application/octet-stream" --data-binary "binarycontent"

# Retrieve binary timemap
curl http://localhost:8080/versioned_bin2/fcr:versions -H "Accept: application/link-format"

# original and timegate links should be to http://localhost:8080/versioned_bin2

# Retrieve description timemap
curl http://localhost:8080/versioned_bin2/fcr:metadata/fcr:versions -H "Accept: application/link-format"

# original and timegate links should be to http://localhost:8080/versioned_bin2/fcr:metadata
```

# Additional Notes:
Depends on #1300 before merged first, so a lot of additional changes will appear until then.

PR is implemented using the first option from https://gist.github.com/bbpennel/a3682a61fdd030c03a9a3f63fb3dc9fc since it involved the smallest number of new nodes

# Interested parties
@whikloj