### PR TITLE
FCREPO-2632. Use 'acl:agentClass foaf:Agent' to denote public access

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/URIConstants.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/URIConstants.java
@@ -186,6 +186,11 @@ final public class URIConstants {
     public static final String FEDORA_WEBAC_ACL_VALUE = FEDORA_WEBAC_NAMESPACE_VALUE + "Acl";
     public static final URI FEDORA_WEBAC_ACL = URI.create(FEDORA_WEBAC_ACL_VALUE);
 
+    /** 
+     * Suffix to distinguish Agent Class roles from Agent roles.
+     */
+    public static final String AGENT_CLASS_SUFFIX = "__agent_class";
+
     private URIConstants() {
     }
 

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizationDelegate.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizationDelegate.java
@@ -19,7 +19,6 @@ package org.fcrepo.auth.webac;
 
 import static java.util.Arrays.stream;
 import static java.util.Collections.unmodifiableMap;
-import static org.fcrepo.auth.webac.URIConstants.FOAF_AGENT_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_CONTROL_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_READ_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_WRITE_VALUE;
@@ -71,24 +70,6 @@ public class WebACAuthorizationDelegate extends AbstractRolesAuthorizationDelega
         map.put(READ_ACCESS_CONTROL, WEBAC_MODE_CONTROL_VALUE);
         actionMap = unmodifiableMap(map);
     }
-
-    /**
-     * The security principal for every request, that represents the foaf:Agent agent class that is used to designate
-     * "everyone".
-     */
-    private static final Principal EVERYONE = new Principal() {
-
-        @Override
-        public String getName() {
-            return FOAF_AGENT_VALUE;
-        }
-
-        @Override
-        public String toString() {
-            return getName();
-        }
-
-    };
 
     @Override
     public boolean rolesHavePermission(final Session userSession, final String absPath,

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -28,6 +28,7 @@ import static java.util.stream.Stream.of;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.riot.Lang.TTL;
+import static org.fcrepo.auth.webac.URIConstants.AGENT_CLASS_SUFFIX;
 import static org.fcrepo.auth.webac.URIConstants.FOAF_AGENT_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.VCARD_GROUP;
 import static org.fcrepo.auth.webac.URIConstants.VCARD_MEMBER_VALUE;
@@ -246,6 +247,12 @@ public class WebACRolesProvider implements AccessRolesProvider {
                 concat(auth.getAgents().stream(), dereferenceAgentGroups(auth.getAgentGroups()).stream())
                     .forEach(agent -> {
                         effectiveRoles.computeIfAbsent(agent, key -> new HashSet<>())
+                            .addAll(auth.getModes().stream().map(URI::toString).collect(toSet()));
+                    });
+                auth.getAgentClasses().stream()
+                    .forEach(agentClass -> {
+                        // Use the AGENT_CLASS_SUFFIX to distinguish from agent roles
+                        effectiveRoles.computeIfAbsent(agentClass + AGENT_CLASS_SUFFIX, key -> new HashSet<>())
                             .addAll(auth.getModes().stream().map(URI::toString).collect(toSet()));
                     });
             });

--- a/fcrepo-auth-webac/src/main/resources/root-authorization.ttl
+++ b/fcrepo-auth-webac/src/main/resources/root-authorization.ttl
@@ -6,5 +6,5 @@
 <> a acl:Authorization ;
    rdfs:label "Root Authorization" ;
    rdfs:comment "By default, all non-Admin agents (foaf:Agent) are denied access (no acl:mode is specified) to all resources." ;
-   acl:agent foaf:Agent ;
+   acl:agentClass foaf:Agent ;
    acl:accessToClass fedora:Resource .

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -22,6 +22,7 @@ import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.graph.Triple.create;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.riot.Lang.TTL;
+import static org.fcrepo.auth.webac.URIConstants.AGENT_CLASS_SUFFIX;
 import static org.fcrepo.auth.webac.URIConstants.VCARD_GROUP;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_AUTHORIZATION;
