### PR TITLE
Fcrepo 2719 - Path conversion for timemaps and mementos

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -479,13 +479,15 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             final Link link = Link.fromUri(uri).rel("describes").build();
             servletResponse.addHeader(LINK, link.toString());
         } else if (resource instanceof FedoraBinary) {
-            final URI uri = getUri(resource.getDescription());
-            final Link.Builder builder = Link.fromUri(uri).rel("describedby");
+            if (!resource.isMemento()) {
+                final URI uri = getUri(resource.getDescription());
+                final Link.Builder builder = Link.fromUri(uri).rel("describedby");
 
-            if (includeAnchor) {
-                builder.param("anchor", getUri(resource).toString());
+                if (includeAnchor) {
+                    builder.param("anchor", getUri(resource).toString());
+                }
+                servletResponse.addHeader(LINK, builder.build().toString());
             }
-            servletResponse.addHeader(LINK, builder.build().toString());
 
             final String path = context.getContextPath().equals("/") ? "" : context.getContextPath();
             final String constraintURI = uriInfo.getBaseUri().getScheme() + "://" +

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -157,8 +157,15 @@ public class FedoraVersioning extends ContentExposingResource {
             @ContentLocation final InputStream requestBodyStream)
             throws InvalidChecksumException, MementoDatetimeFormatException {
 
-        final AcquiredLock lock = lockManager.lockForWrite(resource().findOrCreateTimeMap().getPath(),
+        final FedoraResource timeMap = resource().findOrCreateTimeMap();
+        // If the timemap was created in this request, commit it.
+        if (timeMap.isNew()) {
+            session.commit();
+        }
+
+        final AcquiredLock lock = lockManager.lockForWrite(timeMap.getPath(),
             session.getFedoraSession(), nodeService);
+
 
         try {
             final MediaType contentType = getSimpleContentType(requestContentType);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -166,7 +166,6 @@ public class FedoraVersioning extends ContentExposingResource {
         final AcquiredLock lock = lockManager.lockForWrite(timeMap.getPath(),
             session.getFedoraSession(), nodeService);
 
-
         try {
             final MediaType contentType = getSimpleContentType(requestContentType);
 
@@ -180,7 +179,7 @@ public class FedoraVersioning extends ContentExposingResource {
             try {
                 mementoInstant = (isBlank(datetimeHeader) ? Instant.now()
                     : Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(datetimeHeader)));
-            } catch (DateTimeParseException e) {
+            } catch (final DateTimeParseException e) {
                 throw new MementoDatetimeFormatException("Invalid memento date-time value. "
                         + "Please use RFC-1123 date-time format, such as 'Tue, 3 Jun 2008 11:05:30 GMT'", e);
             }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractVersioningIT.java
@@ -208,4 +208,8 @@ public abstract class AbstractVersioningIT extends AbstractResourceIT {
                 linkHeaders.stream().map(Link::valueOf)
                         .anyMatch(l -> l.getRel().equals(CONSTRAINED_BY.getURI())));
     }
+
+    protected static void assertMementoUri(final String mementoUri, final String subjectUri) {
+        assertTrue(mementoUri.matches(subjectUri + "/fcr:versions/\\d+"));
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -97,6 +97,7 @@ public class FedoraVersioningIT extends AbstractVersioningIT {
         createVersionedContainer(id, subjectUri);
 
         final String mementoUri = createContainerMementoWithBody(subjectUri, null);
+        assertMementoUri(mementoUri, subjectUri);
 
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
             final DatasetGraph results = dataset.asDatasetGraph();
@@ -207,6 +208,7 @@ public class FedoraVersioningIT extends AbstractVersioningIT {
         createVersionedContainer(id, subjectUri);
 
         final String mementoUri = createContainerMementoWithBody(subjectUri, null);
+        assertMementoUri(mementoUri, subjectUri);
 
         final HttpGet httpGet = new HttpGet(mementoUri);
         try (final CloseableDataset dataset = getDataset(httpGet)) {
@@ -226,6 +228,7 @@ public class FedoraVersioningIT extends AbstractVersioningIT {
         createVersionedContainer(id, subjectUri);
 
         final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        assertMementoUri(mementoUri, subjectUri);
         final Node mementoSubject = createURI(mementoUri);
         final Node subject = createURI(subjectUri);
 
@@ -323,6 +326,7 @@ public class FedoraVersioningIT extends AbstractVersioningIT {
         createVersionedBinary(id);
 
         final String mementoUri = createMemento(subjectUri, null, null, null);
+        assertMementoUri(mementoUri, subjectUri);
 
         final HttpGet httpGet = new HttpGet(mementoUri);
         try (final CloseableHttpResponse response = execute(httpGet)) {
@@ -352,6 +356,7 @@ public class FedoraVersioningIT extends AbstractVersioningIT {
 
         final String mementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
                 OCTET_STREAM_TYPE, null);
+        assertMementoUri(mementoUri, subjectUri);
 
         // Verify that the memento has the updated binary
         try (final CloseableHttpResponse response = execute(new HttpGet(mementoUri))) {
@@ -369,6 +374,7 @@ public class FedoraVersioningIT extends AbstractVersioningIT {
 
         final String mementoUri = createMemento(subjectUri, null,
                 OCTET_STREAM_TYPE, BINARY_UPDATED);
+        assertMementoUri(mementoUri, subjectUri);
 
         final HttpGet httpGet = new HttpGet(mementoUri);
         try (final CloseableHttpResponse response = execute(httpGet)) {
@@ -386,6 +392,7 @@ public class FedoraVersioningIT extends AbstractVersioningIT {
 
         final String mementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
                 OCTET_STREAM_TYPE, BINARY_UPDATED);
+        assertMementoUri(mementoUri, subjectUri);
 
         // Verify that the memento has the updated binary
         try (final CloseableHttpResponse response = execute(new HttpGet(mementoUri))) {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -208,14 +208,14 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
         if (uriTemplate.match(resource.getURI(), values) && values.containsKey("path")) {
             String path = "/" + values.get("path");
 
-            final boolean metadata = path.endsWith("/" + FCR_METADATA);
             final boolean timemap = path.endsWith("/" + FCR_VERSIONS);
-
-            if (metadata) {
-                path = replaceOnce(path, "/" + FCR_METADATA, EMPTY);
-            }
             if (timemap) {
                 path = replaceOnce(path, "/" + FCR_VERSIONS, EMPTY);
+            }
+
+            final boolean metadata = path.endsWith("/" + FCR_METADATA);
+            if (metadata) {
+                path = replaceOnce(path, "/" + FCR_METADATA, EMPTY);
             }
 
             path = forward.convert(path);
@@ -252,7 +252,7 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
     private Node getNode(final String path) throws RepositoryException {
         try {
             return getJcrSession(session).getNode(path);
-        } catch (IllegalArgumentException ex) {
+        } catch (final IllegalArgumentException ex) {
             throw new InvalidResourceIdentifierException("Illegal path: " + path);
         }
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -257,31 +257,29 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
         }
     }
 
-    private static String getPath(final FedoraResource resource) {
-        if (resource instanceof FedoraTimeMap) {
-            // the path is relative to the parent, and unique so fake it here.
-            final FedoraResource parent = resource.getContainer();
-            final String parentPath = parent.getPath();
-            return parentPath + "/" + FCR_VERSIONS;
-        }
-        return resource.getPath();
-    }
-
-    private static String getRelativePath(final FedoraResource child, final FedoraResource ancestor) {
-        return child.getPath().substring(ancestor.getPath().length());
-    }
-
     /**
      * Get only the resource path to this resource, before embedding it in a full URI
      * @param resource
      * @return
      */
     private String doBackwardPathOnly(final FedoraResource resource) {
-        final String path = reverse.convert(getPath(resource));
+        final FedoraResource pathResource;
+        if (resource instanceof FedoraTimeMap) {
+            final FedoraTimeMap timemap = (FedoraTimeMap) resource;
+            pathResource = timemap.getOriginalResource();
+        } else {
+            pathResource = resource;
+        }
+
+        String path = reverse.convert(pathResource.getPath());
+
         if (path != null) {
 
-            if (resource instanceof NonRdfSourceDescription) {
-                return path + "/" + FCR_METADATA;
+            if (pathResource instanceof NonRdfSourceDescription) {
+                path += "/" + FCR_METADATA;
+            }
+            if (resource instanceof FedoraTimeMap) {
+                path += "/" + FCR_VERSIONS;
             }
 
             return path;

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -83,8 +83,12 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
 
     private static final Logger LOGGER = getLogger(HttpResourceConverter.class);
 
-    // Regex pattern which decomposes a http resource uri into fcr components
-    final static Pattern FORWARD_COMPONENT_PATTERN = Pattern.compile(
+    // Regex pattern which decomposes a http resource uri into components
+    // First group is the path of the resource or original resource,
+    // second group determines if it is an fcr:metadata non-rdf source,
+    // third group determines if the path is for a memento or timemap,
+    // and the fourth group allows for a memento identifier
+    private final static Pattern FORWARD_COMPONENT_PATTERN = Pattern.compile(
             "(.*?)(/" + FCR_METADATA + ")?(/" + FCR_VERSIONS + "(/\\d+)?)?$");
 
     protected List<Converter<String, String>> translationChain;

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -59,7 +59,7 @@ import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.FedoraTimeMap;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
-import org.fcrepo.kernel.modeshape.FedoraBinaryImpl;
+import org.fcrepo.kernel.modeshape.NonRdfSourceDescriptionImpl;
 import org.fcrepo.kernel.modeshape.TombstoneImpl;
 import org.fcrepo.kernel.modeshape.identifiers.HashConverter;
 import org.fcrepo.kernel.modeshape.identifiers.NamespaceConverter;
@@ -229,7 +229,7 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
                     } else {
                         try {
                             final Node originalNode = getNode(basePath);
-                            binary = FedoraBinaryImpl.hasMixin(originalNode);
+                            binary = NonRdfSourceDescriptionImpl.hasMixin(originalNode);
                         } catch (final RepositoryException e) {
                             throw new RepositoryRuntimeException(e);
                         }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverterTest.java
@@ -58,7 +58,6 @@ import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
 import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 
@@ -260,12 +259,7 @@ public class HttpResourceConverterTest {
     public void testDoForwardWithBinaryTimemap() throws Exception {
         final Resource resource = createResource("http://localhost:8080/some/binary/fcr:versions");
         when(session.getNode("/binary")).thenReturn(node);
-        when(node.isNodeType(FEDORA_BINARY)).thenReturn(true);
-
-        final Node binaryDescription = mock(Node.class);
-        when(binaryDescription.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION)).thenReturn(true);
-        when(binaryDescription.getNode(JCR_CONTENT)).thenReturn(contentNode);
-        when(node.getParent()).thenReturn(binaryDescription);
+        when(node.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION)).thenReturn(true);
 
         when(session.getNode("/binary/fedora:binaryTimemap")).thenReturn(timeMapNode);
 
@@ -354,7 +348,7 @@ public class HttpResourceConverterTest {
         when(session.getNode("/binary/fedora:binaryTimemap/20180315180915")).thenReturn(mementoNode);
 
         when(session.getNode("/binary")).thenReturn(node);
-        when(node.isNodeType(FEDORA_BINARY)).thenReturn(true);
+        when(node.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION)).thenReturn(true);
 
         final FedoraResource converted = converter.convert(resource);
         assertTrue("Converted resource must be a binary", converted instanceof FedoraBinary);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
@@ -47,6 +47,8 @@ public interface FedoraTypes {
 
     String MEMENTO_DATETIME = "memento:mementoDatetime";
 
+    String MEMENTO_ORIGINAL = "memento:original";
+
     String LDP_BASIC_CONTAINER = "ldp:BasicContainer";
 
     String LDP_CONTAINER = "ldp:Container";

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraTimeMap.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraTimeMap.java
@@ -23,4 +23,10 @@ package org.fcrepo.kernel.api.models;
  */
 public interface FedoraTimeMap extends FedoraResource {
 
+    /**
+     * Get the Original Resource to which this TimeMap/TimeGate applies.
+     *
+     * @return the original resource for this
+     */
+    FedoraResource getOriginalResource();
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -441,6 +441,9 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
                 if (ldpcvNode.canAddMixin(FEDORA_TIME_MAP)) {
                     ldpcvNode.addMixin(FEDORA_TIME_MAP);
                 }
+
+                // Set reference from timegate/map to original resource
+                ldpcvNode.setProperty(MEMENTO_ORIGINAL, getNode());
             }
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
@@ -780,10 +783,10 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
      * @throws InteractionModelViolationException when attempting to change the interaction model
      */
     private void checkInteractionModel(final UpdateRequest request) {
-        final List<Quad> deleteQuads = new ArrayList<Quad>();
-        final List<Quad> updateQuads = new ArrayList<Quad>();
+        final List<Quad> deleteQuads = new ArrayList<>();
+        final List<Quad> updateQuads = new ArrayList<>();
 
-        for (Update operation : request.getOperations()) {
+        for (final Update operation : request.getOperations()) {
             if (operation instanceof UpdateModify) {
                 final UpdateModify op = (UpdateModify) operation;
                 deleteQuads.addAll(op.getDeleteQuads());

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraTimeMapImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraTimeMapImpl.java
@@ -17,11 +17,17 @@
  */
 package org.fcrepo.kernel.modeshape;
 
+import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.nodeConverter;
+
+import java.util.Optional;
+
 import javax.jcr.Node;
+import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.FedoraTimeMap;
 
 /**
@@ -29,7 +35,6 @@ import org.fcrepo.kernel.api.models.FedoraTimeMap;
  * @since Oct. 04, 2017
  */
 public class FedoraTimeMapImpl extends FedoraResourceImpl implements FedoraTimeMap {
-
 
     /**
      * Construct a {@link org.fcrepo.kernel.api.models.FedoraResource} from an existing JCR Node
@@ -62,6 +67,18 @@ public class FedoraTimeMapImpl extends FedoraResourceImpl implements FedoraTimeM
     public static boolean hasMixin(final Node node) {
         try {
             return node.isNodeType(FEDORA_TIME_MAP);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+    @Override
+    public FedoraResource getOriginalResource() {
+        try {
+            final Property originalProperty = node.getProperty(MEMENTO_ORIGINAL);
+            final Node originalNode = originalProperty.getNode();
+
+            return Optional.of(originalNode).map(nodeConverter::convert).orElse(null);
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -27,6 +27,7 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_CONTAINMENT;
 import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
+import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_BINARY_TIME_MAP;
 import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_TIME_MAP;
 import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.fcrepo.kernel.modeshape.rdf.impl.RequiredPropertiesUtil.assertRequiredContainerTriples;
@@ -200,7 +201,8 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     }
 
     private String makeMementoPath(final FedoraResource resource, final Instant datetime) {
-        return resource.getPath() + "/" + LDPCV_TIME_MAP + "/" + MEMENTO_DATETIME_ID_FORMATTER.format(datetime);
+        final String ldpcvName = resource instanceof FedoraBinary ? LDPCV_BINARY_TIME_MAP : LDPCV_TIME_MAP;
+        return resource.getPath() + "/" + ldpcvName + "/" + MEMENTO_DATETIME_ID_FORMATTER.format(datetime);
     }
 
     protected String getUri(final FedoraResource resource,

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
@@ -522,15 +522,11 @@ public abstract class FedoraTypesUtils implements FedoraTypes {
                 return empty();
             }
 
-            //check ancestors recursively only either of the following two cases applies:
+            // check ancestors recursively only either of the following two cases applies:
             // 1. the PARENT is a FEDORA_PAIRTREE
-            // 2. the PARENT is FEDORA_NON_RDF_SOURCE_DESCRIPTION AND the the NODE itself NOT a FEDORA_TIME_MAP.
-            //Time maps of Fedora binaries must be handled slightly differently due to the fact that
-            //the TimeMap is a child of the resource description rather than the resource itself as is the
-            //case for RDF sources.
+            // 2. the PARENT is FEDORA_NON_RDF_SOURCE_DESCRIPTION
             final Node parent = node.getParent();
-            if (parent.isNodeType(FEDORA_PAIRTREE) ||
-                (parent.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION) && !node.isNodeType(FEDORA_TIME_MAP))) {
+            if (parent.isNodeType(FEDORA_PAIRTREE) || parent.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION)) {
                 return getContainingNode(parent);
             }
             return Optional.of(parent);

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -79,6 +79,7 @@
  * A Fedora LDPCv TimeMap.
  */
 [fedora:TimeMap] > fedora:Resource mixin
+  - memento:original (REFERENCE)
 
 /*
  * A Fedora LDPRm Memento.

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtilsTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtilsTest.java
@@ -17,14 +17,11 @@
  */
 package org.fcrepo.kernel.modeshape.utils;
 
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_SKOLEM;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_TIME_MAP;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.ROOT;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.isBinaryContentProperty;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.property2values;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getClosestExistingAncestor;
-import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getContainingNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getReferencePropertyName;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isSkolemNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isReferenceProperty;
@@ -386,14 +383,5 @@ public class FedoraTypesUtilsTest {
         when(mockNode.getPrimaryNodeType()).thenReturn(mockNodeType);
         when(mockNodeType.getName()).thenReturn(ROOT);
         assertFalse(isExternalNode.test(mockNode));
-    }
-
-    @Test
-    public void testGetBinaryTimeMapShouldReturnDirectParent() throws RepositoryException {
-        when(mockNode.getDepth()).thenReturn(1);
-        when(mockNode.isNodeType(FEDORA_TIME_MAP)).thenReturn(true);
-        when(mockParent.isNodeType(FEDORA_NON_RDF_SOURCE_DESCRIPTION)).thenReturn(true);
-        when(mockNode.getParent()).thenReturn(mockParent);
-        assertEquals(mockParent, getContainingNode(mockNode).get());
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2719

# What does this Pull Request do?
Refactor of http converter and other mechanisms required to get memento and timemap URIs translated back and forth between http and jcr path.

# What's new?
* Fixes memento uri so that it doesn't expose the node name of the timemap, instead correctly shows fcr:versions.
* FedoraTimeMap objects now track and provide helper to get the original resource the timemap applies to.
  * adds memento:original property for fedora:TimeMap type
* Updates http uri conversion to account for mementos, forward and backward
* Switches binary timemaps and mementos to using fedora:binaryTimemap node for storage
* Updates http uri conversion to account for binary mementos using a different node name
* Adds unit tests for timemap and memento uri conversion
* Suppresses description link header in responses for binary mementos since the descriptions are versioned separately.
* Removes changes to way that an objects container was retrieved since it is no longer used for timemaps

# Forward Mapping Examples:
The following examples explain how http uris for resources should be converted to internal paths
```
binary/fcr:metadata/fcr:versions (non-rdf desc timemap)
=> binary/fedora:timemap

binary/fcr:versions (binary timemap)
=> binary/fedora:binaryTimemap

container/fcr:versions (container timemap)
=> container/fedora:timemap

binary/fcr:metadata/fcr:versions/2018 (non-rdf source desc memento)
=> binary/fedora:timemap/2018

binary/fcr:versions/2018 (binary memento)
=> binary/fedora:timemap/2018

container/fcr:versions/2018 
=> container/fedora:binaryTimemap/2018

binary/fcr:metadata
=> binary

binary
=> binary/jcr:content

container
=> container
```

# Backward Mapping
```
binary/fedora:binaryTimemap (timemap for binary)
=> binary/fcr:versions

binary/fedora:timemap (timemap for non-rdf source description)
=> binary/fcr:metadata/fcr:versions

container/fedora:timemap (timemape for container)
=> container/fcr:versions

binary/fedora:binaryTimemap/2018 (binary memento)
=> binary/fcr:versions/2018

binary/fedora:timemap/2018 (non-rdf description memento)
=> binary/fcr:metadata/fcr:versions/2018

container/fedora:timemap/2018 (container memento)
=> container/fcr:versions/2018

binary (non-rdf)
=> binary/fcr:metadata

binary/jcr:content
=> binary

container
=> container
```

# How should this be tested?

```
# Create versioned container
curl -i -XPOST -H "Slug:versioned_res3" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/"

# Create memento of container
curl -XPOST http://localhost:8080/versioned_res3/fcr:versions

# Resulting Location should be http://localhost:8080/versioned_res3/fcr:versions/<datetime>

# Create versioned binary
curl -i -XPOST -H "Slug:versioned_bin3" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" -H "Content-Type: application/octet-stream" --data-binary "binarycontent" "http://localhost:8080/"

# Create memento
curl -XPOST http://localhost:8080/versioned_bin3/fcr:versions

# Resulting Location should be http://localhost:8080/versioned_bin3/fcr:versions/<datetime>
```

# Additional Notes:
There is not currently a way to create a version of a binary description, waiting on ticket https://jira.duraspace.org/browse/FCREPO-2708 to finish out binary memento creation.
