### PR TITLE
FCREPO-2774: fixes javadoc-related compile warnings

### DIFF
--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/FedoraEventSerializerTestBase.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/FedoraEventSerializerTestBase.java
@@ -102,10 +102,6 @@ public class FedoraEventSerializerTestBase {
         when(mockEvent.getInfo()).thenReturn(auxInfo);
     }
 
-
-    /**
-     * @param model
-     */
     protected void testModel(final Model model) {
         final Resource resourceSubject = createResource(baseUrl + path);
         final Resource eventSubject = createResource(eventResourceId);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -220,6 +220,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @param rdfStream to which response RDF will be concatenated
      * @return HTTP response
      * @throws IOException in case of error extracting content
+     * @throws UnsupportedAccessTypeException if mimeType not a valid message/external-body content type
      */
     protected Response getContent(final String rangeValue,
                                   final int limit,
@@ -268,7 +269,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     /**
      * Checks if media type matches "message/external-body"
-     * @param mediaType
+     * @param mediaType media-type to check
      * @return true if matches
      */
     protected boolean isExternalBody(final MediaType mediaType) {
@@ -745,6 +746,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     /**
      * Returns an acceptable plain text media type if possible, or null if not.
+     * @return an acceptable plain-text media type, or null
      */
     protected MediaType acceptabePlainTextMediaType() {
         final List<MediaType> acceptable = headers.getAcceptableMediaTypes();
@@ -848,7 +850,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @param requestBodyStream rdf request body
      * @param contentType content type of body
      * @return Model containing triples from request body
-     * @throws MalformedRdfException
+     * @throws MalformedRdfException in case rdf json cannot be parsed
      */
     protected Model parseBodyAsModel(final InputStream requestBodyStream,
             final MediaType contentType) throws MalformedRdfException {
@@ -910,6 +912,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * This method returns a MediaType for a binary resource.
      * If the resource's media type is syntactically incorrect, it will
      * return 'application/octet-stream' as the media type.
+     *
+     * @return the media type of of a binary resource
      */
     protected MediaType getBinaryResourceMediaType() {
         try {
@@ -1005,7 +1009,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     /**
      * @param rootThrowable The original throwable
      * @param throwable The throwable under direct scrutiny.
-     * @throws InvalidChecksumException
+     * @throws InvalidChecksumException in case there was a checksum mismatch
      */
     protected void checkForInsufficientStorageException(final Throwable rootThrowable, final Throwable throwable)
         throws InvalidChecksumException {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -100,7 +100,6 @@ public class FedoraAcl extends ContentExposingResource {
     }
 
     @Override
-    @Override
     protected String externalPath() {
         return externalPath;
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -65,6 +65,9 @@ public class FedoraAcl extends ContentExposingResource {
 
     /**
      * PUT to create FedoraWebacACL resource.
+     *
+     * @return the response for a request to create a Fedora WebAc acl
+     * @throws ConstraintViolationException in case this action would violate a constraint on repository structure
      */
     @PUT
     public Response createFedoraWebacAcl() throws ConstraintViolationException {
@@ -96,6 +99,7 @@ public class FedoraAcl extends ContentExposingResource {
         }
     }
 
+    @Override
     @Override
     protected String externalPath() {
         return externalPath;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -381,6 +381,7 @@ public class FedoraLdp extends ContentExposingResource {
      * @throws InvalidChecksumException if invalid checksum exception occurred
      * @throws MalformedRdfException if malformed rdf exception occurred
      * @throws UnsupportedAlgorithmException if an unsupported algorithm exception occurs
+     * @throws UnsupportedAccessTypeException if the access type of the resource is not supported
      */
     @PUT
     @Consumes
@@ -607,6 +608,7 @@ public class FedoraLdp extends ContentExposingResource {
      * @throws IOException if IO exception occurred
      * @throws MalformedRdfException if malformed rdf exception occurred
      * @throws UnsupportedAlgorithmException if an unsupported algorithm exception occurs
+     * @throws UnsupportedAccessTypeException if the access type of the resource is not supported
      */
     @POST
     @Consumes({MediaType.APPLICATION_OCTET_STREAM + ";qs=1.000", WILDCARD})

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -306,7 +306,6 @@ public class FedoraVersioning extends ContentExposingResource {
     }
 
     @Override
-    @Override
     protected String externalPath() {
         return externalPath;
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -231,7 +231,11 @@ public class FedoraVersioning extends ContentExposingResource {
     /**
      * Get the list of versions for the object
      *
+     * @param rangeValue starting and ending byte offsets
+     * @param acceptValue the rdf media-type
      * @return List of versions for the object as RDF
+     * @throws IOException in case of error extracting content
+     * @throws UnsupportedAccessTypeException if mimeType not a valid message/external-body content type
      */
     @GET
     @HtmlTemplate(value = "fcr:versions")
@@ -301,6 +305,7 @@ public class FedoraVersioning extends ContentExposingResource {
         this.resource = resource;
     }
 
+    @Override
     @Override
     protected String externalPath() {
         return externalPath;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -309,6 +309,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     /**
      * POST to create LDPCv without memento-datetime must ignore body
+     *
+     * @throws Exception in case of error with test
      */
     @Test
     public void testCreateVersionWithBody() throws Exception {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/SynchonizedStreamRDFWrapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/SynchonizedStreamRDFWrapper.java
@@ -30,8 +30,8 @@ import org.apache.jena.sparql.core.Quad;
 public class SynchonizedStreamRDFWrapper extends StreamRDFWrapper {
 
     /**
-     * 
-     * @param stream
+     *
+     * @param stream the StreamRDF
      */
     public SynchonizedStreamRDFWrapper(final StreamRDF stream) {
         super(stream);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PreconditionException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PreconditionException.java
@@ -27,13 +27,15 @@ import static org.apache.http.HttpStatus.SC_NOT_MODIFIED;
  */
 public class PreconditionException extends RepositoryRuntimeException {
 
+    private static final long serialVersionUID = 1L;
+
     private int httpStatus;
 
     /**
      * Ordinary constructor
-     * 
+     *
      * @param msg error message
-     * @param httpStatus
+     * @param httpStatus the http status code
      */
     public PreconditionException(final String msg, final int httpStatus) {
         super(msg);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/CacheEntry.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/CacheEntry.java
@@ -41,6 +41,7 @@ public interface CacheEntry {
      * Check the fixity of a {@link CacheEntry} with list of digest algorithms
      * @param algorithms the given algorithms
      * @return a {@link FixityResult} containing the relevant data
+     * @throws UnsupportedAlgorithmException in case the fixity check tries to use an unsupported algorithm
      */
     Collection<URI> checkFixity(final Collection<String> algorithms) throws UnsupportedAlgorithmException;
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentType.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/MessageExternalBodyContentType.java
@@ -40,7 +40,7 @@ public class MessageExternalBodyContentType {
     /**
      * Utility method to parse the external body content in format: message/external-body; access-type=URL;
      * url="http://www.example.com/file"
-     * 
+     *
      * @param mimeType the MimeType value for external resource
      * @return MessageExternalBodyContentType value
      * @throws UnsupportedAccessTypeException if mimeType param is not a valid message/external-body content type.
@@ -75,7 +75,7 @@ public class MessageExternalBodyContentType {
     }
 
     /**
-     * @return
+     * @return the resource location
      */
     public String getResourceLocation() {
         return this.resourceLocation;

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/FedoraEventImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/FedoraEventImpl.java
@@ -101,6 +101,7 @@ public class FedoraEventImpl implements FedoraEvent {
      * @param path the node path corresponding to this event
      * @param resourceTypes the rdf types of the corresponding resource
      * @param userID the acting user for this event
+     * @param userURI the uri of the acting user for this event
      * @param date the timestamp for this event
      * @param info supplementary information
      */
@@ -115,6 +116,7 @@ public class FedoraEventImpl implements FedoraEvent {
      * @param path the node path corresponding to this event
      * @param resourceTypes the rdf types of the corresponding resource
      * @param userID the acting user for this event
+     * @param userURI the uri of the acting user for this event
      * @param date the timestamp for this event
      * @param info supplementary information
      */

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/RequiredPropertiesUtil.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/RequiredPropertiesUtil.java
@@ -57,11 +57,11 @@ public class RequiredPropertiesUtil {
             NON_RDF_SOURCE, FEDORA_BINARY, FEDORA_RESOURCE);
 
     /**
-     * Throws a ConstraintViolationException if the model does not contain all required server managed triples for a
+     * Throws a ConstraintViolationException if the model does not contain all required server-managed triples for a
      * container.
      *
      * @param model rdf to validate
-     * @throws ConstraintViolationException
+     * @throws ConstraintViolationException if model does not contain all required server-managed triples for container
      */
     public static void assertRequiredContainerTriples(final Model model)
             throws ConstraintViolationException {
@@ -70,11 +70,12 @@ public class RequiredPropertiesUtil {
     }
 
     /**
-     * Throws a ConstraintViolationException if the model does not contain all required server managed triples for a
+     * Throws a ConstraintViolationException if the model does not contain all required server-managed triples for a
      * binary description.
      *
      * @param model rdf to validate
-     * @throws ConstraintViolationException
+     * @throws ConstraintViolationException if model does not contain all required server-managed triples for binary
+     * description
      */
     public static void assertRequiredBinaryTriples(final Model model)
             throws ConstraintViolationException {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraSessionUserUtil.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraSessionUserUtil.java
@@ -44,8 +44,8 @@ public class FedoraSessionUserUtil {
 
     /**
      * Returns the user agent based on the session user id.
-     * @param sessionUserId
-     * @return
+     * @param sessionUserId the acting user's id for this session
+     * @return the uri of the user agent
      */
     public static URI getUserURI(final String sessionUserId) {
         // user id could be in format <anonymous>, remove < at the beginning and the > at the end in this case.

--- a/fcrepo-metrics/src/main/java/org/fcrepo/metrics/MetricsContextListener.java
+++ b/fcrepo-metrics/src/main/java/org/fcrepo/metrics/MetricsContextListener.java
@@ -26,11 +26,12 @@ import com.codahale.metrics.servlets.AdminServletContextListener;
 /**
  * A ServletContextListener to set the ServletContext attributes that the
  * Metrics servlets expect.
- * 
+ *
  * @author Edwin Shin
  * @see <a
  *      href="http://metrics.codahale.com/manual/servlets/">http://metrics.codahale.com/manual/servlets/</a>
  */
+@SuppressWarnings("deprecation")
 @WebListener
 public class MetricsContextListener extends AdminServletContextListener {
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2774

# What does this Pull Request do?
There were a  number of compile warnings related to javadoc on a build using mvn verify. This PR removes all but one of those (@awoods advised to leave the HtmlTemplate class as it was)

# How should this be tested? run mvn verify -DskipTests and inspect console output for javadoc-related warnings

# Interested parties
@awoods @dbernstein 