@@ -265,7 +266,8 @@ public class WebACRolesProviderTest {
 
     @Test
     public void acl03Test1() throws RepositoryException {
-        final String agent = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgent = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgentRoleClass = foafAgent + AGENT_CLASS_SUFFIX;
         final String accessTo = "/dark/archive/sunshine";
         final String acl = "/acls/03";
         final String auth1 = acl + "/auth_restricted.ttl";
@@ -293,8 +295,8 @@ public class WebACRolesProviderTest {
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent in the roles map", 1, roles.size());
-        assertEquals("The agent should have exactly one mode", 1, roles.get(agent).size());
-        assertTrue("The agent should be able to read", roles.get(agent).contains(WEBAC_MODE_READ_VALUE));
+        assertEquals("The agent should have exactly one mode", 1, roles.get(foafAgentRoleClass).size());
+        assertTrue("The agent should be able to read", roles.get(foafAgentRoleClass).contains(WEBAC_MODE_READ_VALUE));
     }
 
     @Test
@@ -333,7 +335,8 @@ public class WebACRolesProviderTest {
 
     @Test
     public void acl04Test() throws RepositoryException {
-        final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgent = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgentRoleClass = foafAgent + AGENT_CLASS_SUFFIX;
         final String agent2 = "Editors";
         final String accessTo = "/public_collection";
         final String acl = "/acls/04";
@@ -362,15 +365,16 @@ public class WebACRolesProviderTest {
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly two agents", 2, roles.size());
-        assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
-        assertTrue("The agent should be able to read", roles.get(agent1).contains(WEBAC_MODE_READ_VALUE));
+        assertEquals("The agent should have one mode", 1, roles.get(foafAgentRoleClass).size());
+        assertTrue("The agent should be able to read", roles.get(foafAgentRoleClass).contains(WEBAC_MODE_READ_VALUE));
         assertEquals("The agent should have two modes", 2, roles.get(agent2).size());
         assertTrue("The agent should be able to read", roles.get(agent2).contains(WEBAC_MODE_READ_VALUE));
         assertTrue("The agent should be able to write", roles.get(agent2).contains(WEBAC_MODE_READ_VALUE));
     }
 
     public void acl05Test() throws RepositoryException {
-        final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgent = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgentRoleClass = foafAgent + AGENT_CLASS_SUFFIX;
         final String agent2 = "Admins";
         final String accessTo = "/mixedCollection";
         final String acl = "/acls/05";
@@ -400,15 +404,16 @@ public class WebACRolesProviderTest {
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly two agents", 2, roles.size());
-        assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
-        assertTrue("The agent should be able to read", roles.get(agent1).contains(WEBAC_MODE_READ_VALUE));
+        assertEquals("The agent should have one mode", 1, roles.get(foafAgentRoleClass).size());
+        assertTrue("The agent should be able to read", roles.get(foafAgentRoleClass).contains(WEBAC_MODE_READ_VALUE));
         assertEquals("The agent should have one mode", 1, roles.get(agent2).size());
         assertTrue("The agent should be able to read", roles.get(agent2).contains(WEBAC_MODE_READ_VALUE));
     }
 
     @Test
     public void acl05Test2() throws RepositoryException {
-        final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgent = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgentRoleClass = foafAgent + AGENT_CLASS_SUFFIX;
         final String accessTo = "/someOtherCollection";
         final String acl = "/acls/05";
         final String auth1 = acl + "/auth_restricted.ttl";
@@ -437,8 +442,8 @@ public class WebACRolesProviderTest {
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly agent", 1, roles.size());
-        assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
-        assertTrue("The agent should be able to read", roles.get(agent1).contains(WEBAC_MODE_READ_VALUE));
+        assertEquals("The agent should have one mode", 1, roles.get(foafAgentRoleClass).size());
+        assertTrue("The agent should be able to read", roles.get(foafAgentRoleClass).contains(WEBAC_MODE_READ_VALUE));
     }
 
     /* (non-Javadoc)
@@ -530,7 +535,8 @@ public class WebACRolesProviderTest {
 
     @Test
     public void noAclTest1() throws RepositoryException {
-        final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgent = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgentRoleClass = foafAgent + AGENT_CLASS_SUFFIX;
 
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
             .thenReturn(new DefaultRdfStream(createURI("subject")));
@@ -540,12 +546,13 @@ public class WebACRolesProviderTest {
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent", 1, roles.size());
-        assertEquals("The agent should have zero modes", 0, roles.get(agent1).size());
+        assertEquals("The agent should have zero modes", 0, roles.get(foafAgentRoleClass).size());
     }
 
     @Test
     public void noAclTestMalformedRdf2() throws RepositoryException {
-        final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgent = "http://xmlns.com/foaf/0.1/Agent";
+        final String foafAgentRoleClass = foafAgent + AGENT_CLASS_SUFFIX;
 
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
             .thenReturn(new DefaultRdfStream(createURI("subject")));
@@ -560,7 +567,7 @@ public class WebACRolesProviderTest {
         System.clearProperty(ROOT_AUTHORIZATION_PROPERTY);
 
         assertEquals("There should be exactly one agent", 1, roles.size());
-        assertEquals("The agent should have zero modes", 0, roles.get(agent1).size());
+        assertEquals("The agent should have zero modes", 0, roles.get(foafAgentRoleClass).size());
     }
 
     @Test

--- a/fcrepo-auth-webac/src/test/resources/acls/03/auth_open.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/03/auth_open.ttl
@@ -2,6 +2,6 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
 <> a acl:Authorization ;
-   acl:agent foaf:Agent ;
+   acl:agentClass foaf:Agent ;
    acl:mode acl:Read ;
    acl:accessTo </rest/dark/archive/sunshine> .

--- a/fcrepo-auth-webac/src/test/resources/acls/04/auth1.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/04/auth1.ttl
@@ -2,6 +2,6 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
 <> a acl:Authorization ;
-   acl:agent foaf:Agent ;
+   acl:agentClass foaf:Agent ;
    acl:mode acl:Read ;
    acl:accessTo </rest/public_collection> .

--- a/fcrepo-auth-webac/src/test/resources/acls/05/auth_open.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/05/auth_open.ttl
@@ -3,6 +3,6 @@
 @prefix eg: <http://example.com/terms#> .
 
 <> a acl:Authorization ;
-   acl:agent foaf:Agent ;
+   acl:agentClass foaf:Agent ;
    acl:mode acl:Read ;
    acl:accessToClass eg:publicImage .


### PR DESCRIPTION
Changes:
- The getRoles method in the roles provider class will include agentClass roles and the agentClass roles will be distinguished from the agent roles using a suffix.
- The authorization delegate will treat the EVERYONE principal as a special case and check for matching agentClass roles from the roles provider.
- Updated tests accordingly.

https://jira.duraspace.org/browse/FCREPO-2632