### PR TITLE
Add ShiroAuthenticationProvider to fcrepo-webapp config.

### DIFF
--- a/fcrepo-configs/src/main/resources/config/servlet-auth/repository.json
+++ b/fcrepo-configs/src/main/resources/config/servlet-auth/repository.json
@@ -24,7 +24,7 @@
             "useOnFailedLogin" : false
         },
         "providers" : [
-            { "classname" : "org.fcrepo.auth.common.ServletContainerAuthenticationProvider" }
+            { "classname" : "org.fcrepo.auth.common.ShiroAuthenticationProvider" }
         ]
     },
     "garbageCollection" : {

--- a/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
+++ b/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
@@ -39,7 +39,11 @@
 
     <bean name="modeshapeRepofactory"
         class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
-        p:repositoryConfiguration="${fcrepo.modeshape.configuration}"/>
+        p:repositoryConfiguration="${fcrepo.modeshape.configuration}"
+        depends-on="authenticationProvider"/>
+  
+    <bean name="authenticationProvider" class="org.fcrepo.auth.common.ShiroAuthenticationProvider"/>
+        
 
 
     <!-- **************************

--- a/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
@@ -11,6 +11,15 @@
 		<param-name>contextConfigLocation</param-name>
 		<param-value>WEB-INF/classes/spring/repository.xml</param-value>
 	</context-param>
+  
+  <context-param>
+    <param-name>shiroEnvironmentClass</param-name>
+    <param-value>org.apache.shiro.web.env.DefaultWebEnvironment</param-value>
+  </context-param>
+    
+  <listener>
+    <listener-class>org.apache.shiro.web.env.EnvironmentLoaderListener</listener-class>
+  </listener>
 
   <!-- To allow request object to be wired to WebACAuthorizingRealm -->
   <listener>


### PR DESCRIPTION

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2794

# What does this Pull Request do?
Add ShiroAuthenticationProvider to fcrepo-webapp config.

# What's new?
Include ShiroAuthenticationProvider as the Modeshape authentication provider in the spring config for fcrepo-webapp and the common fcrepo-config repository.json Modeshape configuration file for servlet-auth.

# How should this be tested?
`mvn clean install` of the fcrepo4 project should return no errors.

# Additional Notes:
I retained the BypassAdminAuthenticationProvider on every test repository.json except for the one that was using the ServletContainerAuthenticationProvider.

# Interested parties
@dbernstein, @fcrepo4/committers
