### PR TITLE
Fcrepo-2793 Describedby property from descriptions

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -77,6 +77,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_CHILD;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
@@ -750,6 +751,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
             graph.find().forEachRemaining(quad -> {
                 assertEquals("Found a triple with incorrect subject!", correctDSSubject, quad.getSubject());
             });
+            assertTrue(graph.contains(ANY, ANY, DESCRIBED_BY.asNode(),
+                    createURI(serverAddress + id + "/x/fcr:metadata")));
         }
     }
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContext.java
@@ -50,13 +50,14 @@ public class ContentRdfContext extends NodeRdfContext {
         // if there's an accessible jcr:content node, include information about it
         if (resource instanceof NonRdfSourceDescription) {
             final FedoraResource contentNode = resource().getOriginalResource().getDescribedResource();
-            final Node subject = uriFor(resource());
-            final Node contentSubject = uriFor(contentNode);
+            final FedoraResource descNode = resource().getOriginalResource();
+            final Node subject = uriFor(contentNode);
+            final Node descObject = uriFor(descNode);
             // add triples representing parent-to-content-child relationship
-            concat(of(create(subject, DESCRIBES.asNode(), contentSubject)));
+            concat(of(create(subject, DESCRIBED_BY.asNode(), descObject)));
         } else if (resource instanceof FedoraBinary) {
-            final FedoraResource description = resource.getOriginalResource().getDescription();
-            concat(of(create(uriFor(resource), DESCRIBED_BY.asNode(), uriFor(description))));
+            final FedoraResource contentNode = resource.getOriginalResource();
+            concat(of(create(uriFor(contentNode), DESCRIBES.asNode(), uriFor(contentNode))));
         }
     }
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContextTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContextTest.java
@@ -59,21 +59,21 @@ public class ContentRdfContextTest {
 
     @Test
     public void testForLowLevelStorageTriples() throws IOException {
-        try (final ContentRdfContext contentRdfContext = new ContentRdfContext(mockResource, idTranslator)) {
+        try (final ContentRdfContext contentRdfContext = new ContentRdfContext(mockBinary, idTranslator)) {
             final Model results = contentRdfContext.collect(toModel());
             logRdf("Retrieved RDF for testForLowLevelStorageTriples():", results);
-            assertTrue("Didn't find triple showing node has content!", results.contains(mockSubject, DESCRIBES,
-                    mockContentSubject));
+            assertTrue("Didn't find triple showing node has content!",
+                    results.contains(mockContentSubject, DESCRIBES, mockContentSubject));
         }
     }
 
     @Test
-    public void testFedoraBinaryTriples() {
+    public void testDescriptionTriples() {
 
-        try (final ContentRdfContext contentRdfContext = new ContentRdfContext(mockBinary, idTranslator)) {
+        try (final ContentRdfContext contentRdfContext = new ContentRdfContext(mockResource, idTranslator)) {
             final Model results = contentRdfContext.collect(toModel());
-            assertTrue("Didn't find triple showing content has node!", results.contains(mockContentSubject,
-                    DESCRIBED_BY, mockSubject));
+            assertTrue("Didn't find triple showing content has node!",
+                    results.contains(mockContentSubject, DESCRIBED_BY, mockSubject));
         }
     }
 
@@ -86,7 +86,7 @@ public class ContentRdfContextTest {
         when(mockBinaryNode.getSession()).thenReturn(mockSession);
         when(mockResource.getNode()).thenReturn(mockNode);
         when(mockNode.getSession()).thenReturn(mockSession);
-        when(mockResource.getPath()).thenReturn("/mockNode");
+        when(mockResource.getPath()).thenReturn("/mockNode/fedora:description");
         when(mockSession.getRepository()).thenReturn(mockRepository);
         when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
         when(mockWorkspace.getNamespaceRegistry()).thenReturn(mockNamespaceRegistry);
@@ -97,7 +97,7 @@ public class ContentRdfContextTest {
         when(mockNode.getMixinNodeTypes()).thenReturn(new NodeType[] {});
         when(mockBinaryNode.getMixinNodeTypes()).thenReturn(new NodeType[]{});
         when(mockBinaryNode.hasProperties()).thenReturn(false);
-        when(mockBinary.getPath()).thenReturn("/mockNode/jcr:content");
+        when(mockBinary.getPath()).thenReturn("/mockNode");
         idTranslator = new DefaultIdentifierTranslator(mockSession);
         when(mockNode.getPrimaryNodeType()).thenReturn(mockNodeType);
         when(mockBinaryNode.getPrimaryNodeType()).thenReturn(mockNodeType);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2793

# What does this Pull Request do?
Fixes bug introduced by binary refactory which resulted in binary descriptions returning "describes" properties instead of "describedby" as in fcrepo 4.x.

# What's new?
Describedby property returned in triples for NonRdfSource
Describes property returned in triples for FedoraBinaryImpl (not clear how this is ever used, now or before)
Added check to verify that describedby property is returned in FedoraLdp

# How should this be tested?
Creating a binary then making a GET request to its fcr:metadata endpoint to verify describedby property returned.

# Additional Notes:
I'm not sure if returning "describes" for FedoraBinaryImpl is still needed (previously it was returned by NonRdfSourceDescription when that was used as the datastream instead of description). Tests pass without it (except for ContentRdfContextTest.testForLowLevelStorageTriples which is directly checking it).