### PR TITLE
acl:Append DELETE and PATCH authorization

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/CachedSparqlRequest.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/CachedSparqlRequest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.webac;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * An extension of HttpServletRequestWrapper that caches the InputStream as
+ * byte array and overrides the getInputStream to return a new InputStream
+ * object each time based on the cached byte array.
+ * 
+ * @author mohideen
+ */
+public class CachedSparqlRequest extends HttpServletRequestWrapper {
+
+    private byte[] cachedContent;
+
+    private BufferedReader reader;
+
+    /**
+     * Create a new CachedSparqlRequest for the given servlet request.
+     * @param request the original servlet request
+     */
+    public CachedSparqlRequest(final ServletRequest request) {
+        super((HttpServletRequest) request);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        if (getRequest().getInputStream() != null) {
+            if (this.cachedContent == null) {
+                this.cachedContent = IOUtils.toByteArray(getRequest().getInputStream());
+            }
+            return new CustomServletInputStream(cachedContent);
+        }
+        return null;
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        if (this.reader == null) {
+            this.reader = new BufferedReader(new InputStreamReader(getInputStream(),
+                    getCharacterEncoding()));
+        }
+        return this.reader;
+    }
+
+    private class CustomServletInputStream extends ServletInputStream {
+
+        private ByteArrayInputStream buffer;
+
+        public CustomServletInputStream(final byte[] contents) {
+            this.buffer = new ByteArrayInputStream(contents);
+        }
+
+        @Override
+        public int read() throws IOException {
+            return buffer.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+            return buffer.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(final ReadListener listener) {
+            throw new RuntimeException("Not implemented");
+        }
+    }
+}

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -47,7 +47,6 @@ import org.apache.jena.update.UpdateRequest;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.Subject;
 import org.slf4j.Logger;
-import org.springframework.web.util.ContentCachingRequestWrapper;
 
 /**
  * @author peichman
@@ -137,10 +136,9 @@ public class WebACFilter implements Filter {
             return false;
         }
         if (httpRequest.getInputStream() != null) {
-            final ContentCachingRequestWrapper cachedRequest = new ContentCachingRequestWrapper(httpRequest);
             boolean noDeletes = false;
             try {
-                noDeletes = !hasDeleteClause(IOUtils.toString(cachedRequest.getInputStream(), UTF_8));
+                noDeletes = !hasDeleteClause(IOUtils.toString(httpRequest.getInputStream(), UTF_8));
             } catch (QueryParseException ex) {
                 log.error("Cannot verify authorization! Exception while inspecting SPARQL query!", ex);
             }

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
@@ -146,6 +146,16 @@ public class WebACFilterTest {
         when(mockSubject.isPermitted(writePermission)).thenReturn(true);
     }
 
+    private void setupAuthUserReadAppendWrite() {
+        // authenticated user with read and write permissions
+        when(mockSubject.isAuthenticated()).thenReturn(true);
+        when(mockSubject.hasRole(FEDORA_ADMIN_ROLE)).thenReturn(false);
+        when(mockSubject.hasRole(FEDORA_USER_ROLE)).thenReturn(true);
+        when(mockSubject.isPermitted(readPermission)).thenReturn(true);
+        when(mockSubject.isPermitted(appendPermission)).thenReturn(true);
+        when(mockSubject.isPermitted(writePermission)).thenReturn(true);
+    }
+
     @Test
     public void testAdminUserGet() throws ServletException, IOException {
         setupAdminUser();
@@ -396,6 +406,17 @@ public class WebACFilterTest {
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
     }
+
+    @Test
+    public void testAuthUserReadAppendWriteDelete() throws ServletException, IOException {
+        setupAuthUserReadAppendWrite();
+        // DELETE => 200
+        request.setRequestURI(testPath);
+        request.setMethod("DELETE");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_OK, response.getStatus());
+    }
+
     @After
     public void clearSubject() {
         // unbind the subject to the thread

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -426,7 +426,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
      *  3. Deny(403) on DELETE.
      *  4. Deny(403) on PATCH with SPARQL DELETE statements.
      *  5. Allow(400) on PATCH with empty SPARQL content.
-     *  6. Deny(403) on PATCH with non-SPARQL content,
+     *  6. Deny(403) on PATCH with non-SPARQL content.
      */
     @Test
     public void scenario18Test1() throws IOException, UnsupportedEncodingException {
@@ -527,7 +527,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     /**
-     * Test cases to verify authorization with acl:Read, acl:Append and 
+     * Test cases to verify authorization with acl:Read, acl:Append and
      * acl:Write modes configured in the acl authorization of an resource.
      * Tests:
      *  1. Allow(200) on GET.

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -417,6 +417,17 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(requestGet3));
     }
 
+    /**
+     * Test cases to verify authorization with only acl:Append mode configured
+     * in the acl authorization of an resource.
+     * Tests:
+     *  1. Deny(403) on GET.
+     *  2. Allow(204) on PATCH.
+     *  3. Deny(403) on DELETE.
+     *  4. Deny(403) on PATCH with SPARQL DELETE statements.
+     *  5. Allow(400) on PATCH with empty SPARQL content.
+     *  6. Deny(403) on PATCH with non-SPARQL content,
+     */
     @Test
     public void scenario18Test1() throws IOException, UnsupportedEncodingException {
         final String testObj = ingestObj("/rest/append_only_resource");
@@ -469,6 +480,14 @@ public class WebACRecipesIT extends AbstractResourceIT {
 
     }
 
+    /**
+     * Test cases to verify authorization with acl:Read and acl:Append modes
+     * configured in the acl authorization of an resource.
+     * Tests:
+     *  1. Allow(200) on GET.
+     *  2. Allow(204) on PATCH.
+     *  3. Deny(403) on DELETE.
+     */
     @Test
     public void scenario18Test2() throws IOException, UnsupportedEncodingException {
         final String testObj = ingestObj("/rest/read_append_resource");
@@ -507,6 +526,14 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(requestDelete));
     }
 
+    /**
+     * Test cases to verify authorization with acl:Read, acl:Append and 
+     * acl:Write modes configured in the acl authorization of an resource.
+     * Tests:
+     *  1. Allow(200) on GET.
+     *  2. Allow(204) on PATCH.
+     *  3. Allow(204) on DELETE.
+     */
     @Test
     public void scenario18Test3() throws IOException, UnsupportedEncodingException {
         final String testObj = ingestObj("/rest/read_append_write_resource");

--- a/fcrepo-auth-webac/src/test/resources/acls/18/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/18/acl.ttl
@@ -1,0 +1,3 @@
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
+
+<> a webac:Acl .

--- a/fcrepo-auth-webac/src/test/resources/acls/18/append_only.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/18/append_only.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<> a acl:Authorization ;
+   acl:agent "user18" ;
+   acl:mode acl:Append ;
+   acl:accessTo </rest/append_only_resource> .

--- a/fcrepo-auth-webac/src/test/resources/acls/18/read_append.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/18/read_append.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<> a acl:Authorization ;
+   acl:agent "user18" ;
+   acl:mode acl:Read, acl:Append ;
+   acl:accessTo </rest/read_append_resource> .

--- a/fcrepo-auth-webac/src/test/resources/acls/18/read_append_write.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/18/read_append_write.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<> a acl:Authorization ;
+   acl:agent "user18" ;
+   acl:mode acl:Read, acl:Append, acl:Write ;
+   acl:accessTo </rest/read_append_write_resource> .


### PR DESCRIPTION
Resolves:
https://jira.duraspace.org/browse/FCREPO-2715
https://jira.duraspace.org/browse/FCREPO-2716

# What does this Pull Request do?
1. Adds Unit & IT Tests to verify acl:Append permission is not sufficient to make http DELETE requests.
2. Implements acl:Append PATCH logic to specifically deny patches that include Sparql DELETE statements and allow only specific requests. Also, adds Unit and IT tests to verify acl:Append PATCH logic.

# What's new?
Created a new CachedSparqlRequest class to support reading the InputStream from the request object multiple times (First time in the filter to verify that there are no delete statements and secondly in the FedoraLDP). The spring provided ContentCachingRequestWrapper could not be used as the MessageBodyReader in Fedora only has access to the request's InputStream, but not to the getContentAsByteArray method of the ContentCachingRequestWrapper.

# How should this be tested?
Maven build tests and manual interaction with the webapp to verify the acl:Append http DELETE & PATCH authorization.

# Additional Notes:
We would need FCREPO-2783 for the createdBy and lastModifiedBy user to work correctly.

# Interested parties
@fcrepo4/committers, @peichman-umd 
