### PR TITLE
Fcr 2815 - Support Mementos of External Binaries

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -603,6 +603,23 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     }
 
     /**
+     * Multi-value Link header values parsed by the javax.ws.rs.core are not split out by the framework Therefore we
+     * must do this ourselves.
+     *
+     * @param rawLinks the list of unprocessed links
+     * @return List of strings containing one link value per string.
+     */
+    protected List<String> unpackLinks(final List<String> rawLinks) {
+        if (rawLinks == null) {
+            return null;
+        }
+
+        return rawLinks.stream()
+                .flatMap(x -> Arrays.asList(x.split(",")).stream())
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Add any resource-specific headers to the response
      * @param resource the resource
      */

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -74,7 +74,6 @@ import java.net.URLDecoder;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -503,25 +502,6 @@ public class FedoraLdp extends ContentExposingResource {
         } finally {
             lock.release();
         }
-    }
-
-
-
-    /**
-     * Multi-value Link header values parsed by the javax.ws.rs.core are not split out by the framework
-     * Therefore we must do this ourselves.
-     *
-     * @param rawLinks the list of unprocessed links
-     * @return List of strings containing one link value per string.
-     */
-    private List<String> unpackLinks(final List<String> rawLinks) {
-        if (rawLinks == null) {
-            return null;
-        }
-
-        return rawLinks.stream()
-                       .flatMap(x -> Arrays.asList(x.split(",")).stream())
-                       .collect(Collectors.toList());
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -35,6 +35,7 @@ import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
@@ -589,5 +590,24 @@ public abstract class AbstractResourceIT {
             final Link linkB = Link.valueOf(x.getValue());
             return linkB.equals(linkA);
         }).count();
+    }
+
+    protected String getExternalContentLinkHeader(final String url, final String handling, final String mimeType) {
+        // leave lots of room to leave things out of the link to test variations.
+        String link = "";
+        if (url != null && !url.isEmpty()) {
+            link += "<" + url + ">";
+        }
+
+        link += "; rel=\"" + EXTERNAL_CONTENT + "\"";
+
+        if (handling != null && !handling.isEmpty()) {
+            link += "; handling=\"" + handling + "\"";
+        }
+
+        if (mimeType != null && !mimeType.isEmpty()) {
+            link += "; type=\"" + mimeType + "\"";
+        }
+        return link;
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -79,7 +79,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_CHILD;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
@@ -420,26 +419,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue("MD5 fixity checksum doesn't match",
                     digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
         }
-    }
-
-    private String getExternalContentLinkHeader(final String url, final String handling, final String mimeType) {
-        // leave lots of room to leave things out of the link to test variations.
-        String link = "";
-        if (url != null && !url.isEmpty()) {
-            link += "<" + url + ">";
-        }
-
-        link += "; rel=\"" + EXTERNAL_CONTENT + "\"";
-
-        if (handling != null && !handling.isEmpty()) {
-            link += "; handling=\"" + handling + "\"";
-        }
-
-        if (mimeType != null && !mimeType.isEmpty()) {
-            link += "; type=\"" + mimeType + "\"";
-        }
-        LOGGER.info("Created link: {}", link);
-        return link;
     }
 
     @Test

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -103,4 +103,22 @@ public interface VersionService {
     FedoraBinary createBinaryVersion(FedoraSession session, FedoraBinary resource, Instant dateTime,
             StoragePolicyDecisionPoint storagePolicyDecisionPoint)
             throws InvalidChecksumException;
+
+    /**
+     * @param session the session in which the resource resides
+     * @param resource the binary resource to version
+     * @param dateTime the date/time of the version
+     * @param checksums Collection of checksum URIs of the content (optional)
+     * @param externalHandling What type of handling the external resource needs (proxy or redirect)
+     * @param externalUrl Url for the external resourcej
+     * @return the version
+     * @throws InvalidChecksumException if there are errors applying checksums
+     */
+    FedoraBinary createExternalBinaryVersion(final FedoraSession session,
+            final FedoraBinary resource,
+            final Instant dateTime,
+            final Collection<URI> checksums,
+            final String externalHandling,
+            final String externalUrl)
+            throws InvalidChecksumException;
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -241,6 +241,25 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     }
 
     @Override
