### PR TITLE
Ensures that it is possible to create a resource with an  ACL when th…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -641,7 +641,14 @@ public class FedoraLdp extends ContentExposingResource {
 
     private void checkAclUriExists(final URI resourceAcl) {
         try {
-            final FedoraResource aclResource = getResourceFromPath(resourceAcl.getPath());
+            //extract external path
+            final String contextPath = this.uriInfo.getBaseUri().getPath();
+
+            final String path = !resourceAcl.getPath().startsWith(contextPath) ?
+                                    resourceAcl.getPath() :
+                                    resourceAcl.getPath().substring(contextPath.length());
+
+            final FedoraResource aclResource = getResourceFromPath(path);
             if (aclResource == null) {
                 throw new InvalidACLException("The ACL URI in the link header does not exist");
             }
@@ -652,7 +659,6 @@ public class FedoraLdp extends ContentExposingResource {
                 throw e;
             }
         }
-
     }
 
     private void addResourceAcl(final URI resourceAcl) {


### PR DESCRIPTION
…e fedora-webapp uses a non zero-length context path.

Resolves https://jira.duraspace.org/browse/FCREPO-2722

**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2722

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://jira.duraspace.org/browse/FCREPO-2705
https://github.com/fcrepo4/fcrepo4/pull/1302

# What does this Pull Request do?
This PR fixes a problem that arises when validating an ACL URI  on resource PUT when the fedora instance is using a non-zero-length context path such as /fcrepo/rest or /rest.


# How should this be tested?

```
#build and run the one-click
mvn clean install -pl fcrepo-webapp -Pone-click; java -jar fcrepo-webapp/target/fcrepo-webapp-5.0.0-SNAPSHOT-jetty-console.jar --headless 

# First create an acl 
curl -v -XPUT "http://localhost:8080/rest/acl1" -u fedoraAdmin:fedoraAdmin 

# create rdf resource with acl on POST 
 curl -v -XPOST -H "Link: <http://localhost:8080/rest/acl1>; rel=\"acl\"" "http://localhost:8080/rest/" -H "Slug: test1" -u fedoraAdmin:fedoraAdmin 
# validate the server response is a 201 Created

# Interested parties
@yinlinchen
@harringj