### PR TITLE
Stop using Slug header for versions from HTML UI

### DIFF
--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -192,13 +192,8 @@
 
   function createVersionSnapshot(e) {
       const uri = document.getElementById('main').getAttribute('resource');
-      var name = document.getElementById('version_id').value.trim();
-      if (!name) {
-          const d = new Date();
-          name = 'version.' + d.getFullYear().toString() + (d.getMonth()+1).toString() + d.getDate().toString() + d.getHours() + d.getMinutes() + d.getSeconds();
-      }
 
-      http('POST', uri + '/fcr:versions', [['Slug', name]], function(res) {
+      http('POST', uri + '/fcr:versions', function(res) {
         if (res.status == 201) {
           window.location = uri + '/fcr:versions';
         } else {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2697 and https://jira.duraspace.org/browse/FCREPO-2768

# What does this Pull Request do?
Allows you to use the Create Version button in the HTML UI, but not trying to send a Slug header.

# What's new?


# How should this be tested?

Before PR, make a resource and press the button. Get an error.
After PR, make a resource and press the button. Get redirected to the fcr:versions page (which is blank). But if you `curl` the resource there is a version created.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
