### PR TITLE
Address 500 Response on TimeMap with bad Accept header

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -238,7 +238,7 @@ public class FedoraVersioning extends ContentExposingResource {
     @HtmlTemplate(value = "fcr:versions")
     @Produces({ TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
         N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
-        TURTLE_X, TEXT_HTML_WITH_CHARSET, APPLICATION_LINK_FORMAT, "*/*" })
+        TURTLE_X, TEXT_HTML_WITH_CHARSET, APPLICATION_LINK_FORMAT })
     public Response getVersionList(@HeaderParam("Range") final String rangeValue,
         @HeaderParam("Accept") final String acceptValue) throws IOException, UnsupportedAccessTypeException {
         if (!resource().isVersioned()) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -29,6 +29,7 @@ import static javax.ws.rs.core.Link.fromUri;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -393,6 +394,19 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedBinary(id);
 
         verifyTimemapResponse(subjectUri, id);
+    }
+
+    @Test
+    public void testGetTimeMapResponseWithBadAcceptHeader() throws Exception {
+        createVersionedContainer(id, subjectUri);
+
+        final HttpGet httpGet = getObjMethod(id + "/" + FCR_VERSIONS);
+        httpGet.setHeader("Accept", "application/arbitrary");
+        try (final CloseableHttpResponse response = execute(httpGet)) {
+            assertEquals("Should get a 'Not Acceptable' response!", NOT_ACCEPTABLE.getStatusCode(), getStatus(
+                    response));
+        }
+
     }
 
     @Test


### PR DESCRIPTION
- Remove "\*/\*"

Resolves: https://jira.duraspace.org/browse/FCREPO-2731

**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2731

# What does this Pull Request do?
Change the 500 response to a '406 Not Acceptable' on TimeMap with bad Accept header

# How should this be tested?
1. Create a versioned resource
```
curl -i -XPOST -H "Slug: obj" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" 
"http://localhost:8080/rest/"
```
2. Verify response using following command list
Bad Accept header 
```
curl http://localhost:8080/rest/obj3/fcr:version -H"Accept: junk/format"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: application/format-junk"
```
Good Accept header
```
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: application/json_ld"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: application/ld+json"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: text/turtle"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: application/x-turtle"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: application/n-triples"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: application/rdf+xml"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: text/n3"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: text/rdf+n3"
curl http://localhost:8080/rest/obj/fcr:versions -H"Accept: text/plain"
```

# Interested parties
Tag (@dbernstein ) 
