### PR TITLE
Disambiguate content-type headers

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -22,6 +22,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
 import static org.fcrepo.kernel.api.FedoraExternalContent.COPY;
 import static org.fcrepo.kernel.api.FedoraExternalContent.REDIRECT;
 import static org.fcrepo.kernel.api.FedoraExternalContent.PROXY;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -57,7 +58,7 @@ public class ExternalContentHandler {
     private static final Logger LOGGER = getLogger(FedoraLdp.class);
 
     public final static String HANDLING = "handling";
-    public final static String CONTENT_TYPE = "type";
+    public final static String EXT_CONTENT_TYPE = "type";
 
     private final Link link;
     private final String handling;
@@ -83,7 +84,7 @@ public class ExternalContentHandler {
         final Map<String, String> map = link.getParams();
         // handling will be in the map, where as content type may not be
         handling = map.get(HANDLING).toLowerCase();
-        type = map.get(CONTENT_TYPE) != null ? map.get(CONTENT_TYPE).toLowerCase() : null;
+        type = map.get(EXT_CONTENT_TYPE) != null ? map.get(EXT_CONTENT_TYPE).toLowerCase() : null;
         contentType = type != null ? MediaType.valueOf(type) : findContentType(getURL());
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_LOCATION;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_CREATED;
+
+import javax.ws.rs.core.Link;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+
+/**
+ * @author whikloj
+ * @since 2018-07-10
+ */
+public class ExternalContentHandlerIT extends AbstractResourceIT {
+
+    private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
+
+    @Test
+    public void testRemoteUriContentType() throws Exception {
+        final HttpPost method = postObjMethod();
+        method.addHeader(CONTENT_TYPE, "audio/ogg");
+        method.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        method.setEntity(new StringEntity("xyz"));
+        final String external_location;
+        final String final_location = "proxy_resource";
+
+        // Make an external remote URI.
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(SC_CREATED, getStatus(response));
+            external_location = getLocation(response);
+        }
+        // Make an external content resource proxying the above URI.
+        final HttpPut put = putObjMethod(final_location);
+        final String externalLink = Link.fromUri(external_location)
+            .rel("http://fedora.info/definitions/fcrepo#ExternalContent").param("handling", "proxy").build().toString();
+        put.addHeader("Link", externalLink);
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(SC_CREATED, getStatus(response));
+        }
+        // Get the external content proxy resource.
+        try (final CloseableHttpResponse response = execute(getObjMethod(final_location))) {
+            assertEquals(SC_OK, getStatus(response));
+            assertEquals("audio/ogg", response.getFirstHeader(CONTENT_TYPE).getValue());
+            assertEquals(external_location, response.getFirstHeader(CONTENT_LOCATION).getValue());
+        }
+
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertEquals;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpStatus.SC_CREATED;
 
-import javax.ws.rs.core.Link;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -56,9 +55,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
         // Make an external content resource proxying the above URI.
         final HttpPut put = putObjMethod(final_location);
-        final String externalLink = Link.fromUri(external_location)
-            .rel("http://fedora.info/definitions/fcrepo#ExternalContent").param("handling", "proxy").build().toString();
-        put.addHeader("Link", externalLink);
+        put.addHeader(LINK, getExternalContentLinkHeader(external_location, "proxy", null));
         try (final CloseableHttpResponse response = execute(put)) {
             assertEquals(SC_CREATED, getStatus(response));
         }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2827

# What does this Pull Request do?
Renames the ExternalContentHandler static `CONTENT_TYPE` to `EXT_CONTENT_TYPE` (which resolves to `type`) to avoid naming confusion with the various public statics `CONTENT_TYPE` which resolve to `Content-Type`.

# What's new?
Simple rename and a static import, along with a test.

# How should this be tested?

Before the PR, created a proxied external content resource pointing at a remote web server that **does** return a `Content-Type` header. 

This header is not used and your resource with have a `Content-Type: application/octet-stream`.

After this PR your resource should have the same `Content-Type` that the remote server returns.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
