### PR TITLE
Fcrepo 2708/2709 - Binary and Description Mementos

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -425,7 +425,7 @@ public class WebACRolesProvider implements AccessRolesProvider {
         try {
             final IdentifierConverter<Resource, FedoraResource> translator =
                 new DefaultIdentifierTranslator(getJcrNode(resource).getSession());
-            final List<String> acls = resource.getTriples(translator, PROPERTIES)
+            final List<String> acls = resource.getOriginalResource().getTriples(translator, PROPERTIES)
                     .filter(triple -> triple.getPredicate().equals(createURI(WEBAC_ACCESS_CONTROL_VALUE)))
                     .map(triple -> {
                         if (triple.getObject().isURI()) {

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -118,6 +118,7 @@ public class WebACRolesProviderTest {
         when(mockSession.getJcrSession()).thenReturn(mockJcrSession);
 
         when(mockResource.getNode()).thenReturn(mockNode);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockNode.getDepth()).thenReturn(0);
     }
 
@@ -129,11 +130,13 @@ public class WebACRolesProviderTest {
         when(mockResource.getContainer()).thenReturn(mockParentResource);
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(new DefaultRdfStream(createURI("subject")));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockNode.getDepth()).thenReturn(1);
 
         when(mockParentResource.getNode()).thenReturn(mockParentNode);
         when(mockParentResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(new DefaultRdfStream(createURI("subject")));
+        when(mockParentResource.getOriginalResource()).thenReturn(mockParentResource);
         when(mockParentNode.getDepth()).thenReturn(0);
 
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
@@ -153,12 +156,14 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn(accessTo + "/foo");
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(new DefaultRdfStream(createURI("subject")));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockNode.getDepth()).thenReturn(1);
 
         when(mockParentResource.getNode()).thenReturn(mockParentNode);
         when(mockParentResource.getPath()).thenReturn(accessTo);
         when(mockParentResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockParentResource.getOriginalResource()).thenReturn(mockParentResource);
         when(mockParentNode.getDepth()).thenReturn(0);
 
         when(mockProperty.getString()).thenReturn(acl);
@@ -193,6 +198,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn(accessTo);
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth);
@@ -221,6 +227,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn(accessTo);
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth);
@@ -247,6 +254,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn(accessTo);
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth);
@@ -277,6 +285,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn(accessTo);
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
@@ -311,6 +320,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn(accessTo);
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
@@ -346,6 +356,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn(accessTo);
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
@@ -421,6 +432,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getTypes()).thenReturn(Arrays.asList(URI.create("http://example.com/terms#publicImage")));
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
@@ -465,6 +477,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getTypes()).thenReturn(new ArrayList<>());
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth);
@@ -510,6 +523,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getTypes()).thenReturn(new ArrayList<>());
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth);
@@ -542,6 +556,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn(accessTo);
         when(mockResource.getTriples(anyObject(), eq(PROPERTIES)))
                 .thenReturn(getResourceRdfStream(accessTo, acl));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         when(mockAuthorizationResource1.getTypes()).thenReturn(Arrays.asList(WEBAC_AUTHORIZATION));
         when(mockAuthorizationResource1.getPath()).thenReturn(auth1);
@@ -571,6 +586,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn("/");
         when(mockResource.getTypes()).thenReturn(
                 Arrays.asList(URI.create(REPOSITORY_NAMESPACE + "Resource")));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent", 1, roles.size());
