### PR TITLE
Created ShiroAuthenticationProvider

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroAuthenticationProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.common;
+
+import java.util.Map;
+
+import javax.jcr.Credentials;
+
+import org.apache.shiro.SecurityUtils;
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.security.AuthenticationProvider;
+
+/**
+ * Modeshape authentication provider that gets its security context from the current Shiro Subject.
+ *
+ * @author peichman
+ */
+public class ShiroAuthenticationProvider implements AuthenticationProvider {
+
+    @Override
+    public ExecutionContext authenticate(final Credentials credentials, final String repositoryName,
+            final String workspaceName, final ExecutionContext repositoryContext,
+            final Map<String, Object> sessionAttributes) {
+
+        return repositoryContext.with(new ShiroSecurityContext(SecurityUtils.getSubject()));
+    }
+
+}

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroSecurityContext.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroSecurityContext.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.auth.common;
+
+import org.apache.http.auth.BasicUserPrincipal;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.apache.shiro.subject.Subject;
+import org.modeshape.jcr.security.SecurityContext;
+
+/**
+ * Security context that is simply a thin wrapper around a Shiro Subject.
+ * 
+ * @author peichman
+ */
+public class ShiroSecurityContext implements SecurityContext {
+
+    private Subject user;
+
+    private String userName;
+
+    /**
+     * Create a new security context using the given Shiro subject. That subject will typically be the value returned
+     * by a call to {@code SecurityUtils.getSubject()}.
+     *
+     * @param user subject to create the security context for
+     */
+    public ShiroSecurityContext(final Subject user) {
+        this.user = user;
+        final PrincipalCollection principals = user.getPrincipals();
+        final BasicUserPrincipal userPrincipal = principals.oneByType(BasicUserPrincipal.class);
+        if (userPrincipal != null) {
+            this.userName = userPrincipal.getName();
+        } else {
+            this.userName = null;
+        }
+    }
+
+    @Override
+    public boolean isAnonymous() {
+        return !user.isAuthenticated();
+    }
+
+    @Override
+    public String getUserName() {
+        return userName;
+    }
+
+    @Override
+    public boolean hasRole(final String roleName) {
+        // Under this custom PEP regime, all users have modeshape read and write
+        // roles.
+        if ("read".equals(roleName)) {
+            return true;
+        } else if ("write".equals(roleName)) {
+            return true;
+        } else if ("admin".equals(roleName)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void logout() {
+        // this method intentionally does nothing
+    }
+
+}

--- a/fcrepo-auth-webac/src/test/resources/repository-test.json
+++ b/fcrepo-auth-webac/src/test/resources/repository-test.json
@@ -19,9 +19,11 @@
   "security" : {
     "anonymous" : {
       "roles" : ["readonly","readwrite","admin"],
-      "useOnFailedLogin" : true
+      "useOnFailedLogin" : false
     },
-    "providers" : []
+    "providers" : [
+      { "classname": "org.fcrepo.auth.common.ShiroAuthenticationProvider" }
+    ]
   },
   "node-types" : ["fedora-node-types.cnd"]
 }

--- a/fcrepo-auth-webac/src/test/resources/spring-test/repo.xml
+++ b/fcrepo-auth-webac/src/test/resources/spring-test/repo.xml
@@ -10,9 +10,12 @@
   <!-- Context that supports the actual ModeShape JCR itself -->
   <context:annotation-config />
 
-  <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean">
+  <bean name="modeshapeRepofactory" class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
+    depends-on="authenticationProvider">
     <property name="repositoryConfiguration" value="${fcrepo.modeshape.configuration:repository-test.json}" />
   </bean>
+
+  <bean name="authenticationProvider" class="org.fcrepo.auth.common.ShiroAuthenticationProvider"/>
 
   <bean name="accessRolesProvider" class="org.fcrepo.auth.webac.WebACRolesProvider"/>
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2783

**Other Relevant Links**
* This is intended to supersede https://github.com/fcrepo4/fcrepo4/pull/1350

# What does this Pull Request do?
Modeshape authentication provider that inspects the Shiro SecurityUtils to get the current user. Uses a ShiroSecurityContext that is basically a thin wrapper around the Shiro current user Subject.

# What's new?
The ShiroSecurityContext wraps a Shiro Subject and responds "true" to all role queries for "read", "write", or "admin" (following the model of the ServletContainerAuthenticationProvider)

# How should this be tested?
Running the WebAC integration tests (which now have this authentication provider configured) should pass. There are not yet unit tests for this class itself, or other integration tests.

# Additional Notes
This definitely needs more tests written, but I wanted to get this code out there for folks to take a look at.

# Interested parties
@mohideen, @dbernstein, @awoods, @fcrepo4/committers
