### PR TITLE
Creating a Memento in the same second as an existing Memento throws 409.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -20,10 +20,10 @@ package org.fcrepo.http.api;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.ok;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
-import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_LINK_FORMAT;
 import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
@@ -220,7 +220,7 @@ public class FedoraVersioning extends ContentExposingResource {
         } catch (final RepositoryRuntimeException e) {
             if (e.getCause() instanceof ItemExistsException) {
                 throw new ClientErrorException("Memento with provided datetime already exists",
-                        PRECONDITION_FAILED);
+                        CONFLICT);
             } else {
                 throw e;
             }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -356,7 +356,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, MEMENTO_DATETIME);
 
         try (final CloseableHttpResponse response = execute(createVersionMethod)) {
-            assertEquals("Duplicate memento datetime should return 412 status",
+            assertEquals("Duplicate memento datetime should return 409 status",
                     CONFLICT.getStatusCode(), getStatus(response));
         }
 


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2728

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2728

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Changes the return code from 412 to 409 when creating mementos with identical date times.

# How should this be tested?
```
# create versioned resource
curl -i -XPOST -H "Slug: versioned_resource_2" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest"
# snap a version
curl http://localhost:8080/rest/versioned_resource_2 | curl -v -XPOST http://localhost:8080/rest/versioned_resource_2/fcr:versions -H "Memento-DateTime: Fri, 16 Mar 2018 20:52:17 GMT" -H "Content-Type: text/turtle" --data-binary "@-"
# confirm successful.

# try it again
curl http://localhost:8080/rest/versioned_resource_2 | curl -v -XPOST http://localhost:8080/rest/versioned_resource_2/fcr:versions -H "Memento-DateTime: Fri, 16 Mar 2018 20:52:17 GMT" -H "Content-Type: text/turtle" --data-binary "@-"

#confirm 409 response.
```

