### PR TITLE
Enable Shiro in the fcrepo-webapp via Spring configuration

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/AbstractPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/AbstractPrincipalProvider.java
@@ -71,7 +71,7 @@ abstract class AbstractPrincipalProvider implements PrincipalProvider {
                 log.debug("Shiro Principal object is not found in session!");
                 currentPrincipals = newPrincipals;
               } else {
-                currentPrincipals = new HashSet<Principal>((Set<Principal>) principals.asSet());
+                currentPrincipals = new HashSet<>((Set<Principal>) principals.asSet());
                 log.debug("Number of Principals already in session object: {}", currentPrincipals.size());
                 currentPrincipals.addAll(newPrincipals);
             }

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -68,11 +68,13 @@ public class WebACFilter implements Filter {
                 if (!isAuthorized(currentUser, httpRequest)) {
                     // if the user is not authorized, set response to forbidden
                     ((HttpServletResponse) response).sendError(SC_FORBIDDEN);
+                    return;
                 }
             } else {
                 log.debug("User has no recognized servlet container role");
                 // missing a container role, return forbidden
                 ((HttpServletResponse) response).sendError(SC_FORBIDDEN);
+                return;
             }
         } else {
             log.debug("User is NOT authenticated");
@@ -80,6 +82,7 @@ public class WebACFilter implements Filter {
             if (!isAuthorized(currentUser, httpRequest)) {
                 // if anonymous user is not authorized, set response to forbidden
                 ((HttpServletResponse) response).sendError(SC_FORBIDDEN);
+                return;
             }
         }
 

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -540,7 +540,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
+    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void testDelegatedUserAccess() throws IOException {
         logger.debug("testing delegated authentication");
         final String targetPath = "/rest/foo";
@@ -622,7 +622,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
     public void testAgentAsUri() throws IOException {
         final String id = "/rest/" + getRandomUniqueId();
         final String testObj = ingestObj(id);
@@ -683,7 +682,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
     public void testInvalidAccessControlLink() throws IOException {
         final String id = "/rest/" + getRandomUniqueId();
         ingestObj(id);
@@ -702,7 +700,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
     public void testRegisterNamespace() throws IOException {
         final String testObj = ingestObj("/rest/test_namespace");
         final String acl1 = ingestAcl("fedoraAdmin", "/acls/13/acl.ttl", "/acls/13/authorization.ttl");
@@ -720,7 +717,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
     public void testRegisterNodeType() throws IOException {
         final String testObj = ingestObj("/rest/test_nodetype");
         final String acl1 = ingestAcl("fedoraAdmin", "/acls/14/acl.ttl", "/acls/14/authorization.ttl");
@@ -740,7 +736,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
 
 
     @Test
-    @Ignore("Until WebACAuthorizingRealm is complete: https://jira.duraspace.org/browse/FCREPO-2760")
     public void testDeletePropertyAsUser() throws IOException {
         final String testObj = ingestObj("/rest/test_delete");
         final String acl1 = ingestAcl("fedoraAdmin", "/acls/15/acl.ttl", "/acls/15/authorization.ttl");

--- a/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
+++ b/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
@@ -39,15 +39,14 @@
 
     <bean name="modeshapeRepofactory"
         class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
-        p:repositoryConfiguration="${fcrepo.modeshape.configuration}"
-        depends-on="authenticationProvider"/>
+        p:repositoryConfiguration="${fcrepo.modeshape.configuration}"/>
 
 
     <!-- **************************
               Authentication
          ************************** -->
 
-    <!-- Optional PrincipalProvider that will inspect the request header, "some-header", for user role values -->
+    <!-- Optional PrincipalProvider filter that will inspect the request header, "some-header", for user role values -->
     <!--
     <bean name="headerProvider" class="org.fcrepo.auth.common.HttpHeaderPrincipalProvider">
         <property name="headerName" value="some-header"/>
@@ -55,7 +54,7 @@
     </bean>
     -->
 
-    <!-- Optional PrincipalProvider that will use container configured roles as principals -->
+    <!-- Optional PrincipalProvider filter that will use container configured roles as principals -->
     <!--
     <bean name="containerRolesProvider" class="org.fcrepo.auth.common.ContainerRolesPrincipalProvider">
       <property name="roleNames">
@@ -67,33 +66,53 @@
     </bean>
     -->
 
-    <!-- delegatedPrincipleProvider allows a single user to be passed in the header "On-Behalf-Of",
+    <!-- delegatedPrincipleProvider filter allows a single user to be passed in the header "On-Behalf-Of",
            this is to be used as the actor making the request when authenticating.
            NOTE: On users with the role fedoraAdmin can delegate to another user.
            NOTE: Only supported in WebAC authentication -->
     <bean name="delegatedPrincipalProvider" class="org.fcrepo.auth.common.DelegateHeaderPrincipalProvider"/>
 
+    <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
 
-    <!-- Defines a set of PrincipleProviders -->
-    <util:set id="principalProviderSet">
-      <ref bean="delegatedPrincipalProvider"/>
-      <!--<ref bean="headerProvider"/>-->
-      <!--<ref bean="containerRolesProvider"/>-->
-    </util:set>
+    <!-- Shiro Auth Confiuration -->
+    <!-- Define the Shiro Realm implementation you want to use to connect to your back-end -->
+    <!-- WebAC Authorization Realm -->
+    <bean id="webACAuthorizingRealm" class="org.fcrepo.auth.webac.WebACAuthorizingRealm" />
 
-    <!-- **** WebAC Authentication **** -->
-      <bean name="fad" class="org.fcrepo.auth.webac.WebACAuthorizationDelegate"/>
-      <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
+    <!-- Servlet Container Authentication Realm -->
+    <bean id="servletContainerAuthenticatingRealm" class="org.fcrepo.auth.common.ServletContainerAuthenticatingRealm" />
 
+    <!-- Security Manager  -->
+    <bean id="securityManager" class="org.apache.shiro.web.mgt.DefaultWebSecurityManager">
+      <property name="realms">
+        <util:set set-class="java.util.HashSet">
+          <ref bean="webACAuthorizingRealm"/>
+          <ref bean="servletContainerAuthenticatingRealm"/>
+        </util:set>
+      </property>
+      <!-- By default the servlet container sessions will be used.  Uncomment this line
+          to use shiro's native sessions (see the JavaDoc for more): -->
+      <!-- <property name="sessionMode" value="native"/> -->
+    </bean>
 
-    <!-- Creates a servlet container authentication provider with the supplied FAD and set
-         of principles providers.
+    <!-- Post processor that automatically invokes init() and destroy() methods -->
+    <bean id="lifecycleBeanPostProcessor" class="org.apache.shiro.spring.LifecycleBeanPostProcessor"/>
 
-         *** To use authorization, see steps on line 32 of this file. ***
-    -->
-    <bean name="authenticationProvider" class="org.fcrepo.auth.common.ServletContainerAuthenticationProvider">
-      <property name="fad" ref="fad"/>
-      <property name="principalProviders" ref="principalProviderSet"/>
+    <!-- Authentication Filter -->
+    <bean id="servletContainerAuthFilter" class="org.fcrepo.auth.common.ServletContainerAuthFilter"/>
+
+    <!-- Authorization Filter -->
+    <bean id="webACFilter" class="org.fcrepo.auth.webac.WebACFilter"/>
+
+    <bean id="shiroFilter" class="org.apache.shiro.spring.web.ShiroFilterFactoryBean">
+      <property name="securityManager" ref="securityManager"/>
+      <property name="filterChainDefinitions">
+        <value>
+          <!-- The Auth filter should come first, followed by 0 or more of the principal provider filters, -->
+          <!-- and finally the webACFilter -->
+          /** = servletContainerAuthFilter,delegatedPrincipalProvider,webACFilter
+        </value>
+      </property>
     </bean>
 
     <!-- **************************

--- a/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
@@ -12,6 +12,17 @@
 		<param-value>WEB-INF/classes/spring/repository.xml</param-value>
 	</context-param>
 
+  <!-- The filter-name matches name of a 'shiroFilter' bean inside applicationContext.xml -->
+  <filter>
+      <filter-name>shiroFilter</filter-name>
+      <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+      <init-param>
+          <param-name>targetFilterLifecycle</param-name>
+          <param-value>true</param-value>
+      </init-param>
+  </filter>
+
+
 	<listener>
 		<listener-class>org.fcrepo.http.commons.FedoraContextLoaderListener</listener-class>
 	</listener>
@@ -38,6 +49,14 @@
     <filter-name>ETagFilter</filter-name>
     <filter-class>org.springframework.web.filter.ShallowEtagHeaderFilter</filter-class>
   </filter>
+
+  <!-- Make sure any request you want accessible to Shiro is filtered. /* catches all -->
+  <!-- requests.  Usually this filter mapping is defined first (before all others) to -->
+  <!-- ensure that Shiro works in subsequent filters in the filter chain:             -->
+  <filter-mapping>
+      <filter-name>shiroFilter</filter-name>
+      <url-pattern>/*</url-pattern>
+  </filter-mapping>
 
   <filter-mapping>
     <filter-name>ETagFilter</filter-name>

--- a/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
@@ -12,6 +12,13 @@
 		<param-value>WEB-INF/classes/spring/repository.xml</param-value>
 	</context-param>
 
+  <!-- To allow request object to be wired to WebACAuthorizingRealm -->
+  <listener>
+    <listener-class>
+      org.springframework.web.context.request.RequestContextListener
+    </listener-class>
+  </listener>
+
   <!-- The filter-name matches name of a 'shiroFilter' bean inside applicationContext.xml -->
   <filter>
       <filter-name>shiroFilter</filter-name>


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2763

Alternate to #1339 

# What does this Pull Request do?
Enable Shiro in the fcrepo-webapp via Spring configuration.

# Additional Notes:
-  Ignores removed for tests that were waiting on FCREPO-2760
- Fixed AbstractPrincipalProvider bug that was revealed while running the maven tests with spring configuration. Changes:
  * The principals returned from the asSet() is unmodifiable. Creating a new HashSet from the returned set.
  * Check for the null condition on Principal object retrieved from the session.
  * Update/Set the principals to session only when there are new Principals.
  * Filter chain be called.

# How should this be tested?
1. Build and test with Maven
2. Manually test interacting with the fcrepo-webapp after starting it with `mvn jetty:run` (or other means).

# Interested parties
@fcrepo4/committers, @peichman-umd 
