### PR TITLE
FCREPO-2733 Add header link rel=original to TimeGate

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -503,6 +503,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             servletResponse.addHeader(LINK, versionedResource.toString());
             final Link mementoTimeGate = Link.fromUri(RdfLexicon.VERSIONING_TIMEGATE_TYPE).rel("type").build();
             servletResponse.addHeader(LINK, mementoTimeGate.toString());
+            final Link original = Link.fromUri(getUri(resource.getDescribedResource())).rel("original").build();
+            servletResponse.addHeader(LINK, original.toString());
             final Link timegate = Link.fromUri(getUri(resource.getDescribedResource())).rel("timegate").build();
             servletResponse.addHeader(LINK, timegate.toString());
             final Link timemap =

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1160,6 +1160,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals("Didn't get an OK (200) response!", OK.getStatusCode(), getStatus(response));
         checkForVersionedResourceLinkHeader(response);
         checkForMementoTimeGateLinkHeader(response);
+        checkForLinkHeader(response, subjectURI, "original");
         checkForLinkHeader(response, subjectURI, "timegate");
         checkForLinkHeader(response, subjectURI + "/" + FCR_VERSIONS, "timemap");
         assertEquals(1, Arrays.asList(response.getHeaders("Vary")).stream().filter(x -> x.getValue().contains(


### PR DESCRIPTION
Resolves https://jira.duraspace.org/browse/FCREPO-2733

Adds Link: \<link to LDPRv\>; rel="original" for a LDPRv

## How to test this PR
```
1. Create a versioned resource
$ curl -i -XPOST -H "Slug: VersionedResource" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest" -H "Content-Type: text/n3" --data-binary "<> <info:fedora/test/field> \"Versioned Resource\""

2. Check for rel="original" link header
$ curl -i http://localhost:8080/rest/VersionedResource
HTTP/1.1 200 OK
...
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
Link: <http://localhost:8080/rest/VersionedResource>; rel="original"
Link: <http://localhost:8080/rest/VersionedResource>; rel="timegate"
Link: <http://localhost:8080/rest/VersionedResource/fcr:versions>; rel="timemap"
...
```