### PR TITLE
Make useful exceptions for inaccessible external content

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ExternalContentAccessExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ExternalContentAccessExceptionMapper.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.Status.BAD_GATEWAY;
+import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.fcrepo.kernel.api.exception.ExternalContentAccessException;
+
+import org.slf4j.Logger;
+
+/**
+ * ExternalContentException mapper
+ *
+ * @author whikloj
+ * @since 2018-07-11
+ */
+@Provider
+public class ExternalContentAccessExceptionMapper
+    implements ExceptionMapper<ExternalContentAccessException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(ExternalContentAccessExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final ExternalContentAccessException exception) {
+        debugException(this, exception, LOGGER);
+        return status(BAD_GATEWAY).entity(exception.getMessage()).type(TEXT_PLAIN_WITH_CHARSET)
+            .build();
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ExternalContentAccessException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ExternalContentAccessException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Exception when attempting to access an external-content URI has problems.
+ *
+ * @author whikloj
+ * @since 2018-07-11
+ */
+public class ExternalContentAccessException extends RepositoryRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor
+     * 
+     * @param msg the message
+     * @param rootCause the causing Exception
+     */
+    public ExternalContentAccessException(final String msg, final Throwable rootCause) {
+        super(msg, rootCause);
+    }
+
+}

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/UrlBinary.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/UrlBinary.java
@@ -38,6 +38,7 @@ import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.ExternalContentAccessException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
@@ -84,7 +85,7 @@ public class UrlBinary extends AbstractFedoraBinary {
         try {
             return getResourceUri().toURL().openStream();
         } catch (final IOException e) {
-            throw new RepositoryRuntimeException(e);
+            throw new ExternalContentAccessException("Problems getting external content : " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2828

# What does this Pull Request do?
Wraps the `IOException` returned by a failed access of a remote site in a new `ExternalContentAccessException` and returns it as a `502 Bad Gateway` response.

# How should this be tested?

Create a proxied external content to a controllable webserver. 

```
curl -ufedoraAdmin:fedoraAdmin -i http://localhost:8080/rest/simple_external -XPUT -H"Link: <http://static-ldp.localhost:8111/2012-12-01/IMG_20121201_113805.jpg>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"" -H"Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel=\"type\""
```

`GET` the resource
```
> curl -i -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/simple_external
HTTP/1.1 200 OK
Date: Fri, 13 Jul 2018 15:37:16 GMT
Set-Cookie: JSESSIONID=o3n17jmzy9a28f7g3uooxdym;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 12-Jul-2018 15:37:16 GMT
ETag: "734344dd5c3764b9235e2ee36c50e86de966e48c"
Last-Modified: Fri, 13 Jul 2018 15:36:21 GMT
Content-Type: image/jpeg
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Fri, 13 Jul 2018 15:36:21 GMT"; modification-date="Fri, 13 Jul 2018 15:36:21 GMT"; size=1377502
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8080/rest/simple_external/fcr:metadata>; rel="describedby"
Link: <http://localhost:8080/static/constraints/NonRDFSourceConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Accept-External-Content-Handling: copy,redirect,proxy
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Link: <http://localhost:8080/rest/simple_external/fcr:acl>; rel="acl"
Content-Location: http://static-ldp.localhost:8111/2012-12-01/IMG_20121201_113805.jpg
Cache-Control: no-transform, must-revalidate, max-age=0
Content-Length: 1377502
Server: Jetty(9.3.1.v20150714)

????\ExifII*

.....
```

Shut down the remote webserver and perform the same `GET` request

```
> curl -i -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/simple_external
HTTP/1.1 502 Bad Gateway
Date: Fri, 13 Jul 2018 15:59:36 GMT
Set-Cookie: JSESSIONID=q48uyx5bizoi1x0pdx6m8vy3p;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 12-Jul-2018 15:59:36 GMT
ETag: "734344dd5c3764b9235e2ee36c50e86de966e48c"
Last-Modified: Fri, 13 Jul 2018 15:36:21 GMT
Content-Type: text/plain;charset=utf-8
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Fri, 13 Jul 2018 15:36:21 GMT"; modification-date="Fri, 13 Jul 2018 15:36:21 GMT"; size=1377502
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8080/rest/simple_external/fcr:metadata>; rel="describedby"
Link: <http://localhost:8080/static/constraints/NonRDFSourceConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Accept-External-Content-Handling: copy,redirect,proxy
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Link: <http://localhost:8080/rest/simple_external/fcr:acl>; rel="acl"
Content-Location: http://static-ldp.localhost:8111/2012-12-01/IMG_20121201_113805.jpg
Content-Length: 54
Server: Jetty(9.3.1.v20150714)

Problems getting external content : Connection refused
```

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@bbpennel @bseeger @dbernstein @awoods 