@@ -588,6 +604,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn("/");
         when(mockResource.getTypes()).thenReturn(
                 Arrays.asList(URI.create(REPOSITORY_NAMESPACE + "Resource")));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         System.setProperty(ROOT_AUTHORIZATION_PROPERTY, "./target/test-classes/logback-test.xml");
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -498,7 +498,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             servletResponse.addHeader(LINK, link.toString());
         } else if (resource instanceof FedoraBinary) {
             // Link to the original description
-            final FedoraResource description = resource.getOriginalResource().getDescribedResource();
+            final FedoraResource description = resource.getOriginalResource().getDescription();
             final URI uri = getUri(description);
             final Link.Builder builder = Link.fromUri(uri).rel("describedby");
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -204,7 +204,7 @@ public class FedoraVersioning extends ContentExposingResource {
                 }
                 // Create rdf memento if the request resource was an rdf resource or a binary from the
                 // current version of the original resource.
-                if (!isBinary || (isBinary && createFromExisting)) {
+                if (!isBinary || createFromExisting) {
                     // Version the description in case the original is a binary
                     final FedoraResource originalResource = resource().getDescription();
                     final InputStream bodyStream = createFromExisting ? null : requestBodyStream;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -144,7 +144,6 @@ public class FedoraVersioning extends ContentExposingResource {
      *
      * @param datetimeHeader memento-datetime header
      * @param requestContentType Content-Type of the request body
-     * @param contentDisposition Content-Disposition
      * @param digest digests of the request body
      * @param requestBodyStream request body stream
      * @return response
@@ -186,11 +185,6 @@ public class FedoraVersioning extends ContentExposingResource {
             }
 
             final boolean createFromExisting = isBlank(datetimeHeader);
-
-            if (requestContentType == null && !createFromExisting) {
-                throw new ClientErrorException("Content Type is required for creating a binary memento",
-                        UNSUPPORTED_MEDIA_TYPE);
-            }
 
             try {
                 LOGGER.info("Request to add version for date '{}' for '{}'", datetimeHeader, externalPath);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/url/HttpApiResources.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/url/HttpApiResources.java
@@ -30,6 +30,7 @@ import org.fcrepo.http.api.repository.FedoraRepositoryTransactions;
 import org.fcrepo.http.commons.api.rdf.UriAwareResourceModelFactory;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 
 import org.springframework.stereotype.Component;
@@ -56,7 +57,7 @@ public class HttpApiResources implements UriAwareResourceModelFactory {
             addRepositoryStatements(uriInfo, model, s);
         }
 
-        if (resource.getDescribedResource() instanceof FedoraBinary) {
+        if (resource instanceof NonRdfSourceDescription && !resource.isMemento()) {
             addContentStatements(idTranslator, (FedoraBinary)resource.getDescribedResource(), model);
         }
         return model;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -253,11 +253,13 @@ public class FedoraLdpTest {
         when(mockNonRdfSourceDescription.getEtagValue()).thenReturn("");
         when(mockNonRdfSourceDescription.getPath()).thenReturn(binaryDescriptionPath);
         when(mockNonRdfSourceDescription.getDescribedResource()).thenReturn(mockBinary);
+        when(mockNonRdfSourceDescription.getOriginalResource()).thenReturn(mockNonRdfSourceDescription);
 
         when(mockBinary.getEtagValue()).thenReturn("");
         when(mockBinary.getPath()).thenReturn(binaryPath);
         when(mockBinary.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockBinary.getDescribedResource()).thenReturn(mockBinary);
+        when(mockBinary.getOriginalResource()).thenReturn(mockBinary);
 
         when(mockHeaders.getHeaderString("user-agent")).thenReturn("Test UserAgent");
 
@@ -387,6 +389,7 @@ public class FedoraLdpTest {
     public void testHeadWithBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockResource.getMimeType()).thenReturn("image/jpeg");
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -438,6 +441,7 @@ public class FedoraLdpTest {
     public void testHeadWithExternalBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockResource.getMimeType()).thenReturn("message/external-body; access-type=URL; URL=\"some:uri\"");
         final Response actual = testObj.head();
         assertEquals(TEMPORARY_REDIRECT.getStatusCode(), actual.getStatus());
@@ -451,6 +455,7 @@ public class FedoraLdpTest {
         final NonRdfSourceDescription mockResource
                 = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP RDFSource", mockResponse.getHeaders(LINK).contains("<" + LDP_NAMESPACE +
@@ -494,6 +499,7 @@ public class FedoraLdpTest {
     public void testOptionWithBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Response actual = testObj.options();
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldNotAdvertiseAcceptPostFlavors();
@@ -507,6 +513,7 @@ public class FedoraLdpTest {
         final NonRdfSourceDescription mockResource
                 = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Response actual = testObj.options();
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldNotAdvertiseAcceptPostFlavors();
@@ -738,6 +745,7 @@ public class FedoraLdpTest {
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getMimeType()).thenReturn("text/plain");
         when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPNonRDFSource();
@@ -756,6 +764,7 @@ public class FedoraLdpTest {
     public void testGetWithExternalMessageBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockResource.getMimeType()).thenReturn("message/external-body; access-type=URL; URL=\"some:uri\"");
         when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
         final Response actual = testObj.getResource(null);
@@ -772,6 +781,7 @@ public class FedoraLdpTest {
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getMimeType()).thenReturn("message/external-body; access-type=URL;");
         when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Response actual = testObj.getResource(null);
         assertEquals(UNSUPPORTED_MEDIA_TYPE.getStatusCode(), actual.getStatus());
     }
@@ -784,6 +794,7 @@ public class FedoraLdpTest {
         final NonRdfSourceDescription mockResource
                 = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockBinary.getTriples(eq(idTranslator), any(TripleCategory.class)))
             .thenReturn(new DefaultRdfStream(createURI("mockBinary")));
         when(mockBinary.getTriples(eq(idTranslator), any(EnumSet.class)))

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/url/HttpApiResourcesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/url/HttpApiResourcesTest.java
@@ -31,6 +31,7 @@ import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
 import org.fcrepo.http.commons.session.HttpSession;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -65,6 +66,9 @@ public class HttpApiResourcesTest {
     @Mock
     private FedoraBinary mockBinary;
 
+    @Mock
+    private NonRdfSourceDescription mockDescription;
+
     @Before
     public void setUp() {
         testObj = new HttpApiResources();
@@ -96,13 +100,15 @@ public class HttpApiResourcesTest {
     }
 
     @Test
-    public void shouldDecorateDatastreamsWithLinksToFixityChecks() {
+    public void shouldDecorateDescriptionWithLinksToFixityChecks() {
+        when(mockDescription.getDescribedResource()).thenReturn(mockBinary);
+        when(mockDescription.getPath()).thenReturn("/some/path/to/datastream/fedora:description");
         when(mockBinary.getPath()).thenReturn("/some/path/to/datastream");
         when(mockBinary.getDescribedResource()).thenReturn(mockBinary);
         final Resource graphSubject = mockSubjects.reverse().convert(mockBinary);
 
         final Model model =
-            testObj.createModelForResource(mockBinary, uriInfo, mockSubjects);
+            testObj.createModelForResource(mockDescription, uriInfo, mockSubjects);
 
         assertTrue(model.contains(graphSubject, HAS_FIXITY_SERVICE));
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -426,6 +426,20 @@ public abstract class AbstractResourceIT {
         return dcResp;
     }
 
+    protected CloseableHttpResponse setDescriptionProperty(final String id, final String txId,
+            final String propertyUri, final String value) throws IOException {
+        final HttpPatch postProp = new HttpPatch(serverAddress + (txId != null ? txId + "/" : "") + id +
+                "/fcr:metadata");
+        postProp.setHeader(CONTENT_TYPE, "application/sparql-update");
+        final String updateString =
+                "INSERT { <" + serverAddress + id + "> <" + propertyUri + "> \"" + value + "\" } WHERE { }";
+        postProp.setEntity(new StringEntity(updateString));
+        final CloseableHttpResponse dcResp = execute(postProp);
+        assertEquals(dcResp.getStatusLine().toString(), NO_CONTENT.getStatusCode(), getStatus(dcResp));
+        postProp.releaseConnection();
+        return dcResp;
+    }
+
     /**
      * Creates a transaction, asserts that it's successful and returns the transaction location.
      *

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -173,11 +173,11 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testGetTimeMapResponseMultipleMementos() throws Exception {
         createVersionedContainer(id);
         final String memento1 =
-                RFC_1123_DATE_TIME.format(LocalDateTime.of(2000, 1, 1, 00, 00, 00).atOffset(ZoneOffset.UTC));
+            RFC_1123_DATE_TIME.format(LocalDateTime.of(2000, 1, 1, 00, 00, 00).atOffset(ZoneOffset.UTC));
         final String memento2 =
-                RFC_1123_DATE_TIME.format(LocalDateTime.of(2015, 8, 13, 18, 30, 0).atOffset(ZoneOffset.UTC));
+            RFC_1123_DATE_TIME.format(LocalDateTime.of(2015, 8, 13, 18, 30, 0).atOffset(ZoneOffset.UTC));
         final String memento3 =
-                RFC_1123_DATE_TIME.format(LocalDateTime.of(1980, 5, 31, 9, 15, 30).atOffset(ZoneOffset.UTC));
+            RFC_1123_DATE_TIME.format(LocalDateTime.of(1980, 5, 31, 9, 15, 30).atOffset(ZoneOffset.UTC));
         createContainerMementoWithBody(subjectUri, memento1);
         createContainerMementoWithBody(subjectUri, memento2);
         createContainerMementoWithBody(subjectUri, memento3);
@@ -569,7 +569,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     private void verifyTimemapResponse(final String uri, final String id, final String mementoDateTime)
-            throws Exception {
+        throws Exception {
         final String[] mementoDateTimes = { mementoDateTime };
         verifyTimemapResponse(uri, id, mementoDateTimes, null, null);
     }
@@ -585,33 +585,32 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * @throws Exception
      */
     private void verifyTimemapResponse(final String uri, final String id, final String[] mementoDateTime,
-            final String rangeStart, final String rangeEnd)
-            throws Exception {
+        final String rangeStart, final String rangeEnd)
+        throws Exception {
         final String ldpcvUri = uri + "/" + FCR_VERSIONS;
         final List<Link> listLinks = new ArrayList<>();
         listLinks.add(Link.fromUri(uri).rel("original").build());
         listLinks.add(Link.fromUri(uri).rel("timegate").build());
 
-        final javax.ws.rs.core.Link.Builder selfLink = Link.fromUri(ldpcvUri).rel("self").type(
-                APPLICATION_LINK_FORMAT);
+        final javax.ws.rs.core.Link.Builder selfLink = Link.fromUri(ldpcvUri).rel("self").type(APPLICATION_LINK_FORMAT);
         if (rangeStart != null && rangeEnd != null) {
             selfLink.param("from", rangeStart).param("until",
-                    rangeEnd);
+                rangeEnd);
         }
         listLinks.add(selfLink.build());
         if (mementoDateTime != null) {
             for (final String memento : mementoDateTime) {
                 final TemporalAccessor instant = RFC_1123_DATE_TIME.parse(memento);
                 listLinks.add(Link.fromUri(ldpcvUri + "/" + MEMENTO_DATETIME_ID_FORMATTER.format(instant))
-                        .rel("memento")
-                        .param("datetime", memento)
-                        .build());
+                              .rel("memento")
+                    .param("datetime", memento)
+                              .build());
             }
         }
 
         final Link[] expectedLinks = listLinks.stream()
-                .sorted((a, b) -> a.toString().compareTo(b.toString()))
-                .toArray(Link[]::new);
+                                              .sorted((a,b) ->a.toString().compareTo(b.toString()))
+                                              .toArray(Link[]::new);
 
         final HttpGet httpGet = getObjMethod(id + "/" + FCR_VERSIONS);
         httpGet.setHeader("Accept", APPLICATION_LINK_FORMAT);
@@ -626,11 +625,11 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             checkForLinkHeader(response, VERSIONING_TIMEMAP_TYPE, "type");
             checkForLinkHeader(response, ldpcvUri + "/" + FCR_ACL, "acl");
             final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(",\n"));
-            // the links from the body are not
+            //the links from the body are not
 
             final Link[] bodyLinks = bodyList.stream().map(String::trim).filter(t -> !t.isEmpty())
-                    .sorted((a, b) -> a.toString().compareTo(b.toString()))
-                    .map(Link::valueOf).toArray(Link[]::new);
+                                                      .sorted((a,b) ->a.toString().compareTo(b.toString()))
+                                                      .map(Link::valueOf).toArray(Link[]::new);
             assertArrayEquals(expectedLinks, bodyLinks);
         }
     }
@@ -734,8 +733,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                     results.contains(ANY, mementoSubject, DC.title.asNode(), ANY));
             assertFalse("Memento type should not be visible",
                     results.contains(ANY, mementoSubject, RDF.type.asNode(), MEMENTO_TYPE_NODE));
-            assertFalse("Property added to original must not appear in memento",
-                    results.contains(ANY, mementoSubject, DC.title.asNode(), ANY));
+            assertTrue("Must have binary type",
+                    results.contains(ANY, mementoSubject, RDF.type.asNode(), FEDORA_BINARY.asNode()));
         }
 
         // No binary memento should be created when specifically creating a description memento.
@@ -779,10 +778,12 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
             final DatasetGraph results = dataset.asDatasetGraph();
 
-            final Node mementoSubject = createURI(mementoUri);
+            final Node mementoSubject = createURI(subjectUri);
 
             assertFalse("Memento type should not be visible",
                     results.contains(ANY, mementoSubject, RDF.type.asNode(), MEMENTO_TYPE_NODE));
+            assertTrue("Memento must have first updated property",
+                    results.contains(ANY, mementoSubject, TEST_PROPERTY_NODE, createLiteral("bar")));
         }
     }
 
@@ -991,14 +992,14 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         createVersionedContainer(id);
         final String memento1 =
-                FMT.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
+            FMT.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
         final String memento2 =
-                FMT.format(ISO_INSTANT.parse("2016-06-17T11:41:00Z", Instant::from));
+            FMT.format(ISO_INSTANT.parse("2016-06-17T11:41:00Z", Instant::from));
         final String version2Uri = createLDPRSMementoWithExistingBody(memento2);
 
         final String request1Datetime =
-                FMT.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
+            FMT.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
         final HttpGet getMemento = getObjMethod(id);
         getMemento.addHeader(ACCEPT_DATETIME, request1Datetime);
 
@@ -1010,7 +1011,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
 
         final String request2Datetime =
-                FMT.format(ISO_INSTANT.parse("2018-01-10T00:00:00Z", Instant::from));
+            FMT.format(ISO_INSTANT.parse("2018-01-10T00:00:00Z", Instant::from));
         final HttpGet getMemento2 = getObjMethod(id);
         getMemento2.addHeader(ACCEPT_DATETIME, request2Datetime);
 
@@ -1029,7 +1030,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         createVersionedContainer(id);
         final String requestDatetime =
-                FMT.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
+            FMT.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
         final HttpGet getMemento = getObjMethod(id);
         getMemento.addHeader(ACCEPT_DATETIME, requestDatetime);
 
@@ -1112,7 +1113,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
 
         final String memento1 =
-                FMT.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
+            FMT.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
         final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
         final HttpGet getRequest = new HttpGet(version1Uri);
 
@@ -1135,7 +1136,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedBinary(id, "text/plain", "This is some versioned content");
 
         final String memento1 =
-                FMT.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
+            FMT.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
         final String version1Uri = createLDPNRMementoWithExistingBody(memento1);
         final HttpGet getRequest = new HttpGet(version1Uri);
 
@@ -1169,7 +1170,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     private String createMementoWithExistingBody(final String id, final String mementoDateTime, final boolean isLDPNR)
-            throws Exception {
+        throws Exception {
         final HttpGet getRequest = getObjMethod(id);
         if (!isLDPNR) {
             getRequest.setHeader(ACCEPT, NTRIPLES);
@@ -1179,7 +1180,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 // Resource exists so get the body to put back with header
                 final String body = EntityUtils.toString(response.getEntity());
                 final String mimeType =
-                        response.getFirstHeader(CONTENT_TYPE).getValue();
+                    response.getFirstHeader(CONTENT_TYPE).getValue();
                 return createMemento(serverAddress + id, mementoDateTime, mimeType, body);
             }
         }
@@ -1268,7 +1269,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * @throws Exception
      */
     private String createVersionedBinary(final String id, final String mimeType, final String content)
-            throws Exception {
+        throws Exception {
         final HttpPost createMethod = postObjMethod();
         createMethod.addHeader("Slug", id);
         if (mimeType == null && content == null) {
@@ -1299,12 +1300,12 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     private static void assertNoMementoDatetimeHeaderPresent(final CloseableHttpResponse response) {
         assertNull("No memento datetime header set in response",
-                response.getFirstHeader(MEMENTO_DATETIME_HEADER));
+            response.getFirstHeader(MEMENTO_DATETIME_HEADER));
     }
 
     private static void assertMementoDatetimeHeaderPresent(final CloseableHttpResponse response) {
         assertNotNull("No memento datetime header set in response",
-                response.getFirstHeader(MEMENTO_DATETIME_HEADER));
+            response.getFirstHeader(MEMENTO_DATETIME_HEADER));
     }
 
     private static void assertMementoDatetimeHeaderMatches(final CloseableHttpResponse response,

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -33,7 +33,6 @@ import static javax.ws.rs.core.Response.Status.FOUND;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
-import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
@@ -608,19 +607,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(descGet)) {
             assertMementoDatetimeHeaderPresent(response);
             assertHasLink(response, type, RDF_SOURCE.getURI());
-        }
-    }
-
-    @Test
-    public void testCreateVersionOfBinaryWithDatetime() throws Exception {
-        createVersionedBinary(id);
-
-        final HttpPost createVersionMethod = postObjMethod(id + "/" + FCR_VERSIONS);
-        createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, MEMENTO_DATETIME);
-
-        try (final CloseableHttpResponse response = execute(createVersionMethod)) {
-            assertEquals("Must reject memento creation without Content Type",
-                    UNSUPPORTED_MEDIA_TYPE.getStatusCode(), getStatus(response));
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -405,11 +405,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals("Expected delete to succeed",
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
 
-        final String mementoTombstoneUri = mementoUri + "/fcr:tombstone";
-        assertEquals("Expected delete to succeed",
-                NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoTombstoneUri)));
-
-        assertEquals("Delete memento must be removed",
+        assertEquals("Deleted memento must be removed",
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
 
         final String recreatedUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
@@ -419,12 +415,38 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     @Test
     public void testDeleteAndPostBinaryMemento() throws Exception {
+        createVersionedBinary(id);
 
+        final String mementoUri = createLDPNRMementoWithExistingBody(MEMENTO_DATETIME);
+
+        assertEquals("Expected delete to succeed",
+                NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
+
+        assertEquals("Deleted memento must be removed",
+                NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
+
+        final String recreatedUri = createLDPNRMementoWithExistingBody(MEMENTO_DATETIME);
+        assertEquals("Recreated memento must exist",
+                OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
 
     @Test
     public void testDeleteAndPostDescriptionMemento() throws Exception {
+        createVersionedBinary(id);
 
+        final String descId = id + "/" + FCR_METADATA;
+        final String descUri = serverAddress + descId;
+        final String mementoUri = createMementoWithExistingBody(descId, MEMENTO_DATETIME, false);
+
+        assertEquals("Expected delete to succeed",
+                NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
+
+        assertEquals("Deleted memento must be removed",
+                NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
+
+        final String recreatedUri = createContainerMementoWithBody(descUri, MEMENTO_DATETIME);
+        assertEquals("Recreated memento must exist",
+                OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
 
     @Test

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -132,7 +132,7 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
                 final Node node = getNode(path);
 
                 final boolean metadata = values.containsKey("path")
-                        && values.get("path").endsWith("/" + FCR_METADATA);
+                        && values.get("path").contains("/" + FCR_METADATA);
 
                 final FedoraResource fedoraResource = nodeConverter.convert(node);
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -69,7 +69,16 @@ public interface FedoraResource {
     FedoraResource getContainer();
 
     /**
+     * Get the Original Resource for which this resource is a memento. If this resource is not a memento,
+     * then it is the original.
+     *
+     * @return the original resource for this
+     */
+    FedoraResource getOriginalResource();
+
+    /**
      * Get the TimeMap/LDPCv of this resource
+     *
      * @return the container for TimeMap/LDPCv of this resource
      */
     FedoraResource getTimeMap();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/BinaryService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/BinaryService.java
@@ -17,12 +17,32 @@
  */
 package org.fcrepo.kernel.api.services;
 
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.models.FedoraBinary;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 
 /**
  * @author cabeer
  * @since 10/10/14
  */
 public interface BinaryService extends Service<FedoraBinary> {
+
+    /**
+     * Retrieves a FedoraBinary instance by session and path.
+     *
+     * @param session session
+     * @param path path of binary datastream
+     * @return retrieved FedoraBinary
+     */
+    FedoraBinary findOrCreateBinary(FedoraSession session, String path);
+
+    /**
+     * Retrieves a binary description instance by session and path.
+     *
+     * @param session session
+     * @param path path of description
+     * @return retrieved NonRdfSourceDescription
+     */
+    NonRdfSourceDescription findOrCreateDescription(FedoraSession session, String path);
 
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -69,7 +69,8 @@ public interface VersionService {
             Lang rdfFormat);
 
     /**
-     * Explicitly creates a version of a binary resource. If no contentStream is provided, then
+     * Explicitly creates a version of a binary resource. If contentStream is provided, then it will be used as the
+     * content of the binary memento. Otherwise, the current state of the binary will be used.
      *
      * @param session the session in which the resource resides
      * @param resource the binary resource to version
@@ -90,7 +91,7 @@ public interface VersionService {
             throws InvalidChecksumException;
 
     /**
-     * Explicitly creates a version of a binary resource. If no contentStream is provided, then
+     * Explicitly creates a version of a binary resource from the current state of that binary.
      *
      * @param session the session in which the resource resides
      * @param resource the binary resource to version

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -25,8 +25,11 @@ import java.util.Collection;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.Lang;
 import org.fcrepo.kernel.api.FedoraSession;
+import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 
 /**
  * Service for creating versions of resources
@@ -69,17 +72,34 @@ public interface VersionService {
      * Explicitly creates a version of a binary resource. If no contentStream is provided, then
      *
      * @param session the session in which the resource resides
-     * @param resource the resource to version
+     * @param resource the binary resource to version
      * @param dateTime the date/time of the version
      * @param contentStream if provided, the content in this stream will be used as the content of the new binary
      *        memento. If null, then the current state of the binary will be used.
-     * @param filename filename of the binary
-     * @param mimetype mimetype of the binary
      * @param checksums Collection of checksum URIs of the content (optional)
+     * @param storagePolicyDecisionPoint optional storage policy
+     * @throws InvalidChecksumException if there are errors applying checksums
      * @return the version
      */
-    FedoraResource createBinaryVersion(FedoraSession session, FedoraResource resource, Instant dateTime,
-            InputStream contentStream, String filename, String mimetype, Collection<URI> checksums);
+    FedoraBinary createBinaryVersion(FedoraSession session,
+            FedoraBinary resource,
+            Instant dateTime,
+            InputStream contentStream,
+            Collection<URI> checksums,
+            StoragePolicyDecisionPoint storagePolicyDecisionPoint)
+            throws InvalidChecksumException;
 
-
+    /**
+     * Explicitly creates a version of a binary resource. If no contentStream is provided, then
+     *
+     * @param session the session in which the resource resides
+     * @param resource the binary resource to version
+     * @param dateTime the date/time of the version
+     * @param storagePolicyDecisionPoint optional storage policy
+     * @return the version
+     * @throws InvalidChecksumException
+     */
+    FedoraBinary createBinaryVersion(FedoraSession session, FedoraBinary resource, Instant dateTime,
+            StoragePolicyDecisionPoint storagePolicyDecisionPoint)
+            throws InvalidChecksumException;
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
@@ -484,7 +484,7 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
             if (descNode == null) {
                 return false;
             }
-            return getDescriptionNode().hasProperty(relPath);
+            return descNode.hasProperty(relPath);
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
@@ -113,7 +113,8 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
             final Node node = getNode();
             if (isMemento()) {
                 final String mementoName = node.getName();
-                return node.getNode("../../" + FEDORA_DESCRIPTION + "/" + LDPCV_TIME_MAP + "/" + mementoName);
+                return node.getParent().getParent().getNode(FEDORA_DESCRIPTION)
+                        .getNode(LDPCV_TIME_MAP).getNode(mementoName);
             }
             return getNode().getNode(FEDORA_DESCRIPTION);
         } catch (final RepositoryException e) {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
@@ -100,7 +100,7 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
 
     @Override
     public FedoraResource getDescription() {
-        final Node descNode = getDescriptionNode();
+        final Node descNode = getDescriptionNodeOrNull();
         if (descNode == null) {
             return null;
         }
@@ -437,7 +437,9 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
     public void delete() {
         final FedoraResource description = getDescription();
 
-        description.delete();
+        if (description != null) {
+            description.delete();
+        }
 
         super.delete();
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraBinaryImpl.java
@@ -100,14 +100,34 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
 
     @Override
     public FedoraResource getDescription() {
+        final Node descNode = getDescriptionNode();
+        if (descNode == null) {
+            return null;
+        }
         return new NonRdfSourceDescriptionImpl(getDescriptionNode());
     }
 
     @Override
     protected Node getDescriptionNode() {
         try {
+            final Node node = getNode();
+            if (isMemento()) {
+                final String mementoName = node.getName();
+                return node.getNode("../../" + FEDORA_DESCRIPTION + "/" + LDPCV_TIME_MAP + "/" + mementoName);
+            }
             return getNode().getNode(FEDORA_DESCRIPTION);
         } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+    private Node getDescriptionNodeOrNull() {
+        try {
+            return getDescriptionNode();
+        } catch (final RepositoryRuntimeException e) {
+            if (e.getCause() instanceof PathNotFoundException) {
+                return null;
+            }
             throw new RepositoryRuntimeException(e);
         }
     }
@@ -152,16 +172,7 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
             throws InvalidChecksumException {
 
         try {
-            final Node descNode = getDescriptionNode();
             final Node dsNode = getNode();
-
-            if (descNode != null) {
-                descNode.setProperty(HAS_MIME_TYPE, contentType);
-            }
-
-            if (originalFileName != null) {
-                descNode.setProperty(FILENAME, originalFileName);
-            }
 
             LOGGER.debug("Created content node at path: {}", dsNode.getPath());
 
@@ -193,9 +204,20 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
             final Collection<URI> nonNullChecksums = (null == checksums) ? new HashSet<>() : checksums;
             verifyChecksums(nonNullChecksums, dataProperty);
 
+            final Node descNode = getDescriptionNodeOrNull();
+
             decorateContentNode(dsNode, descNode, nonNullChecksums);
             FedoraTypesUtils.touch(dsNode);
-            FedoraTypesUtils.touch(descNode);
+
+            if (descNode != null) {
+                descNode.setProperty(HAS_MIME_TYPE, contentType);
+
+                if (originalFileName != null) {
+                    descNode.setProperty(FILENAME, originalFileName);
+                }
+
+                FedoraTypesUtils.touch(descNode);
+            }
 
             LOGGER.debug("Created data property at path: {}", dataProperty.getPath());
 
@@ -327,10 +349,14 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
                 return getDescriptionProperty(HAS_MIME_TYPE).getString()
                         .replace(FIELD_DELIMITER + XSDstring.getURI(), "");
             }
-            return "application/octet-stream";
+        } catch (final RepositoryRuntimeException e) {
+            if (!(e.getCause() instanceof PathNotFoundException) || !isMemento()) {
+                throw e;
+            }
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }
+        return "application/octet-stream";
     }
 
     /*
@@ -441,8 +467,10 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
             final String[] checksumArray = new String[checksums.size()];
             checksums.stream().map(Object::toString).collect(Collectors.toSet()).toArray(checksumArray);
 
-            descNode.setProperty(CONTENT_DIGEST, checksumArray);
-            descNode.setProperty(CONTENT_SIZE, dataProperty.getLength());
+            if (descNode != null) {
+                descNode.setProperty(CONTENT_DIGEST, checksumArray);
+                descNode.setProperty(CONTENT_SIZE, dataProperty.getLength());
+            }
 
             LOGGER.debug("Decorated data property at path: {}", dataProperty.getPath());
         }
@@ -450,6 +478,10 @@ public class FedoraBinaryImpl extends FedoraResourceImpl implements FedoraBinary
 
     private boolean hasDescriptionProperty(final String relPath) {
         try {
+            final Node descNode = getDescriptionNodeOrNull();
+            if (descNode == null) {
+                return false;
+            }
             return getDescriptionNode().hasProperty(relPath);
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -565,6 +565,9 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     @Override
     public void delete() {
         try {
+            // Precalculate before node is removed
+            final boolean isMemento = isMemento();
+
             // Remove inbound references to this resource and, recursively, any of its children
             removeReferences(node);
 
@@ -581,7 +584,9 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
             node.remove();
 
             if (parent != null) {
-                createTombstone(parent, name);
+                if (!isMemento) {
+                    createTombstone(parent, name);
+                }
 
                 // also update membershipResources for Direct/Indirect Containers
                 containingNode.filter(UncheckedPredicate.uncheck((final Node ancestor) ->

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -177,8 +177,6 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
     public static final String LDPCV_TIME_MAP = "fedora:timemap";
 
-    public static final String LDPCV_BINARY_TIME_MAP = "fedora:binaryTimemap";
-
     public static final String CONTAINER_WEBAC_ACL = "fedora:acl";
 
     // A curried type accepting resource, translator, and "minimality", returning triples.
@@ -413,12 +411,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     @Override
     public FedoraResource getTimeMap() {
         try {
-            final Node timeMapNode;
-            if (this instanceof FedoraBinary) {
-                timeMapNode = getNode().getParent().getNode(LDPCV_BINARY_TIME_MAP);
-            } else {
-                timeMapNode = node.getNode(LDPCV_TIME_MAP);
-            }
+            final Node timeMapNode = node.getNode(LDPCV_TIME_MAP);
             return Optional.of(timeMapNode).map(nodeConverter::convert).orElse(null);
         } catch (final PathNotFoundException e) {
             throw new PathNotFoundRuntimeException(e);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
@@ -77,7 +77,7 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
         try {
             if (isMemento()) {
                 final String mementoName = node.getName();
-                return node.getNode("../../../" + LDPCV_TIME_MAP + "/" + mementoName);
+                return node.getParent().getParent().getParent().getNode(LDPCV_TIME_MAP).getNode(mementoName);
             }
             return node.getParent();
         } catch (final PathNotFoundException e) {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
@@ -73,6 +73,10 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
     private Node getContentNode() {
         LOGGER.trace("Retrieved datastream content node.");
         try {
+            if (isMemento()) {
+                final String mementoName = node.getName();
+                return node.getNode("../../../" + LDPCV_TIME_MAP + "/" + mementoName);
+            }
             return node.getParent();
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
@@ -24,11 +24,13 @@ import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isNonRdfSourceD
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
+import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -78,6 +80,8 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
                 return node.getNode("../../../" + LDPCV_TIME_MAP + "/" + mementoName);
             }
             return node.getParent();
+        } catch (final PathNotFoundException e) {
+            throw new PathNotFoundRuntimeException(e);
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }
@@ -86,7 +90,8 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
     @Override
     public RdfStream getTriples(final IdentifierConverter<Resource, FedoraResource> idTranslator,
                                 final Set<? extends TripleCategory> contexts) {
-        final FedoraResource described = getDescribedResource();
+        final FedoraResource described = getOriginalResource().getDescribedResource();
+
         final org.apache.jena.graph.Node describedNode = idTranslator.reverse().convert(described).asNode();
         final String resourceUri = idTranslator.reverse().convert(this).getURI();
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContext.java
@@ -36,6 +36,7 @@ import org.apache.jena.rdf.model.Resource;
  * @since 10/16/14
  */
 public class ContentRdfContext extends NodeRdfContext {
+
     /**
      * Default constructor.
      *
@@ -48,14 +49,13 @@ public class ContentRdfContext extends NodeRdfContext {
 
         // if there's an accessible jcr:content node, include information about it
         if (resource instanceof NonRdfSourceDescription) {
-            final FedoraResource contentNode = resource().getDescribedResource();
+            final FedoraResource contentNode = resource().getOriginalResource().getDescribedResource();
             final Node subject = uriFor(resource());
             final Node contentSubject = uriFor(contentNode);
             // add triples representing parent-to-content-child relationship
             concat(of(create(subject, DESCRIBES.asNode(), contentSubject)));
-
         } else if (resource instanceof FedoraBinary) {
-            final FedoraResource description = resource.getDescription();
+            final FedoraResource description = resource.getOriginalResource().getDescription();
             concat(of(create(uriFor(resource), DESCRIBED_BY.asNode(), uriFor(description))));
         }
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/RequiredPropertiesUtil.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/RequiredPropertiesUtil.java
@@ -77,7 +77,7 @@ public class RequiredPropertiesUtil {
      * @throws ConstraintViolationException if model does not contain all required server-managed triples for binary
      * description
      */
-    public static void assertRequiredBinaryTriples(final Model model)
+    public static void assertRequiredDescriptionTriples(final Model model)
             throws ConstraintViolationException {
         assertContainsRequiredProperties(model, REQUIRED_PROPERTIES);
         assertContainsRequiredTypes(model, BINARY_TYPES);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -253,9 +253,9 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
         if (contentStream == null) {
             LOGGER.debug("Creating memento {} for resource {} using existing state", mementoPath, resource.getPath());
             // Creating memento from existing resource
-            populateBinaryMementoFromExisting(resource, memento);
+            populateBinaryMementoFromExisting(resource, memento, storagePolicyDecisionPoint);
         } else {
-            memento.setContent(contentStream, null, checksums, null, null);
+            memento.setContent(contentStream, null, checksums, null, storagePolicyDecisionPoint);
         }
 
         decorateWithMementoProperties(session, mementoPath, dateTime);
@@ -263,8 +263,8 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
         return memento;
     }
 
-    private void populateBinaryMementoFromExisting(final FedoraBinary resource, final FedoraBinary memento)
-            throws InvalidChecksumException {
+    private void populateBinaryMementoFromExisting(final FedoraBinary resource, final FedoraBinary memento,
+            final StoragePolicyDecisionPoint storagePolicyDecisionPoint) throws InvalidChecksumException {
 
         final Node contentNode = getJcrNode(resource);
         List<URI> checksums = null;
@@ -283,7 +283,7 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
             }
 
             memento.setContent(resource.getContent(), null, checksums,
-                    null, null);
+                    null, storagePolicyDecisionPoint);
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -186,6 +186,9 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
         return mementoResource;
     }
 
+    /*
+     * Creates a minimal container node for further population elsewhere
+     */
     private Container createContainer(final FedoraSession session, final String path) {
         try {
             final Node node = findOrCreateNode(session, path, NT_FOLDER);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -18,12 +18,19 @@
 package org.fcrepo.kernel.modeshape.services;
 
 import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO;
 import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO_DATETIME;
+import static org.fcrepo.kernel.api.FedoraTypes.CONTENT_DIGEST;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_FIXITY_SERVICE;
+import static org.fcrepo.kernel.api.RdfLexicon.NT_LEAF_NODE;
+import static org.fcrepo.kernel.api.RdfLexicon.NT_VERSION_FILE;
 import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_CONTAINMENT;
 import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
@@ -31,10 +38,11 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
 import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_TIME_MAP;
 import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.fcrepo.kernel.modeshape.rdf.impl.RequiredPropertiesUtil.assertRequiredContainerTriples;
+import static org.fcrepo.kernel.modeshape.rdf.impl.RequiredPropertiesUtil.assertRequiredDescriptionTriples;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
 import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.fcrepo.kernel.api.utils.SubjectMappingUtil.mapSubject;
-
 import java.io.InputStream;
 import java.net.URI;
 import java.time.Instant;
@@ -45,11 +53,15 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
+import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -61,17 +73,22 @@ import org.apache.jena.riot.Lang;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
+import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.api.services.VersionService;
+import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.kernel.modeshape.ContainerImpl;
 import org.fcrepo.kernel.modeshape.rdf.impl.InternalIdentifierTranslator;
+import org.fcrepo.kernel.modeshape.FedoraBinaryImpl;
+import org.fcrepo.kernel.modeshape.NonRdfSourceDescriptionImpl;
 import org.fcrepo.kernel.modeshape.utils.iterators.RelaxedRdfAdder;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
@@ -124,10 +141,16 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
 
         assertMementoDoesNotExist(session, mementoPath);
 
-        final FedoraResource mementoResource = createContainer(session, mementoPath);
-        final String mementoUri = getUri(mementoResource, idTranslator);
+        // Construct an unpopulated resource of the appropriate type for new memento
+        final FedoraResource mementoResource;
+        if (resource instanceof Container) {
+            mementoResource = createContainer(session, mementoPath);
+        } else {
+            mementoResource = createNonRdfSourceMemento(session, mementoPath);
+        }
 
-        final String resourceUri = getUri(resource, idTranslator);
+        final String mementoUri = getUri(mementoResource, idTranslator);
+        final String resourceUri = getUri(resource.getDescribedResource(), idTranslator);
 
         final RdfStream mementoRdfStream;
         if (rdfInputStream == null) {
@@ -138,7 +161,14 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
             inputModel.read(rdfInputStream, mementoUri, rdfFormat.getName());
 
             // Validate server managed triples are provided
-            assertRequiredContainerTriples(inputModel);
+            if (resource instanceof Container) {
+                assertRequiredContainerTriples(inputModel);
+            } else {
+                assertRequiredDescriptionTriples(inputModel);
+
+                // Remove fixity service reference due to disallowed fcr prefix
+                inputModel.removeAll(null, HAS_FIXITY_SERVICE, null);
+            }
 
             mementoRdfStream = DefaultRdfStream.fromModel(createURI(mementoUri), inputModel);
         }
@@ -165,6 +195,27 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
             }
 
             return new ContainerImpl(node);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+    /*
+     * Creates memento node for non-rdf source using leaf node type
+     */
+    private NonRdfSourceDescription createNonRdfSourceMemento(final FedoraSession session, final String path) {
+        try {
+            final Node descNode = findOrCreateNode(session, path, NT_LEAF_NODE);
+
+            if (descNode.canAddMixin(FEDORA_NON_RDF_SOURCE_DESCRIPTION)) {
+                descNode.addMixin(FEDORA_NON_RDF_SOURCE_DESCRIPTION);
+            }
+
+            if (descNode.canAddMixin(FEDORA_BINARY)) {
+                descNode.addMixin(FEDORA_BINARY);
+            }
+
+            return new NonRdfSourceDescriptionImpl(descNode);
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }
@@ -206,26 +257,82 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     }
 
     @Override
-    public FedoraResource createBinaryVersion(final FedoraSession session,
-            final FedoraResource resource,
+    public FedoraBinary createBinaryVersion(final FedoraSession session,
+            final FedoraBinary resource,
+            final Instant dateTime,
+            final StoragePolicyDecisionPoint storagePolicyDecisionPoint)
+            throws InvalidChecksumException {
+        return createBinaryVersion(session, resource, dateTime, null, null, storagePolicyDecisionPoint);
+    }
+
+    @Override
+    public FedoraBinary createBinaryVersion(final FedoraSession session,
+            final FedoraBinary resource,
             final Instant dateTime,
             final InputStream contentStream,
-            final String filename,
-            final String mimetype,
-            final Collection<URI> checksums) {
+            final Collection<URI> checksums,
+            final StoragePolicyDecisionPoint storagePolicyDecisionPoint) throws InvalidChecksumException {
 
         final String mementoPath = makeMementoPath(resource, dateTime);
 
         assertMementoDoesNotExist(session, mementoPath);
 
-        LOGGER.debug("Creating memento {} for resource {} using existing state", mementoPath, resource.getPath());
-        nodeService.copyObject(session, resource.getPath(), mementoPath);
+        final FedoraBinary memento = createBinary(session, mementoPath);
 
-        final FedoraBinary memento = binaryService.findOrCreate(session, mementoPath);
+        if (contentStream == null) {
+            LOGGER.debug("Creating memento {} for resource {} using existing state", mementoPath, resource.getPath());
+            // Creating memento from existing resource
+            populateBinaryMementoFromExisting(resource, memento);
+        } else {
+            memento.setContent(contentStream, null, checksums, null, null);
+        }
 
         decorateWithMementoProperties(session, mementoPath, dateTime);
 
         return memento;
+    }
+
+    private FedoraBinary createBinary(final FedoraSession session, final String path) {
+        try {
+            final Node dsNode = findOrCreateNode(session, path, NT_VERSION_FILE);
+
+            if (dsNode.canAddMixin(FEDORA_RESOURCE)) {
+                dsNode.addMixin(FEDORA_RESOURCE);
+            }
+            if (dsNode.canAddMixin(FEDORA_BINARY)) {
+                dsNode.addMixin(FEDORA_BINARY);
+            }
+
+            return new FedoraBinaryImpl(dsNode);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+    private void populateBinaryMementoFromExisting(final FedoraBinary resource, final FedoraBinary memento)
+            throws InvalidChecksumException {
+
+        final Node contentNode = getJcrNode(resource);
+        List<URI> checksums = null;
+        // Retrieve all existing digests from the original
+        try {
+            if (contentNode.hasProperty(CONTENT_DIGEST)) {
+                final Property digestProperty = contentNode.getProperty(CONTENT_DIGEST);
+                checksums = stream(digestProperty.getValues())
+                        .map(d -> {
+                            try {
+                                return URI.create(d.getString());
+                            } catch (final RepositoryException e) {
+                                throw new RepositoryRuntimeException(e);
+                            }
+                        }).collect(Collectors.toList());
+            }
+
+            memento.setContent(resource.getContent(), null, checksums,
+                    null, null);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
     }
 
     private String makeMementoPath(final FedoraResource resource, final Instant datetime) {

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContextTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContextTest.java
@@ -81,6 +81,7 @@ public class ContentRdfContextTest {
     public void setUp() throws RepositoryException {
         initMocks(this);
         when(mockBinary.getNode()).thenReturn(mockBinaryNode);
+        when(mockBinary.getOriginalResource()).thenReturn(mockBinary);
         when(mockBinary.getDescription()).thenReturn(mockResource);
         when(mockBinaryNode.getSession()).thenReturn(mockSession);
         when(mockResource.getNode()).thenReturn(mockNode);
@@ -91,6 +92,7 @@ public class ContentRdfContextTest {
         when(mockWorkspace.getNamespaceRegistry()).thenReturn(mockNamespaceRegistry);
         when(mockNamespaceRegistry.getURI("jcr")).thenReturn(JCR_NAMESPACE);
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockNode.hasProperties()).thenReturn(false);
         when(mockNode.getMixinNodeTypes()).thenReturn(new NodeType[] {});
         when(mockBinaryNode.getMixinNodeTypes()).thenReturn(new NodeType[]{});

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/BinaryServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/BinaryServiceImplTest.java
@@ -95,10 +95,11 @@ public class BinaryServiceImplTest {
         when(mockDsNode.isNew()).thenReturn(true);
         when(mockDsNode.isNodeType(FEDORA_BINARY)).thenReturn(true);
         final String testPath = "/foo/bar";
-        when(mockRoot.getNode(testPath.substring(1))).thenReturn(mockDsNode);
-        when(mockSession.getNode("/")).thenReturn(mockRoot);
+        when(mockDsNode.getPath()).thenReturn(testPath);
 
-        when(mockDsNode.getNode("fedora:description")).thenReturn(mockDescNode);
+        when(mockSession.getNode("/")).thenReturn(mockRoot);
+        when(mockRoot.getNode(testPath.substring(1))).thenReturn(mockDsNode);
+        when(mockRoot.getNode(testPath.substring(1) + "/fedora:description")).thenReturn(mockDescNode);
 
         testObj.findOrCreate(testSession, testPath);
         verify(mockRoot).getNode(testPath.substring(1));


### PR DESCRIPTION
**JIRA Tickets**: 
https://jira.duraspace.org/browse/FCREPO-2708
https://jira.duraspace.org/browse/FCREPO-2709

# What does this Pull Request do?
Adds support for creating binary and descriptions mementos from request body.

# What's new?
* Binary mementos can be created from submitted body or existing resource.
* Description mementos can be created from existing resource and submitted bodies. Can be created without a binary memento.
* When a binary memento is created from original resource, description is also created
* Binary mementos use content type from description memento at the same datetime if available, otherwise the default mimetype is returned.
* No longer uses modeshape copy to create binary mementos from existing resources
* describes and describedby links for mementos reference originals
* Binary properties provided with memento creation request are ignored since they will be supplied by the submitted description.
* Added helper method for FedoraResource to getOriginalResource
* Refactor to consolidate binary and description creation in binary service rather than duplicating in version service.

# How should this be tested?
```
# Create versioned binary
curl -i -XPOST -H "Slug:versioned_bin11" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" -H "Content-Type: text/plain" --data-binary "binarycontent" "http://localhost:8080/"

# Create historic memento with content
curl -XPOST http://localhost:8080/versioned_bin11/fcr:versions -H "Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT" -H "Content-Type: text/plain" --data-binary "text content"

# Create historic memento with no content
curl -XPOST http://localhost:8080/versioned_bin11/fcr:versions -H "Memento-Datetime: Sat, 1 Jan 2000 01:00:00 GMT"

# Create memento from current version
curl -XPOST http://localhost:8080/versioned_bin11/fcr:versions

curl -v <uri from response of last command>
# Memento-Datetime: <should be roughly current time>
# Content-Type: text/plain
# Describedby: http://localhost:8080/versioned_bin11/fcr:metadata
# "binarycontent"

curl -v <uri from response of last command, insert "/fcr:metadata" before "/fcr:versions">
# Should return normal RDF response with mimetype = text/plain

curl -v http://localhost:8080/versioned_bin11/fcr:versions/20000101000000
# Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT
# Content-Type: application/octet-stream (content type provided when making memento is ignored)
# "text content"

curl -v http://localhost:8080/versioned_bin11/fcr:versions/20000101010000
# Memento-Datetime: Sat, 1 Jan 2000 01:00:00 GMT
# Content-Type: application/octet-stream
# ""

# Check that the original is OK
curl -v http://localhost:8080/versioned_bin11
# Content-Type: text/plain
# "binarycontent"



curl -v http://localhost:8080/versioned_bin11/fcr:metadata/fcr:versions/20000101000000
# Status: 404 (not created yet)

echo '<http://localhost:8080/versioned_bin11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#NonRdfSourceDescription> .
<http://localhost:8080/versioned_bin11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Binary> .
<http://localhost:8080/versioned_bin11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://fedora.info/definitions/v4/repository#Resource> .
<http://localhost:8080/versioned_bin11> <http://fedora.info/definitions/v4/repository#lastModifiedBy> "bypassAdmin" .
<http://localhost:8080/versioned_bin11> <http://www.loc.gov/premis/rdf/v1#hasSize> "13"^^<http://www.w3.org/2001/XMLSchema#long> .
<http://localhost:8080/versioned_bin11> <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#hasMimeType> "text/awesome" .
<http://localhost:8080/versioned_bin11> <http://fedora.info/definitions/v4/repository#createdBy> "bypassAdmin" .
<http://localhost:8080/versioned_bin11> <http://fedora.info/definitions/v4/repository#created> "2018-04-26T19:43:12.137Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/versioned_bin11> <http://www.loc.gov/premis/rdf/v1#hasMessageDigest> <urn:sha1:23dec4c4f917668fdbcc8ea717b0b6f5a3395d51> .
<http://localhost:8080/versioned_bin11> <http://fedora.info/definitions/v4/repository#lastModified> "2018-04-26T19:43:12.137Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://localhost:8080/versioned_bin11> <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#filename> "" .
<http://localhost:8080/versioned_bin11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#NonRDFSource> .
<http://localhost:8080/versioned_bin11> <http://fedora.info/definitions/v4/repository#writable> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
<http://localhost:8080/versioned_bin11> <http://www.iana.org/assignments/relation/describes> <http://localhost:8080/versioned_bin11> .
<http://localhost:8080/versioned_bin11> <http://fedora.info/definitions/v4/repository#hasFixityService> </fcr:fixity> .' | curl -XPOST -H "Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT" http://localhost:8080/versioned_bin11/fcr:metadata/fcr:versions -H "Content-Type: application/n-triples" --data-binary "@-"

curl -v http://localhost:8080/versioned_bin11/fcr:metadata/fcr:versions/20000101000000
# Should return subjected RDF with mimetype = text/awesome

curl -v http://localhost:8080/versioned_bin11/fcr:versions/20000101000000
# Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT
# Content-Type: text/awesome (content type should now be coming from description)
# "text content"

# Create description memento from original
curl -XPOST http://localhost:8080/versioned_bin11/fcr:metadata/fcr:versions

# Verify description memento created
curl -v <uri from response of last command>
# rdf matching original, mimetype = text/plain

curl -v <uri from response of previous command with "/fcr:metadata" removed>
# status: 404

```

# Additional Notes:
I intend to see about turning on more of the disabled tests in FedoraVersioningIT, but wanted to get PR created.

# Interested parties
@fcrepo4/committers
