### PR TITLE
Fcrepo-2792 Description Timemap without binary memento

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/ChildrenRdfContext.java
@@ -54,7 +54,7 @@ public class ChildrenRdfContext extends NodeRdfContext {
             LOGGER.trace("Found children of this resource: {}", resource.getPath());
 
             concat(resource().getChildren().peek(child -> LOGGER.trace("Creating triple for child node: {}", child))
-                    .map(child -> create(subject(), CONTAINS.asNode(), uriFor(child.getDescribedResource()))));
+                    .map(child -> create(subject(), CONTAINS.asNode(), uriFor(child))));
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2792

# What does this Pull Request do?
Fixes a bug that caused 404 response when getting RDF of a description timemap when a description memento existed without an associated binary memento

# What's new?
* Removes switching over to using described resource when populating children properties
* Adds integration test

# How should this be tested?
Included integration test and testing described in the ticket.
