### PR TITLE
Fixes Error on PUT to Binary Resource with status 409.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1329,6 +1329,15 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPutBinaryChildViolation() throws IOException {
+        final String id = getRandomUniqueId();
+        createDatastream(id, "binary", "some-content");
+
+        final String location = serverAddress + id + "/binary/xx";
+        assertEquals("Should be a 409 Conflict!", CONFLICT.getStatusCode(), getStatus(new HttpPut(location)));
+    }
+
+    @Test
     public void testBinaryEtags() throws IOException, InterruptedException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-2773

Fixes the Error on PUT to Binary Resource with status 409 instead.

# How should this be tested?
```
1. Create binary resource
curl -i -ufedoraAdmin:fedoraAdmin -XPUT --data-binary "some-content" -H"Content-Type: text/plain" localhost:8080/rest/binary

2. PUT to add child resource and verify status 409 retuned with no error stacktrace
curl -i -ufedoraAdmin:fedoraAdmin -XPUT localhost:8080/rest/binary/xx
```
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
