### PR TITLE
Ensure that all resources created via the HTML UI are versionable

### DIFF
--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -70,6 +70,9 @@
       });
     }
 
+    //both ldp-rs and ldp-nr resources should be created as versionable resources.
+    headers.push(['Link', '<http://mementoweb.org/ns#OriginalResource>; rel=\"type\"']);
+
     if (mixin == 'binary') {
       const update_file = document.getElementById('binary_payload').files[0];
       const reader = new FileReader();


### PR DESCRIPTION
resources.

**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2767

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR is a first step in bringing versioning support back into the HTML UI.  As a precondition for creating versions,  resources must be created with a link header that indicates the resource is to be versionable.  Now when you hit the "Create" button in the HTML UI, the resource is versionable.

# What's new?
From the UI perspective nothing visible has changed.

# How should this be tested?

1.  build and start the webapp.
2.  create a container named "test"
3.  ``curl -v http://localhost:8080/rest/test``
4. check that the timemap, timegate, and http://mementoweb.org/ns#OriginalResource (rel=type) link is present in the results.
5. Repeat 2-4 with a binary.
# Additional Notes:
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies?  No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No.
* Could this change impact execution of existing code? Probably not.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
