### PR TITLE
Add correct headers for Mementos

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -516,6 +516,17 @@ public abstract class AbstractResourceIT {
     }
 
     /**
+     * Test a response for the absence of a specific LINK header
+     *
+     * @param response the HTTP response
+     * @param uri the URI not to exist in the LINK header
+     * @param rel the rel argument to check for
+     */
+    protected void assertNoLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+        assertEquals(0, countLinkHeader(response, uri, rel));
+    }
+
+    /**
      * Test a response for a specific LINK header
      *
      * @param response the HTTP response


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2614

# What does this Pull Request do?
Adds correct Link headers to Mementos

# How should this be tested?

1. Create a versioned resource
```
     curl -u fedoraAdmin:fedoraAdmin -i -XPOST -H "Slug: resource1" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest"
```
1. Create a version
```
     curl -u fedoraAdmin:fedoraAdmin -i -XPOST "http://localhost:8080/rest/resource1/fcr:versions"
```
1. GET the Memento

Old version
```
> curl -I -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/resource1/fcr:versions/20010308210303
HTTP/1.1 200 OK
Date: Wed, 18 Apr 2018 18:50:43 GMT
ETag: W/"4a6c1a2b7f38d9a2137e02c8dd936d100bf18830"
Last-Modified: Fri, 02 Mar 2018 19:43:57 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
Memento-Datetime: Thu, 8 Mar 2001 21:03:03 GMT
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://localhost:8080/rest/resource1/fcr:versions/20010308210303/fcr:acl>; rel="acl"
Allow: GET,HEAD,OPTIONS,DELETE
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 1821
Server: Jetty(9.3.1.v20150714)
```

New version
```
> curl -I -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/resource1/fcr:versions/20010308210303
HTTP/1.1 200 OK
Date: Wed, 18 Apr 2018 20:10:50 GMT
ETag: W/"4a6c1a2b7f38d9a2137e02c8dd936d100bf18830"
Last-Modified: Fri, 02 Mar 2018 19:43:57 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
Memento-Datetime: Thu, 8 Mar 2001 21:03:03 GMT
Link: <http://mementoweb.org/ns#Memento>; rel="type"
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://localhost:8080/rest/resource1/fcr:versions/20010308210303/fcr:acl>; rel="acl"
Link: <http://localhost:8080/rest/resource1>; rel="timegate"
Link: <http://localhost:8080/rest/resource1>; rel="original"
Link: <http://localhost:8080/rest/resource1/fcr:versions>; rel="timemap"
Allow: GET,HEAD,OPTIONS,DELETE
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 0
Server: Jetty(9.3.1.v20150714)
```

Note the new Link headers.
```
Link: <http://mementoweb.org/ns#Memento>; rel="type"
Link: <http://localhost:8080/rest/resource1>; rel="timegate"
Link: <http://localhost:8080/rest/resource1>; rel="original"
Link: <http://localhost:8080/rest/resource1/fcr:versions>; rel="timemap"
```

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.


# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
