### PR TITLE
GET on LDP-NR ACL returns 200 (rather than 500).

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -26,6 +26,8 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
+import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -101,6 +103,14 @@ public class FedoraAclIT extends AbstractResourceIT {
             // verify the acl container for binary is translated to fcr:acl
             assertEquals(subjectUri + "/x/" + FCR_ACL, aclLocation);
         }
+
+        try (final CloseableDataset dataset = getDataset(new HttpGet(aclLocation))) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(ANY,
+                                      createURI(aclLocation),
+                                      createURI(RDF_NAMESPACE + "type"),
+                                      createURI(LDP_NAMESPACE + "RDFSource")));
+        }
     }
 
     @Test
@@ -173,4 +183,5 @@ public class FedoraAclIT extends AbstractResourceIT {
         assertEquals(NOT_FOUND.getStatusCode(), getStatus(getNotFound));
 
     }
+
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -127,7 +127,6 @@ import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
-import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.FedoraTimeMap;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
@@ -482,7 +481,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         final Node parentNode;
 
         try {
-            if (this instanceof FedoraBinary) {
+            if (this instanceof NonRdfSourceDescription) {
                 parentNode = getNode().getParent();
             } else {
                 parentNode = getNode();


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2832

**GET on LDP-NR ACL returns 200 (rather than 500)**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2832

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Now GETs on  LDP-NR ACL return 200 rather than a 500 response code.

# How should this be tested?

```
# create an LDP-NR
curl -v -X PUT -H "Content-Type: text/plain" --data-binary "This is a test body" http://localhost:8080/rest/test

# create an ACL
curl -v -X PUT --data-binary "This is a test body" http://localhost:8080/rest/test/fcr:acl

# Get the ACL
curl -v -X GET http://localhost:8080/rest/test/fcr:acl
# Verify that the response is 200. 

```
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
