### PR TITLE
1. GET on ACL resources now returning the fedora:acl node rather than…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -31,14 +31,14 @@ import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.PARTIAL_CONTENT;
-import static javax.ws.rs.core.Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE;
 import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.notAcceptable;
 import static javax.ws.rs.core.Response.ok;
 import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.PARTIAL_CONTENT;
+import static javax.ws.rs.core.Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE;
 import static javax.ws.rs.core.Variant.mediaTypes;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
@@ -83,6 +83,9 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -91,8 +94,8 @@ import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -116,9 +119,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Splitter;
 import org.apache.jena.atlas.RuntimeIOException;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
@@ -144,8 +144,8 @@ import org.fcrepo.kernel.api.exception.PreconditionException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
-import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
+import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -277,7 +277,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @param resource the fedora resource
      * @return {@link RdfStream}
      */
-    protected RdfStream getResourceTriples(final int limit, final FedoraResource resource) {
+    private RdfStream getResourceTriples(final int limit, final FedoraResource resource) {
 
         final PreferTag returnPreference;
 
@@ -354,7 +354,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @return Binary blob
      * @throws IOException if io exception occurred
      */
-    protected Response getBinaryContent(final String rangeValue, final FedoraResource resource)
+    private Response getBinaryContent(final String rangeValue, final FedoraResource resource)
             throws IOException {
             final FedoraBinary binary = (FedoraBinary)resource;
             final CacheControl cc = new CacheControl();
@@ -914,7 +914,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @return Model containing triples from request body
      * @throws MalformedRdfException in case rdf json cannot be parsed
      */
-    protected Model parseBodyAsModel(final InputStream requestBodyStream,
+    private Model parseBodyAsModel(final InputStream requestBodyStream,
             final MediaType contentType, final FedoraResource resource) throws MalformedRdfException {
         final Lang format = contentTypeToLang(contentType.toString());
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -31,14 +31,14 @@ import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.PARTIAL_CONTENT;
+import static javax.ws.rs.core.Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE;
 import static javax.ws.rs.core.Response.created;
 import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.notAcceptable;
 import static javax.ws.rs.core.Response.ok;
 import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.PARTIAL_CONTENT;
-import static javax.ws.rs.core.Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE;
 import static javax.ws.rs.core.Variant.mediaTypes;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
@@ -47,6 +47,13 @@ import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
 import static org.apache.jena.vocabulary.RDF.type;
+import static org.fcrepo.http.api.FedoraVersioning.MEMENTO_DATETIME_HEADER;
+import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2;
+import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
+import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.fcrepo.kernel.api.FedoraExternalContent.COPY;
 import static org.fcrepo.kernel.api.FedoraExternalContent.PROXY;
 import static org.fcrepo.kernel.api.FedoraExternalContent.REDIRECT;
@@ -74,18 +81,8 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RequiredRdfContext.MINIMAL;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
-import static org.fcrepo.http.api.FedoraVersioning.MEMENTO_DATETIME_HEADER;
-import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2;
-import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
-import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -94,8 +91,8 @@ import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -118,6 +115,10 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import org.apache.jena.atlas.RuntimeIOException;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
@@ -143,8 +144,8 @@ import org.fcrepo.kernel.api.exception.PreconditionException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
-import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
+import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -154,7 +155,6 @@ import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.kernel.api.utils.ContentDigest;
-
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.jvnet.hk2.annotations.Optional;
 import org.slf4j.Logger;
@@ -201,7 +201,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     @Optional
     StoragePolicyDecisionPoint storagePolicyDecisionPoint;
 
-    protected FedoraResource resource;
+    private FedoraResource fedoraResource;
 
     @Inject
     protected  PathLockManager lockManager;
@@ -216,41 +216,38 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected static final Splitter.MapSplitter RFC3230_SPLITTER =
         Splitter.on(',').omitEmptyStrings().trimResults().withKeyValueSeparator(Splitter.on('=').limit(2));
 
-    protected Response getContent(final String rangeValue,
-            final RdfStream rdfStream) throws IOException, UnsupportedAccessTypeException {
-        return getContent(rangeValue, -1, rdfStream);
-    }
-
     /**
      * This method returns an HTTP response with content body appropriate to the following arguments.
      *
      * @param rangeValue starting and ending byte offsets, see {@link Range}
      * @param limit is the number of child resources returned in the response, -1 for all
      * @param rdfStream to which response RDF will be concatenated
+     * @param resource the fedora resource
      * @return HTTP response
      * @throws IOException in case of error extracting content
      * @throws UnsupportedAccessTypeException if mimeType not a valid message/external-body content type
      */
     protected Response getContent(final String rangeValue,
                                   final int limit,
-                                  final RdfStream rdfStream) throws IOException, UnsupportedAccessTypeException {
+                                  final RdfStream rdfStream,
+                                  final FedoraResource resource) throws IOException, UnsupportedAccessTypeException {
 
         final RdfNamespacedStream outputStream;
 
-        if (resource() instanceof FedoraBinary) {
-            return getBinaryContent(rangeValue);
+        if (resource instanceof FedoraBinary) {
+            return getBinaryContent(rangeValue, resource);
         } else {
             outputStream = new RdfNamespacedStream(
                     new DefaultRdfStream(rdfStream.topic(), concat(rdfStream,
-                        getResourceTriples(limit))),
+                        getResourceTriples(limit, resource))),
                     session.getFedoraSession().getNamespaces());
         }
-        setVaryAndPreferenceAppliedHeaders(servletResponse, prefer);
+        setVaryAndPreferenceAppliedHeaders(servletResponse, prefer, resource);
         return ok(outputStream).build();
     }
 
     protected void setVaryAndPreferenceAppliedHeaders(final HttpServletResponse servletResponse,
-            final MultiPrefer prefer) {
+            final MultiPrefer prefer, final FedoraResource resource) {
         if (prefer != null) {
             prefer.getReturn().addResponseHeaders(servletResponse);
         }
@@ -258,7 +255,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         // add vary headers
         final List<String> varyValues = new ArrayList<>(VARY_HEADERS);
 
-        if (resource().isVersioned()) {
+        if (resource.isVersioned()) {
             varyValues.add(ACCEPT_DATETIME);
         }
 
@@ -269,17 +266,19 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
 
 
-    protected RdfStream getResourceTriples() {
-        return getResourceTriples(-1);
+    protected RdfStream getResourceTriples(final FedoraResource resource) {
+        return getResourceTriples(-1, resource);
     }
 
     /**
      * This method returns a stream of RDF triples associated with this target resource
      *
      * @param limit is the number of child resources returned in the response, -1 for all
+     * @param resource the fedora resource
      * @return {@link RdfStream}
      */
-    protected RdfStream getResourceTriples(final int limit) {
+    protected RdfStream getResourceTriples(final int limit, final FedoraResource resource) {
+
         final PreferTag returnPreference;
 
         if (prefer != null && prefer.hasReturn()) {
@@ -298,49 +297,49 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         final List<Stream<Triple>> streams = new ArrayList<>();
 
         if (returnPreference.getValue().equals("minimal")) {
-            streams.add(getTriples(of(PROPERTIES, MINIMAL)).filter(tripleFilter));
+            streams.add(getTriples(resource, of(PROPERTIES, MINIMAL)).filter(tripleFilter));
 
             if (ldpPreferences.prefersServerManaged()) {
-                streams.add(getTriples(of(SERVER_MANAGED, MINIMAL)));
+                streams.add(getTriples(resource, of(SERVER_MANAGED, MINIMAL)));
             }
         } else {
-            streams.add(getTriples(PROPERTIES).filter(tripleFilter));
+            streams.add(getTriples(resource, PROPERTIES).filter(tripleFilter));
 
             // Additional server-managed triples about this resource
             if (ldpPreferences.prefersServerManaged()) {
-                streams.add(getTriples(SERVER_MANAGED));
+                streams.add(getTriples(resource, SERVER_MANAGED));
             }
 
             // containment triples about this resource
             if (ldpPreferences.prefersContainment()) {
                 if (limit == -1) {
-                    streams.add(getTriples(LDP_CONTAINMENT));
+                    streams.add(getTriples(resource, LDP_CONTAINMENT));
                 } else {
-                    streams.add(getTriples(LDP_CONTAINMENT).limit(limit));
+                    streams.add(getTriples(resource, LDP_CONTAINMENT).limit(limit));
                 }
             }
 
             // LDP container membership triples for this resource
             if (ldpPreferences.prefersMembership()) {
-                streams.add(getTriples(LDP_MEMBERSHIP));
+                streams.add(getTriples(resource, LDP_MEMBERSHIP));
             }
 
             // Include inbound references to this object
             if (ldpPreferences.prefersReferences()) {
-                streams.add(getTriples(INBOUND_REFERENCES));
+                streams.add(getTriples(resource, INBOUND_REFERENCES));
             }
 
             // Embed the children of this object
             if (ldpPreferences.prefersEmbed()) {
-                streams.add(getTriples(EMBED_RESOURCES));
+                streams.add(getTriples(resource, EMBED_RESOURCES));
             }
         }
 
         final RdfStream rdfStream = new DefaultRdfStream(
-                asNode(resource()), streams.stream().reduce(empty(), Stream::concat));
+                asNode(resource), streams.stream().reduce(empty(), Stream::concat));
 
         if (httpTripleUtil != null && ldpPreferences.prefersServerManaged()) {
-            return httpTripleUtil.addHttpComponentModelsForResourceToStream(rdfStream, resource(), uriInfo,
+            return httpTripleUtil.addHttpComponentModelsForResourceToStream(rdfStream, resource, uriInfo,
                     translator());
         }
 
@@ -351,12 +350,13 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * Get the binary content of a datastream
      *
      * @param rangeValue the range value
+     * @param resource the fedora resource
      * @return Binary blob
      * @throws IOException if io exception occurred
      */
-    protected Response getBinaryContent(final String rangeValue)
+    protected Response getBinaryContent(final String rangeValue, final FedoraResource resource)
             throws IOException {
-            final FedoraBinary binary = (FedoraBinary)resource();
+            final FedoraBinary binary = (FedoraBinary)resource;
             final CacheControl cc = new CacheControl();
             cc.setMaxAge(0);
             cc.setMustRevalidate(true);
@@ -405,22 +405,14 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             // we set the content-type explicitly to avoid content-negotiation from getting in the way
             // getBinaryResourceMediaType will try to use the mime type on the resource, falling back on
             // 'application/octet-stream' if the mime type is syntactically invalid
-            return builder.type(getBinaryResourceMediaType().toString())
+            return builder.type(getBinaryResourceMediaType(resource).toString())
                     .cacheControl(cc)
                     .build();
 
         }
 
-    protected RdfStream getTriples(final Set<? extends TripleCategory> x) {
-        return getTriples(resource(), x);
-    }
-
     protected RdfStream getTriples(final FedoraResource resource, final Set<? extends TripleCategory> x) {
         return resource.getTriples(translator(), x);
-    }
-
-    protected RdfStream getTriples(final TripleCategory x) {
-        return getTriples(resource(), x);
     }
 
     protected RdfStream getTriples(final FedoraResource resource, final TripleCategory x) {
@@ -437,10 +429,10 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     }
 
     protected FedoraResource resource() {
-        if (resource == null) {
-            resource = getResourceFromPath(externalPath());
+        if (fedoraResource == null) {
+            fedoraResource = getResourceFromPath(externalPath());
         }
-        return resource;
+        return fedoraResource;
     }
 
     /**
@@ -537,18 +529,11 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     }
 
     /**
-     * Utility constructor using resource() function.
-     */
-    protected void addLinkAndOptionsHttpHeaders() {
-        addLinkAndOptionsHttpHeaders(resource());
-    }
-
-    /**
      * Add Link and Option headers
      *
      * @param resource the resource to generate headers for
      */
-    private void addLinkAndOptionsHttpHeaders(final FedoraResource resource) {
+    protected void addLinkAndOptionsHttpHeaders(final FedoraResource resource) {
         // Add Link headers
         addResourceLinkHeaders(resource);
 
@@ -664,7 +649,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             servletResponse.addHeader(LINK, "<" + LDP_NAMESPACE + "RDFSource>;rel=\"type\"");
         }
         if (httpHeaderInject != null) {
-            httpHeaderInject.addHttpHeaderToResponseStream(servletResponse, uriInfo, resource());
+            httpHeaderInject.addHttpHeaderToResponseStream(servletResponse, uriInfo, resource);
         }
 
         addLinkAndOptionsHttpHeaders(resource);
@@ -866,7 +851,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 prefer.getReturn().addResponseHeaders(servletResponse);
             }
             final RdfNamespacedStream rdfStream = new RdfNamespacedStream(
-                new DefaultRdfStream(asNode(resource()), getResourceTriples()),
+                new DefaultRdfStream(asNode(resource), getResourceTriples(resource)),
                 session().getFedoraSession().getNamespaces());
             return builder.entity(rdfStream).build();
         }
@@ -913,7 +898,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                                              final InputStream requestBodyStream,
                                              final MediaType contentType,
                                              final RdfStream resourceTriples) throws MalformedRdfException {
-        final Model inputModel = parseBodyAsModel(requestBodyStream, contentType);
+        final Model inputModel = parseBodyAsModel(requestBodyStream, contentType, resource);
 
         ensureValidMemberRelation(inputModel);
 
@@ -925,17 +910,18 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      *
      * @param requestBodyStream rdf request body
      * @param contentType content type of body
+     * @param resource the fedora resource
      * @return Model containing triples from request body
      * @throws MalformedRdfException in case rdf json cannot be parsed
      */
     protected Model parseBodyAsModel(final InputStream requestBodyStream,
-            final MediaType contentType) throws MalformedRdfException {
+            final MediaType contentType, final FedoraResource resource) throws MalformedRdfException {
         final Lang format = contentTypeToLang(contentType.toString());
 
         final Model inputModel;
         try {
             inputModel = createDefaultModel();
-            inputModel.read(requestBodyStream, getUri(resource()).toString(), format.getName().toUpperCase());
+            inputModel.read(requestBodyStream, getUri(resource).toString(), format.getName().toUpperCase());
             return inputModel;
         } catch (final RiotException e) {
             throw new BadRequestException("RDF was not parsable: " + e.getMessage(), e);
@@ -988,15 +974,15 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * This method returns a MediaType for a binary resource.
      * If the resource's media type is syntactically incorrect, it will
      * return 'application/octet-stream' as the media type.
-     *
+     * @param  resource the fedora resource
      * @return the media type of of a binary resource
      */
-    protected MediaType getBinaryResourceMediaType() {
+    protected MediaType getBinaryResourceMediaType(final FedoraResource resource) {
         try {
-            return MediaType.valueOf(((FedoraBinary) resource()).getMimeType());
+            return MediaType.valueOf(((FedoraBinary) resource).getMimeType());
         } catch (final IllegalArgumentException e) {
             LOGGER.warn("Syntactically incorrect MediaType encountered on resource {}: '{}'",
-                    resource().getPath(), ((FedoraBinary)resource()).getMimeType());
+                    resource.getPath(), ((FedoraBinary)resource).getMimeType());
             return MediaType.APPLICATION_OCTET_STREAM_TYPE;
         }
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -80,15 +80,11 @@ public class FedoraAcl extends ContentExposingResource {
 
     private static final Logger LOGGER = getLogger(FedoraAcl.class);
 
-    @Context
-    protected Request request;
-    @Context
-    protected HttpServletResponse servletResponse;
-    @Context
-    protected UriInfo uriInfo;
+    @Context protected Request request;
+    @Context protected HttpServletResponse servletResponse;
+    @Context protected UriInfo uriInfo;
 
-    @PathParam("path")
-    protected String externalPath;
+    @PathParam("path") protected String externalPath;
 
     /**
      * Default JAX-RS entry point
@@ -142,7 +138,7 @@ public class FedoraAcl extends ContentExposingResource {
      * @throws IOException if IO exception occurred
      */
     @PATCH
-    @Consumes( {contentTypeSPARQLUpdate})
+    @Consumes({ contentTypeSPARQLUpdate })
     @Timed
     public Response updateSparql(@ContentLocation final InputStream requestBodyStream)
         throws IOException, ItemNotFoundException {
@@ -206,14 +202,14 @@ public class FedoraAcl extends ContentExposingResource {
      *
      * @param rangeValue the range value
      * @return a binary or the triples for the specified node
-     * @throws IOException                    if IO exception occurred
+     * @throws IOException if IO exception occurred
      * @throws UnsupportedAlgorithmException  if unsupported digest algorithm occurred
      * @throws UnsupportedAccessTypeException if unsupported access-type occurred
      */
     @GET
-    @Produces( {TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
+    @Produces({ TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
                 N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
-                TURTLE_X, TEXT_HTML_WITH_CHARSET})
+                TURTLE_X, TEXT_HTML_WITH_CHARSET })
     public Response getResource(@HeaderParam("Range") final String rangeValue)
             throws IOException, UnsupportedAlgorithmException, UnsupportedAccessTypeException, ItemNotFoundException {
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -316,7 +316,7 @@ public class FedoraLdp extends ContentExposingResource {
      * @param resource The fedora resource
      * @return A 302 Found response or 404 if no mementos.
      */
-    protected Response getMemento(final String datetimeHeader, final FedoraResource resource) {
+    private Response getMemento(final String datetimeHeader, final FedoraResource resource) {
         try {
             final Instant mementoDatetime = Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(datetimeHeader));
             final FedoraResource memento = resource.findMementoByDatetime(mementoDatetime);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -160,7 +160,8 @@ public class FedoraVersioning extends ContentExposingResource {
             @HeaderParam(LINK) final List<String> rawLinks)
             throws InvalidChecksumException, MementoDatetimeFormatException {
 
-        final FedoraResource timeMap = resource().findOrCreateTimeMap();
+        final FedoraResource resource = resource();
+        final FedoraResource timeMap = resource.findOrCreateTimeMap();
         // If the timemap was created in this request, commit it.
         if (timeMap.isNew()) {
             session.commit();
@@ -330,9 +331,7 @@ public class FedoraVersioning extends ContentExposingResource {
         } else {
             final AcquiredLock readLock = lockManager.lockForRead(theTimeMap.getPath());
             try (final RdfStream rdfStream = new DefaultRdfStream(asNode(theTimeMap))) {
-                // Need to set the timemap as the resource for the below function.
-                setResource(theTimeMap);
-                return getContent(rangeValue, getChildrenLimit(), rdfStream);
+                return getContent(rangeValue, getChildrenLimit(), rdfStream, theTimeMap);
             } finally {
                 readLock.release();
             }
@@ -354,15 +353,6 @@ public class FedoraVersioning extends ContentExposingResource {
         LOGGER.info("OPTIONS for '{}'", externalPath);
         addResourceHttpHeaders(theTimeMap);
         return ok().build();
-    }
-
-    /**
-     * Set the resource to an alternate from that retrieved automatically.
-     *
-     * @param resource a FedoraResource
-     */
-    private void setResource(final FedoraResource resource) {
-        this.resource = resource;
     }
 
     @Override

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -83,10 +83,12 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
     private static final Logger LOGGER = getLogger(HttpResourceConverter.class);
 
     // Regex pattern which decomposes a http resource uri into components
-    // First group is the path of the resource or original resource,
-    // second group determines if it is an fcr:metadata non-rdf source,
-    // third group determines if the path is for a memento or timemap,
-    // the fourth group allows for a memento identifier, and the fifth group for ACL
+    // The first group is the path of the resource or original resource.
+    // The second group determines if it is an fcr:metadata non-rdf source.
+    // The third group determines if the path is for a memento or timemap.
+    // The fourth group allows for a memento identifier.
+    // The fifth group for allows ACL.
+    // The sixth group allows for any hashed suffixes on the acls.
     private final static Pattern FORWARD_COMPONENT_PATTERN = Pattern.compile(
             "(.*?)(/" + FCR_METADATA + ")?(/" + FCR_VERSIONS + "(/\\d+)?)?(/" + FCR_ACL + "(\\#\\w+)?)?$");
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -58,7 +58,6 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.TombstoneException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.models.FedoraWebacAcl;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.modeshape.TombstoneImpl;
 import org.fcrepo.kernel.modeshape.identifiers.HashConverter;
@@ -89,7 +88,7 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
     // third group determines if the path is for a memento or timemap,
     // the fourth group allows for a memento identifier, and the fifth group for ACL
     private final static Pattern FORWARD_COMPONENT_PATTERN = Pattern.compile(
-            "(.*?)(/" + FCR_METADATA + ")?(/" + FCR_VERSIONS + "(/\\d+)?)?(/" + FCR_ACL + ")?$");
+            "(.*?)(/" + FCR_METADATA + ")?(/" + FCR_VERSIONS + "(/\\d+)?)?(/" + FCR_ACL + "(\\#\\w+)?)?$");
 
     protected List<Converter<String, String>> translationChain;
 
@@ -290,10 +289,7 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
             throw new RepositoryRuntimeException("Unable to process reverse chain for resource " + resource);
         }
 
-        if (resource instanceof FedoraWebacAcl) {
-            // For ACL container, replace the name with fcr:acl path
-            path = replaceOnce(path, "/" + CONTAINER_WEBAC_ACL, "/" + FCR_ACL);
-        }
+        path = replaceOnce(path, "/" + CONTAINER_WEBAC_ACL, "/" + FCR_ACL);
 
         path = replaceOnce(path, "/" + LDPCV_TIME_MAP, "/" + FCR_VERSIONS);
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverterTest.java
@@ -17,30 +17,6 @@
  */
 package org.fcrepo.http.commons.api.rdf;
 
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
-import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_TIME_MAP;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_WEBAC_ACL;
-import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO;
-import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO_ORIGINAL;
-import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_DESCRIPTION;
-import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import javax.jcr.Workspace;
-import javax.jcr.version.Version;
-import javax.jcr.version.VersionHistory;
-import javax.jcr.version.VersionManager;
-import javax.ws.rs.core.UriBuilder;
-
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.commons.session.HttpSession;
 import org.fcrepo.kernel.api.FedoraSession;
@@ -63,6 +39,30 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.version.Version;
+import javax.jcr.version.VersionHistory;
+import javax.jcr.version.VersionManager;
+import javax.ws.rs.core.UriBuilder;
+
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_TIME_MAP;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_WEBAC_ACL;
+import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO;
+import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO_ORIGINAL;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_DESCRIPTION;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 /**
  * @author cabeer

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -59,6 +59,7 @@ import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunction
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getContainingNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.hasInternalNamespace;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isAcl;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isInternalNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isMemento;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.ldpInsertedContentProperty;
@@ -129,7 +130,6 @@ import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.FedoraTimeMap;
-import org.fcrepo.kernel.api.models.FedoraWebacAcl;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.GraphDifferencer;
@@ -473,7 +473,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
     @Override
     public boolean isAcl() {
-        return this instanceof FedoraWebacAcl;
+        return isAcl.test(getNode());
     }
 
 
@@ -515,8 +515,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
                 LOGGER.debug("Created Webac ACL {}", aclNode.getPath());
 
                 // add mixin type fedora:Resource
-                if (node.canAddMixin(FEDORA_RESOURCE)) {
-                    node.addMixin(FEDORA_RESOURCE);
+                if (aclNode.canAddMixin(FEDORA_RESOURCE)) {
+                    aclNode.addMixin(FEDORA_RESOURCE);
                 }
 
                 // add mixin type webac:Acl

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
@@ -139,6 +139,12 @@ public abstract class FedoraTypesUtils implements FedoraTypes {
      */
     public static Predicate<Node> isMemento = new AnyTypesPredicate(MEMENTO);
 
+
+    /**
+     * Predicate for determining whether this {@link Node} is an Web ACL.
+     */
+    public static Predicate<Node> isAcl = new AnyTypesPredicate(FEDORA_WEBAC_ACL);
+
     /**
      * Check if a property is a reference property.
      */


### PR DESCRIPTION
… the resource.

2. The subjects, including hash URIs  of the ACL's triples are now correct - ie .../fcr:acl.
3. Refactors ContentExposingResource to require passing the target fedora resource
   explicitly to helper methods in order to enhance the readability of the code and
   reduce the risk of introducing bugs.

Resolves:
https://jira.duraspace.org/browse/FCREPO-2810
https://jira.duraspace.org/browse/FCREPO-2832

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR in essence ensures that the subject URIs returned in the RDF of an ACL resource are correct.  In addition the code fixes a bug that was causing the parent triples of fcr:acl to be returned instead of fcr:acl's triples.  It ensures  that the PATCH command on ACLs which was writing to the fcr:acl parent is writing to the fcr:acl resource

# How should this be tested?


```
# create an RDF resource
curl -u fedoraAdmin:fedoraAdmin -v -X PUT  http://localhost:8080/rest/container
# create an ACL resource under it
curl -u fedoraAdmin:fedoraAdmin -v -X PUT  http://localhost:8080/rest/container/fcr:acl
# Add authorizations with Hash URI.
curl -u fedoraAdmin:fedoraAdmin -v -X PATCH -H "Content-Type: application/sparql-update" --data-binary "PREFIX acl: <http://www.w3.org/ns/auth/acl#> INSERT { <#writeAccess> acl:mode acl:write . } WHERE { }" http://localhost:8080/rest/container/fcr:acl
# Get the ACL and make sure that the subjects are all correct.
curl -u fedoraAdmin:fedoraAdmin -v http://localhost:8080/rest/container/fcr:acl
```


# Additional Notes:
Currently this only works for RDF Sources.  Another PR is coming shortly that will allow binaries to be tested as well.
