### PR TITLE
Create WebACAuthorizingRealm class.

### DIFF
--- a/fcrepo-auth-webac/pom.xml
+++ b/fcrepo-auth-webac/pom.xml
@@ -187,6 +187,17 @@
       <type>test-jar</type>
     </dependency>
 
+	<dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-core</artifactId>
+      <version>1.4.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+		  <artifactId>commons-collections</artifactId>
+		</exclusion>
+	  </exclusions>
+	</dependency>
   </dependencies>
 
   <build>

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.webac;
+
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.SimpleAuthorizationInfo;
+import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.subject.PrincipalCollection;
+
+/**
+ * Authorization-only realm that performs authorization checks using WebAC ACLs stored in a Fedora repository. It
+ * locates the ACL for the currently requested resource and parses the ACL RDF into a set of {@link WebACPermission}
+ * instances.
+ *
+ * @author peichman
+ */
+public class WebACAuthorizingRealm extends AuthorizingRealm {
+
+    /* (non-Javadoc)
+     * @see org.apache.shiro.realm.AuthorizingRealm#doGetAuthorizationInfo(org.apache.shiro.subject.PrincipalCollection)
+     */
+    @Override
+    protected AuthorizationInfo doGetAuthorizationInfo(final PrincipalCollection principals) {
+        final SimpleAuthorizationInfo authzInfo = new SimpleAuthorizationInfo();
+        return authzInfo;
+    }
+
+    /**
+     * This realm is authorization-only.
+     */
+    @Override
+    protected AuthenticationInfo doGetAuthenticationInfo(final AuthenticationToken token)
+            throws AuthenticationException {
+        return null;
+    }
+
+    /**
+     * This realm is authorization-only.
+     */
+    @Override
+    public boolean supports(final AuthenticationToken token) {
+        return false;
+    }
+}

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACPermission.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACPermission.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.webac;
+
+import java.net.URI;
+
+import org.apache.shiro.authz.Permission;
+
+/**
+ * A WebAC permission represents a particular mode of access (e.g., acl:read) to a particular resource. Both the mode
+ * and resource are URIs. One WebAC permission implies another if and only if their mode and resource URIs are both
+ * equal to the other's.
+ *
+ * @author peichman
+ */
+public class WebACPermission implements Permission {
+
+    private URI resource;
+
+    private URI mode;
+
+    /**
+     * @param mode
+     * @param resource
+     */
+    public WebACPermission(final URI mode, final URI resource) {
+        this.mode = mode;
+        this.resource = resource;
+    }
+
+    /**
+     * @param p permission to compare to
+     */
+    @Override
+    public boolean implies(final Permission p) {
+        final WebACPermission perm = (WebACPermission) p;
+        return perm.getResource().equals(resource) && perm.getMode().equals(mode);
+    }
+
+    /**
+     * @return the mode
+     */
+    public URI getMode() {
+        return mode;
+    }
+
+    /**
+     * @return the resource
+     */
+    public URI getResource() {
+        return resource;
+    }
+
+}

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACPermissionTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACPermissionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.webac;
+
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_READ;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_WRITE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+
+import org.junit.Test;
+
+/**
+ * @author peichman
+ */
+public class WebACPermissionTest {
+
+    private static final URI resourceA = URI.create("http://localhost:8080/fcrepo/test");
+
+    private static final URI resourceB = URI.create("http://localhost:8080/fcrepo/test2");
+
+    @Test
+    public void testEquality() {
+        final WebACPermission p1 = new WebACPermission(WEBAC_MODE_READ, resourceA);
+        final WebACPermission p2 = new WebACPermission(WEBAC_MODE_READ, resourceA);
+        assertTrue(p1.implies(p2));
+        assertTrue(p2.implies(p1));
+    }
+
+    @Test
+    public void testInequalityOfResources() {
+        final WebACPermission p1 = new WebACPermission(WEBAC_MODE_READ, resourceA);
+        final WebACPermission p2 = new WebACPermission(WEBAC_MODE_READ, resourceB);
+        assertFalse(p1.implies(p2));
+        assertFalse(p2.implies(p1));
+    }
+
+    @Test
+    public void testInequalityOfModes() {
+        final WebACPermission p1 = new WebACPermission(WEBAC_MODE_READ, resourceA);
+        final WebACPermission p2 = new WebACPermission(WEBAC_MODE_WRITE, resourceA);
+        assertFalse(p1.implies(p2));
+        assertFalse(p2.implies(p1));
+    }
+
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2759

* PR #1324 should be merged before this
* Implementation work will continue in https://jira.duraspace.org/browse/FCREPO-2760

# What does this Pull Request do?
Create WebACAuthorizingRealm class.

# What's new?
Authorization-only Shiro realm. Implementation (see https://jira.duraspace.org/browse/FCREPO-2760) will locate the ACL for the currently requested resource and parse the ACL RDF into a set of WebACPermission instances.

# How should this be tested?
* Compile the `fcrepo-auth-webac` module with `mvn clean install`

# Interested parties
@fcrepo4/committers
