### PR TITLE
FCREPO-2632. Use 'acl:agentClass foaf:Agent' to denote public access

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/AbstractRolesAuthorizationDelegate.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/AbstractRolesAuthorizationDelegate.java
@@ -65,7 +65,7 @@ public abstract class AbstractRolesAuthorizationDelegate implements FedoraAuthor
      * Gather effectives roles
      *
      * @param acl access control list
-     * @param principals effective principals
+     * @param principals effective principals of agents and foaf agentClass
      * @return set of effective content roles
      */
     public static Set<String> resolveUserRoles(final Map<String, Collection<String>> acl,

--- a/fcrepo-auth-webac/src/main/resources/root-authorization.ttl
+++ b/fcrepo-auth-webac/src/main/resources/root-authorization.ttl
@@ -6,5 +6,5 @@
 <> a acl:Authorization ;
    rdfs:label "Root Authorization" ;
    rdfs:comment "By default, all non-Admin agents (foaf:Agent) are denied access (no acl:mode is specified) to all resources." ;
-   acl:agent foaf:Agent ;
+   acl:agentClass foaf:Agent ;
    acl:accessToClass fedora:Resource .

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -529,6 +529,40 @@ public class WebACRolesProviderTest {
     }
 
     @Test
+    public void acl17Test1() throws RepositoryException {
+        final String foafAgent = "http://xmlns.com/foaf/0.1/Agent";
+        final String accessTo = "/dark/archive/sunshine";
+        final String acl = "/acls/17";
+        final String auth1 = acl + "/auth_valid_foaf_agent.ttl";
+        final String auth2 = acl + "/auth_invalid_foaf_agent.ttl";
+
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockProperty.getString()).thenReturn(acl);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
+                .thenReturn(getResourceRdfStream(accessTo, acl));
+
+        when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
+        when(mockAuthorizationResource1.getTriples(anyObject(), eq(PROPERTIES)))
+                .thenReturn(getRdfStreamFromResource(auth1, TTL));
+
+        when(mockAuthorizationResource2.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
+        when(mockAuthorizationResource2.getPath()).thenReturn(auth2);
+        when(mockAuthorizationResource2.getTriples(anyObject(), eq(PROPERTIES)))
+                .thenReturn(getRdfStreamFromResource(auth2, TTL));
+
+        when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1, mockAuthorizationResource2));
+
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be only one valid role", 1, roles.size());
+        assertEquals("The foafAgent should have exactly one valid mode", 1, roles.get(foafAgent).size());
+        assertTrue("The foafAgent should be able to write", roles.get(foafAgent).contains(WEBAC_MODE_WRITE_VALUE));
+    }
+
+    @Test
     public void noAclTest1() throws RepositoryException {
         final String agent1 = "http://xmlns.com/foaf/0.1/Agent";
 

--- a/fcrepo-auth-webac/src/test/resources/acls/03/auth_open.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/03/auth_open.ttl
@@ -2,6 +2,6 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
 <> a acl:Authorization ;
-   acl:agent foaf:Agent ;
+   acl:agentClass foaf:Agent ;
    acl:mode acl:Read ;
    acl:accessTo </rest/dark/archive/sunshine> .

--- a/fcrepo-auth-webac/src/test/resources/acls/04/auth1.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/04/auth1.ttl
@@ -2,6 +2,6 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
 <> a acl:Authorization ;
-   acl:agent foaf:Agent ;
+   acl:agentClass foaf:Agent ;
    acl:mode acl:Read ;
    acl:accessTo </rest/public_collection> .

--- a/fcrepo-auth-webac/src/test/resources/acls/05/auth_open.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/05/auth_open.ttl
@@ -3,6 +3,6 @@
 @prefix eg: <http://example.com/terms#> .
 
 <> a acl:Authorization ;
-   acl:agent foaf:Agent ;
+   acl:agentClass foaf:Agent ;
    acl:mode acl:Read ;
    acl:accessToClass eg:publicImage .

--- a/fcrepo-auth-webac/src/test/resources/acls/17/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/17/acl.ttl
@@ -1,0 +1,3 @@
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
+
+<> a webac:Acl .

--- a/fcrepo-auth-webac/src/test/resources/acls/17/auth_invalid_foaf_agent.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/17/auth_invalid_foaf_agent.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<> a acl:Authorization ;
+   acl:agent foaf:Agent ;
+   acl:mode acl:Read ;
+   acl:accessTo </rest/dark/archive/sunshine> .

--- a/fcrepo-auth-webac/src/test/resources/acls/17/auth_valid_foaf_agent.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/17/auth_valid_foaf_agent.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<> a acl:Authorization ;
+   acl:agentClass foaf:Agent ;
+   acl:mode acl:Write ;
+   acl:accessTo </rest/dark/archive/sunshine> .


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2632

An alternate implementation of PR: #1321 

# What does this Pull Request do?
Changes to treat foaf:Agent as an acl:agentClass instead of acl:agent.

# What's new?
The getRoles method in the roles provider class will also include agentClass roles for the foaf:Agent.

# How should this be tested?

Maven build with tests.

# Interested parties
@whikloj 
