### PR TITLE
Fcr 2817 - Fix local file uri

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -174,7 +174,7 @@ public class ExternalContentHandler {
         LOGGER.debug("scheme is {}", scheme);
         if (scheme != null) {
             if (scheme.equals("file")) {
-                return new FileInputStream(uri.toString());
+                return new FileInputStream(uri.getPath());
             } else if (scheme.equals("http") || scheme.equals("https")) {
                 return uri.toURL().openStream();
             }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2817

# What does this Pull Request do?
Fixes bug when combining a local file external content binary with the copy directive.

# What's new?
Uses uri path instead of serializing the entire uri when retrieving the content of a local file.
Adds integration test for local file with copy mode.

# How should this be tested?
New integration test should pass.

The following command should work, and the resulting binary should be retrievable:
```
curl -i -H"Link: <file:///Users/whikloj/Desktop/wonderful.tiff>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"copy\"; type=\"image/tiff\"" -XPUT -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_redirect_local_file

curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_redirect_local_file
```

# Interested parties
@whikloj @bseeger @dbernstein 
