### PR TITLE
Use WebACRolesProvider to check ACLs in WebACAuthorizationRealm

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerAuthToken.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerAuthToken.java
@@ -22,6 +22,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.http.auth.BasicUserPrincipal;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.fcrepo.auth.common.ContainerRolesPrincipalProvider.ContainerRolesPrincipal;
 import org.slf4j.Logger;
@@ -35,7 +36,7 @@ public class ContainerAuthToken implements AuthenticationToken {
 
     public static final String AUTHORIZED = "AUTHORIZED";
 
-    private String servletUsername;
+    private BasicUserPrincipal servletUser;
 
     private Set<ContainerRolesPrincipal> servletRoles;
 
@@ -44,7 +45,7 @@ public class ContainerAuthToken implements AuthenticationToken {
      * @param servletRoleNames roles returned from servlet container authentication
      */
     public ContainerAuthToken(final String servletUsername, final Set<String> servletRoleNames) {
-        this.servletUsername = servletUsername;
+        servletUser = new BasicUserPrincipal(servletUsername);
         log.debug("Setting servlet username {}", servletUsername);
         this.servletRoles = new HashSet<>();
         for (String roleName : servletRoleNames) {
@@ -55,7 +56,7 @@ public class ContainerAuthToken implements AuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return servletUsername;
+        return servletUser;
     }
 
     /**

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthFilter.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthFilter.java
@@ -66,6 +66,8 @@ public class ServletContainerAuthFilter implements Filter {
             throws IOException, ServletException {
         final HttpServletRequest httpRequest = (HttpServletRequest) request;
         final Principal servletUser = httpRequest.getUserPrincipal();
+        final Subject currentUser = SecurityUtils.getSubject();
+
         if (servletUser != null) {
             log.debug("There is a servlet user: {}", servletUser.getName());
             final Set<String> roles = new HashSet<>();
@@ -78,10 +80,11 @@ public class ServletContainerAuthFilter implements Filter {
             }
             final ContainerAuthToken token = new ContainerAuthToken(servletUser.getName(), roles);
             log.debug("Credentials for servletUser = {}", token.getCredentials());
-            final Subject currentUser = SecurityUtils.getSubject();
             currentUser.login(token);
         } else {
             log.debug("Anonymous request");
+            // ensure the user is actually logged out
+            currentUser.logout();
         }
         chain.doFilter(request, response);
     }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticatingRealm.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticatingRealm.java
@@ -49,7 +49,7 @@ public class ServletContainerAuthenticatingRealm extends AuthenticatingRealm {
         principals.add(authToken.getPrincipal(), getName());
         // container-managed auth roles
         principals.addAll(authToken.getRoles(), getName());
-        return new SimpleAuthenticationInfo(principals, ContainerAuthToken.AUTHORIZED, getName());
+        return new SimpleAuthenticationInfo(principals, ContainerAuthToken.AUTHORIZED);
     }
 
     @Override

--- a/fcrepo-auth-webac/pom.xml
+++ b/fcrepo-auth-webac/pom.xml
@@ -129,7 +129,6 @@
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
       <version>${jersey.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -147,7 +146,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -177,7 +175,6 @@
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-http-api</artifactId>
       <version>5.0.0-SNAPSHOT</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/fcrepo-auth-webac/pom.xml
+++ b/fcrepo-auth-webac/pom.xml
@@ -129,6 +129,7 @@
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
       <version>${jersey.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -17,8 +17,25 @@
  */
 package org.fcrepo.auth.webac;
 
+import static org.fcrepo.auth.common.ServletContainerAuthFilter.FEDORA_ADMIN_ROLE;
+import static org.fcrepo.auth.common.ServletContainerAuthFilter.FEDORA_USER_ROLE;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.net.URI;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.http.auth.BasicUserPrincipal;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
@@ -27,8 +44,15 @@ import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.fcrepo.auth.common.ContainerRolesPrincipalProvider.ContainerRolesPrincipal;
+import org.fcrepo.http.api.FedoraLdp;
+import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
+import org.fcrepo.http.commons.session.HttpSession;
+import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.modeshape.FedoraResourceImpl;
 import org.slf4j.Logger;
-
 /**
  * Authorization-only realm that performs authorization checks using WebAC ACLs stored in a Fedora repository. It
  * locates the ACL for the currently requested resource and parses the ACL RDF into a set of {@link WebACPermission}
@@ -40,7 +64,44 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
 
     private static final Logger log = getLogger(WebACAuthorizingRealm.class);
 
-    private static final ContainerRolesPrincipal adminPrincipal = new ContainerRolesPrincipal("fedoraAdmin");
+    private static final ContainerRolesPrincipal adminPrincipal = new ContainerRolesPrincipal(FEDORA_ADMIN_ROLE);
+
+    private static final ContainerRolesPrincipal userPrincipal = new ContainerRolesPrincipal(FEDORA_USER_ROLE);
+
+    @Inject
+    private SessionFactory sessionFactory;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Inject
+    private WebACRolesProvider rolesProvider;
+
+    private HttpSession session;
+
+    private HttpSession session() {
+        if (session == null) {
+            session = sessionFactory.getSession(request);
+        }
+        return session;
+    }
+
+    protected IdentifierConverter<Resource, FedoraResource> idTranslator;
+
+    protected IdentifierConverter<Resource, FedoraResource> translator() {
+        if (idTranslator == null) {
+            idTranslator = new HttpResourceConverter(session(), UriBuilder.fromResource(FedoraLdp.class));
+        }
+
+        return idTranslator;
+    }
+
+    /**
+     * Useful for constructing URLs
+     */
+    @Context
+    protected UriInfo uriInfo;
+
 
     @Override
     protected AuthorizationInfo doGetAuthorizationInfo(final PrincipalCollection principals) {
@@ -48,9 +109,42 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
 
         // if the user was assigned the "fedoraAdmin" container role, they get the
         // "fedoraAdmin" application role
-        final ContainerRolesPrincipal containerRole = principals.oneByType(ContainerRolesPrincipal.class);
-        if (containerRole != null && containerRole.equals(adminPrincipal)) {
-            authzInfo.addRole("fedoraAdmin");
+        if (principals.byType(ContainerRolesPrincipal.class).contains(adminPrincipal)) {
+            authzInfo.addRole(FEDORA_ADMIN_ROLE);
+        } else {
+            // otherwise, they are a normal user
+            authzInfo.addRole(FEDORA_USER_ROLE);
+
+            // for non-admins, we must check the ACL for the requested resource
+            // convert the request URI to a JCR node
+            final FedoraResource fedoraResource = getResourceOrParentFromPath(request.getPathInfo());
+
+            if (fedoraResource != null) {
+                final Node node = ((FedoraResourceImpl) fedoraResource).getNode();
+
+                // check ACL for the request URI and get a mapping of agent => modes
+                final Map<String, Collection<String>> roles = rolesProvider.getRoles(node, true);
+
+                for (Object o : principals.asList()) {
+                    log.debug("User has principal with name: {}", ((Principal) o).getName());
+                }
+                final Principal userPrincipal = principals.oneByType(BasicUserPrincipal.class);
+                if (userPrincipal != null) {
+                    log.debug("Basic user principal username: {}", userPrincipal.getName());
+                    final Collection<String> modesForUser = roles.get(userPrincipal.getName());
+                    if (modesForUser != null) {
+                        // add WebACPermission instance for each mode in the Authorization
+                        final URI fullRequestURI = URI.create(request.getRequestURL().toString());
+                        for (String mode : modesForUser) {
+                            final WebACPermission perm = new WebACPermission(URI.create(mode), fullRequestURI);
+                            authzInfo.addObjectPermission(perm);
+                            log.debug("Added permission {}", perm);
+                        }
+                    }
+                } else {
+                    log.debug("No basic user principal found");
+                }
+            }
         }
 
         return authzInfo;
@@ -72,4 +166,25 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
     public boolean supports(final AuthenticationToken token) {
         return false;
     }
+
+    private FedoraResource getResourceOrParentFromPath(final String path) {
+        FedoraResource resource = null;
+        log.debug("Attempting to get FedoraResource for {}", path);
+        try {
+            resource = translator().convert(translator().toDomain(path));
+            log.debug("Got FedoraResource for {}", path);
+        } catch (RepositoryRuntimeException e) {
+            if (e.getCause() instanceof PathNotFoundException) {
+                log.debug("Path {} does not exist", path);
+                // go up the path looking for a node that exists
+                if (path.length() > 1) {
+                    final int lastSlash = path.lastIndexOf("/");
+                    final int end = lastSlash > 0 ? lastSlash : lastSlash + 1;
+                    resource = getResourceOrParentFromPath(path.substring(0, end));
+                }
+            }
+        }
+        return resource;
+    }
+
 }

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -86,9 +86,9 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
         return session;
     }
 
-    protected IdentifierConverter<Resource, FedoraResource> idTranslator;
+    private IdentifierConverter<Resource, FedoraResource> idTranslator;
 
-    protected IdentifierConverter<Resource, FedoraResource> translator() {
+    private IdentifierConverter<Resource, FedoraResource> translator() {
         if (idTranslator == null) {
             idTranslator = new HttpResourceConverter(session(), UriBuilder.fromResource(FedoraLdp.class));
         }
@@ -100,7 +100,7 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
      * Useful for constructing URLs
      */
     @Context
-    protected UriInfo uriInfo;
+    private UriInfo uriInfo;
 
 
     @Override

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -56,6 +56,7 @@ public class WebACFilter implements Filter {
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
             throws IOException, ServletException {
         final Subject currentUser = SecurityUtils.getSubject();
+        final HttpServletRequest httpRequest = (HttpServletRequest) request;
 
         if (currentUser.isAuthenticated()) {
             log.debug("User is authenticated");
@@ -64,7 +65,6 @@ public class WebACFilter implements Filter {
             } else if (currentUser.hasRole(FEDORA_USER_ROLE)) {
                 log.debug("User has fedoraUser role");
                 // non-admins are subject to permission checks
-                final HttpServletRequest httpRequest = (HttpServletRequest) request;
                 if (!isAuthorized(currentUser, httpRequest)) {
                     // if the user is not authorized, set response to forbidden
                     ((HttpServletResponse) response).sendError(SC_FORBIDDEN);
@@ -76,6 +76,11 @@ public class WebACFilter implements Filter {
             }
         } else {
             log.debug("User is NOT authenticated");
+            // anonymous users are subject to permission checks
+            if (!isAuthorized(currentUser, httpRequest)) {
+                // if anonymous user is not authorized, set response to forbidden
+                ((HttpServletResponse) response).sendError(SC_FORBIDDEN);
+            }
         }
 
         // proceed to the next filter
@@ -89,6 +94,7 @@ public class WebACFilter implements Filter {
 
     private boolean isAuthorized(final Subject currentUser, final HttpServletRequest httpRequest) {
         final URI requestURI = URI.create(httpRequest.getRequestURL().toString());
+        log.debug("Request URI is {}", requestURI);
         switch (httpRequest.getMethod()) {
         case "GET":
             return currentUser.isPermitted(new WebACPermission(WEBAC_MODE_READ, requestURI));

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACPermission.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACPermission.java
@@ -82,4 +82,9 @@ public class WebACPermission implements Permission {
         return resource;
     }
 
+    @Override
+    public String toString() {
+        return "[" + mode.toString() + " " + resource.toString() + "]";
+    }
+
 }

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -44,7 +44,7 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.nodeConverter;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
-import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isNonRdfSourceDescription;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isFedoraBinary;
 import static org.fcrepo.kernel.modeshape.utils.FedoraSessionUserUtil.USER_AGENT_BASE_URI_PROPERTY;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -83,8 +83,8 @@ import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.modeshape.FedoraBinaryImpl;
 import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 import org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter;
 import org.fcrepo.kernel.modeshape.rdf.impl.DefaultIdentifierTranslator;
@@ -196,8 +196,8 @@ public class WebACRolesProvider implements AccessRolesProvider {
 
         // Get the effective ACL by searching the target node and any ancestors.
         final Optional<ACLHandle> effectiveAcl = getEffectiveAcl(
-                isNonRdfSourceDescription.test(getJcrNode(resource)) ?
-                    ((NonRdfSourceDescription)nodeConverter.convert(getJcrNode(resource))).getDescribedResource() :
+                isFedoraBinary.test(getJcrNode(resource)) ? ((FedoraBinaryImpl) nodeConverter.convert(
+                        getJcrNode(resource))).getDescription() :
                     resource);
 
         // Construct a list of acceptable acl:accessTo values for the target resource.

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
@@ -88,6 +88,12 @@ public class WebACFilterTest {
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
         filterChain = new MockFilterChain();
+
+        // set default request URI and path info
+        // for the purposes of this test, there is no context path
+        // so the request URI and path info are the same
+        request.setPathInfo(testPath);
+        request.setRequestURI(testPath);
     }
 
     private void setupAdminUser() {
@@ -127,7 +133,6 @@ public class WebACFilterTest {
     public void testAdminUserGet() throws ServletException, IOException {
         setupAdminUser();
         // GET => 200
-        request.setRequestURI(testPath);
         request.setMethod("GET");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -137,7 +142,6 @@ public class WebACFilterTest {
     public void testAdminUserPost() throws ServletException, IOException {
         setupAdminUser();
         // GET => 200
-        request.setRequestURI(testPath);
         request.setMethod("POST");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -147,7 +151,6 @@ public class WebACFilterTest {
     public void testAdminUserPut() throws ServletException, IOException {
         setupAdminUser();
         // GET => 200
-        request.setRequestURI(testPath);
         request.setMethod("PUT");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -157,7 +160,6 @@ public class WebACFilterTest {
     public void testAdminUserPatch() throws ServletException, IOException {
         setupAdminUser();
         // GET => 200
-        request.setRequestURI(testPath);
         request.setMethod("PATCH");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -167,7 +169,6 @@ public class WebACFilterTest {
     public void testAdminUserDelete() throws ServletException, IOException {
         setupAdminUser();
         // GET => 200
-        request.setRequestURI(testPath);
         request.setMethod("DELETE");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -177,7 +178,6 @@ public class WebACFilterTest {
     public void testAuthUserNoPermsGet() throws ServletException, IOException {
         setupAuthUserNoPerms();
         // GET => 403
-        request.setRequestURI(testPath);
         request.setMethod("GET");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -187,7 +187,6 @@ public class WebACFilterTest {
     public void testAuthUserNoPermsPost() throws ServletException, IOException {
         setupAuthUserNoPerms();
         // POST => 403
-        request.setRequestURI(testPath);
         request.setMethod("POST");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -197,7 +196,6 @@ public class WebACFilterTest {
     public void testAuthUserNoPermsPut() throws ServletException, IOException {
         setupAuthUserNoPerms();
         // PUT => 403
-        request.setRequestURI(testPath);
         request.setMethod("PUT");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -207,7 +205,6 @@ public class WebACFilterTest {
     public void testAuthUserNoPermsPatch() throws ServletException, IOException {
         setupAuthUserNoPerms();
         // PATCH => 403
-        request.setRequestURI(testPath);
         request.setMethod("PATCH");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -217,7 +214,6 @@ public class WebACFilterTest {
     public void testAuthUserNoPermsDelete() throws ServletException, IOException {
         setupAuthUserNoPerms();
         // DELETE => 403
-        request.setRequestURI(testPath);
         request.setMethod("DELETE");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -227,7 +223,6 @@ public class WebACFilterTest {
     public void testAuthUserReadOnlyGet() throws ServletException, IOException {
         setupAuthUserReadOnly();
         // GET => 200
-        request.setRequestURI(testPath);
         request.setMethod("GET");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -237,7 +232,6 @@ public class WebACFilterTest {
     public void testAuthUserReadOnlyPost() throws ServletException, IOException {
         setupAuthUserReadOnly();
         // POST => 403
-        request.setRequestURI(testPath);
         request.setMethod("POST");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -247,7 +241,6 @@ public class WebACFilterTest {
     public void testAuthUserReadOnlyPut() throws ServletException, IOException {
         setupAuthUserReadOnly();
         // PUT => 403
-        request.setRequestURI(testPath);
         request.setMethod("PUT");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -257,7 +250,6 @@ public class WebACFilterTest {
     public void testAuthUserReadOnlyPatch() throws ServletException, IOException {
         setupAuthUserReadOnly();
         // PATCH => 403
-        request.setRequestURI(testPath);
         request.setMethod("PATCH");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -267,7 +259,6 @@ public class WebACFilterTest {
     public void testAuthUserReadOnlyDelete() throws ServletException, IOException {
         setupAuthUserReadOnly();
         // DELETE => 403
-        request.setRequestURI(testPath);
         request.setMethod("DELETE");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
@@ -277,7 +268,6 @@ public class WebACFilterTest {
     public void testAuthUserReadWriteGet() throws ServletException, IOException {
         setupAuthUserReadWrite();
         // GET => 200
-        request.setRequestURI(testPath);
         request.setMethod("GET");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -287,7 +277,6 @@ public class WebACFilterTest {
     public void testAuthUserReadWritePost() throws ServletException, IOException {
         setupAuthUserReadWrite();
         // POST => 200
-        request.setRequestURI(testPath);
         request.setMethod("POST");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -297,7 +286,6 @@ public class WebACFilterTest {
     public void testAuthUserReadWritePut() throws ServletException, IOException {
         setupAuthUserReadWrite();
         // PUT => 200
-        request.setRequestURI(testPath);
         request.setMethod("PUT");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -307,7 +295,6 @@ public class WebACFilterTest {
     public void testAuthUserReadWritePatch() throws ServletException, IOException {
         setupAuthUserReadWrite();
         // PATCH => 200
-        request.setRequestURI(testPath);
         request.setMethod("PATCH");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
@@ -317,7 +304,6 @@ public class WebACFilterTest {
     public void testAuthUserReadWriteDelete() throws ServletException, IOException {
         setupAuthUserReadWrite();
         // DELETE => 200
-        request.setRequestURI(testPath);
         request.setMethod("DELETE");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -193,7 +193,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config")
+    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void scenario2() throws IOException {
         final String id = "/rest/box/bag/collection";
         final String testObj = ingestObj(id);
@@ -227,7 +227,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config")
+    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void scenario3() throws IOException {
         final String idDark = "/rest/dark/archive";
         final String idLight = "/rest/dark/archive/sunshine";
@@ -259,7 +259,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config")
+    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void scenario4() throws IOException {
         final String id = "/rest/public_collection";
         final String testObj = ingestObj(id);
@@ -339,7 +339,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config")
+    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void scenario5() throws IOException {
         final String idPublic = "/rest/mixedCollection/publicObj";
         final String idPrivate = "/rest/mixedCollection/privateObj";

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -160,7 +160,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
     public void scenario1() throws IOException {
         final String testObj = ingestObj("/rest/webacl_box1");
         final String acl1 = ingestAcl("fedoraAdmin", "/acls/01/acl.ttl", "/acls/01/authorization.ttl");
@@ -194,7 +193,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
+    @Ignore("needs principal providers config")
     public void scenario2() throws IOException {
         final String id = "/rest/box/bag/collection";
         final String testObj = ingestObj(id);
@@ -228,7 +227,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
+    @Ignore("needs principal providers config")
     public void scenario3() throws IOException {
         final String idDark = "/rest/dark/archive";
         final String idLight = "/rest/dark/archive/sunshine";
@@ -260,7 +259,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
+    @Ignore("needs principal providers config")
     public void scenario4() throws IOException {
         final String id = "/rest/public_collection";
         final String testObj = ingestObj(id);
@@ -340,7 +339,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
+    @Ignore("needs principal providers config")
     public void scenario5() throws IOException {
         final String idPublic = "/rest/mixedCollection/publicObj";
         final String idPrivate = "/rest/mixedCollection/privateObj";
@@ -380,7 +379,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
     public void scenario9() throws IOException {
         final String idPublic = "/rest/anotherCollection/publicObj";
         final String groups = "/rest/group";
@@ -418,7 +416,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
     public void testAccessToRoot() throws IOException {
         final String id = "/rest/" + getRandomUniqueId();
         final String testObj = ingestObj(id);
@@ -465,7 +462,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
+    @Ignore("FAILING")
     public void testAccessToBinary() throws IOException {
         // Block access to "book"
         final String idBook = "/rest/book";

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -462,7 +462,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("FAILING")
     public void testAccessToBinary() throws IOException {
         // Block access to "book"
         final String idBook = "/rest/book";

--- a/fcrepo-auth-webac/src/test/resources/repository-test.json
+++ b/fcrepo-auth-webac/src/test/resources/repository-test.json
@@ -19,11 +19,9 @@
   "security" : {
     "anonymous" : {
       "roles" : ["readonly","readwrite","admin"],
-      "useOnFailedLogin" : false
+      "useOnFailedLogin" : true
     },
-    "providers" : [
-        { "classname" : "org.fcrepo.auth.common.ServletContainerAuthenticationProvider" }
-    ]
+    "providers" : []
   },
   "node-types" : ["fedora-node-types.cnd"]
 }

--- a/fcrepo-auth-webac/src/test/resources/spring-test/repo.xml
+++ b/fcrepo-auth-webac/src/test/resources/spring-test/repo.xml
@@ -10,30 +10,9 @@
   <!-- Context that supports the actual ModeShape JCR itself -->
   <context:annotation-config />
 
-  <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
-    depends-on="authenticationProvider">
+  <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean">
     <property name="repositoryConfiguration" value="${fcrepo.modeshape.configuration:repository-test.json}" />
   </bean>
-
-  <!-- Optional PrincipalProvider that will inspect the request header, "some-header", for user role values -->
-  <bean name="headerProvider" class="org.fcrepo.auth.common.HttpHeaderPrincipalProvider">
-    <property name="headerName" value="some-header"/>
-    <property name="separator" value=","/>
-  </bean>
-
-  <bean name="delegatedPrincipalProvider" class="org.fcrepo.auth.common.DelegateHeaderPrincipalProvider"/>
-
-  <util:set id="principalProviderSet">
-    <ref bean="headerProvider"/>
-    <ref bean="delegatedPrincipalProvider"/>
-  </util:set>
-
-  <bean name="authenticationProvider" class="org.fcrepo.auth.common.ServletContainerAuthenticationProvider">
-    <property name="fad" ref="fad"/>
-    <property name="principalProviders" ref="principalProviderSet"/>
-  </bean>
-
-  <bean name="fad" class="org.fcrepo.auth.webac.WebACAuthorizationDelegate"/>
 
   <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
 

--- a/fcrepo-auth-webac/src/test/resources/web.xml
+++ b/fcrepo-auth-webac/src/test/resources/web.xml
@@ -24,6 +24,10 @@
     <listener>
         <listener-class>org.apache.shiro.web.env.EnvironmentLoaderListener</listener-class>
     </listener>
+    
+    <listener>
+      <listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
+    </listener>
 
   <servlet>
     <servlet-name>jersey-servlet</servlet-name>

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestAuthenticationRequestFilter.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestAuthenticationRequestFilter.java
@@ -65,7 +65,9 @@ public class TestAuthenticationRequestFilter implements Filter {
         final String username = getUsername(req);
         // Validate the extracted credentials
         Set<String> containerRoles = emptySet();
-        if (FEDORA_ADMIN_USER.equals(username)) {
+        if (username == null) {
+            log.debug("ANONYMOUS");
+        } else if (FEDORA_ADMIN_USER.equals(username)) {
             containerRoles = singleton("fedoraAdmin");
             log.debug("ADMIN AUTHENTICATED");
         } else {
@@ -84,7 +86,7 @@ public class TestAuthenticationRequestFilter implements Filter {
      */
     private static ServletRequest proxy(final HttpServletRequest request,
             final String username, final Set<String> containerRoles) {
-        final Principal user = new GrizzlyPrincipal(username);
+        final Principal user = username != null ? new GrizzlyPrincipal(username) : null;
         final HttpServletRequest result =
                 (HttpServletRequest) newProxyInstance(request.getClass()
                         .getClassLoader(),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2760

# What does this Pull Request do?
Use WebACRolesProvider to check ACLs in WebACAuthorizationRealm

# What's new?
Inject the servlet request into the WebACAuthorizationRealm so that it can find the node (or its parent, if the node doesn't exist yet) corresponding to the request URI. Once it has obtained that node, calls the WebACRolesProvider to get a list of user => mode mappings for the resource. These are translated into WebACPermission objects and added to the authorization info.

Additional fixes and cleanup:
* Removed the FAD and authN provider configuration from the repo.xml Spring configuration. The only remaining WebAC bean in repo.xml is the WebACRolesProvider, since it expects and injected NodeService.
* Fixed up the TestAuthenticationRequestFilter to properly return null for getUserPrincipal() when the request was anonymous.
* Fixed up the ServletContainerAuthenticatingRealm to use the correct constructor for the SimpleAuthenticationInfo class.
* Ensure anonymous users are not authenticated in Shiro by calling currentUser.logout() when an anonymous request is detected.
* Run permission check on anonymous users.
* Un-ignored integration tests in WebACRecipesIT that are now passing.

# How should this be tested?
There are several integration tests in the WebACRecipesIT that are now passing due to this implementation. Run `mvn clean verify` to test.

# Additional Notes:
The tests that are still failing in the WebACRecipesIT suite are ones that rely on the HTTP header principal provider, which has not been wired up to the Shiro stack yet.

# Interested parties
@whikloj, @awoods, @fcrepo4/committers
