### PR TITLE
Support OPTIONS request on LDPRms.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -755,7 +755,10 @@ public class FedoraLdp extends ContentExposingResource {
 
         // Add Options headers
         final String options;
-        if (resource() instanceof FedoraBinary) {
+        if (resource().isMemento()) {
+            options = "GET,HEAD,OPTIONS,DELETE";
+
+        } else if (resource() instanceof FedoraBinary) {
             options = "DELETE,HEAD,GET,PUT,OPTIONS";
 
         } else if (resource() instanceof NonRdfSourceDescription) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractVersioningIT.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.HttpHeaders.LOCATION;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.fcrepo.http.api.FedoraVersioning.MEMENTO_DATETIME_HEADER;
+import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_LINK_FORMAT;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEMAP_TYPE;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import javax.ws.rs.core.Link;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.apache.jena.graph.Node;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFLanguages;
+import org.junit.Before;
+
+import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
+
+/**
+ * @author lsitu
+ * @author bbpennel
+ */
+public abstract class AbstractVersioningIT extends AbstractResourceIT {
+
+    protected static final String VERSIONED_RESOURCE_LINK_HEADER = "<" + VERSIONED_RESOURCE.getURI()
+            + ">; rel=\"type\"";
+    protected static final String BINARY_CONTENT = "binary content";
+    protected static final String BINARY_UPDATED = "updated content";
+
+    protected static final String OCTET_STREAM_TYPE = "application/octet-stream";
+
+    protected static final Node MEMENTO_TYPE_NODE = createURI(MEMENTO_TYPE);
+    protected static final Node TEST_PROPERTY_NODE = createURI("info:test#label");
+
+    protected static final Property TEST_PROPERTY = createProperty("info:test#label");
+
+    final String MEMENTO_DATETIME =
+            RFC_1123_DATE_TIME.format(LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC));
+
+    protected String subjectUri;
+    protected String id;
+
+    @Before
+    public void init() {
+        id = getRandomUniqueId();
+        subjectUri = serverAddress + id;
+    }
+
+    protected void verifyTimemapResponse(final String uri, final String id) throws Exception {
+        final List<Link> listLinks = new ArrayList<Link>();
+        listLinks.add(Link.fromUri(uri).rel("original").build());
+        listLinks.add(Link.fromUri(uri).rel("timegate").build());
+        listLinks
+                .add(Link.fromUri(uri + "/" + FCR_VERSIONS).rel("self").type(APPLICATION_LINK_FORMAT)
+                        .build());
+        final Link[] expectedLinks = listLinks.toArray(new Link[3]);
+
+        final HttpGet httpGet = getObjMethod(id + "/" + FCR_VERSIONS);
+        httpGet.setHeader("Accept", APPLICATION_LINK_FORMAT);
+        try (final CloseableHttpResponse response = execute(httpGet)) {
+            assertEquals("Didn't get a OK response!", OK.getStatusCode(), getStatus(response));
+            checkForLinkHeader(response, VERSIONING_TIMEMAP_TYPE, "type");
+            final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(","));
+            final Link[] bodyLinks = bodyList.stream().map(String::trim).filter(t -> !t.isEmpty())
+                    .map(Link::valueOf).toArray(Link[]::new);
+            assertArrayEquals(expectedLinks, bodyLinks);
+        }
+    }
+
+    protected String createMemento(final String subjectUri, final String mementoDateTime, final String contentType,
+            final String body) throws Exception {
+        final HttpPost createVersionMethod = postObjMethod(id + "/" + FCR_VERSIONS);
+        if (contentType != null) {
+            createVersionMethod.addHeader(CONTENT_TYPE, contentType);
+        }
+        if (body != null) {
+            createVersionMethod.setEntity(new StringEntity(body));
+        }
+        if (mementoDateTime != null) {
+            createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, mementoDateTime);
+        }
+
+        // Create new memento of resource with updated body
+        try (final CloseableHttpResponse response = execute(createVersionMethod)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+            assertMementoDatetimeHeaderPresent(response);
+
+            return response.getFirstHeader(LOCATION).getValue();
+        }
+    }
+
+    protected String createContainerMementoWithBody(final String subjectUri, final String mementoDateTime)
+            throws Exception {
+
+        final String body = createContainerMementoBodyContent(subjectUri, "text/n3");
+        return createMemento(subjectUri, mementoDateTime, "text/n3", body);
+    }
+
+    protected String createContainerMementoBodyContent(final String subjectUri, final String contentType)
+        throws Exception {
+        // Produce new body from current body with changed triple
+        final String body;
+        final HttpGet httpGet = new HttpGet(subjectUri);
+        final Model model = createDefaultModel();
+        final Lang rdfLang = RDFLanguages.contentTypeToLang(contentType);
+        try (final CloseableHttpResponse response = execute(httpGet)) {
+            model.read(response.getEntity().getContent(), "", rdfLang.getName());
+        }
+        final Resource subjectResc = model.getResource(subjectUri);
+        subjectResc.removeAll(TEST_PROPERTY);
+        subjectResc.addLiteral(TEST_PROPERTY, "bar");
+
+        try (StringWriter stringOut = new StringWriter()) {
+            RDFDataMgr.write(stringOut, model, RDFFormat.NTRIPLES);
+            body = stringOut.toString();
+        }
+
+        return body;
+    }
+
+    protected void createVersionedContainer(final String id, final String subjectUri) throws Exception {
+        final HttpPost createMethod = postObjMethod();
+        createMethod.addHeader("Slug", id);
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
+        createMethod.addHeader(LINK, VERSIONED_RESOURCE_LINK_HEADER);
+        createMethod.setEntity(new StringEntity("<" + subjectUri + "> <info:test#label> \"foo\""));
+
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+        }
+    }
+
+    protected void createVersionedBinary(final String id) throws Exception {
+        final HttpPost createMethod = postObjMethod();
+        createMethod.addHeader("Slug", id);
+        createMethod.addHeader(CONTENT_TYPE, OCTET_STREAM_TYPE);
+        createMethod.addHeader(LINK, VERSIONED_RESOURCE_LINK_HEADER);
+        createMethod.setEntity(new StringEntity(BINARY_CONTENT));
+
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+        }
+    }
+
+    protected static void assertMementoDatetimeHeaderPresent(final CloseableHttpResponse response) {
+        assertNotNull("No memento datetime header set in response",
+                response.getHeaders(MEMENTO_DATETIME_HEADER));
+    }
+
+    protected static void assertMementoDatetimeHeaderMatches(final CloseableHttpResponse response,
+            final String expected) {
+        assertMementoDatetimeHeaderPresent(response);
+        assertEquals("Response memento datetime did not match expected value",
+                expected, response.getFirstHeader(MEMENTO_DATETIME_HEADER).getValue());
+    }
+
+    protected static void assertConstrainedByPresent(final CloseableHttpResponse response) {
+        final Collection<String> linkHeaders = getLinkHeaders(response);
+        assertTrue("Constrained by link header no present",
+                linkHeaders.stream().map(Link::valueOf)
+                        .anyMatch(l -> l.getRel().equals(CONSTRAINED_BY.getURI())));
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -179,7 +179,7 @@ import nu.validator.saxtree.TreeBuilder;
  * @author cabeer
  * @author ajs6f
  */
-public class FedoraLdpIT extends AbstractResourceIT {
+public class FedoraLdpIT extends AbstractVersioningIT {
 
     private static final Node DC_IDENTIFIER = DC_11.identifier.asNode();
 
@@ -585,6 +585,18 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Test
+    public void testOptionsMemento() throws Exception {
+        createVersionedContainer(id, subjectUri);
+        final String mementoUri = createContainerMementoWithBody(subjectUri, null);
+
+        final HttpOptions optionsRequest = new HttpOptions(mementoUri);
+        try (final CloseableHttpResponse optionsResponse = execute(optionsRequest)) {
+            assertEquals(OK.getStatusCode(), optionsResponse.getStatusLine().getStatusCode());
+            assertMementoOptionsHeaders(optionsResponse);
+        }
+    }
+
     private static void assertContainerOptionsHeaders(final HttpResponse httpResponse) {
         assertRdfOptionsHeaders(httpResponse);
         final List<String> methods = headerValues(httpResponse, "Allow");
@@ -629,6 +641,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertTrue("Should allow PUT", methods.contains(HttpPut.METHOD_NAME));
         assertTrue("Should allow DELETE", methods.contains(HttpDelete.METHOD_NAME));
         assertTrue("Should allow OPTIONS", methods.contains(HttpOptions.METHOD_NAME));
+    }
+
+    private static void assertMementoOptionsHeaders(final HttpResponse httpResponse) {
+        final List<String> methods = headerValues(httpResponse, "Allow");
+        assertTrue("Should allow GET", methods.contains(HttpGet.METHOD_NAME));
+        assertTrue("Should allow HEAD", methods.contains(HttpHead.METHOD_NAME));
+        assertTrue("Should allow OPTIONS", methods.contains(HttpOptions.METHOD_NAME));
+        assertTrue("Should allow DELETE", methods.contains(HttpDelete.METHOD_NAME));
     }
 
     private static List<String> headerValues(final HttpResponse response, final String headerName) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -17,40 +17,20 @@
  */
 package org.fcrepo.integration.http.api;
 
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.HttpHeaders.LINK;
-import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
-import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
-import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.fcrepo.http.api.FedoraVersioning.MEMENTO_DATETIME_HEADER;
-import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_LINK_FORMAT;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
-import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
-import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEMAP_TYPE;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import java.io.StringWriter;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import javax.ws.rs.core.Link;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
@@ -61,50 +41,17 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.apache.jena.graph.Node;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
-import org.apache.jena.riot.RDFFormat;
-import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
-import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 
 /**
  * @author lsitu
  * @author bbpennel
  */
-public class FedoraVersioningIT extends AbstractResourceIT {
-
-    private static final String VERSIONED_RESOURCE_LINK_HEADER = "<" + VERSIONED_RESOURCE.getURI() + ">; rel=\"type\"";
-    private static final String BINARY_CONTENT = "binary content";
-    private static final String BINARY_UPDATED = "updated content";
-
-    private static final String OCTET_STREAM_TYPE = "application/octet-stream";
-
-    private static final Node MEMENTO_TYPE_NODE = createURI(MEMENTO_TYPE);
-    private static final Node TEST_PROPERTY_NODE = createURI("info:test#label");
-
-    private static final Property TEST_PROPERTY = createProperty("info:test#label");
-
-    final String MEMENTO_DATETIME =
-            RFC_1123_DATE_TIME.format(LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC));
-
-    private String subjectUri;
-    private String id;
-
-    @Before
-    public void init() {
-        id = getRandomUniqueId();
-        subjectUri = serverAddress + id;
-    }
+public class FedoraVersioningIT extends AbstractVersioningIT {
 
     @Test
     public void testDeleteTimeMapForContainer() throws Exception {
@@ -371,27 +318,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         verifyTimemapResponse(descriptionUri, descriptionId);
     }
 
-    private void verifyTimemapResponse(final String uri, final String id) throws Exception {
-        final List<Link> listLinks = new ArrayList<Link>();
-        listLinks.add(Link.fromUri(uri).rel("original").build());
-        listLinks.add(Link.fromUri(uri).rel("timegate").build());
-        listLinks
-                .add(Link.fromUri(uri + "/" + FCR_VERSIONS).rel("self").type(APPLICATION_LINK_FORMAT)
-                        .build());
-        final Link[] expectedLinks = listLinks.toArray(new Link[3]);
-
-        final HttpGet httpGet = getObjMethod(id + "/" + FCR_VERSIONS);
-        httpGet.setHeader("Accept", APPLICATION_LINK_FORMAT);
-        try (final CloseableHttpResponse response = execute(httpGet)) {
-            assertEquals("Didn't get a OK response!", OK.getStatusCode(), getStatus(response));
-            checkForLinkHeader(response, VERSIONING_TIMEMAP_TYPE, "type");
-            final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(","));
-            final Link[] bodyLinks = bodyList.stream().map(String::trim).filter(t -> !t.isEmpty())
-                    .map(Link::valueOf).toArray(Link[]::new);
-            assertArrayEquals(expectedLinks, bodyLinks);
-        }
-    }
-
     @Test
     public void testCreateVersionOfBinary() throws Exception {
         createVersionedBinary(id);
@@ -468,99 +394,5 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertEquals("Binary content of memento must match updated content",
                     BINARY_UPDATED, EntityUtils.toString(response.getEntity()));
         }
-    }
-
-    private String createMemento(final String subjectUri, final String mementoDateTime, final String contentType,
-            final String body) throws Exception {
-        final HttpPost createVersionMethod = postObjMethod(id + "/" + FCR_VERSIONS);
-        if (contentType != null) {
-            createVersionMethod.addHeader(CONTENT_TYPE, contentType);
-        }
-        if (body != null) {
-            createVersionMethod.setEntity(new StringEntity(body));
-        }
-        if (mementoDateTime != null) {
-            createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, mementoDateTime);
-        }
-
-        // Create new memento of resource with updated body
-        try (final CloseableHttpResponse response = execute(createVersionMethod)) {
-            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
-            assertMementoDatetimeHeaderPresent(response);
-
-            return response.getFirstHeader(LOCATION).getValue();
-        }
-    }
-
-    private String createContainerMementoWithBody(final String subjectUri, final String mementoDateTime)
-            throws Exception {
-
-        final String body = createContainerMementoBodyContent(subjectUri, "text/n3");
-        return createMemento(subjectUri, mementoDateTime, "text/n3", body);
-    }
-
-    private String createContainerMementoBodyContent(final String subjectUri, final String contentType)
-        throws Exception {
-        // Produce new body from current body with changed triple
-        final String body;
-        final HttpGet httpGet = new HttpGet(subjectUri);
-        final Model model = createDefaultModel();
-        final Lang rdfLang = RDFLanguages.contentTypeToLang(contentType);
-        try (final CloseableHttpResponse response = execute(httpGet)) {
-            model.read(response.getEntity().getContent(), "", rdfLang.getName());
-        }
-        final Resource subjectResc = model.getResource(subjectUri);
-        subjectResc.removeAll(TEST_PROPERTY);
-        subjectResc.addLiteral(TEST_PROPERTY, "bar");
-
-        try (StringWriter stringOut = new StringWriter()) {
-            RDFDataMgr.write(stringOut, model, RDFFormat.NTRIPLES);
-            body = stringOut.toString();
-        }
-
-        return body;
-    }
-
-    private void createVersionedContainer(final String id, final String subjectUri) throws Exception {
-        final HttpPost createMethod = postObjMethod();
-        createMethod.addHeader("Slug", id);
-        createMethod.addHeader(CONTENT_TYPE, "text/n3");
-        createMethod.addHeader(LINK, VERSIONED_RESOURCE_LINK_HEADER);
-        createMethod.setEntity(new StringEntity("<" + subjectUri + "> <info:test#label> \"foo\""));
-
-        try (final CloseableHttpResponse response = execute(createMethod)) {
-            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
-        }
-    }
-
-    private void createVersionedBinary(final String id) throws Exception {
-        final HttpPost createMethod = postObjMethod();
-        createMethod.addHeader("Slug", id);
-        createMethod.addHeader(CONTENT_TYPE, OCTET_STREAM_TYPE);
-        createMethod.addHeader(LINK, VERSIONED_RESOURCE_LINK_HEADER);
-        createMethod.setEntity(new StringEntity(BINARY_CONTENT));
-
-        try (final CloseableHttpResponse response = execute(createMethod)) {
-            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
-        }
-    }
-
-    private static void assertMementoDatetimeHeaderPresent(final CloseableHttpResponse response) {
-        assertNotNull("No memento datetime header set in response",
-                response.getHeaders(MEMENTO_DATETIME_HEADER));
-    }
-
-    private static void assertMementoDatetimeHeaderMatches(final CloseableHttpResponse response,
-            final String expected) {
-        assertMementoDatetimeHeaderPresent(response);
-        assertEquals("Response memento datetime did not match expected value",
-                expected, response.getFirstHeader(MEMENTO_DATETIME_HEADER).getValue());
-    }
-
-    private static void assertConstrainedByPresent(final CloseableHttpResponse response) {
-        final Collection<String> linkHeaders = getLinkHeaders(response);
-        assertTrue("Constrained by link header no present",
-                linkHeaders.stream().map(Link::valueOf)
-                        .anyMatch(l -> l.getRel().equals(CONSTRAINED_BY.getURI())));
     }
 }


