### PR TITLE
Don't return Content-Length for LDP-NR redirect responses

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -564,6 +564,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                     .build();
 
             servletResponse.addHeader(CONTENT_TYPE, binary.getMimeType());
+            // Returning content-length > 0 causes the client to wait for additional data before following the redirect.
             if (!binary.isRedirect()) {
                 servletResponse.addHeader(CONTENT_LENGTH, String.valueOf(binary.getContentSize()));
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -564,7 +564,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                     .build();
 
             servletResponse.addHeader(CONTENT_TYPE, binary.getMimeType());
-            servletResponse.addHeader(CONTENT_LENGTH, String.valueOf(binary.getContentSize()));
+            if (!binary.isRedirect()) {
+                servletResponse.addHeader(CONTENT_LENGTH, String.valueOf(binary.getContentSize()));
+            }
             servletResponse.addHeader("Accept-Ranges", "bytes");
             servletResponse.addHeader(CONTENT_DISPOSITION, contentDisposition.toString());
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -456,6 +456,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals(TEMPORARY_REDIRECT.getStatusCode(), response.getStatusLine().getStatusCode());
             assertEquals("http://example.com/test", getLocation(response));
             assertEquals("bytes", response.getFirstHeader("Accept-Ranges").getValue());
+            assertEquals("0", response.getFirstHeader("Content-Length").getValue());
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
             assertEquals("attachment", disposition.getType());


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2818


# What does this Pull Request do?
Removes the `Content-Length` header from responses for External-Content Redirect LDP-NRs.

# How should this be tested?

To test the actual timing of a response you need a remote URI to redirect to, but you can test the change to the headers with a local file.

1. `curl -i -ufedoraAdmin:fedoraAdmin -XPUT -H"Link: <file:///path/to/your/file>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"redirect\"" http://localhost:8080/rest/my_redirect`
1. Before the PR
  1. do a HEAD request. 
  1. See the `Content-Length:` greater than 0
1. After the PR
  1. do a HEAD request
  1. See a `Content-Length: 0` header

If you have a remote webserver, you can use that URI and actually see how much faster it is with.
```
curl -G -L -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/my_redirect
```

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@awoods @bbpennel 
