### PR TITLE
Add Accept-Post, Options, and Container type

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -548,7 +548,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      *
      * @param resource the resource to generate headers for
      */
-    protected void addLinkAndOptionsHttpHeaders(final FedoraResource resource) {
+    private void addLinkAndOptionsHttpHeaders(final FedoraResource resource) {
         // Add Link headers
         addResourceLinkHeaders(resource);
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -48,15 +48,12 @@ import static org.apache.jena.riot.WebContent.ctTextCSV;
 import static org.apache.jena.riot.WebContent.ctTextPlain;
 import static org.apache.jena.riot.WebContent.matchContentType;
 import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
 import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_PAIRTREE;
@@ -854,10 +851,7 @@ public class FedoraLdp extends ContentExposingResource {
             options = "MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS";
             servletResponse.addHeader(HTTP_HEADER_ACCEPT_PATCH, contentTypeSPARQLUpdate);
 
-            final String rdfTypes = TURTLE + "," + N3 + "," + N3_ALT2 + ","
-                    + RDF_XML + "," + NTRIPLES + "," + JSON_LD;
-            servletResponse.addHeader("Accept-Post", rdfTypes + "," + MediaType.MULTIPART_FORM_DATA + "," +
-                    contentTypeSPARQLUpdate);
+            addAcceptPostHeader();
         } else {
             options = "";
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -64,8 +64,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.FedoraExternalContent.COPY;
-import static org.fcrepo.kernel.api.FedoraExternalContent.PROXY;
-import static org.fcrepo.kernel.api.FedoraExternalContent.REDIRECT;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -135,7 +133,6 @@ import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
@@ -154,13 +151,9 @@ public class FedoraLdp extends ContentExposingResource {
 
     private static final Logger LOGGER = getLogger(FedoraLdp.class);
 
-    static final String HTTP_HEADER_ACCEPT_PATCH = "Accept-Patch";
-
     static final String WANT_DIGEST = "Want-Digest";
 
     static final String DIGEST = "Digest";
-
-    static final String ACCEPT_EXTERNAL_CONTENT = "Accept-External-Content-Handling";
 
     @PathParam("path") protected String externalPath;
 
@@ -822,7 +815,6 @@ public class FedoraLdp extends ContentExposingResource {
 
         }
         addExternalContentHeaders(resource);
-        addLinkAndOptionsHttpHeaders();
     }
 
     @Override
@@ -830,34 +822,6 @@ public class FedoraLdp extends ContentExposingResource {
         return externalPath;
     }
 
-    private void addLinkAndOptionsHttpHeaders() {
-        // Add Link headers
-        addResourceLinkHeaders(resource());
-
-        // Add Options headers
-        final String options;
-        if (resource().isMemento()) {
-            options = "GET,HEAD,OPTIONS,DELETE";
-
-        } else if (resource() instanceof FedoraBinary) {
-            options = "DELETE,HEAD,GET,PUT,OPTIONS";
-            servletResponse.addHeader(ACCEPT_EXTERNAL_CONTENT, COPY + "," + REDIRECT + "," + PROXY);
-
-        } else if (resource() instanceof NonRdfSourceDescription) {
-            options = "HEAD,GET,DELETE,PUT,PATCH,OPTIONS";
-            servletResponse.addHeader(HTTP_HEADER_ACCEPT_PATCH, contentTypeSPARQLUpdate);
-
-        } else if (resource() instanceof Container) {
-            options = "MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS";
-            servletResponse.addHeader(HTTP_HEADER_ACCEPT_PATCH, contentTypeSPARQLUpdate);
-
-            addAcceptPostHeader();
-        } else {
-            options = "";
-        }
-
-        servletResponse.addHeader("Allow", options);
-    }
 
     private static boolean isRDF(final MediaType requestContentType) {
         if (requestContentType == null) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -271,7 +271,7 @@ public class FedoraVersioning extends ContentExposingResource {
     public Response getVersionList(@HeaderParam("Range") final String rangeValue,
         @HeaderParam("Accept") final String acceptValue) throws IOException, UnsupportedAccessTypeException {
         if (!resource().isVersioned()) {
-            throw new RepositoryVersionRuntimeException("This operation requires that the node be versionable");
+            throw new RepositoryVersionRuntimeException("This operation requires that the resource be versionable");
         }
         final FedoraResource theTimeMap = resource().findOrCreateTimeMap();
         checkCacheControlHeaders(request, servletResponse, theTimeMap, session);
@@ -325,13 +325,13 @@ public class FedoraVersioning extends ContentExposingResource {
     /**
      * Outputs information about the supported HTTP methods, etc.
      *
-     * @return the outputs information about the supported HTTP methods, etc.
+     * @return the information about the supported HTTP methods, etc.
      */
     @OPTIONS
     @Timed
     public Response options() {
         if (!resource().isVersioned()) {
-            throw new RepositoryVersionRuntimeException("This operation requires that the node be versionable");
+            throw new RepositoryVersionRuntimeException("This operation requires that the resource be versionable");
         }
         final FedoraResource theTimeMap = resource().findOrCreateTimeMap();
         LOGGER.info("OPTIONS for '{}'", externalPath);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -58,6 +58,7 @@ import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
+import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -69,7 +70,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.jena.riot.Lang;
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
@@ -319,6 +320,23 @@ public class FedoraVersioning extends ContentExposingResource {
                 readLock.release();
             }
         }
+    }
+
+    /**
+     * Outputs information about the supported HTTP methods, etc.
+     *
+     * @return the outputs information about the supported HTTP methods, etc.
+     */
+    @OPTIONS
+    @Timed
+    public Response options() {
+        if (!resource().isVersioned()) {
+            throw new RepositoryVersionRuntimeException("This operation requires that the node be versionable");
+        }
+        final FedoraResource theTimeMap = resource().findOrCreateTimeMap();
+        LOGGER.info("OPTIONS for '{}'", externalPath);
+        addResourceHttpHeaders(theTimeMap);
+        return ok().build();
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -547,7 +547,7 @@ public abstract class AbstractResourceIT {
      * @param uri the URI not to exist in the LINK header
      * @param rel the rel argument to check for
      */
-    protected void assertNoLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+    protected static void assertNoLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
         assertEquals(0, countLinkHeader(response, uri, rel));
     }
 
@@ -558,7 +558,7 @@ public abstract class AbstractResourceIT {
      * @param uri the URI expected in the LINK header
      * @param rel the rel argument to check for
      */
-    protected void checkForLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+    protected static void checkForLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
         assertEquals(1, countLinkHeader(response, uri, rel));
     }
 
@@ -570,7 +570,7 @@ public abstract class AbstractResourceIT {
      * @param rel the rel argument to check for
      * @param count how many LINK headers should exist
      */
-    protected void checkForNLinkHeaders(final CloseableHttpResponse response, final String uri, final String rel,
+    protected static void checkForNLinkHeaders(final CloseableHttpResponse response, final String uri, final String rel,
         final int count) {
         assertEquals(count, countLinkHeader(response, uri, rel));
     }
@@ -583,7 +583,7 @@ public abstract class AbstractResourceIT {
      * @param rel the rel argument to check for
      * @return the count of LINK headers.
      */
-    private int countLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+    private static int countLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
         final Link linkA = Link.valueOf("<" + uri + ">; rel=" + rel);
         return (int) Arrays.asList(response.getHeaders(LINK)).stream().filter(x -> {
             final Link linkB = Link.valueOf(x.getValue());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -637,13 +637,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertTrue("Should allow POST", methods.contains(HttpPost.METHOD_NAME));
 
         final List<String> postTypes = headerValues(httpResponse, "Accept-Post");
-        assertTrue("POST should support application/sparql-update", postTypes.contains(contentTypeSPARQLUpdate));
         assertTrue("POST should support text/turtle", postTypes.contains(contentTypeTurtle));
         assertTrue("POST should support text/rdf+n3", postTypes.contains(contentTypeN3));
         assertTrue("POST should support text/n3", postTypes.contains(contentTypeN3Alt2));
         assertTrue("POST should support application/rdf+xml", postTypes.contains(contentTypeRDFXML));
         assertTrue("POST should support application/n-triples", postTypes.contains(contentTypeNTriples));
-        assertTrue("POST should support multipart/form-data", postTypes.contains("multipart/form-data"));
     }
 
     private static void assertRdfOptionsHeaders(final HttpResponse httpResponse) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -626,7 +626,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      *
      * @param uri The full URI of the Original Resource.
      * @param id The path of the Original Resource.
-     * @throws Exception
+     * @throws Exception on HTTP request error
      */
     private void verifyTimemapResponse(final String uri, final String id) throws Exception {
         verifyTimemapResponse(uri, id, null, null, null);
@@ -638,7 +638,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * @param uri The full URI of the Original Resource.
      * @param id The path of the Original Resource.
      * @param mementoDateTime a RFC-1123 datetime
-     * @throws Exception
+     * @throws Exception on HTTP request error
      */
     private void verifyTimemapResponse(final String uri, final String id, final String mementoDateTime)
         throws Exception {
@@ -654,7 +654,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * @param mementoDateTime Array of all the RFC-1123 datetimes for all the mementos.
      * @param rangeStart RFC-1123 datetime of the first memento.
      * @param rangeEnd RFC-1123 datetime of the last memento.
-     * @throws Exception
+     * @throws Exception on HTTP request error
      */
     private void verifyTimemapResponse(final String uri, final String id, final String[] mementoDateTime,
         final String rangeStart, final String rangeEnd)
@@ -702,7 +702,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     /**
      * Utility function to verify TimeMap headers
-     * 
+     *
      * @param response the response
      * @param uri the URI of the resource.
      */


### PR DESCRIPTION
**JIRA Ticket**: 
  * https://jira.duraspace.org/browse/FCREPO-2809
  * https://jira.duraspace.org/browse/FCREPO-2811
  * https://jira.duraspace.org/browse/FCREPO-2820

# What does this Pull Request do?
Adds some missing headers and changes the RDFSource type for a timemap to a Container type.

# How should this be tested?

Build and do some `GET`, `HEAD` and `OPTIONS` requests against a `/fcr:versions` endpoint. 
Ensure that 
1. These appear
   ```
    Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
    Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
   ```
1. This appears
   ```
   Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json,multipart/form-data,application/sparql-update
   ```
1. When you do an `OPTIONS` request is has these headers too.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
