### PR TITLE
Create (via PUT) ACL resources.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -484,6 +484,12 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
     }
 
+    protected void addAclHeader(final FedoraResource resource) {
+        if (!(resource instanceof FedoraWebacAcl) && !resource.isMemento()) {
+            servletResponse.addHeader(LINK, buildLink(getUri(resource.getDescribedResource()) + "/" + FCR_ACL, "acl"));
+        }
+    }
+
     protected void addResourceLinkHeaders(final FedoraResource resource) {
         addResourceLinkHeaders(resource, false);
     }
@@ -602,9 +608,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             httpHeaderInject.addHttpHeaderToResponseStream(servletResponse, uriInfo, resource());
         }
 
-        if (!(resource instanceof FedoraWebacAcl) && !resource.isMemento()) {
-            servletResponse.addHeader(LINK, buildLink(getUri(resource.getDescribedResource()) + "/" + FCR_ACL, "acl"));
-        }
+        addAclHeader(resource);
 
         addTimeMapHeader(resource);
         addMementoHeaders(resource);
@@ -779,6 +783,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected Response createUpdateResponse(final FedoraResource resource, final boolean created) {
         addCacheControlHeaders(servletResponse, resource, session);
         addResourceLinkHeaders(resource, created);
+        addAclHeader(resource);
         addMementoHeaders(resource);
 
         if (!created) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -49,7 +49,6 @@ import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORAWEBAC_ACL;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_INDIRECT_CONTAINER;
@@ -142,6 +141,7 @@ import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.FedoraTimeMap;
+import org.fcrepo.kernel.api.models.FedoraWebacAcl;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
@@ -602,7 +602,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             httpHeaderInject.addHttpHeaderToResponseStream(servletResponse, uriInfo, resource());
         }
 