+    public FedoraBinary createExternalBinaryVersion(final FedoraSession session,
+            final FedoraBinary resource,
+            final Instant dateTime,
+            final Collection<URI> checksums,
+            final String externalHandling,
+            final String externalUrl)
+            throws InvalidChecksumException {
+        final String mementoPath = makeMementoPath(resource, dateTime);
+        assertMementoDoesNotExist(session, mementoPath);
+
+        final FedoraBinary memento = binaryService.findOrCreateBinary(session, mementoPath);
+        decorateWithMementoProperties(session, mementoPath, dateTime);
+
+        memento.setExternalContent(null, checksums, null, externalHandling, externalUrl);
+
+        return memento;
+    }
+
+    @Override
     public FedoraBinary createBinaryVersion(final FedoraSession session,
             final FedoraBinary resource,
             final Instant dateTime,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2815

# What does this Pull Request do?
Adds support and testing for external binaries when creating mementos

# What's new?
* Versioning controller now supports external content link header.
* Updated VersionService with a method signature for creating historic external binary mementos.
* Updated VersionServiceImpl to know how to create mementos from the current version of a external binary and from historic versions
* Adds integration tests for copy, proxy and redirect with historic mementos, proxy with current memento.

# How should this be tested?

Memento from a current proxied binary:
```
curl -i -XPUT -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" -H "Link: <https://wiki.duraspace.org/download/attachments/19006307/Feedback_fr.txt>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" "http://localhost:8080/rest/version_current_proxy" -ufedoraAdmin:fedoraAdmin

curl -XPOST http://localhost:8080/rest/version_current_proxy/fcr:versions -ufedoraAdmin:fedoraAdmin

curl -v http://localhost:8080/rest/version_current_proxy
curl -v http://localhost:8080/rest/version_current_proxy/fcr:metadata
# These should return same content as current versions, but with memento header
curl -v -ufedoraAdmin:fedoraAdmin <url of memento>
curl -v -ufedoraAdmin:fedoraAdmin <url of memento>/fcr:metadata
```


Historic memento using `copy` handling:
```
curl -i -XPUT -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" -H "Link: <file:///Users/bbpennel/git/fcrepo4/README.md>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"copy\"; type=\"text/plain\"" "http://localhost:8080/rest/version_copy" -ufedoraAdmin:fedoraAdmin

curl -XPOST http://localhost:8080/rest/version_copy/fcr:versions -H "Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT" -H "Link: <file:///Users/bbpennel/git/fcrepo4/pom.xml>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"copy\"" -ufedoraAdmin:fedoraAdmin

curl -v -ufedoraAdmin:fedoraAdmin <url from last command>
# contains pom.xml
# has memento headers

curl -v -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/version_copy
# returns contents of README.md
```

Historic memento from proxied content with a description added
```
curl -i -XPUT -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" -H "Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" "http://localhost:8080/rest/version_proxy" -ufedoraAdmin:fedoraAdmin


curl -XPOST http://localhost:8080/rest/version_proxy/fcr:versions -H "Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT" -H "Link: <https://wiki.duraspace.org/download/attachments/31655033/fedora_logo_2in.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" -ufedoraAdmin:fedoraAdmin

echo '@prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
@prefix test:  <info:fedora/test/> .
@prefix pcdm:  <http://pcdm.org/models#> .
@prefix memento:  <http://mementoweb.org/ns#> .
@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
@prefix webac:  <http://fedora.info/definitions/v4/webac#> .
@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
@prefix ns001:  <http://www.iana.org/assignments/relation/> .
@prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
@prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix xml:  <http://www.w3.org/XML/1998/namespace> .
@prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .
@prefix xs:  <http://www.w3.org/2001/XMLSchema> .
@prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@prefix dc:  <http://purl.org/dc/elements/1.1/> .<http://localhost:8080/rest/version_proxy>
        rdf:type                 fedora:NonRdfSourceDescription ;
        rdf:type                 fedora:Binary ;
        rdf:type                 fedora:Resource ;
        fedora:lastModifiedBy    "fedoraAdmin" ;
        premis:hasSize           "4167"^^<http://www.w3.org/2001/XMLSchema#long> ;
        ebucore:hasMimeType      "image/png" ;
        fedora:createdBy         "fedoraAdmin" ;
        fedora:created           "2018-07-03T19:00:28.354Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified      "2018-07-03T19:00:28.354Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        ebucore:filename         "" ;
        rdf:type                 ldp:NonRDFSource ;
        fedora:writable          true ;
        ns001:describedby        <http://localhost:8080/rest/version_proxy/fcr:metadata> ;
        fedora:hasFixityService  <http://localhost:8080/rest/version_proxy/fcr:fixity> .' | curl -XPOST -H "Content-Type: text/turtle" -H "Memento-Datetime: Sat, 1 Jan 2000 00:00:00 GMT" --data-binary "@-" http://localhost:8080/rest/version_proxy/fcr:metadata/fcr:versions -ufedoraAdmin:fedoraAdmin
```

# Interested parties
@bseeger @whikloj @awoods 
