### PR TITLE
Add header link rel="original" to TimeMap.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -249,17 +249,18 @@ public class FedoraVersioning extends ContentExposingResource {
 
         LOGGER.info("GET resource '{}'", externalPath);
 
+        final URI parentUri = getUri(resource());
         final Link.Builder resourceLink = Link.fromUri(LDP_NAMESPACE + "Resource").rel("type");
         servletResponse.addHeader(LINK, resourceLink.build().toString());
         final Link.Builder rdfSourceLink = Link.fromUri(LDP_NAMESPACE + "RDFSource").rel("type");
         servletResponse.addHeader(LINK, rdfSourceLink.build().toString());
         servletResponse.addHeader(LINK, Link.fromUri(VERSIONING_TIMEMAP_TYPE).rel("type").build().toString());
+        servletResponse.addHeader(LINK, Link.fromUri(parentUri).rel("original").build().toString());
 
         servletResponse.addHeader("Vary-Post", MEMENTO_DATETIME_HEADER);
         servletResponse.addHeader("Allow", "POST,HEAD,GET,OPTIONS");
 
         if (acceptValue != null && acceptValue.equalsIgnoreCase(APPLICATION_LINK_FORMAT)) {
-            final URI parentUri = getUri(resource());
             final List<Link> versionLinks = new ArrayList<Link>();
             versionLinks.add(Link.fromUri(parentUri).rel("original").build());
             versionLinks.add(Link.fromUri(parentUri).rel("timegate").build());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -418,6 +418,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         httpGet.setHeader("Accept", APPLICATION_LINK_FORMAT);
         try (final CloseableHttpResponse response = execute(httpGet)) {
             assertEquals("Didn't get a OK response!", OK.getStatusCode(), getStatus(response));
+            checkForLinkHeader(response, uri, "original");
             checkForLinkHeader(response, VERSIONING_TIMEMAP_TYPE, "type");
             final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(","));
             final Link[] bodyLinks = bodyList.stream().map(String::trim).filter(t -> !t.isEmpty())


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-2734

Add header link rel="original" to TimeMap.

# How should this be tested?
```
1. Create versioned RDFSource
$ curl -i -XPOST -H "Slug: VersionedResource" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest" -H "Content-Type: text/n3" --data-binary "<> <info:fedora/test/field> \"Versioned Resource\""

2. Verify the existing of header link rel="original"
$ curl -i http://localhost:8080/rest/VersionedResource/fcr:versions
HTTP/1.1 200 OK
Date: Mon, 16 Apr 2018 22:32:10 GMT
ETag: W/"8f487467747c9cb49fbf2ec7b96c2ae03bf67405"
Last-Modified: Mon, 16 Apr 2018 22:29:45 GMT
Link: <http://www.w3.org/ns/ldp#Resource>; rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
Link: <http://mementoweb.org/ns#TimeMap>; rel="type"
Link: <http://localhost:8080/rest/VersionedResource>; rel="original"
Vary-Post: Memento-Datetime
Allow: POST,HEAD,GET,OPTIONS
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>;rel="type"
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 1503
Server: Jetty(9.2.3.v20140905)

3. Create versioned binary NonRdfSource
$ curl -XPOST -H "Slug: versionedBinary" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" http://localhost:8080/rest/ -H "Content-Type: application/octet-stream" --data-binary "Binary Content"

4. Verify the existing of header link rel="original" in the binary and its description timemaps
$ curl -i http://localhost:8080/rest/versionedBinary/fcr:versions
HTTP/1.1 200 OK
Date: Mon, 16 Apr 2018 22:48:23 GMT
Link: <http://www.w3.org/ns/ldp#Resource>; rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
Link: <http://mementoweb.org/ns#TimeMap>; rel="type"
Link: <http://localhost:8080/rest/versionedBinary>; rel="original"
Vary-Post: Memento-Datetime
Allow: POST,HEAD,GET,OPTIONS
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>;rel="type"
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 1170
Server: Jetty(9.2.3.v20140905)

$ curl -i http://localhost:8080/rest/versionedBinary/fcr:metadata/fcr:versions
HTTP/1.1 200 OK
Date: Mon, 16 Apr 2018 22:42:39 GMT
ETag: W/"0ac42aaefdf5b03fb21e9949b3b16ead7f6d50af"
Last-Modified: Mon, 16 Apr 2018 22:41:02 GMT
Link: <http://www.w3.org/ns/ldp#Resource>; rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
Link: <http://mementoweb.org/ns#TimeMap>; rel="type"
Link: <http://localhost:8080/rest/versionedBinary/fcr:metadata>; rel="original"
Vary-Post: Memento-Datetime
Allow: POST,HEAD,GET,OPTIONS
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>;rel="type"
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 1525
Server: Jetty(9.2.3.v20140905)
```