-        if (!resource.hasType(FEDORAWEBAC_ACL) && !resource.isMemento()) {
+        if (!(resource instanceof FedoraWebacAcl) && !resource.isMemento()) {
             servletResponse.addHeader(LINK, buildLink(getUri(resource.getDescribedResource()) + "/" + FCR_ACL, "acl"));
         }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -17,8 +17,12 @@
  */
 package org.fcrepo.http.api;
 
+import static javax.ws.rs.core.Response.created;
+import static javax.ws.rs.core.Response.noContent;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_WEBAC_ACL;
 import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.URI;
 
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.servlet.http.HttpServletResponse;
@@ -35,8 +39,6 @@ import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
-
-import com.google.common.annotations.VisibleForTesting;
 
 /**
  * @author lsitu
@@ -59,15 +61,6 @@ public class FedoraAcl extends ContentExposingResource {
      */
     public FedoraAcl() {
         super();
-    }
-
-    /**
-     * Create a new FedoraNodes instance for a given path
-     * @param externalPath the external path
-     */
-    @VisibleForTesting
-    public FedoraAcl(final String externalPath) {
-        this.externalPath = externalPath;
     }
 
     /**
@@ -94,7 +87,13 @@ public class FedoraAcl extends ContentExposingResource {
             lock.release();
         }
 
-        return createUpdateResponse(aclResource, created);
+        addCacheControlHeaders(servletResponse, resource, session);
+        final URI location = getUri(aclResource);
+        if (created) {
+            return created(location).build();
+        } else {
+            return noContent().location(location).build();
+        }
     }
 
     @Override

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api;
+
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_WEBAC_ACL;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.fcrepo.http.api.PathLockManager.AcquiredLock;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Scope;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * @author lsitu
+ * @since 4/20/18
+ */
+@Scope("request")
+@Path("/{path: .*}/fcr:acl")
+public class FedoraAcl extends ContentExposingResource {
+
+    private static final Logger LOGGER = getLogger(FedoraAcl.class);
+
+    @Context protected Request request;
+    @Context protected HttpServletResponse servletResponse;
+    @Context protected UriInfo uriInfo;
+
+    @PathParam("path") protected String externalPath;
+
+    /**
+     * Default JAX-RS entry point
+     */
+    public FedoraAcl() {
+        super();
+    }
+
+    /**
+     * Create a new FedoraNodes instance for a given path
+     * @param externalPath the external path
+     */
+    @VisibleForTesting
+    public FedoraAcl(final String externalPath) {
+        this.externalPath = externalPath;
+    }
+
+    /**
+     * PUT to create FedoraWebacACL resource.
+     */
+    @PUT
+    public Response createFedoraWebacAcl() throws ConstraintViolationException {
+        if (resource().hasType(FEDORA_WEBAC_ACL) || resource().isMemento()) {
+            throw new BadRequestException("ACL resource creation is not allowed for resource " + resource().getPath());
+        }
+
+        final boolean created;
+        final FedoraResource aclResource;
+
+        final String path = toPath(translator(), externalPath);
+        final AcquiredLock lock = lockManager.lockForWrite(path, session.getFedoraSession(), nodeService);
+        try {
+            LOGGER.info("PUT acl resource '{}'", externalPath);
+
+            aclResource = resource().findOrCreateAcl();
+            created = aclResource.isNew();
+            session.commit();
+        } finally {
+            lock.release();
+        }
+
+        return createUpdateResponse(aclResource, created);
+    }
+
+    @Override
+    protected String externalPath() {
+        return externalPath;
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author lsitu
+ * @author 4/20/2018
+ */
+public class FedoraAclIT extends AbstractResourceIT {
+
+    private String subjectUri;
+    private String id;
+
+    @Before
+    public void init() {
+        id = getRandomUniqueId();
+        subjectUri = serverAddress + id;
+    }
+
+    @Test
+    public void testCreateAcl() throws Exception {
+        createObjectAndClose(id);
+
+        final HttpPut put = new HttpPut(subjectUri + "/" + FCR_ACL);
+        final String aclLocation;
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            aclLocation = response.getFirstHeader("Location").getValue();
+            // verify the acl container is translated to fcr:acl
+            assertEquals(subjectUri + "/" + FCR_ACL, aclLocation);
+        }
+    }
+
+    @Test
+    public void testCreateAclOnAclResource() throws Exception {
+        createObjectAndClose(id);
+
+        final HttpPut put = new HttpPut(subjectUri + "/" + FCR_ACL);
+        final String aclLocation;
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            aclLocation = response.getFirstHeader("Location").getValue();
+        }
+
+        final HttpPut put1 = new HttpPut(aclLocation + "/" + FCR_ACL);
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(put1));
+    }
+
+    @Test
+    public void testCreateAclOnBinary() throws Exception {
+        createDatastream(id, "x", "some content");
+
+        final HttpPut put = new HttpPut(subjectUri + "/x/" + FCR_ACL);
+        final String aclLocation;
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            aclLocation = response.getFirstHeader("Location").getValue();
+            // verify the acl container for binary is translated to fcr:acl
+            assertEquals(subjectUri + "/x/" + FCR_ACL, aclLocation);
+        }
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2999,6 +2999,30 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testAclHeaderWithPost() throws IOException {
+        final String pid = getRandomUniqueId();
+        final HttpPost httpPost = postObjMethod("/");
+        httpPost.addHeader("Slug", pid);
+        final String location = serverAddress + pid;
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            checkForLinkHeader(response, location + "/" + FCR_ACL, "acl");
+        }
+    }
+
+    @Test
+    public void testAclHeaderWithPut() throws IOException {
+        final String pid = getRandomUniqueId();
+        final String location = serverAddress + pid;
+
+        final HttpPut httpPut = new HttpPut(location);
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            checkForLinkHeader(response, location + "/" + FCR_ACL, "acl");
+        }
+    }
+
+    @Test
     @Ignore("This test needs manual intervention to decide how \"good\" the graph looks")
     // TODO Do we have any way to proceed with this kind of aesthetic goal?
     public void testGraphShouldNotBeTooLumpy() throws IOException {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
@@ -43,7 +43,7 @@ public interface FedoraTypes {
 
     String FEDORA_TIME_MAP = "fedora:TimeMap";
 
-    String FEDORAWEBAC_ACL = "fedorawebac:Acl";
+    String FEDORA_WEBAC_ACL = "webac:Acl";
 
     String MEMENTO = "memento:Memento";
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -103,6 +103,18 @@ public interface FedoraResource {
     FedoraResource findMementoByDatetime(Instant mementoDatetime);
 
     /**
+     * Get the ACL of this resource
+     * @return the container for ACL of this resource
+     */
+    FedoraResource getAcl();
+
+    /**
+     * Create the ACL for this resource if it doesn't exist
+     * @return the container for ACL of this resource
+     */
+    FedoraResource findOrCreateAcl();
+
+    /**
      * Get the child of this resource at the given path
      *
      * @param relPath the given path

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraWebacAcl.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraWebacAcl.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.models;
+
+/**
+ * @author lsitu
+ * @since Apr. 19, 2018
+ */
+public interface FedoraWebacAcl extends Container {
+}

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -171,12 +171,10 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
     private static final PropertyConverter propertyConverter = new PropertyConverter();
 
-    @VisibleForTesting
     public static final String LDPCV_TIME_MAP = "fedora:timemap";
 
     public static final String LDPCV_BINARY_TIME_MAP = "fedora:binaryTimemap";
 
-    @VisibleForTesting
     public static final String CONTAINER_WEBAC_ACL = "fedora:acl";
 
     // A curried type accepting resource, translator, and "minimality", returning triples.

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -520,8 +520,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
                 }
 
                 // add mixin type webac:Acl
-                if (aclNode.canAddMixin(FEDORAWEBAC_ACL)) {
-                    aclNode.addMixin(FEDORAWEBAC_ACL);
+                if (aclNode.canAddMixin(FEDORA_WEBAC_ACL)) {
+                    aclNode.addMixin(FEDORA_WEBAC_ACL);
                 }
             }
         } catch (final RepositoryException e) {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraWebacAclImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraWebacAclImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.modeshape;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.models.FedoraWebacAcl;
+
+/**
+ * @author lsitu
+ * @since Apr. 19, 2018
+ */
+public class FedoraWebacAclImpl extends ContainerImpl implements FedoraWebacAcl {
+
+    /**
+     * Construct a {@link org.fcrepo.kernel.api.models.FedoraWebacAcl} from an existing JCR Node
+     * @param node an existing JCR node to be treated as a fcrepo object
+     */
+    public FedoraWebacAclImpl(final Node node) {
+        super(node);
+    }
+
+    /**
+     * Check if the JCR node has a webac:Acl mixin
+     * @param node the JCR node
+     * @return true if the JCR node has the webac:Acl mixin
+     */
+    public static boolean hasMixin(final Node node) {
+        try {
+            return node.isNodeType(FEDORAWEBAC_ACL);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+}

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraWebacAclImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraWebacAclImpl.java
@@ -44,7 +44,7 @@ public class FedoraWebacAclImpl extends ContainerImpl implements FedoraWebacAcl 
      */
     public static boolean hasMixin(final Node node) {
         try {
-            return node.isNodeType(FEDORAWEBAC_ACL);
+            return node.isNodeType(FEDORA_WEBAC_ACL);
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/identifiers/NodeResourceConverter.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/identifiers/NodeResourceConverter.java
@@ -23,6 +23,7 @@ import com.google.common.base.Converter;
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.modeshape.FedoraTimeMapImpl;
+import org.fcrepo.kernel.modeshape.FedoraWebacAclImpl;
 import org.fcrepo.kernel.modeshape.NonRdfSourceDescriptionImpl;
 import org.fcrepo.kernel.modeshape.FedoraBinaryImpl;
 import org.fcrepo.kernel.modeshape.ContainerImpl;
@@ -59,6 +60,8 @@ public class NodeResourceConverter extends Converter<Node, FedoraResource> {
             fedoraResource = new TombstoneImpl(node);
         } else if (FedoraTimeMapImpl.hasMixin(node)) {
             fedoraResource = new FedoraTimeMapImpl(node);
+        } else if (FedoraWebacAclImpl.hasMixin(node)) {
+            fedoraResource = new FedoraWebacAclImpl(node);
         } else {
             fedoraResource = new ContainerImpl(node);
         }

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -40,14 +40,14 @@
 /*
  * A fedora namespace for webac.
  */
-<fedorawebac = 'http://fedora.info/definitions/v4/webac#'>
+<webac = 'http://fedora.info/definitions/v4/webac#'>
 
 <test = 'info:fedora/test/'>
 
 [nt:versionFile] > nt:file
 + fedora:timemap (nt:folder) =fedora:TimeMap
 + fedora:binaryTimemap (nt:folder) =fedora:TimeMap
-+ fedora:acl (nt:folder) =fedorawebac:Acl
++ fedora:acl (nt:folder) =webac:Acl
 
 /*
  * Any Fedora resource.
@@ -96,7 +96,7 @@
 /*
  * A Fedora webac:Acl mixin.
  */
-[fedorawebac:Acl] > fedora:Resource mixin
+[webac:Acl] > fedora:Resource mixin
 
 /*
  * Some content that can have a checksum

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -47,6 +47,7 @@
 [nt:versionFile] > nt:file
 + fedora:timemap (nt:folder) =fedora:TimeMap
 + fedora:binaryTimemap (nt:folder) =fedora:TimeMap
++ fedora:acl (nt:folder) =fedorawebac:Acl
 
 /*
  * Any Fedora resource.
@@ -91,6 +92,11 @@
  */
 [memento:Memento] > fedora:Resource mixin
   - memento:mementoDatetime (DATE)
+
+/*
+ * A Fedora webac:Acl mixin.
+ */
+[fedorawebac:Acl] > fedora:Resource mixin
 
 /*
  * Some content that can have a checksum

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -99,7 +99,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_REPOSITORY_ROOT;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_TIME_MAP;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_TOMBSTONE;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORAWEBAC_ACL;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_WEBAC_ACL;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
@@ -1263,7 +1263,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         session.commit();
 
         final javax.jcr.Node aclNode = jcrSession.getNode("/" + pid).getNode(CONTAINER_WEBAC_ACL);
-        assertTrue(aclNode.isNodeType(FEDORAWEBAC_ACL));
+        assertTrue(aclNode.isNodeType(FEDORA_WEBAC_ACL));
     }
 
     @Test
@@ -1289,7 +1289,7 @@ public class FedoraResourceImplIT extends AbstractIT {
         session.commit();
 
         final javax.jcr.Node aclNode = jcrSession.getNode("/" + pid).getNode(CONTAINER_WEBAC_ACL);
-        assertTrue(aclNode.isNodeType(FEDORAWEBAC_ACL));
+        assertTrue(aclNode.isNodeType(FEDORA_WEBAC_ACL));
     }
 
     private void addVersionLabel(final String label, final FedoraResource r) throws RepositoryException {

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraWebacAclImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraWebacAclImplIT.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.kernel.modeshape;
+
+import static org.fcrepo.kernel.modeshape.FedoraWebacAclImpl.hasMixin;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
+
+import javax.inject.Inject;
+import javax.jcr.RepositoryException;
+
+import org.fcrepo.kernel.api.FedoraRepository;
+import org.fcrepo.kernel.api.FedoraSession;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.models.Container;
+import org.fcrepo.kernel.api.services.ContainerService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * <p>FedoraWebAclImplIT class.</p>
+ *
+ * @author lsitu
+ */
+@Ignore
+@ContextConfiguration({"/spring-test/repo.xml"})
+public class FedoraWebacAclImplIT extends AbstractIT {
+
+    @Inject
+    FedoraRepository repo;
+
+    @Inject
+    ContainerService containerService;
+
+    private FedoraSession session;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() throws RepositoryException {
+        session = repo.login();
+    }
+
+    @After
+    public void tearDown() {
+        session.expire();
+    }
+
+    @Test (expected = RepositoryRuntimeException.class)
+    public void testFedoraWebacAclNodeTypeException() {
+        final String pid = getRandomPid();
+        final Container container = containerService.findOrCreate(session, "/" + pid + "/a");
+        session.expire();
+        hasMixin(getJcrNode(container));
+    }
+}


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-2756

Create ACL resources via PUT.

# What's new?
Create ACL resources via PUT on the static fcr:acl URI http://resource/path/fcr:acl, and the ACL is created in container fedora:acl under the resource like TimeMap instead of linking with the acl:accessControl predicate.

# How should this be tested?
```
1. Create RDFSource
$ curl -i -XPOST -H "Slug: TestObject" -H "Content-Type: text/n3" --data-binary "<> <info:fedora/test/field> \"Test Object\"" http://localhost:8080/rest/

2. Create ACL on the RDFSource and verify status 201 with the location header URI translated to fcr:acl
$ curl -i -XPUT http://localhost:8080/rest/TestObject/fcr:acl
HTTP/1.1 201 Created
Date: Mon, 23 Apr 2018 14:35:18 GMT
ETag: W/"75a70600c3237bd40744b79377f218d444fae0eb"
Last-Modified: Mon, 23 Apr 2018 14:35:18 GMT
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Location: http://localhost:8080/rest/TestObject/fcr:acl
Content-Type: text/plain
Content-Length: 45
Server: Jetty(9.2.3.v20140905)

3. Create NonRdfSource
$ curl -i -XPOST -H "Slug: binary"  http://localhost:8080/rest -H "Content-Type: application/octet-stream" --data-binary "binary content"

4. Create ACL on the NonRdfSource and verify status 201 with the location header URI translated to fcr:acl
$ curl -i -XPUT http://localhost:8080/rest/binary/fcr:acl
HTTP/1.1 201 Created
Date: Mon, 23 Apr 2018 14:50:41 GMT
ETag: W/"cb84ff95041ef51503db7a6b6b01e9db2df1ddd2"
Last-Modified: Mon, 23 Apr 2018 14:50:41 GMT
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Location: http://localhost:8080/rest/binary/fcr:acl
Content-Type: text/plain
Content-Length: 41
Server: Jetty(9.2.3.v20140905)
```