### PR TITLE
Fcrepo 2708 - Create historical binary mementos

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -881,7 +881,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     /**
      * Create a checksum URI object.
      **/
-    private static URI checksumURI( final String checksum ) {
+    protected static URI checksumURI(final String checksum) {
         if (!isBlank(checksum)) {
             return URI.create(checksum);
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -239,7 +239,7 @@ public class FedoraVersioning extends ContentExposingResource {
         }
     }
 
-    protected FedoraBinary createBinaryMementoFromRequest(final FedoraBinary binaryResource,
+    private FedoraBinary createBinaryMementoFromRequest(final FedoraBinary binaryResource,
             final Instant mementoInstant,
             final InputStream requestBodyStream,
             final String digest,

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -203,8 +203,8 @@ public class FedoraVersioning extends ContentExposingResource {
                 if (resource instanceof FedoraBinary) {
                     final FedoraBinary binaryResource = (FedoraBinary) resource;
                     if (createFromExisting) {
-                        memento = versionService.createBinaryVersion(
-                                session.getFedoraSession(), binaryResource, mementoInstant);
+                        memento = versionService.createBinaryVersion(session.getFedoraSession(),
+                                binaryResource, mementoInstant, storagePolicyDecisionPoint);
                     } else {
                         memento = createBinaryMementoFromRequest(binaryResource, mementoInstant,
                                 requestBodyStream, digest, contentDisposition, contentType);
@@ -253,7 +253,8 @@ public class FedoraVersioning extends ContentExposingResource {
         final String originalContentType = contentType != null ? contentType.toString() : "";
 
         return versionService.createBinaryVersion(session.getFedoraSession(), binaryResource,
-                mementoInstant, requestBodyStream, originalFileName, originalContentType, checksumURIs);
+                mementoInstant, requestBodyStream, originalFileName, originalContentType,
+                checksumURIs, storagePolicyDecisionPoint);
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -48,7 +48,10 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.jcr.ItemExistsException;
 import javax.servlet.http.HttpServletResponse;
@@ -80,6 +83,7 @@ import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryVersionRuntimeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
+import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
@@ -197,8 +201,14 @@ public class FedoraVersioning extends ContentExposingResource {
                 // Create memento
                 final FedoraResource memento;
                 if (resource instanceof FedoraBinary) {
-                    memento = versionService.createBinaryVersion(session.getFedoraSession(), resource(),
-                            mementoInstant, null, null, null, null);
+                    final FedoraBinary binaryResource = (FedoraBinary) resource;
+                    if (createFromExisting) {
+                        memento = versionService.createBinaryVersion(
+                                session.getFedoraSession(), binaryResource, mementoInstant);
+                    } else {
+                        memento = createBinaryMementoFromRequest(binaryResource, mementoInstant,
+                                requestBodyStream, digest, contentDisposition, contentType);
+                    }
                 } else {
                     final InputStream bodyStream = createFromExisting ? null : requestBodyStream;
                     final Lang format = createFromExisting ? null : contentTypeToLang(contentType.toString());
@@ -227,6 +237,23 @@ public class FedoraVersioning extends ContentExposingResource {
         } finally {
             lock.release();
         }
+    }
+
+    protected FedoraBinary createBinaryMementoFromRequest(final FedoraBinary binaryResource,
+            final Instant mementoInstant,
+            final InputStream requestBodyStream,
+            final String digest,
+            final ContentDisposition contentDisposition,
+            final MediaType contentType) throws InvalidChecksumException, UnsupportedAlgorithmException {
+
+        final Collection<String> checksums = parseDigestHeader(digest);
+        final Collection<URI> checksumURIs = checksums == null ? new HashSet<>() :
+                checksums.stream().map(checksum -> checksumURI(checksum)).collect(Collectors.toSet());
+        final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
+        final String originalContentType = contentType != null ? contentType.toString() : "";
+
+        return versionService.createBinaryVersion(session.getFedoraSession(), binaryResource,
+                mementoInstant, requestBodyStream, originalFileName, originalContentType, checksumURIs);
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -456,7 +456,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore("Disable until binary version creation from body implemented")
     @Test
     public void testCreateVersionOfBinaryWithDatetimeAndContentType() throws Exception {
         createVersionedBinary(id);
@@ -492,7 +491,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore("Disable until binary version creation from body implemented")
     @Test
     public void testCreateVersionOfBinaryWithDatetimeAndBody() throws Exception {
         createVersionedBinary(id);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -29,6 +29,7 @@ import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 
 /**
  * Service for creating versions of resources
@@ -78,11 +79,13 @@ public interface VersionService {
      * @param filename filename of the binary
      * @param mimetype mimetype of the binary
      * @param checksums Collection of checksum URIs of the content (optional)
+     * @param storagePolicyDecisionPoint optional storage policy
      * @throws InvalidChecksumException if there are errors applying checksums
      * @return the version
      */
     FedoraBinary createBinaryVersion(FedoraSession session, FedoraBinary resource, Instant dateTime,
-            InputStream contentStream, String filename, String mimetype, Collection<URI> checksums)
+            InputStream contentStream, String filename, String mimetype, Collection<URI> checksums,
+            StoragePolicyDecisionPoint storagePolicyDecisionPoint)
             throws InvalidChecksumException;
 
     /**
@@ -91,10 +94,12 @@ public interface VersionService {
      * @param session the session in which the resource resides
      * @param resource the binary resource to version
      * @param dateTime the date/time of the version
+     * @param storagePolicyDecisionPoint optional storage policy
      * @return the version
      * @throws InvalidChecksumException
      */
-    FedoraBinary createBinaryVersion(FedoraSession session, FedoraBinary resource, Instant dateTime)
+    FedoraBinary createBinaryVersion(FedoraSession session, FedoraBinary resource, Instant dateTime,
+            StoragePolicyDecisionPoint storagePolicyDecisionPoint)
             throws InvalidChecksumException;
 
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -25,7 +25,9 @@ import java.util.Collection;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.Lang;
 import org.fcrepo.kernel.api.FedoraSession;
+import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 
 /**
@@ -69,17 +71,30 @@ public interface VersionService {
      * Explicitly creates a version of a binary resource. If no contentStream is provided, then
      *
      * @param session the session in which the resource resides
-     * @param resource the resource to version
+     * @param resource the binary resource to version
      * @param dateTime the date/time of the version
      * @param contentStream if provided, the content in this stream will be used as the content of the new binary
      *        memento. If null, then the current state of the binary will be used.
      * @param filename filename of the binary
      * @param mimetype mimetype of the binary
      * @param checksums Collection of checksum URIs of the content (optional)
+     * @throws InvalidChecksumException if there are errors applying checksums
      * @return the version
      */
-    FedoraResource createBinaryVersion(FedoraSession session, FedoraResource resource, Instant dateTime,
-            InputStream contentStream, String filename, String mimetype, Collection<URI> checksums);
+    FedoraBinary createBinaryVersion(FedoraSession session, FedoraBinary resource, Instant dateTime,
+            InputStream contentStream, String filename, String mimetype, Collection<URI> checksums)
+            throws InvalidChecksumException;
 
+    /**
+     * Explicitly creates a version of a binary resource. If no contentStream is provided, then
+     *
+     * @param session the session in which the resource resides
+     * @param resource the binary resource to version
+     * @param dateTime the date/time of the version
+     * @return the version
+     * @throws InvalidChecksumException
+     */
+    FedoraBinary createBinaryVersion(FedoraSession session, FedoraBinary resource, Instant dateTime)
+            throws InvalidChecksumException;
 
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -81,6 +81,7 @@ import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.api.services.VersionService;
+import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.kernel.modeshape.ContainerImpl;
 import org.fcrepo.kernel.modeshape.FedoraBinaryImpl;
 import org.fcrepo.kernel.modeshape.utils.iterators.RelaxedRdfAdder;
@@ -192,8 +193,9 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     @Override
     public FedoraBinary createBinaryVersion(final FedoraSession session,
             final FedoraBinary resource,
-            final Instant dateTime) throws InvalidChecksumException {
-        return createBinaryVersion(session, resource, dateTime, null, null, null, null);
+            final Instant dateTime,
+            final StoragePolicyDecisionPoint storagePolicyDecisionPoint) throws InvalidChecksumException {
+        return createBinaryVersion(session, resource, dateTime, null, null, null, null, storagePolicyDecisionPoint);
     }
 
     @Override
@@ -203,7 +205,8 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
             final InputStream contentStream,
             final String filename,
             final String mimetype,
-            final Collection<URI> checksums) throws InvalidChecksumException {
+            final Collection<URI> checksums,
+            final StoragePolicyDecisionPoint storagePolicyDecisionPoint) throws InvalidChecksumException {
 
         final String mementoPath = makeMementoPath(resource, dateTime);
 
@@ -217,7 +220,7 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
             // Creating memento from existing resource
             populateBinaryMementoFromExisting(resource, memento);
         } else {
-            // memento.setContent(content, contentType, checksums, originalFileName, storagePolicyDecisionPoint);
+            memento.setContent(contentStream, mimetype, checksums, filename, null);
         }
 
         decorateWithMementoProperties(session, mementoPath, dateTime);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -18,10 +18,15 @@
 package org.fcrepo.kernel.modeshape.services;
 
 import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
 import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.fcrepo.kernel.api.FedoraTypes.CONTENT_DIGEST;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO;
 import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO_DATETIME;
+import static org.fcrepo.kernel.api.RdfLexicon.NT_VERSION_FILE;
 import static org.fcrepo.kernel.api.RequiredRdfContext.EMBED_RESOURCES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_CONTAINMENT;
 import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
@@ -31,7 +36,10 @@ import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_BINARY_TIME_M
 import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_TIME_MAP;
 import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.fcrepo.kernel.modeshape.rdf.impl.RequiredPropertiesUtil.assertRequiredContainerTriples;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
+import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
+import static org.modeshape.jcr.api.JcrConstants.NT_RESOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.InputStream;
@@ -44,15 +52,17 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
+import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -61,6 +71,7 @@ import org.apache.jena.riot.Lang;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
+import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.Container;
@@ -71,6 +82,7 @@ import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.api.services.VersionService;
 import org.fcrepo.kernel.modeshape.ContainerImpl;
+import org.fcrepo.kernel.modeshape.FedoraBinaryImpl;
 import org.fcrepo.kernel.modeshape.utils.iterators.RelaxedRdfAdder;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;;
@@ -178,26 +190,89 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     }
 
     @Override
-    public FedoraResource createBinaryVersion(final FedoraSession session,
-            final FedoraResource resource,
+    public FedoraBinary createBinaryVersion(final FedoraSession session,
+            final FedoraBinary resource,
+            final Instant dateTime) throws InvalidChecksumException {
+        return createBinaryVersion(session, resource, dateTime, null, null, null, null);
+    }
+
+    @Override
+    public FedoraBinary createBinaryVersion(final FedoraSession session,
+            final FedoraBinary resource,
             final Instant dateTime,
             final InputStream contentStream,
             final String filename,
             final String mimetype,
-            final Collection<URI> checksums) {
+            final Collection<URI> checksums) throws InvalidChecksumException {
 
         final String mementoPath = makeMementoPath(resource, dateTime);
 
         assertMementoDoesNotExist(session, mementoPath);
 
         LOGGER.debug("Creating memento {} for resource {} using existing state", mementoPath, resource.getPath());
-        nodeService.copyObject(session, resource.getPath(), mementoPath);
 
-        final FedoraBinary memento = binaryService.findOrCreate(session, mementoPath);
+        final FedoraBinary memento = createBinary(session, mementoPath);
+
+        if (contentStream == null || mimetype == null) {
+            // Creating memento from existing resource
+            populateBinaryMementoFromExisting(resource, memento);
+        } else {
+            // memento.setContent(content, contentType, checksums, originalFileName, storagePolicyDecisionPoint);
+        }
 
         decorateWithMementoProperties(session, mementoPath, dateTime);
 
         return memento;
+    }
+
+    private void populateBinaryMementoFromExisting(final FedoraBinary resource, final FedoraBinary memento)
+            throws InvalidChecksumException {
+
+        final Node contentNode = getJcrNode(resource);
+        List<URI> checksums = null;
+        // Retrieve all existing digests from the original
+        try {
+            if (contentNode.hasProperty(CONTENT_DIGEST)) {
+                final Property digestProperty = contentNode.getProperty(CONTENT_DIGEST);
+                checksums = stream(digestProperty.getValues())
+                        .map(d -> {
+                            try {
+                                return URI.create(d.getString());
+                            } catch (final RepositoryException e) {
+                                throw new RepositoryRuntimeException(e);
+                            }
+                        }).collect(Collectors.toList());
+            }
+
+            memento.setContent(resource.getContent(), resource.getMimeType(), checksums,
+                    resource.getFilename(), null);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+    private FedoraBinary createBinary(final FedoraSession session, final String path) {
+        try {
+            final Node dsNode = findOrCreateNode(session, path, NT_VERSION_FILE);
+
+            if (dsNode.canAddMixin(FEDORA_RESOURCE)) {
+                dsNode.addMixin(FEDORA_RESOURCE);
+            }
+
+            if (dsNode.canAddMixin(FEDORA_NON_RDF_SOURCE_DESCRIPTION)) {
+                dsNode.addMixin(FEDORA_NON_RDF_SOURCE_DESCRIPTION);
+            }
+
+            final Node contentNode = jcrTools.findOrCreateChild(dsNode, JCR_CONTENT, NT_RESOURCE);
+
+            if (contentNode.canAddMixin(FEDORA_BINARY)) {
+                contentNode.addMixin(FEDORA_BINARY);
+            }
+
+            return new FedoraBinaryImpl(contentNode);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
     }
 
     private String makeMementoPath(final FedoraResource resource, final Instant datetime) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2708

# What does this Pull Request do?
Adds support for creating binary mementos from request body.

# What's new?
* No longer uses modeshape copy to create binary mementos from existing resources
* Allows for creation of binary mementos from request
* Adjusts signature of createBinaryMemento methods
* Adds ability to pass in storagePolicyDecisionHints

# How should this be tested?
```
# Create versioned binary
curl -i -XPOST -H "Slug:versioned_bin4" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" -H "Content-Type: application/octet-stream" --data-binary "binarycontent" "http://localhost:8080/"

# Create historic memento with content and mimetype
curl -XPOST http://localhost:8080/versioned_bin4/fcr:versions -H "Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT" -H "Content-Type: text/plain" --data-binary "text content"

# Create historic memento with no content
curl -XPOST http://localhost:8080/versioned_bin4/fcr:versions -H "Memento-Datetime: Sat, 1 Jan 2000 01:00:00 GMT" -H "Content-Type: application/octet-stream"

# Attempt to create memento with no type
curl -XPOST http://localhost:8080/versioned_bin4/fcr:versions -H "Memento-Datetime: Sat, 1 Jan 2000 03:00:00 GMT" --data-binary "no type" -H "Content-Type:" -v
# Reject with 415

# Create memento from current version
curl -XPOST http://localhost:8080/versioned_bin4/fcr:versions

curl -v <uri from response of last command>
# Memento-Datetime: <should be roughly current time>
# Content-Type: application/octet-stream
# "binarycontent"

curl -v http://localhost:8080/versioned_bin4/fcr:versions/20000101000000
# Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT
# Content-Type: text/plain
# "text content"

curl -v http://localhost:8080/versioned_bin4/fcr:versions/20000101010000
# Memento-Datetime: Sat, 1 Jan 2000 01:00:00 GMT
# Content-Type: application/octet-stream
# ""

curl -v http://localhost:8080/versioned_bin4
# Content-Type: application/octet-stream
# "binarycontent"
```