### PR TITLE
Fcrepo-2802 - Update content size for url binaries on 

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/LocalFileBinary.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/LocalFileBinary.java
@@ -102,8 +102,12 @@ public class LocalFileBinary extends UrlBinary {
         if (sizeValue > -1L) {
             return sizeValue;
         }
+        return getRemoteContentSize();
+    }
+
+    @Override
+    protected long getRemoteContentSize() {
         final File file = new File(getResourceUri().getPath());
-        setContentSize(file.length());
         return file.length();
     }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/UrlBinary.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/UrlBinary.java
@@ -103,7 +103,7 @@ public class UrlBinary extends AbstractFedoraBinary {
                     try {
                         return Long.parseLong(contentLength);
                     } catch (final NumberFormatException e) {
-                        LOGGER.debug("Unable to parse Content-Length of remote file {}", resourceUri, e);
+                        LOGGER.warn("Unable to parse Content-Length of remote file {}", resourceUri, e);
                     }
                 }
             }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/UrlBinary.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/UrlBinary.java
@@ -24,6 +24,7 @@ import static org.fcrepo.kernel.api.FedoraExternalContent.REDIRECT;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
@@ -36,8 +37,6 @@ import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.tika.io.IOUtils;
-
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -89,19 +88,28 @@ public class UrlBinary extends AbstractFedoraBinary {
         }
     }
 
-    @Override
-    public long getContentSize() {
-        final long sizeValue = super.getContentSize();
-        if (sizeValue > -1L) {
-            return sizeValue;
-        }
+    protected long getRemoteContentSize() {
+        final URI resourceUri = getResourceUri();
         try {
-            final String content = IOUtils.toString(getResourceUri().toURL().openStream());
-            setContentSize(content.length());
-            return content.length();
+            final HttpURLConnection httpConn = (HttpURLConnection) resourceUri.toURL().openConnection();
+            httpConn.setRequestMethod("HEAD");
+            httpConn.connect();
+
+            final int status = httpConn.getResponseCode();
+
+            if (status == HttpURLConnection.HTTP_OK) {
+                final String contentLength = httpConn.getHeaderField("Content-Length");
+                if (contentLength != null) {
+                    try {
+                        return Long.parseLong(contentLength);
+                    } catch (final NumberFormatException e) {
+                        LOGGER.debug("Unable to parse Content-Length of remote file {}", resourceUri, e);
+                    }
+                }
+            }
+
         } catch (final IOException e) {
-            LOGGER.warn("Error getting getContentSize for '{}' : '{}'", getPath(), getResourceUri());
-            // Error getting remote size.
+            LOGGER.warn("Error getting content size for '{}' : '{}'", getPath(), resourceUri, e);
         }
         return -1L;
     }
@@ -138,7 +146,6 @@ public class UrlBinary extends AbstractFedoraBinary {
             final String[] checksumArray = new String[nonNullChecksums.size()];
             nonNullChecksums.stream().map(Object::toString).collect(Collectors.toSet()).toArray(checksumArray);
 
-
             FedoraTypesUtils.touch(contentNode);
 
             if (descNode != null) {
@@ -152,6 +159,8 @@ public class UrlBinary extends AbstractFedoraBinary {
                 if (originalFileName != null) {
                     descNode.setProperty(FILENAME, originalFileName);
                 }
+                setContentSize(getRemoteContentSize());
+
                 FedoraTypesUtils.touch(descNode);
             }
 
@@ -265,7 +274,6 @@ public class UrlBinary extends AbstractFedoraBinary {
 
         try (final Timer.Context context = timer.time()) {
 
-            final String resourceLocation = getResourceLocation();
             Collection<URI> list = null;
             if (isProxy()) {
                 list = CacheEntryFactory.forProperty(getProperty(PROXY_FOR)).checkFixity(algorithms);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/UrlBinaryIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/UrlBinaryIT.java
@@ -57,6 +57,7 @@ import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -99,14 +100,15 @@ public class UrlBinaryIT extends AbstractIT {
 
         mimeType = "application/octet-stream";
 
-        final FedoraBinary externalContent = binaryService.findOrCreate(session, "/externalContent");
-        externalContent.setExternalContent(mimeType, null, null, "proxy", fileUrl);
-        session.commit();
-
         dsId = makeDsId();
 
+        stubFor(head(urlEqualTo("/file.txt"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Length", Long.toString(EXPECTED_CONTENT.length()))
+                        .withHeader("Content-Type", "text/plain")));
         stubFor(get(urlEqualTo("/file.txt"))
                 .willReturn(aResponse()
+                        .withHeader("Content-Length", Long.toString(EXPECTED_CONTENT.length()))
                         .withHeader("Content-Type", "text/plain")
                         .withBody(EXPECTED_CONTENT)));
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2802

# What does this Pull Request do?
Removes call to set content size property for `UrlBinary`s on read requests (GET or HEAD), to prevent potential unwanted modifications.

# What's new?
* Calls to setContentSize for LocalFile and URL binaries removed from getContentSize call, now only being invoked when the binary is updated.
* Changed how size of an http url is determined to check for a Content-Length header, to avoid memory issues resulting from loading the remote binary into memory to calculate size.

# How should this be tested?
```
##### Http resource

# create the resource 
curl -v -X PUT -H "Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/duraspace-logo.png -ufedoraAdmin:fedoraAdmin

#verify that premis:hasSize property is set
curl http://localhost:8080/rest/duraspace-logo.png/fcr:metadata -ufedoraAdmin:fedoraAdmin
# premis:hasSize           "3361"^^<http://www.w3.org/2001/XMLSchema#long> ;

##### Local File

# Create local file
echo "file content" >> /tmp/local.txt
# Ingest local file
curl -v -X PUT -H "Link: <file:/tmp/local.txt>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/local.txt -ufedoraAdmin:fedoraAdmin

# verify size
curl http://localhost:8080/rest/local.txt/fcr:metadata -ufedoraAdmin:fedoraAdmin
# premis:hasSize           "13"^^<http://www.w3.org/2001/XMLSchema#long> ;

# Change file behind fedora's back
echo "uh oh" >> /tmp/local.txt

# verify size property hasn't changed on a GET operation
curl http://localhost:8080/rest/local.txt/fcr:metadata -ufedoraAdmin:fedoraAdmin
# premis:hasSize           "13"^^<http://www.w3.org/2001/XMLSchema#long> ;
```

# Additional Notes
Triggering unintentional modifications this way would be fairly challenging, but it is best to avoid the possibility as there may be unintended consequences in other use cases. Also, GET on a LocalFileBinary that references a file that doesn't exist currently throws a FileNotFoundException. When that is resolved it might be easier to trigger this.

# Interested parties
@bseeger
