### PR TITLE
Timemap returns Mementos.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -47,8 +47,10 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_FIXITY;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
@@ -68,13 +70,14 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.ws.rs.core.Link;
 
 import org.apache.http.HttpResponse;
@@ -103,14 +106,14 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
-import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
-
 /**
  * @author lsitu
  * @author bbpennel
  */
 public class FedoraVersioningIT extends AbstractResourceIT {
+
+    public static final DateTimeFormatter MEMENTO_DATETIME_ID_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.of("GMT"));
 
     private static final String VERSIONED_RESOURCE_LINK_HEADER = "<" + VERSIONED_RESOURCE.getURI() + ">; rel=\"type\"";
     private static final String BINARY_CONTENT = "binary content";
@@ -123,9 +126,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     private static final Property TEST_PROPERTY = createProperty("info:test#label");
 
-    final String MEMENTO_DATETIME =
+    private final String MEMENTO_DATETIME =
             RFC_1123_DATE_TIME.format(LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC));
-
     private final List<String> rdfTypes = new ArrayList<>(Arrays.asList(POSSIBLE_RDF_RESPONSE_VARIANTS_STRING));
 
     private String subjectUri;
@@ -160,7 +162,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testGetTimeMapResponse() throws Exception {
         createVersionedContainer(id, subjectUri);
 
-        verifyTimemapResponse(subjectUri, id);
+        createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        verifyTimemapResponse(subjectUri, id, MEMENTO_DATETIME);
     }
 
     @Test
@@ -391,7 +394,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testGetTimeMapResponseForBinary() throws Exception {
         createVersionedBinary(id);
-
         verifyTimemapResponse(subjectUri, id);
     }
 
@@ -406,24 +408,49 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     private void verifyTimemapResponse(final String uri, final String id) throws Exception {
-        final List<Link> listLinks = new ArrayList<Link>();
+        verifyTimemapResponse(uri, id, null);
+    }
+
+    private void verifyTimemapResponse(final String uri, final String id, final String mementoDateTime)
+        throws Exception {
+        final String ldpcvUri = uri + "/" + FCR_VERSIONS;
+        final List<Link> listLinks = new ArrayList<>();
         listLinks.add(Link.fromUri(uri).rel("original").build());
         listLinks.add(Link.fromUri(uri).rel("timegate").build());
         listLinks
-                .add(Link.fromUri(uri + "/" + FCR_VERSIONS).rel("self").type(APPLICATION_LINK_FORMAT)
+                .add(Link.fromUri(ldpcvUri).rel("self").type(APPLICATION_LINK_FORMAT)
                         .build());
-        final Link[] expectedLinks = listLinks.toArray(new Link[3]);
+        if (mementoDateTime != null) {
+            final TemporalAccessor instant = RFC_1123_DATE_TIME.parse(mementoDateTime);
+            listLinks.add(Link.fromUri(ldpcvUri + "/" + MEMENTO_DATETIME_ID_FORMATTER.format(instant))
+                              .rel("memento")
+                              .param("datetime", mementoDateTime)
+                              .build());
+        }
 
+        final Link[] expectedLinks = listLinks.toArray(new Link[0]);
         final HttpGet httpGet = getObjMethod(id + "/" + FCR_VERSIONS);
         httpGet.setHeader("Accept", APPLICATION_LINK_FORMAT);
         try (final CloseableHttpResponse response = execute(httpGet)) {
             assertEquals("Didn't get a OK response!", OK.getStatusCode(), getStatus(response));
             checkForLinkHeader(response, uri, "original");
             checkForLinkHeader(response, VERSIONING_TIMEMAP_TYPE, "type");
-            final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(","));
+            final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(",\n"));
+            //the links from the body are not
             final Link[] bodyLinks = bodyList.stream().map(String::trim).filter(t -> !t.isEmpty())
-                    .map(Link::valueOf).toArray(Link[]::new);
+                                                      .map(Link::valueOf).toArray(Link[]::new);
+
+            final Comparator<Link> linkComparator = new Comparator<Link>() {
+                @Override
+                public int compare(final Link o1, final Link o2) {
+                    return o1.toString().compareTo(o2.toString());
+                }
+            };
+
+            Arrays.sort(expectedLinks, linkComparator);
+            Arrays.sort(bodyLinks, linkComparator);
             assertArrayEquals(expectedLinks, bodyLinks);
+
         }
     }
 


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2732

** Displays mementos in application/link-format.**
* * *


# How should this be tested?
```
#Create the versioned resource

curl -u fedoraAdmin:secret3 -i -XPOST -H "Slug: versioned_resource_2" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest"

#Create a version
curl -X POST  "http://localhost:8080/rest/versioned_resource_2/fcr:versions" -u fedoraAdmin:secret3

#Display the timemap in application/link-format

curl -v http://localhost:8080/rest/versioned_resource_2/fcr:metadata -H "Accept: application/link-format" -u fedoraAdmin:fedoraAdmin
```
You should see the newly created memento in the timemap listed among the other links in the body of the response like this:
```
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
* Server auth using Basic with user 'fedoraAdmin'
> GET /rest/versioned_resource_2/fcr:versions HTTP/1.1
> Host: localhost:8080
> Authorization: Basic ZmVkb3JhQWRtaW46ZmVkb3JhQWRtaW4=
> User-Agent: curl/7.43.0
> Accept: application/link-format
> 
< HTTP/1.1 200 OK
< Date: Wed, 18 Apr 2018 07:14:00 GMT
< ETag: W/"5ab87c1a2fa7c848afc48929a13cd5aff2f19186"
< Last-Modified: Wed, 18 Apr 2018 03:10:27 GMT
< Link: <http://www.w3.org/ns/ldp#Resource>; rel="type"
< Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
< Link: <http://mementoweb.org/ns#TimeMap>; rel="type"
< Link: <http://localhost:8080/rest/versioned_resource_2>; rel="original"
< Vary-Post: Memento-Datetime
< Allow: POST,HEAD,GET,OPTIONS
< Content-Type: application/link-format
< Content-Length: 378
< Server: Jetty(9.3.1.v20150714)
< 
<http://localhost:8080/rest/versioned_resource_2>; rel="original",
<http://localhost:8080/rest/versioned_resource_2>; rel="timegate",
<http://localhost:8080/rest/versioned_resource_2/fcr:versions/20180418031027>; rel="memento"; datetime="Wed, 18 Apr 2018 03:10:27 GMT",
<http://localhost:8080/rest/versioned_resource_2/fcr:versions>; rel="self"; type="application/link-format",
```



