### PR TITLE
Fix FCREPO-2687 - Restrict Cross Domain ACL

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -643,6 +643,15 @@ public class FedoraLdp extends ContentExposingResource {
     private void checkAclUriExistsAndHasCorrectType(final URI resourceAcl) {
         FedoraResource aclResource = null;
         try {
+
+            final String aclHost = resourceAcl.getHost();
+            final String serverHost = (headers.getHeaderString("X-Forwarded-Host") == null) ? this.uriInfo
+                    .getBaseUri().getHost() : headers.getHeaderString("X-Forwarded-Host");
+
+            if (!serverHost.equals(aclHost)) {
+                throw new InvalidACLException("Cross Domain ACLs is not allowed");
+            }
+
             //extract external path
             final String contextPath = this.uriInfo.getBaseUri().getPath();
 
@@ -669,13 +678,6 @@ public class FedoraLdp extends ContentExposingResource {
 
     private void addResourceAcl(final URI resourceAcl) {
         if (resourceAcl != null) {
-            final String aclHost = resourceAcl.getHost();
-            final String serverHost = this.uriInfo.getBaseUri().getHost();
-
-            if (!serverHost.equals(aclHost)) {
-                throw new InvalidACLException("Cross Domain ACLs is not allowed");
-            }
-
             final String sparql =
                     "PREFIX acl: <" + WEBAC_NAMESPACE_VALUE + ">\n" +
                     "INSERT { \n" +

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -649,7 +649,7 @@ public class FedoraLdp extends ContentExposingResource {
                     .getBaseUri().getHost() : headers.getHeaderString("X-Forwarded-Host");
 
             if (!serverHost.equals(aclHost)) {
-                throw new InvalidACLException("Cross Domain ACLs is not allowed");
+                throw new InvalidACLException("Cross Domain ACLs are not allowed");
             }
 
             //extract external path

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -669,6 +669,13 @@ public class FedoraLdp extends ContentExposingResource {
 
     private void addResourceAcl(final URI resourceAcl) {
         if (resourceAcl != null) {
+            final String aclHost = resourceAcl.getHost();
+            final String serverHost = this.uriInfo.getBaseUri().getHost();
+
+            if (!serverHost.equals(aclHost)) {
+                throw new InvalidACLException("Cross Domain ACLs is not allowed");
+            }
+
             final String sparql =
                     "PREFIX acl: <" + WEBAC_NAMESPACE_VALUE + ">\n" +
                     "INSERT { \n" +

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1304,6 +1304,17 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
     }
 
+    @Test
+    public void testPostCreateRDFSourceWithOutsideAcl() throws IOException {
+        final String aclURI = "http://outside.fedora.com";
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut createMethod = new HttpPut(subjectURI);
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
+        assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
+    }
+
     private void verifyAccessControlTripleIsPresent(final String aclURI, final String subjectURI) throws IOException {
         verifyAccessControlTripleIsPresent(aclURI, subjectURI, subjectURI);
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1219,6 +1219,31 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPostCreateNonRDFSourceWithOtherDomainAcl() throws IOException {
+        final String aclURI = createOtherDomainAcl();
+        final String subjectPid = getRandomUniqueId();
+        final HttpPost createMethod = new HttpPost(serverAddress);
+        createMethod.addHeader(CONTENT_TYPE, "text/plain");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.addHeader("Slug", subjectPid);
+        createMethod.setEntity(new StringEntity("test body"));
+        assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
+    }
+
+    @Test
+    public void testPostCreateNonRDFSourceWithOtherForwardedHostAcl() throws IOException {
+        final String aclURI = createAcl();
+        final String subjectPid = getRandomUniqueId();
+        final HttpPost createMethod = new HttpPost(serverAddress);
+        createMethod.addHeader(CONTENT_TYPE, "text/plain");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.addHeader("Slug", subjectPid);
+        createMethod.addHeader("X-Forwarded-Host", "otherdomain.com");
+        createMethod.setEntity(new StringEntity("test body"));
+        assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
+    }
+
+    @Test
     public void testPutCreateNonRDFSourceWithAcl() throws IOException {
         final String aclURI = createAcl();
         final String subjectURI = serverAddress + getRandomUniqueId();
@@ -1228,6 +1253,29 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createMethod.setEntity(new StringEntity("test body"));
         assertEquals(CREATED.getStatusCode(), getStatus(createMethod));
         verifyAccessControlTripleIsPresent(aclURI, subjectURI, subjectURI + "/fcr:metadata");
+    }
+
+    @Test
+    public void testPutCreateNonRDFSourceWithOtherDomainAcl() throws IOException {
+        final String aclURI = createOtherDomainAcl();
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut createMethod = new HttpPut(subjectURI);
+        createMethod.addHeader(CONTENT_TYPE, "text/plain");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.setEntity(new StringEntity("test body"));
+        assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
+    }
+
+    @Test
+    public void testPutCreateNonRDFSourceWithOtherForwardedHostAcl() throws IOException {
+        final String aclURI = createAcl();
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut createMethod = new HttpPut(subjectURI);
+        createMethod.addHeader(CONTENT_TYPE, "text/plain");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.addHeader("X-Forwarded-Host", "otherdomain.com");
+        createMethod.setEntity(new StringEntity("test body"));
+        assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
     }
 
     @Test
@@ -1271,6 +1319,31 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPostCreateRDFSourceWithOtherDomainAcl() throws IOException {
+        final String aclURI = createOtherDomainAcl();
+        final String subjectPid = getRandomUniqueId();
+        final HttpPost createMethod = new HttpPost(serverAddress);
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.addHeader("Slug", subjectPid);
+        createMethod.setEntity(new StringEntity("<> <info:test#label> \"foo\""));
+        assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
+    }
+
+    @Test
+    public void testPostCreateRDFSourceWithOtherForwardedHostAcl() throws IOException {
+        final String aclURI = createAcl();
+        final String subjectPid = getRandomUniqueId();
+        final HttpPost createMethod = new HttpPost(serverAddress);
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.addHeader("Slug", subjectPid);
+        createMethod.addHeader("X-Forwarded-Host", "otherdomain.com");
+        createMethod.setEntity(new StringEntity("<> <info:test#label> \"foo\""));
+        assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
+    }
+
+    @Test
     public void testPutCreateRDFSourceWithAcl() throws IOException {
         final String aclURI = createAcl();
         final String subjectURI = serverAddress + getRandomUniqueId();
@@ -1305,12 +1378,24 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testPostCreateRDFSourceWithOutsideAcl() throws IOException {
-        final String aclURI = "http://outside.fedora.com";
+    public void testPutCreateRDFSourceWithOtherDomainAcl() throws IOException {
+        final String aclURI = createOtherDomainAcl();
         final String subjectURI = serverAddress + getRandomUniqueId();
         final HttpPut createMethod = new HttpPut(subjectURI);
         createMethod.addHeader(CONTENT_TYPE, "text/n3");
         createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
+        assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
+    }
+
+    @Test
+    public void testPutCreateRDFSourceWithOtherForwardedHostAcl() throws IOException {
+        final String aclURI = createAcl();
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut createMethod = new HttpPut(subjectURI);
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.addHeader("X-Forwarded-Host", "otherdomain.com");
         createMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
         assertEquals(CONFLICT.getStatusCode(), getStatus(createMethod));
     }
@@ -1331,6 +1416,19 @@ public class FedoraLdpIT extends AbstractResourceIT {
     private String createAcl() throws UnsupportedEncodingException {
         final String aclPid = "acl" + getRandomUniqueId();
         final String aclURI = serverAddress + aclPid;
+        createObjectAndClose(aclPid);
+        final HttpPatch patch = patchObjMethod(aclPid);
+        patch.addHeader(CONTENT_TYPE, "application/sparql-update");
+        // add webac:Acl type to aclURI
+        patch.setEntity(new StringEntity(
+                "INSERT { <> a <http://fedora.info/definitions/v4/webac#Acl> } WHERE {}"));
+        assertEquals("Couldn't add webac:Acl type", NO_CONTENT.getStatusCode(), getStatus(patch));
+        return aclURI;
+    }
+
+    private String createOtherDomainAcl() throws UnsupportedEncodingException {
+        final String aclPid = "acl" + getRandomUniqueId();
+        final String aclURI = "http://otherdomain.com:8080/" + aclPid;
         createObjectAndClose(aclPid);
         final HttpPatch patch = patchObjMethod(aclPid);
         patch.addHeader(CONTENT_TYPE, "application/sparql-update");

--- a/fcrepo-webapp/src/main/webapp/static/constraints/InvalidACLException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/InvalidACLException.rdf
@@ -20,5 +20,7 @@
         the ACL URI in the link header does not exist or exists but does not contain a triple indicating rdf:type of
         http://fedora.info/definitions/v4/webac#Acl
         </rdfs:comment>
+        <rdfs:comment xml:lang="en">Fedora does not allow cross domain ACLs.
+        </rdfs:comment>
     </owl:Ontology>
 </rdf:RDF>

--- a/fcrepo-webapp/src/main/webapp/static/constraints/InvalidACLException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/InvalidACLException.rdf
@@ -16,11 +16,8 @@
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <owl:Ontology rdf:about="static/constraints/InvalidACLException">
         <rdfs:label xml:lang="en">Invalid ACL Exception</rdfs:label>
-        <rdfs:comment xml:lang="en">Fedora wasn't able to create the LDPR with the specified LDP-RS as the ACL. Either
-        the ACL URI in the link header does not exist or exists but does not contain a triple indicating rdf:type of
-        http://fedora.info/definitions/v4/webac#Acl
-        </rdfs:comment>
-        <rdfs:comment xml:lang="en">Fedora does not allow cross domain ACLs.
+        <rdfs:comment xml:lang="en">Fedora wasn't able to create the LDPR with the specified LDP-RS as the ACL for one of the following reasons:
+        the ACL URI in the link header does not exist, the ACL URI exists but does not contain a triple indicating rdf:type of http://fedora.info/definitions/v4/webac#Acl, or the ACL URI does not have the same domain as the LDPR.
         </rdfs:comment>
     </owl:Ontology>
 </rdf:RDF>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2687

# What does this Pull Request do?
This PR is to solve the issue that Fedora does not allow to create a link to an ACL resource that is outside of the repository. 

Example:
For example, the following should not be allowed: 
* create rdf resource with acl on POST 
```
curl -v -XPUT -H "Link: <http://google.com>; rel=\"acl\"" "http://localhost:8080/rest/test" 
```
# How should this be tested?

1. create rdf resource with acl on POST 
```
curl -v -XPUT -H "Link: <http://google.com>; rel=\"acl\"" "http://localhost:8080/rest/test" 
```
2. It should return 409 CONFLICT with a message "Cross Domain ACLs is not allowed" 
 
# Interested parties
Tag @awoods @dbernstein 
