### PR TITLE
Adds support for deleting an ACL Resource.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -18,8 +18,6 @@
 package org.fcrepo.http.api;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.noContent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -39,6 +37,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import javax.jcr.ItemNotFoundException;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
@@ -209,7 +208,7 @@ public class FedoraAcl extends ContentExposingResource {
         N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
         TURTLE_X, TEXT_HTML_WITH_CHARSET })
     public Response getResource(@HeaderParam("Range") final String rangeValue)
-            throws IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException {
+            throws IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException, ItemNotFoundException {
 
         final FedoraResource aclResource = resource().getAcl();
 
@@ -238,7 +237,7 @@ public class FedoraAcl extends ContentExposingResource {
      */
     @DELETE
     @Timed
-    public Response deleteObject() {
+    public Response deleteObject() throws ItemNotFoundException {
 
         hasRestrictedPath(externalPath);
         LOGGER.info("Delete resource '{}'", externalPath);
@@ -262,7 +261,7 @@ public class FedoraAcl extends ContentExposingResource {
         }
     }
 
-    private Response notFound() {
-        return status(NOT_FOUND).entity("Resource does not exist.").build();
+    private Response notFound() throws ItemNotFoundException {
+        throw new ItemNotFoundException("Resource does not exist.");
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -213,7 +213,7 @@ public class FedoraAcl extends ContentExposingResource {
         final FedoraResource aclResource = resource().getAcl();
 
         if (aclResource == null) {
-            return notFound();
+            throwItemNotFoundException();
         }
 
         checkCacheControlHeaders(request, servletResponse, aclResource, session);
@@ -251,17 +251,18 @@ public class FedoraAcl extends ContentExposingResource {
             }
             session.commit();
 
-            if (aclResource != null) {
-                return noContent().build();
-            } else {
-                return notFound();
+            if (aclResource == null) {
+                throwItemNotFoundException();
             }
+
+            return noContent().build();
+
         } finally {
             lock.release();
         }
     }
 
-    private Response notFound() throws ItemNotFoundException {
+    private void throwItemNotFoundException() throws ItemNotFoundException {
         throw new ItemNotFoundException("Resource does not exist.");
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -213,7 +213,7 @@ public class FedoraAcl extends ContentExposingResource {
         final FedoraResource aclResource = resource().getAcl();
 
         if (aclResource == null) {
-            throwItemNotFoundException();
+            throw new ItemNotFoundException();
         }
 
         checkCacheControlHeaders(request, servletResponse, aclResource, session);
@@ -252,7 +252,7 @@ public class FedoraAcl extends ContentExposingResource {
             session.commit();
 
             if (aclResource == null) {
-                throwItemNotFoundException();
+                throw new ItemNotFoundException();
             }
 
             return noContent().build();
@@ -262,7 +262,4 @@ public class FedoraAcl extends ContentExposingResource {
         }
     }
 
-    private void throwItemNotFoundException() throws ItemNotFoundException {
-        throw new ItemNotFoundException("Resource does not exist.");
-    }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -18,6 +18,8 @@
 package org.fcrepo.http.api;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.noContent;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -37,11 +39,11 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PUT;
@@ -53,6 +55,7 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import com.codahale.metrics.annotation.Timed;
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.http.api.PathLockManager.AcquiredLock;
 import org.fcrepo.http.commons.domain.ContentLocation;
@@ -67,8 +70,6 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
-
-import com.codahale.metrics.annotation.Timed;
 
 /**
  * @author lsitu
@@ -212,6 +213,10 @@ public class FedoraAcl extends ContentExposingResource {
 
         final FedoraResource aclResource = resource().getAcl();
 
+        if (aclResource == null) {
+            return notFound();
+        }
+
         checkCacheControlHeaders(request, servletResponse, aclResource, session);
 
         LOGGER.info("GET resource '{}'", externalPath);
@@ -224,5 +229,40 @@ public class FedoraAcl extends ContentExposingResource {
         } finally {
             readLock.release();
         }
+    }
+
+    /**
+     * Deletes an object.
+     *
+     * @return response
+     */
+    @DELETE
+    @Timed
+    public Response deleteObject() {
+
+        hasRestrictedPath(externalPath);
+        LOGGER.info("Delete resource '{}'", externalPath);
+
+        final AcquiredLock lock = lockManager.lockForDelete(resource().getPath());
+
+        try {
+            final FedoraResource aclResource = resource().getAcl();
+            if (aclResource != null) {
+                aclResource.delete();
+            }
+            session.commit();
+
+            if (aclResource != null) {
+                return noContent().build();
+            } else {
+                return notFound();
+            }
+        } finally {
+            lock.release();
+        }
+    }
+
+    private Response notFound() {
+        return status(NOT_FOUND).entity("Resource does not exist.").build();
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -103,6 +103,13 @@ public interface FedoraResource {
     boolean isMemento();
 
     /**
+     * Returns true if this resource is an ACL.
+     *
+     * @return true if the resource is an ACL.
+     */
+    boolean isAcl();
+
+    /**
      * Retrieve the Memento with the closest datetime to the request.
      *
      * @param mementoDatetime The requested date time.


### PR DESCRIPTION
In implementing the feature, I also fixed the failure
to properly return a 404 on a non-existent ACL.

Resolves:
https://jira.duraspace.org/browse/FCREPO-2831
https://jira.duraspace.org/browse/FCREPO-2833

**Delete ACL Resource**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2833 and https://jira.duraspace.org/browse/FCREPO-2831


# What does this Pull Request do?
Adds support for deleting an ACL resource.  Also ensures that 404 is returned when the ACL does not exist.

# How should this be tested?

`# create a container
curl -v -X PUT  http://localhost:8080/rest/container  -u fedoraAdmin:fedoraAdmin
# Get an ACL and verify 404 response: 
 curl -v -X GET  http://localhost:8080/rest/container/fcr:acl  -u fedoraAdmin:fedoraAdmin
# create ACL
curl -v -X PUT  http://localhost:8080/rest/container/fcr:acl  -u fedoraAdmin:fedoraAdmin
# verify ACL exists
curl -v -X GET  http://localhost:8080/rest/container/fcr:acl  -u fedoraAdmin:fedoraAdmin
# DELETE an ACL and verify 204 response: 
 curl -v -X DELETE  http://localhost:8080/rest/container/fcr:acl  -u fedoraAdmin:fedoraAdmin
# Ensure delete was successful by getting ACL and verify 404 response: 
 curl -v -X GET  http://localhost:8080/rest/container/fcr:acl  -u fedoraAdmin:fedoraAdmin
`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
