### PR TITLE
FCREPO-2710: Ignore referential integrity of memento properties.

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/InternalIdentifierTranslator.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/InternalIdentifierTranslator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.modeshape.rdf.impl;
+
+import javax.jcr.Session;
+
+/**
+ * A Converter {@link org.fcrepo.kernel.api.identifiers.IdentifierConverter} that translates
+ * referencing resource identifier into un-dereference-able internal identifier
+ *
+ * @author lsitu
+ * @since Apr 25, 2018
+ */
+public class InternalIdentifierTranslator extends PrefixingIdentifierTranslator {
+
+    /**
+     * Construct the graph with a placeholder resource namespace
+     * @param session Session to lookup nodes
+     */
+    public InternalIdentifierTranslator(final Session session) {
+        super(session, "fedora:uribase/");
+    }
+
+}

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -76,6 +76,8 @@ import org.fcrepo.kernel.modeshape.utils.iterators.RelaxedRdfAdder;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * This service exposes management of node versioning for resources and binaries.
  *
@@ -91,6 +93,7 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     private static final DateTimeFormatter MEMENTO_DATETIME_ID_FORMATTER =
             DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.of("GMT"));
 
+    @VisibleForTesting
     public static final Set<TripleCategory> VERSION_TRIPLES = new HashSet<>(asList(
             PROPERTIES, SERVER_MANAGED, LDP_MEMBERSHIP, LDP_CONTAINMENT));
 
@@ -183,9 +186,9 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
      * @param t the Triple to convert
      * @param idTranslator the Converter that convert the resource uri to a path
      * @param internalIdTranslator the Converter that convert a path to internal identifier
-     * @return
+     * @return Triple a triple with referencing resource uri converted to internal identifier
      */
-    protected Triple convertToInternalReference(final Triple t,
+    private Triple convertToInternalReference(final Triple t,
             final IdentifierConverter<Resource, FedoraResource> idTranslator,
             final IdentifierConverter<Resource, FedoraResource> internalIdTranslator) {
         if (t.getObject().isURI() && idTranslator.inDomain(createResource(t.getObject().getURI()))) {
@@ -193,7 +196,7 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
                     .getPath();
             final Resource obj = createResource(internalIdTranslator.toDomain(path).getURI());
 
-            LOGGER.debug("Converting referencing resource uri {} to internal indentifier {}.",
+            LOGGER.debug("Converting referencing resource uri {} to internal identifier {}.",
                     t.getObject().getURI(), obj.getURI());
 
             return new Triple(t.getSubject(), t.getPredicate(), obj.asNode());


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-2710

Ignore referential integrity of memento properties by converting the referencing resource URI to internal identifier. The internal identifier will be converted back during memento retrieval and users won't see any changes.

# What's new?
Persist referencing resource identifier as internal identifier in mementos to pertain the resource reference even when the referencing resource is deleted.

# How should this be tested?
```
1. Create a resource with a versioned resource that is referencing the resource:
curl -i -XPOST -H "Slug: ReferencingResource" "http://localhost:8080/rest"
curl -i -XPOST -H "Slug: VersionedResource" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" "http://localhost:8080/rest" -H "Content-Type: text/n3" --data-binary "PREFIX pcdm: <http://pcdm.org/models#> <> pcdm:hasMember <http://localhost:8080/rest/ReferencingResource>"

2. Create memento and verify the referenecing resource is in the memento.
curl -i -XPOST "http://localhost:8080/rest/VersionedResource/fcr:versions"
curl -i "http://localhost:8080/rest/VersionedResource/fcr:versions/<memento id>"

3. Remove the referencing resource created in step #1
curl -i -XDELETE "http://localhost:8080/rest/ReferencingResource"

4. Verify that the versioned resource is no longer referencing that resource but it's still in the memento
curl -i "http://localhost:8080/rest/VersionedResource"
curl -i "http://localhost:8080/rest/VersionedResource/fcr:versions/<memento id>"
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
