### PR TITLE
Ensures mementos return the correct subject.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -533,19 +533,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
             // Ensure that the subject of the memento is the original reosurce
             assertTrue("Subjects should be the original resource, not the memento: " + graph,
-                       !graph.contains(ANY,
-                                       createURI(
-                                           mementoUri),
-                                       ANY,
-                                       ANY));
-
+                       !graph.contains(ANY, createURI(mementoUri), ANY, ANY));
         }
-
-        try (final CloseableHttpResponse getResponse1 = execute(new HttpGet(mementoUri));
-             final CloseableDataset dataset = getDataset(getResponse1);) {
-            final DatasetGraph graph = dataset.asDatasetGraph();
-        }
-
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -335,7 +335,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         try (final CloseableDataset dataset = getDataset(httpGet)) {
             final DatasetGraph results = dataset.asDatasetGraph();
 
-            final Node mementoSubject = createURI(mementoUri);
+            final Node mementoSubject = createURI(subjectUri);
 
             assertTrue("Memento created without datetime must retain original state",
                     results.contains(ANY, mementoSubject, TEST_PROPERTY_NODE, createLiteral("foo")));
@@ -350,7 +350,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         assertMementoUri(mementoUri, subjectUri);
-        final Node mementoSubject = createURI(mementoUri);
+        final Node mementoSubject = createURI(subjectUri);
         final Node subject = createURI(subjectUri);
 
         // Verify that the memento has the new property added to it
@@ -397,7 +397,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                     CONFLICT.getStatusCode(), getStatus(response));
         }
 
-        final Node mementoSubject = createURI(mementoUri);
+        final Node mementoSubject = createURI(subjectUri);
         // Verify first memento content persists
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
             final DatasetGraph results = dataset.asDatasetGraph();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -522,13 +522,30 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                     ANY, createURI("http://pcdm.org/models#hasMember"), createURI(resource)));
         }
 
-        // Ensure that the resource reference is still in memento
         try (final CloseableHttpResponse getResponse1 = execute(new HttpGet(mementoUri));
                 final CloseableDataset dataset = getDataset(getResponse1);) {
+
             final DatasetGraph graph = dataset.asDatasetGraph();
+
+            // Ensure that the resource reference is still in memento
             assertTrue("Expected resource NOT found: " + graph, graph.contains(ANY,
                     ANY, createURI("http://pcdm.org/models#hasMember"), createURI(resource)));
+
+            // Ensure that the subject of the memento is the original reosurce
+            assertTrue("Subjects should be the original resource, not the memento: " + graph,
+                       !graph.contains(ANY,
+                                       createURI(
+                                           mementoUri),
+                                       ANY,
+                                       ANY));
+
         }
+
+        try (final CloseableHttpResponse getResponse1 = execute(new HttpGet(mementoUri));
+             final CloseableDataset dataset = getDataset(getResponse1);) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+        }
+
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
@@ -103,12 +103,12 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
                 .reduce(empty(), Stream::concat)
                 .map(t -> mapSubject(t, resourceUri, describedNode));
 
-        // if a memento, convert object references from referential integrity ignoring internal URL back to
-        // the original external URL.
+        // if a memento, convert subjects to original resource and object references from referential integrity
+        // ignoring internal URL back the original external URL.
         if (isMemento()) {
             final IdentifierConverter<Resource, FedoraResource> internalIdTranslator =
                     new InternalIdentifierTranslator(getSession());
-            triples = triples.map(convertInternalResource(idTranslator, internalIdTranslator));
+            triples = triples.map(convertMementoReferences(idTranslator, internalIdTranslator));
         }
 
         return new DefaultRdfStream(idTranslator.reverse().convert(described).asNode(), triples);


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2771

# What does this Pull Request do?
This PR ensures that mementos return the original resource URI as the subject rather than the memento.

# How should this be tested?
```
# create a versioned ldpnr  
curl -u fedoraAdmin:fedoraAdmin -v -X PUT  http://localhost:8080/rest/test-ldpnr --data-binary "test" -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\""

# create a memento of ldpnr
curl -u fedoraAdmin:fedoraAdmin -v -X POST  http://localhost:8080/rest/test-ldpnr/fcr:versions

# retrieve the memento using the timegate of the description and verify the subject refers to the original resource.
curl -v -L -X GET http://localhost:8080/rest/test-ldpnr/fcr:metadata -H "Accept-Datetime: Wed, 18 Jul 2018 22:42:34 GMT"  -u fedoraAdmin:fedoraAdmin

# create a versioned ldpr  
curl -u fedoraAdmin:fedoraAdmin -v -X PUT  http://localhost:8080/rest/test-ldpr  -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\""

# create a memento of ldpr
curl -u fedoraAdmin:fedoraAdmin -v -X POST  http://localhost:8080/rest/test-ldpr/fcr:versions

# retrieve the memento using the timegate of the resource and verify the subject refers to the original resource.
curl -v -L -X GET http://localhost:8080/rest/test-ldpr -H "Accept-Datetime: Wed, 18 Jul 2018 22:42:34 GMT"  -u fedoraAdmin:fedoraAdmin
```
# Additional Notes:

Example:
* Does this change require documentation to be updated? No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? Potentially it could impact performance of memento retrieval.

# Interested parties
@bseeger , @whikloj , @bbpennel , @fcrepo4/committers
