### PR TITLE
Add ACL link header to TimeMap and remove it from Mementos.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -519,10 +519,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 buildLink(constraintURI, CONSTRAINED_BY.getURI()));
         }
 
-        if (!resource.hasType(FEDORAWEBAC_ACL)) {
-            servletResponse.addHeader(LINK, buildLink(getUri(resource.getDescribedResource()) + "/" + FCR_ACL, "acl"));
-        }
-
         if (resource.isVersioned()) {
             servletResponse.addHeader(LINK, buildLink(RdfLexicon.VERSIONED_RESOURCE.getURI(), "type"));
             servletResponse.addHeader(LINK, buildLink(RdfLexicon.VERSIONING_TIMEGATE_TYPE, "type"));
@@ -604,6 +600,10 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
         if (httpHeaderInject != null) {
             httpHeaderInject.addHttpHeaderToResponseStream(servletResponse, uriInfo, resource());
+        }
+
+        if (!resource.hasType(FEDORAWEBAC_ACL) && !resource.isMemento()) {
+            servletResponse.addHeader(LINK, buildLink(getUri(resource.getDescribedResource()) + "/" + FCR_ACL, "acl"));
         }
 
         addTimeMapHeader(resource);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -53,6 +53,7 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_FIXITY;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
@@ -505,6 +506,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             checkForLinkHeader(response, uri, "timegate");
             checkForLinkHeader(response, uri + "/" + FCR_VERSIONS, "timemap");
             checkForLinkHeader(response, VERSIONING_TIMEMAP_TYPE, "type");
+            checkForLinkHeader(response, ldpcvUri + "/" + FCR_ACL , "acl");
             final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(",\n"));
             //the links from the body are not
 
@@ -989,6 +991,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             checkForLinkHeader(response, subjectUri + "/" + FCR_VERSIONS, "timemap");
             assertNoLinkHeader(response, VERSIONED_RESOURCE.toString(), "type");
             assertNoLinkHeader(response, VERSIONING_TIMEMAP_TYPE.toString(), "type");
+            assertNoLinkHeader(response, version1Uri + "/" + FCR_ACL, "acl");
         }
     }
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-2765

Add acl link header to TimeMap and remove the existing acl link header from Mementos.

# How should this be tested?
```
1. Create versioned resource
curl -i -XPOST -H "Slug: VersionedResource" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest" -H "Content-Type: text/n3" --data-binary "<> <info:fedora/test/field> \"Versioned Resource\""

2. Verify that the fcr:acl link header exists in TimeMap
$ curl -i http://localhost:8080/rest/VersionedResource/fcr:versions
HTTP/1.1 200 OK
Date: Thu, 19 Apr 2018 22:17:13 GMT
ETag: W/"b940adc98bd47077e86012f112a06caca1049a4e"
Last-Modified: Thu, 19 Apr 2018 22:15:42 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>;rel="type"
Link: <http://localhost:8080/rest/VersionedResource/fcr:versions/fcr:acl>; rel="acl"
Link: <http://mementoweb.org/ns#TimeMap>; rel="type"
Link: <http://localhost:8080/rest/VersionedResource>; rel="original"
Link: <http://localhost:8080/rest/VersionedResource>; rel="timegate"
Link: <http://localhost:8080/rest/VersionedResource/fcr:versions>; rel="timemap"
Vary-Post: Memento-Datetime
Allow: POST,HEAD,GET,OPTIONS,DELETE
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 1570
Server: Jetty(9.2.3.v20140905)

3. Create a Memento and verify that the fcr:acl link header doesn't exists
echo '<http://localhost:8080/rest/VersionedResource> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Container> .
<http://localhost:8080/rest/VersionedResource> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Resource> .
<http://localhost:8080/rest/VersionedResource> <http://fedora.info/definitions/v4/repository#lastModifiedBy> "bypassAdmin" .
<http://localhost:8080/rest/VersionedResource> <http://fedora.info/definitions/v4/repository#createdBy> "bypassAdmin" .
<http://localhost:8080/rest/VersionedResource> <http://fedora.info/definitions/v4/repository#created> "2018-03-16T21:06:36.868Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/VersionedResource> <http://fedora.info/definitions/v4/repository#lastModified> "2018-03-16T21:06:36.868Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/rest/VersionedResource> <info:fedora/test/field> "V 1" .
<http://localhost:8080/rest/VersionedResource> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#RDFSource> .
<http://localhost:8080/rest/VersionedResource> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container> .
<http://localhost:8080/rest/VersionedResource> <http://fedora.info/definitions/v4/repository#writable> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .' | curl -XPOST -i -H "Memento-Datetime: Tue, 3 Jun 2008 11:05:30 GMT" http://localhost:8080/rest/VersionedResource/fcr:versions -H "Content-Type: application/n-triples" --data-binary "@-"

$ curl -i http://localhost:8080/rest/VersionedResource/fcr:versions/20080603110530
HTTP/1.1 200 OK
Date: Thu, 19 Apr 2018 22:22:23 GMT
ETag: W/"727756c955194400a79d95d72db250eb0ba28900"
Last-Modified: Fri, 16 Mar 2018 21:06:36 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
Memento-Datetime: Tue, 3 Jun 2008 11:05:30 GMT
Link: <http://mementoweb.org/ns#Memento>; rel="type"
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://localhost:8080/rest/VersionedResource>; rel="timegate"
Link: <http://localhost:8080/rest/VersionedResource>; rel="original"
Link: <http://localhost:8080/rest/VersionedResource/fcr:versions>; rel="timemap"
Allow: GET,HEAD,OPTIONS,DELETE
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 1727
Server: Jetty(9.2.3.v20140905)
```