### PR TITLE
FCR-2796 - Fix External Identifier Retrieval

### DIFF
--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/ExternalResourceCacheEntry.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/ExternalResourceCacheEntry.java
@@ -69,7 +69,7 @@ public class ExternalResourceCacheEntry extends BinaryCacheEntry {
     public String getExternalIdentifier() {
         try {
             LOGGER.debug("getExternalIdentifier for property {} ", property().getName());
-            return property().getValue().toString();
+            return property().getValue().getString();
         } catch (final RepositoryException e) {
             throw new RepositoryRuntimeException(e);
         }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/LocalFileBinaryIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/LocalFileBinaryIT.java
@@ -49,7 +49,6 @@ import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.modeshape.rdf.impl.DefaultIdentifierTranslator;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.slf4j.Logger;
@@ -178,10 +177,6 @@ public class LocalFileBinaryIT extends AbstractIT {
                 contentFile.toURI().toURL().toString());
     }
 
-    @Ignore
-    // Something in the ExternalResourceCacheEntry is returning
-    // binary (80B, SHA1=dcd59309841b261c56d45cfa6a587e46991c43c8)
-    // instead of a URI.
     @Test
     public void testCheckFixity() throws Exception {
         final FedoraBinary binary = binaryService.findOrCreate(session, dsId);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/UrlBinaryTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/UrlBinaryTest.java
@@ -277,7 +277,7 @@ public class UrlBinaryTest {
             when(proxyURLProperty.getString()).thenReturn(fileUrl);
             when(proxyURLProperty.getValue()).thenReturn(mockURIValue);
             when(proxyURLProperty.getName()).thenReturn(PROXY_FOR.toString());
-            when(mockURIValue.toString()).thenReturn(fileUrl);
+            when(mockURIValue.getString()).thenReturn(fileUrl);
 
             when(mockContent.hasProperty(PROXY_FOR)).thenReturn(true);
             when(mockContent.getProperty(PROXY_FOR)).thenReturn(proxyURLProperty);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/ExternalResourceCacheEntryTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/utils/ExternalResourceCacheEntryTest.java
@@ -60,7 +60,7 @@ public class ExternalResourceCacheEntryTest {
     @Before
     public void setUp() throws RepositoryException {
         when(mockProperty.getValue()).thenReturn(mockValue);
-        when(mockValue.toString()).thenReturn(RESOURCE_URL);
+        when(mockValue.getString()).thenReturn(RESOURCE_URL);
         testObj = new ExternalResourceCacheEntry(mockProperty);
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2796

# What does this Pull Request do?
Fixes issue with retrieving external binary url properties during fixity checks and reenables `LocalFileBinaryIT.testCheckFixity`

# What's new?
Modeshape is translating the PROXY_URL property from a String into a Binary on `session.commit()`. As a result, `toString()` on the value returns a representation of a binary, while `getString()` returns the value of the binary. While this behavior is odd, `getString()` is probably desired and was used in the previous implementation:
https://github.com/fcrepo4/fcrepo4/blame/ffbd215c109bebf37279f858ec60ce76f3caa452/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/ExternalResourceCacheEntry.java#L70

# How should this be tested?
It is an update to a test, so that should pass.

# Interested parties
@bseeger @whikloj 
