### PR TITLE
FCREPO-2764. Reimplement PrincipalProviders as Servlet Filters.

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/AbstractPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/AbstractPrincipalProvider.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
  * This abstract class implements the Filter interface to add principals
  * to the session so that Shiro can evaluate the principals.
  * 
- * The getPrincipals methods is left as the responsibility of the classes
+ * The getPrincipals method is left as the responsibility of the classes
  * that will be extending this abstract class.
  *
  * @author Mohamed Abdul Rasheed
@@ -50,7 +50,7 @@ abstract class AbstractPrincipalProvider implements PrincipalProvider {
 
     private static final Logger log = getLogger(AbstractPrincipalProvider.class);
 
-    public static final String REALM_NAME = "org.fcrepo.auth.webac.WebACAuthorizingRealm";
+    private static final String REALM_NAME = "org.fcrepo.auth.webac.WebACAuthorizingRealm";
 
     @Override
     public void init(final FilterConfig filterConfig) throws ServletException {

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/AbstractPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/AbstractPrincipalProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.common;
+
+import static org.apache.shiro.subject.support.DefaultSubjectContext.PRINCIPALS_SESSION_KEY;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Set;
+
+import org.apache.shiro.subject.PrincipalCollection;
+import org.apache.shiro.subject.SimplePrincipalCollection;
+import org.slf4j.Logger;
+
+/**
+ * This abstract class implements the Filter interface to add principals
+ * to the session so that Shiro can evaluate the principals.
+ * 
+ * The getPrincipals methods is left as the responsibility of the classes
+ * that will be extending this abstract class.
+ *
+ * @author Mohamed Abdul Rasheed
+ * @see PrincipalProvider
+ */
+abstract class AbstractPrincipalProvider implements PrincipalProvider {
+
+    private static final Logger log = getLogger(AbstractPrincipalProvider.class);
+
+    public static final String REALM_NAME = "org.fcrepo.auth.webac.WebACAuthorizingRealm";
+
+    @Override
+    public void init(final FilterConfig filterConfig) throws ServletException {
+        // this method intentionally left empty
+    }
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+            throws IOException, ServletException {
+        final HttpServletRequest hsRequest = (HttpServletRequest) request;
+        final HttpSession session = hsRequest.getSession();
+        PrincipalCollection principals = (PrincipalCollection) session.getAttribute(PRINCIPALS_SESSION_KEY);
+        final Set<Principal> currentPrincipals = (Set<Principal>) principals.asSet();
+        log.debug("Number of Principals already in session object: {}", currentPrincipals.size());
+        currentPrincipals.addAll(getPrincipals(hsRequest));
+        log.debug("Number of Principals after processing current request: {}", currentPrincipals.size());
+        principals = new SimplePrincipalCollection(currentPrincipals, REALM_NAME);
+        hsRequest.getSession().setAttribute(PRINCIPALS_SESSION_KEY, principals);
+    }
+
+    @Override
+    public void destroy() {
+        // this method intentionally left empty
+    }
+}

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerRolesPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerRolesPrincipalProvider.java
@@ -19,15 +19,13 @@ package org.fcrepo.auth.common;
 
 import static java.util.Collections.emptySet;
 
+import javax.servlet.http.HttpServletRequest;
+
 import java.security.Principal;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import javax.jcr.Credentials;
-import javax.servlet.http.HttpServletRequest;
-
-import org.modeshape.jcr.api.ServletCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Kevin S. Clarke
  * @see PrincipalProvider
  */
-public class ContainerRolesPrincipalProvider implements PrincipalProvider {
+public class ContainerRolesPrincipalProvider extends AbstractPrincipalProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ContainerRolesPrincipalProvider.class);
 
@@ -101,23 +99,14 @@ public class ContainerRolesPrincipalProvider implements PrincipalProvider {
     /*
      * (non-Javadoc)
      * @see
-     * org.fcrepo.auth.PrincipalProvider#getPrincipals(javax.jcr.Credentials)
+     * org.fcrepo.auth.PrincipalProvider#getPrincipals(javax.servlet.http.HttpServletRequest)
      */
     @Override
-    public Set<Principal> getPrincipals(final Credentials credentials) {
+    public Set<Principal> getPrincipals(final HttpServletRequest request) {
         LOGGER.debug("Checking for principals using {}", ContainerRolesPrincipalProvider.class.getSimpleName());
 
-        if (!(credentials instanceof ServletCredentials)) {
-            LOGGER.debug("Credentials is not an instanceof ServletCredentials");
-
-            return emptySet();
-        }
-
-        final ServletCredentials servletCredentials = (ServletCredentials) credentials;
-        final HttpServletRequest request = servletCredentials.getRequest();
-
         if (request == null) {
-            LOGGER.debug("Servlet request from servletCredentials was null");
+            LOGGER.debug("Servlet request was null");
 
             return emptySet();
         }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProvider.java
@@ -17,11 +17,12 @@
  */
 package org.fcrepo.auth.common;
 
-import org.fcrepo.kernel.api.exception.RepositoryConfigurationException;
+import javax.servlet.http.HttpServletRequest;
 
-import javax.jcr.Credentials;
 import java.security.Principal;
 import java.util.Set;
+
+import org.fcrepo.kernel.api.exception.RepositoryConfigurationException;
 
 /**
  * An example principal provider that extracts principals from request headers.
@@ -44,12 +45,12 @@ public class DelegateHeaderPrincipalProvider extends HttpHeaderPrincipalProvider
     }
 
     /**
-     * @param credentials from which the principal header is extracted
+     * @param request from which the principal header is extracted
      * @return null if no delegate found, and the delegate if one found
      * @throws RepositoryConfigurationException if more than one delegate found
      */
-    public Principal getDelegate(final Credentials credentials) {
-        final Set<Principal> principals = getPrincipals(credentials);
+    public Principal getDelegate(final HttpServletRequest request) {
+        final Set<Principal> principals = getPrincipals(request);
         // No delegate
         if (principals.size() == 0) {
             return null;

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/HttpHeaderPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/HttpHeaderPrincipalProvider.java
@@ -19,11 +19,9 @@ package org.fcrepo.auth.common;
 
 import static java.util.Collections.emptySet;
 
-import org.modeshape.jcr.api.ServletCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.Credentials;
 import javax.servlet.http.HttpServletRequest;
 
 import java.security.Principal;
@@ -37,7 +35,7 @@ import java.util.Set;
  * @author Mike Daines
  * @see PrincipalProvider
  */
-public class HttpHeaderPrincipalProvider implements PrincipalProvider {
+public class HttpHeaderPrincipalProvider extends AbstractPrincipalProvider {
 
     protected static class HttpHeaderPrincipal implements Principal {
 
@@ -97,12 +95,12 @@ public class HttpHeaderPrincipalProvider implements PrincipalProvider {
     }
 
     /*
-     * (non-Javadoc)
-     * @see
-     * org.fcrepo.auth.PrincipalProvider#getPrincipals(javax.jcr.Credentials)
-     */
+    * (non-Javadoc)
+    * @see
+    * org.fcrepo.auth.PrincipalProvider#getPrincipals(javax.servlet.http.HttpServletRequest)
+    */
     @Override
-    public Set<Principal> getPrincipals(final Credentials credentials) {
+    public Set<Principal> getPrincipals(final HttpServletRequest request) {
         LOGGER.debug("Checking for principals using {}", HttpHeaderPrincipalProvider.class.getSimpleName());
 
         if (headerName == null || separator == null) {
@@ -111,16 +109,6 @@ public class HttpHeaderPrincipalProvider implements PrincipalProvider {
         }
 
         LOGGER.debug("Trying to get principals from header: {}; separator: {}", headerName, separator);
-
-        if (!(credentials instanceof ServletCredentials)) {
-            LOGGER.debug("Credentials is not an instanceof ServletCredentials");
-            return emptySet();
-        }
-
-        final ServletCredentials servletCredentials =
-                (ServletCredentials) credentials;
-
-        final HttpServletRequest request = servletCredentials.getRequest();
 
         if (request == null) {
             LOGGER.debug("Servlet request from servletCredentials was null");

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/PrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/PrincipalProvider.java
@@ -17,7 +17,8 @@
  */
 package org.fcrepo.auth.common;
 
-import javax.jcr.Credentials;
+import javax.servlet.Filter;
+import javax.servlet.http.HttpServletRequest;
 
 import java.security.Principal;
 import java.util.Set;
@@ -36,19 +37,18 @@ import java.util.Set;
  * @author Gregory Jansen
  * @see HttpHeaderPrincipalProvider
  */
-public interface PrincipalProvider {
+public interface PrincipalProvider extends Filter {
 
     /**
      * Extract principals from the provided credentials.
      * <p>
-     * If no principals can be extracted, for example because the credentials
-     * are of a different type than expected, implementations of this method
+     * If no principals can be extracted, implementations of this method
      * should return the empty set rather than null.
      * </p>
      *
-     * @param credentials the credentials
+     * @param request the request
      * @return a set of security principals
      */
-    Set<Principal> getPrincipals(Credentials credentials);
+    Set<Principal> getPrincipals(HttpServletRequest request);
 
 }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/PrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/PrincipalProvider.java
@@ -40,7 +40,7 @@ import java.util.Set;
 public interface PrincipalProvider extends Filter {
 
     /**
-     * Extract principals from the provided credentials.
+     * Extract principals from the provided HttpServletRequest.
      * <p>
      * If no principals can be extracted, implementations of this method
      * should return the empty set rather than null.

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
@@ -185,7 +185,8 @@ public final class ServletContainerAuthenticationProvider implements
     private Principal getDelegatedPrincipal(final Credentials credentials) {
         for (final PrincipalProvider provider : this.getPrincipalProviders()) {
             if (provider instanceof DelegateHeaderPrincipalProvider) {
-                return ((DelegateHeaderPrincipalProvider) provider).getDelegate(credentials);
+                final HttpServletRequest request = ((ServletCredentials) credentials).getRequest();
+                return ((DelegateHeaderPrincipalProvider) provider).getDelegate(request);
             }
         }
         return null;
@@ -213,10 +214,10 @@ public final class ServletContainerAuthenticationProvider implements
             // if the provider is DelegateHeader, it is either already processed (if logged user has fedora admin role)
             // or should be ignored completely (the user was not in admin role, so on-behalf-of header must be ignored)
             if (!(p instanceof DelegateHeaderPrincipalProvider)) {
-                final Set<Principal> ps = p.getPrincipals(credentials);
+                final Set<Principal> ps = p.getPrincipals(((ServletCredentials) credentials).getRequest());
 
                 if (ps != null) {
-                    principals.addAll(p.getPrincipals(credentials));
+                    principals.addAll(p.getPrincipals(((ServletCredentials) credentials).getRequest()));
                 }
             }
         }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ContainerRolesPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ContainerRolesPrincipalProviderTest.java
@@ -34,7 +34,6 @@ import org.fcrepo.auth.common.ContainerRolesPrincipalProvider.ContainerRolesPrin
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.modeshape.jcr.api.ServletCredentials;
 
 /**
  * Tests for {@link ContainerRolesPrincipalProvider}.
@@ -42,9 +41,6 @@ import org.modeshape.jcr.api.ServletCredentials;
  * @author Kevin S. Clarke
  */
 public class ContainerRolesPrincipalProviderTest {
-
-    @Mock
-    private ServletCredentials credentials;
 
     @Mock
     private HttpServletRequest request;
@@ -57,7 +53,6 @@ public class ContainerRolesPrincipalProviderTest {
     @Before
     public void setUp() {
         initMocks(this);
-        when(credentials.getRequest()).thenReturn(request);
         provider = new ContainerRolesPrincipalProvider();
     }
 
@@ -69,7 +64,7 @@ public class ContainerRolesPrincipalProviderTest {
         when(request.isUserInRole("a")).thenReturn(true);
         provider.setRoleNames(newHashSet("a"));
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(1, principals.size());
         assertTrue("The principals should contain 'a'", principals.contains(new ContainerRolesPrincipal("a")));
@@ -84,7 +79,7 @@ public class ContainerRolesPrincipalProviderTest {
         when(request.isUserInRole("b")).thenReturn(true);
         provider.setRoleNames(newHashSet("a", "b"));
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(2, principals.size());
         assertTrue("The principals should contain 'a'", principals.contains(new ContainerRolesPrincipal("a")));
@@ -100,7 +95,7 @@ public class ContainerRolesPrincipalProviderTest {
         when(request.isUserInRole("b")).thenReturn(true);
         provider.setRoleNames(newHashSet(" a", "b "));
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(2, principals.size());
         assertTrue("The principals should contain 'a'", principals.contains(new ContainerRolesPrincipal("a")));
@@ -112,32 +107,31 @@ public class ContainerRolesPrincipalProviderTest {
      */
     @Test
     public void testNoConfigedRoleNames() {
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
         assertTrue("Empty set expected when no role names configured", principals.isEmpty());
     }
 
     /**
-     * Test for {@link ContainerRolesPrincipalProvider#getPrincipals(javax.jcr.Credentials)}.
+     * Test for {@link ContainerRolesPrincipalProvider#getPrincipals(javax.servlet.http.HttpServletRequest)}.
      */
     @Test
     public void testNoRequest() {
-        when(credentials.getRequest()).thenReturn(null);
         provider.setRoleNames(newHashSet("a"));
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(null);
         assertTrue("Empty set expected when no request supplied", principals.isEmpty());
 
     }
 
     /**
-     * Test for {@link ContainerRolesPrincipalProvider#getPrincipals(javax.jcr.Credentials)}.
+     * Test for {@link ContainerRolesPrincipalProvider#getPrincipals(javax.servlet.http.HttpServletRequest)}.
      */
     @Test
     public void testPrincipalEqualsDifferentClass() {
         when(request.isUserInRole("a")).thenReturn(true);
         provider.setRoleNames(newHashSet("a"));
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
         final Principal principal = principals.iterator().next();
 
         assertNotEquals("Principals should not be equal if not the same class", principal, mock(Principal.class));

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProviderTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.modeshape.jcr.api.ServletCredentials;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -42,27 +41,23 @@ public class DelegateHeaderPrincipalProviderTest {
     private final DelegateHeaderPrincipalProvider provider = new DelegateHeaderPrincipalProvider();
 
     @Mock
-    private ServletCredentials credentials;
-
-    @Mock
     private HttpServletRequest request;
 
     @Before
     public void setUp() {
-        when(credentials.getRequest()).thenReturn(request);
     }
 
     @Test
     public void testGetDelegate0() {
         when(request.getHeader(DELEGATE_HEADER)).thenReturn(null);
-        assertNull("No delegates should return null", provider.getDelegate(credentials));
+        assertNull("No delegates should return null", provider.getDelegate(request));
     }
 
     @Test
     public void testGetDelegate1() {
         final String user = "user1";
         when(request.getHeader(DELEGATE_HEADER)).thenReturn(user);
-        assertNotNull("Should be a delegate!", provider.getDelegate(credentials));
-        assertEquals(user, provider.getDelegate(credentials).getName());
+        assertNotNull("Should be a delegate!", provider.getDelegate(request));
+        assertEquals(user, provider.getDelegate(request).getName());
     }
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
@@ -28,9 +28,7 @@ import org.fcrepo.auth.common.HttpHeaderPrincipalProvider.HttpHeaderPrincipal;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.modeshape.jcr.api.ServletCredentials;
 
-import javax.jcr.Credentials;
 import javax.servlet.http.HttpServletRequest;
 
 import java.security.Principal;
@@ -44,9 +42,6 @@ import java.util.Set;
 public class HttpHeaderPrincipalProviderTest {
 
     @Mock
-    private ServletCredentials credentials;
-
-    @Mock
     private HttpServletRequest request;
 
     private HttpHeaderPrincipalProvider provider;
@@ -54,7 +49,6 @@ public class HttpHeaderPrincipalProviderTest {
     @Before
     public void setUp() {
         initMocks(this);
-        when(credentials.getRequest()).thenReturn(request);
 
         provider = new HttpHeaderPrincipalProvider();
     }
@@ -67,7 +61,7 @@ public class HttpHeaderPrincipalProviderTest {
         provider.setHeaderName("Groups");
         provider.setSeparator(",");
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(2, principals.size());
         assertTrue("The principals should contain 'a'", principals
@@ -85,7 +79,7 @@ public class HttpHeaderPrincipalProviderTest {
         provider.setHeaderName("Groups");
         provider.setSeparator(",");
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(2, principals.size());
         assertTrue("The principals should contain 'a'", principals
@@ -98,7 +92,7 @@ public class HttpHeaderPrincipalProviderTest {
     @Test
     public void testNoHeaderName() {
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
 
         assertTrue("Empty set expected when no header name configured", principals.isEmpty());
 
@@ -109,21 +103,9 @@ public class HttpHeaderPrincipalProviderTest {
 
         provider.setHeaderName("Groups");
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
 
         assertTrue("Empty set expected when no separator name configured", principals.isEmpty());
-
-    }
-
-    @Test
-    public void testInvalidCredentials() {
-
-        provider.setHeaderName("Groups");
-        provider.setSeparator(",");
-
-        final Set<Principal> principals = provider.getPrincipals(mock(Credentials.class));
-
-        assertTrue("Empty set expected when incorrect type of credentials supplied", principals.isEmpty());
 
     }
 
@@ -133,9 +115,7 @@ public class HttpHeaderPrincipalProviderTest {
         provider.setHeaderName("Groups");
         provider.setSeparator(",");
 
-        when(credentials.getRequest()).thenReturn(null);
-
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(null);
 
         assertTrue("Empty set expected when no request supplied", principals.isEmpty());
 
@@ -149,7 +129,7 @@ public class HttpHeaderPrincipalProviderTest {
         provider.setHeaderName("Groups");
         provider.setSeparator(",");
 
-        final Set<Principal> principals = provider.getPrincipals(credentials);
+        final Set<Principal> principals = provider.getPrincipals(request);
 
         final Principal principal = principals.iterator().next();
 

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticationProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticationProviderTest.java
@@ -156,7 +156,7 @@ public class ServletContainerAuthenticationProviderTest {
 
         when(principal.getName()).thenReturn("adminName");
 
-        when(delegateProvider.getDelegate(creds)).thenReturn(delegatePrincipal);
+        when(delegateProvider.getDelegate(request)).thenReturn(delegatePrincipal);
         when(delegatePrincipal.getName()).thenReturn("delegatedUserName");
 
         final ExecutionContext result =
@@ -177,11 +177,11 @@ public class ServletContainerAuthenticationProviderTest {
 
         when(principal.getName()).thenReturn("userName");
 
-        when(delegateProvider.getDelegate(creds)).thenReturn(delegatePrincipal);
+        when(delegateProvider.getDelegate(request)).thenReturn(delegatePrincipal);
         when(delegatePrincipal.getName()).thenReturn("delegatedUserName");
 
         // delegateProvider being HeaderProvider returns the header content in getPrincipals regardless of logged user
-        when(delegateProvider.getPrincipals(creds)).thenReturn(Sets.newHashSet(delegatePrincipal));
+        when(delegateProvider.getPrincipals(request)).thenReturn(Sets.newHashSet(delegatePrincipal));
 
 
         final ExecutionContext result =
@@ -265,7 +265,7 @@ public class ServletContainerAuthenticationProviderTest {
         final Principal groupPrincipal = mock(Principal.class);
         groupPrincipals.add(groupPrincipal);
         final HttpHeaderPrincipalProvider principalProvider = mock(HttpHeaderPrincipalProvider.class);
-        when(principalProvider.getPrincipals(any(Credentials.class))).thenReturn(groupPrincipals);
+        when(principalProvider.getPrincipals(any(HttpServletRequest.class))).thenReturn(groupPrincipals);
 
         final Set<PrincipalProvider> providers = new HashSet<>();
         providers.add(principalProvider);


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2764

# What does this Pull Request do?
Reimplement the principal providers as Servlet Filters.

# What's new?
Added an AbstractPrincipalProvider class that takes care of adding principals to the session for Shiro.

# How should this be tested?
IT tests needs to be added when all the issues under https://jira.duraspace.org/browse/FCREPO-2753 are complete.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.
The ServletContainerAuthenticationProvider class has been updated to make it compatible with the PrinicipalProvider interface changes to avoid build failure. The ServletContainerAuthenticationProvider class can be ultimately removed when the Shiro based implementation is completed.

# Interested parties
@fcrepo4/committers, @peichman-umd 
