### PR TITLE
Prevent modification requests to LDPRm.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -28,9 +28,11 @@ import static javax.ws.rs.core.MediaType.WILDCARD;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.notAcceptable;
 import static javax.ws.rs.core.Response.ok;
+import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
@@ -108,6 +110,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.domain.ContentLocation;
 import org.fcrepo.http.commons.domain.PATCH;
+import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
@@ -355,6 +358,12 @@ public class FedoraLdp extends ContentExposingResource {
 
         hasRestrictedPath(externalPath);
 
+        if (externalPath.contains("/" + FedoraTypes.FCR_VERSIONS)) {
+            addLinkAndOptionsHttpHeaders();
+
+            return status(METHOD_NOT_ALLOWED).build();
+        }
+
         final String interactionModel = checkInteractionModel(links);
 
         if (isExternalBody(requestContentType)) {
@@ -474,6 +483,13 @@ public class FedoraLdp extends ContentExposingResource {
     public Response updateSparql(@ContentLocation final InputStream requestBodyStream)
             throws IOException {
         hasRestrictedPath(externalPath);
+
+        if (externalPath.contains("/" + FedoraTypes.FCR_VERSIONS)) {
+            addLinkAndOptionsHttpHeaders();
+
+            return status(METHOD_NOT_ALLOWED).build();
+        }
+
         if (null == requestBodyStream) {
             throw new BadRequestException("SPARQL-UPDATE requests must have content!");
         }
@@ -554,6 +570,12 @@ public class FedoraLdp extends ContentExposingResource {
                                  @HeaderParam("Digest") final String digest)
             throws InvalidChecksumException, IOException, MalformedRdfException, UnsupportedAlgorithmException,
             UnsupportedAccessTypeException {
+
+        if (externalPath.contains("/" + FedoraTypes.FCR_VERSIONS)) {
+            addLinkAndOptionsHttpHeaders();
+
+            return status(METHOD_NOT_ALLOWED).build();
+        }
 
         final String interactionModel = checkInteractionModel(links);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -784,6 +784,48 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Test
+    public void testPatchOnMemento() throws Exception {
+        createVersionedContainer(id, subjectUri);
+
+        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final HttpPatch patch = new HttpPatch(mementoUri);
+        patch.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patch.setEntity(new StringEntity(
+                "INSERT DATA { <> <" + title.getURI() + "> \"Memento title\" } "));
+
+        // status 405: PATCH on memento is not allowed.
+        assertEquals(405, getStatus(patch));
+    }
+
+    @Test
+    public void testPostOnMemento() throws Exception {
+        createVersionedContainer(id, subjectUri);
+
+        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String body = createContainerMementoBodyContent(subjectUri, "text/n3");
+        final HttpPost post = new HttpPost(mementoUri);
+        post.addHeader(CONTENT_TYPE, "text/n3");
+        post.setEntity(new StringEntity(body));
+
+        // status 405: POST on memento is not allowed.
+        assertEquals(405, getStatus(post));
+    }
+
+    @Test
+    public void testPutOnMemento() throws Exception {
+        createVersionedContainer(id, subjectUri);
+
+        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String body = createContainerMementoBodyContent(subjectUri, "text/n3");
+        final HttpPut put = new HttpPut(mementoUri);
+        put.addHeader(CONTENT_TYPE, "text/n3");
+        put.setEntity(new StringEntity(body));
+
+        // status 405: PUT on memento is not allowed.
+        assertEquals(405, getStatus(put));
+    }
+
     private static void assertMementoOptionsHeaders(final HttpResponse httpResponse) {
         final List<String> methods = headerValues(httpResponse, "Allow");
         assertTrue("Should allow GET", methods.contains(HttpGet.METHOD_NAME));


### PR DESCRIPTION
Prevent modification requests to LDPRm.

https://jira.duraspace.org/browse/FCREPO-2616

# How should this be tested?
```
1. Create versioned resource:
curl -i -XPOST -H "Slug: v1" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest" -H "Content-Type: text/n3" --data-binary "<> <info:fedora/test/field> \"V 1\""

2. Create memento:
echo '<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Container> .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Resource> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#lastModifiedBy> "bypassAdmin" .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#createdBy> "bypassAdmin" .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#created> "2018-03-16T21:06:36.868Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#lastModified> "2018-03-16T21:06:36.868Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/v1> <info:fedora/test/field> "V 1" .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#RDFSource> .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#writable> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .' | curl -XPOST -i -H "Memento-Datetime: Tue, 3 Jun 2008 11:05:30 GMT" http://localhost:8080/rest/v1/fcr:versions -H "Content-Type: application/n-triples" --data-binary "@-"

HTTP/1.1 201 Created
Date: Fri, 16 Mar 2018 21:09:11 GMT
ETag: W/"4fc136363752e39f03716e2ca0febf0b59280fe0"
Last-Modified: Fri, 16 Mar 2018 21:06:36 GMT
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Memento-Datetime: Tue, 3 Jun 2008 11:05:30 GMT
Location: http://localhost:8080/rest/v1/fcr:versions/20080603110530
Content-Type: text/plain
Content-Length: 57
Server: Jetty(9.2.3.v20140905)

http://localhost:8080/rest/v1/fcr:versions/20080603110530

3. Verify PATCH on memento is disallowed:
curl -XPATCH -i -H "Content-Type: application/sparql-update" --data "INSERT DATA { <> <http://purl.org/dc/elements/1.1/title> \"New memento title\" } ." http://localhost:8080/rest/v1/fcr:versions/20080603110530

HTTP/1.1 405 Method Not Allowed
Date: Fri, 16 Mar 2018 21:22:04 GMT
Allow: DELETE,GET,OPTIONS
Content-Type: text/plain;charset=utf-8
Content-Length: 27
Server: Jetty(9.2.3.v20140905)

4. Verify POST on memento is disallowed:
echo '<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Container> .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Resource> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#lastModifiedBy> "bypassAdmin" .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#createdBy> "bypassAdmin" .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#created> "2018-03-16T21:06:36.868Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#lastModified> "2018-03-16T21:06:36.868Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/v1> <info:fedora/test/field> "Memento title - V 1" .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#RDFSource> .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#writable> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .' | curl -XPOST -i http://localhost:8080/rest/v1/fcr:versions/20080603110530 -H "Content-Type: application/n-triples" --data-binary "@-"

HTTP/1.1 405 Method Not Allowed
Date: Fri, 16 Mar 2018 21:12:10 GMT
Allow: DELETE,GET,OPTIONS
Content-Type: text/plain;charset=utf-8
Content-Length: 27
Server: Jetty(9.2.3.v20140905)

5. Verify PUT on memento is disallowed:
echo '<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Container> .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Resource> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#lastModifiedBy> "bypassAdmin" .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#createdBy> "bypassAdmin" .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#created> "2018-03-16T21:06:36.868Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#lastModified> "2018-03-16T21:06:36.868Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/v1> <info:fedora/test/field> "Updated Memento title - V 1" .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#RDFSource> .
<http://localhost:8080/rest/v1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container> .
<http://localhost:8080/rest/v1> <http://fedora.info/definitions/v4/repository#writable> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .' | curl -XPUT -i http://localhost:8080/rest/v1/fcr:versions/20080603110530 -H "Content-Type: application/n-triples" --data-binary "@-"

HTTP/1.1 405 Method Not Allowed
Date: Fri, 16 Mar 2018 21:14:41 GMT
Allow: DELETE,GET,OPTIONS
Content-Type: text/plain;charset=utf-8
Content-Length: 27
Server: Jetty(9.2.3.v20140905)```
