### PR TITLE
PUT requests to fcr:acl now accept RDF bodies.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -121,7 +121,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         final HttpPatch patch = new HttpPatch(aclURI);
         patch.addHeader(CONTENT_TYPE, "application/sparql-update");
         patch.setEntity(new StringEntity("PREFIX acl: <http://www.w3.org/ns/auth/acl#> " +
-                                         "INSERT { <#writeAccess> acl:mode acl:write . } WHERE { }"));
+                                         "INSERT { <#writeAccess> acl:mode acl:Write . } WHERE { }"));
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(patch));
 
         //verify the patch worked
@@ -130,7 +130,7 @@ public class FedoraAclIT extends AbstractResourceIT {
             assertTrue(graph.contains(ANY,
                                       createURI(aclURI + "#writeAccess"),
                                       createURI("http://www.w3.org/ns/auth/acl#mode"),
-                                      createURI("http://www.w3.org/ns/auth/acl#write")));
+                                      createURI("http://www.w3.org/ns/auth/acl#Write")));
         }
 
     }
@@ -194,10 +194,7 @@ public class FedoraAclIT extends AbstractResourceIT {
                                "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n" +
                                "@prefix ldp: <http://www.w3.org/ns/ldp#> .\n" +
                                "\n" +
-                               "<#authorization_1> a acl:Authorization ;\n" +
-                               "    acl:agentClass foaf:Agent ;\n" +
-                               "    acl:accessToClass ldp:Resource ;\n" +
-                               "    acl:default <https://example.org/root/> ;\n" +
+                               "<#readAccess> a acl:Authorization ;\n" +
                                "    acl:mode acl:Read .";
 
         put.setEntity(new StringEntity(aclBody));
@@ -211,5 +208,15 @@ public class FedoraAclIT extends AbstractResourceIT {
             assertEquals(subjectUri + "/" + FCR_ACL, aclLocation);
 
         }
+
+        //verify the put worked
+        try (final CloseableDataset dataset = getDataset(new HttpGet(aclLocation))) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(ANY,
+                                      createURI(aclLocation + "#readAccess"),
+                                      createURI("http://www.w3.org/ns/auth/acl#mode"),
+                                      createURI("http://www.w3.org/ns/auth/acl#Read")));
+        }
+
     }
 }


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2808

# What does this Pull Request do?
Allows user to specify a RDF body in a PUT request on an ACL resource.

# How should this be tested?
1. Save the following to a file call acl.ttl
```
@prefix acl: <http://www.w3.org/ns/auth/acl#> . 
@prefix foaf: <http://xmlns.com/foaf/0.1/> . 
@prefix ldp: <http://www.w3.org/ns/ldp#> . 
                                
<#authorization_1> a acl:Authorization ; 
                   acl:agentClass foaf:Agent ; 
                   acl:accessToClass ldp:Resource ; 
                   acl:default <https://example.org/root/> ; 
                   acl:mode acl:Read .
```

2.  create a resource
```
curl -X PUT http://localhost:8080/rest/test
```
3. create the acl using a body
```
curl -v -X PUT  http://localhost:8080/rest/test/fcr:acl -H "Content-Type: text/turtle" --data-binary "@acl.ttl"
```
4. verify that the resource was properly created:
```
curl -v -X GET  http://localhost:8080/rest/test/fcr:acl 
```


# Interested parties
@peichman-umd , @fcrepo4/committers