### PR DESCRIPTION
Support OPTIONS request on LDPRms.

https://jira.duraspace.org/browse/FCREPO-2615


# How should this be tested?
```
1. Create versioned resource:
curl -i -XPOST -H "Slug: v1" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest" -H "Content-Type: text/n3" --data-binary "<> <info:fedora/test/field> \"V 1\""

2. Create memento:
echo '<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Container> .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Resource> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#lastModifiedBy> "bypassAdmin" .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#createdBy> "bypassAdmin" .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#created> "2018-03-15T16:16:36.88Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#lastModified> "2018-03-15T16:16:36.88Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/v1> <info:fedora/test/field> "V 1" .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#RDFSource> .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#writable> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .' | curl -XPOST -i -H "Memento-Datetime: Tue, 3 Jun 2008 11:05:30 GMT" http://localhost:8080/rest/v1/fcr:versions -H "Content-Type: application/n-triples" --data-binary "@-"

HTTP/1.1 201 Created
Date: Thu, 15 Mar 2018 16:18:59 GMT
ETag: W/"531846f3e5adfbf96fbc8c5568aa8226012ab1ad"
Last-Modified: Thu, 15 Mar 2018 16:16:36 GMT
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Memento-Datetime: Tue, 3 Jun 2008 11:05:30 GMT
Location: http://localhost:8080/rest/v1/fedora:timemap/20080603110530
Content-Type: text/plain
Content-Length: 59
Server: Jetty(9.2.3.v20140905)

3. Verify OPTIONS request:
curl -i -XOPTIONS "http://localhost:8080/rest/v1/fedora:timemap/20080603110530"

HTTP/1.1 200 OK
Date: Thu, 15 Mar 2018 16:20:24 GMT
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Allow: GET,HEAD,OPTIONS,DELETE
Content-Length: 0
Server: Jetty(9.2.3.v20140905)```
