### PR TITLE
Fcrepo 2791 Convert internal identifiers for binary descriptions

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -51,6 +51,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
+import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBES;
 import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
@@ -78,6 +79,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import javax.ws.rs.core.Link;
 
@@ -103,6 +105,7 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.DC;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
@@ -515,6 +518,56 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             final DatasetGraph graph = dataset.asDatasetGraph();
             assertTrue("Expected resource NOT found: " + graph, graph.contains(ANY,
                     ANY, createURI("http://pcdm.org/models#hasMember"), createURI(resource)));
+        }
+    }
+
+    @Test
+    public void testDescriptionMementoReference() throws Exception {
+        // Create binary with description referencing other resource
+        createVersionedBinary(id);
+
+        final String referencedPid = getRandomUniqueId();
+        final String referencedResource = serverAddress + referencedPid;
+        createObjectAndClose(referencedPid);
+
+        final String metadataId = id + "/fcr:metadata";
+        final String metadataUri = serverAddress + metadataId;
+
+        final String relation = "http://purl.org/dc/elements/1.1/relation";
+        final HttpPatch updateObjectGraphMethod = patchObjMethod(metadataId);
+        updateObjectGraphMethod.addHeader(CONTENT_TYPE, "application/sparql-update");
+        updateObjectGraphMethod.setEntity(new StringEntity(
+                "INSERT {" + " <> <" + relation + "> <" + referencedResource + "> } WHERE {}"));
+        executeAndClose(updateObjectGraphMethod);
+
+        // Create memento
+        final String mementoUri = createMemento(subjectUri, null, null, null);
+        assertMementoUri(mementoUri, subjectUri);
+
+        // Delete referenced resource
+        assertEquals("Expected delete to succeed",
+                NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(referencedResource)));
+
+        // Ensure that the resource reference is gone
+        try (final CloseableHttpResponse getResponse1 = execute(new HttpGet(metadataUri));
+                final CloseableDataset dataset = getDataset(getResponse1);) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertFalse("Expected NOT to have resource: " + graph, graph.contains(ANY,
+                    ANY, createURI(relation), createURI(referencedResource)));
+        }
+
+        final String descMementoUrl = mementoUri.replace(FCR_VERSIONS, "fcr:metadata/fcr:versions");
+        // Ensure that the resource reference is still in memento
+        try (final CloseableHttpResponse getResponse1 = execute(new HttpGet(descMementoUrl));
+                final CloseableDataset dataset = getDataset(getResponse1);) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue("Expected resource NOT found: " + graph, graph.contains(ANY,
+                    createURI(serverAddress + id), createURI(relation), createURI(referencedResource)));
+
+            // Verify that described by link persists and there is only one
+            final Iterator<Quad> describedIt = graph.find(ANY, ANY, DESCRIBES.asNode(), ANY);
+            assertEquals(serverAddress + id, describedIt.next().getObject().getURI());
+            assertFalse(describedIt.hasNext());
         }
     }
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ContentRdfContext.java
@@ -49,8 +49,12 @@ public class ContentRdfContext extends NodeRdfContext {
 
         // if there's an accessible jcr:content node, include information about it
         if (resource instanceof NonRdfSourceDescription) {
-            final FedoraResource contentNode = resource().getOriginalResource().getDescribedResource();
-            final FedoraResource descNode = resource().getOriginalResource();
+            // describedby property should already be in response
+            if (resource.isMemento()) {
+                return;
+            }
+            final FedoraResource contentNode = resource().getDescribedResource();
+            final FedoraResource descNode = resource();
             final Node subject = uriFor(contentNode);
             final Node descObject = uriFor(descNode);
             // add triples representing parent-to-content-child relationship


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2791

# What does this Pull Request do?
Fixes describedby property on a binary description response to return the external url, and related fixes.

# What's new?
* Adds internal identifier conversion when returning the triples of descriptions
* Fixes issue when converting from internal resource identifiers in mementos (properties which reference resources prefixed so that they ignore referential integrity), where internal modeshape paths were not being converted to external paths when generating triples (this meant that a describedby property would return the node name `id/fedora:description` instead of `id/fcr:metadata`)
* When listing children, no longer converts children from description to FedoraBinary since it is no longer necessary after binary/description refactor and it was breaking timemap responses
* Expands javadoc/comments related to internal identifier conversion, slight refactoring of conversion for consistency and to skip a little extra work, and renamed a method to indicate identifier conversion was happening there now. 
* Skipping addition of duplicate describedby property for description memento triples responses.

# How should this be tested?
See instructions in ticket.

# Additional Notes:
Still not sure if we need to keep addition of `describes` property for responses from FedoraBinary since it doesn't seem like anything uses the triples from it.