### PR TITLE
Fcrepo 2835 - Allowed external paths configuration

### DIFF
--- a/fcrepo-auth-webac/src/test/resources/allowed_external_paths.txt
+++ b/fcrepo-auth-webac/src/test/resources/allowed_external_paths.txt
@@ -1,0 +1,3 @@
+http://
+https://
+file:///

--- a/fcrepo-auth-webac/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-auth-webac/src/test/resources/spring-test/rest.xml
@@ -21,4 +21,15 @@
   </util:list>
 
   <context:component-scan base-package="org.fcrepo"  />
+  
+  <!-- External content configuration -->
+  <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
+      init-method="init">
+    <property name="configPath" value="src/test/resources/allowed_external_paths.txt" />
+    <property name="monitorForChanges" value="false" />
+  </bean>
+  
+  <bean name="externalContentHandlerFactory" class="org.fcrepo.http.api.ExternalContentHandlerFactory">
+    <property name="validator" ref="externalContentPathValidator" />
+  </bean>
 </beans>

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -206,6 +206,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     @Inject
     protected  PathLockManager lockManager;
 
+    @Inject
+    protected ExternalContentHandlerFactory extContentHandlerFactory;
+
     private static final Predicate<Triple> IS_MANAGED_TYPE = t -> t.getPredicate().equals(type.asNode()) &&
             isManagedNamespace.test(t.getObject().getNameSpace());
     private static final Predicate<Triple> IS_MANAGED_TRIPLE = IS_MANAGED_TYPE

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -18,7 +18,6 @@
 package org.fcrepo.http.api;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
-import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
 import static org.fcrepo.kernel.api.FedoraExternalContent.COPY;
 import static org.fcrepo.kernel.api.FedoraExternalContent.REDIRECT;
 import static org.fcrepo.kernel.api.FedoraExternalContent.PROXY;
@@ -39,10 +38,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 
 /**
@@ -77,7 +73,7 @@ public class ExternalContentHandler {
      *
      *  @param linkHeader actual link header from request
      */
-    public ExternalContentHandler(final String linkHeader) {
+    protected ExternalContentHandler(final String linkHeader) {
         // if it parses, then we're mostly good to go.
         link = parseLinkHeader(linkHeader);
 
@@ -134,33 +130,6 @@ public class ExternalContentHandler {
      */
     public boolean isProxy() {
         return handling != null ? handling.equals(PROXY) : false;
-    }
-
-    /**
-     * Looks for ExternalContent link header and if it finds one it will return a new
-     * ExternalContentHandler object based on the found Link header.
-     *
-     * @param links - links from the request header
-     * @return External Content Handler Object if Link header found, else null
-     */
-    public static ExternalContentHandler createFromLinks(final List<String> links) {
-
-        if (links == null) {
-            return null;
-        }
-
-        final List<String> externalContentLinks = links.stream()
-                .filter(x -> x.contains(EXTERNAL_CONTENT.toString()))
-                .collect(Collectors.toList());
-
-        if (externalContentLinks.size() > 1) {
-            // got a problem, you can only have one ExternalContent links
-            throw new ExternalMessageBodyException("More then one External Content Link header in request");
-        } else if (externalContentLinks.size() == 1) {
-            return new ExternalContentHandler(externalContentLinks.get(0));
-        }
-
-        return null;
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandlerFactory.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandlerFactory.java
@@ -18,11 +18,13 @@
 package org.fcrepo.http.api;
 
 import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
+import org.slf4j.Logger;
 
 /**
  * Constructs ExternalContentHandler objects from link headers
@@ -30,6 +32,8 @@ import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
  * @author bbpennel
  */
 public class ExternalContentHandlerFactory {
+
+    private static final Logger LOGGER = getLogger(ExternalContentHandlerFactory.class);
 
     private ExternalContentPathValidator validator;
 
@@ -59,7 +63,12 @@ public class ExternalContentHandlerFactory {
             final String link = externalContentLinks.get(0);
             final String uri = getUriString(link);
             // Validate that the URI is valid according to allowed set of external uris
-            validator.validate(uri);
+            try {
+                validator.validate(uri);
+            } catch (final ExternalMessageBodyException e) {
+                LOGGER.warn("Rejected invalid external path {}", uri);
+                throw e;
+            }
 
             return new ExternalContentHandler(link);
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandlerFactory.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandlerFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api;
+
+import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
+
+/**
+ * Constructs ExternalContentHandler objects from link headers
+ *
+ * @author bbpennel
+ */
+public class ExternalContentHandlerFactory {
+
+    private ExternalContentPathValidator validator;
+
+    /**
+     * Looks for ExternalContent link header and if it finds one it will return a new ExternalContentHandler object
+     * based on the found Link header. If multiple external content headers were found or the URI provided in the
+     * header is not a valid external content path, then an ExternalMessageBodyException will be thrown.
+     *
+     * @param links links from the request header
+     * @return External Content Handler Object if Link header found, else null
+     * @throws ExternalMessageBodyException thrown if more than one external content link was provided, or if the URL
+     *         of the header was not a valid external content path.
+     */
+    public ExternalContentHandler createFromLinks(final List<String> links) throws ExternalMessageBodyException {
+        if (links == null) {
+            return null;
+        }
+
+        final List<String> externalContentLinks = links.stream()
+                .filter(x -> x.contains(EXTERNAL_CONTENT.toString()))
+                .collect(Collectors.toList());
+
+        if (externalContentLinks.size() > 1) {
+            // got a problem, you can only have one ExternalContent links
+            throw new ExternalMessageBodyException("More then one External Content Link header in request");
+        } else if (externalContentLinks.size() == 1) {
+            final String link = externalContentLinks.get(0);
+            final String uri = getUriString(link);
+            // Validate that the URI is valid according to allowed set of external uris
+            validator.validate(uri);
+
+            return new ExternalContentHandler(link);
+        }
+
+        return null;
+    }
+
+    private static String getUriString(final String link) {
+        final String value = link.trim();
+        if (value.startsWith("<")) {
+            final int gtIndex = value.indexOf('>');
+            if (gtIndex != -1) {
+                return value.substring(1, gtIndex).trim();
+            } else {
+                throw new IllegalArgumentException("Missing token > in " + value);
+            }
+        } else {
+            throw new IllegalArgumentException("Missing starting token < in " + value);
+        }
+    }
+
+    /**
+     * Set the external content path validator
+     *
+     * @param validator validator
+     */
+    public void setValidator(final ExternalContentPathValidator validator) {
+        this.validator = validator;
+    }
+}

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -58,7 +58,7 @@ public class ExternalContentPathValidator {
 
     private final Pattern RELATIVE_MOD_PATTERN = Pattern.compile(".*(^|/)\\.\\.($|/).*");
 
-    private String allowedListPath;
+    private String configPath;
 
     private List<String> allowedList;
 
@@ -112,7 +112,7 @@ public class ExternalContentPathValidator {
      * Initialize the allow list
      */
     public void init() throws IOException {
-        if (isEmpty(allowedListPath)) {
+        if (isEmpty(configPath)) {
             return;
         }
 
@@ -138,12 +138,12 @@ public class ExternalContentPathValidator {
      * @throws IOException
      */
     private synchronized void loadAllowedPaths() throws IOException {
-        try (final Stream<String> stream = Files.lines(Paths.get(allowedListPath))) {
+        try (final Stream<String> stream = Files.lines(Paths.get(configPath))) {
             allowedList = stream.map(line -> line.trim().toLowerCase())
                 .filter(line -> {
                     if (line.contains("../") || !SCHEME_PATTERN.matcher(line).matches()) {
                         LOGGER.error("Invalid path {} specified in external path configuration {}",
-                                line, allowedListPath);
+                                line, configPath);
                         return false;
                     }
                     return true;
@@ -159,9 +159,9 @@ public class ExternalContentPathValidator {
             return;
         }
 
-        final Path path = Paths.get(allowedListPath);
+        final Path path = Paths.get(configPath);
         if (!path.toFile().exists()) {
-            LOGGER.debug("Allow list configuration {} does not exist, disabling monitoring", allowedListPath);
+            LOGGER.debug("Allow list configuration {} does not exist, disabling monitoring", configPath);
             return;
         }
         final Path directoryPath = path.getParent();
@@ -232,10 +232,10 @@ public class ExternalContentPathValidator {
     /**
      * Set the file path for the allowed external path configuration
      *
-     * @param allowListPath
+     * @param configPath
      */
-    public void setAllowListPath(final String allowListPath) {
-        this.allowedListPath = allowListPath;
+    public void setConfigPath(final String configPath) {
+        this.configPath = configPath;
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -74,8 +74,8 @@ public class ExternalContentPathValidator {
      * Validates that an external path is valid. The path must be an HTTP or file URI within the allow list of paths,
      * be absolute, and contain no relative modifier.
      *
-     * @param extPath
-     * @throws ExternalMessageBodyException
+     * @param extPath external binary path to validate
+     * @throws ExternalMessageBodyException thrown if the path is invalid.
      */
     public void validate(final String extPath) throws ExternalMessageBodyException {
         if (allowedList == null || allowedList.size() == 0) {
@@ -101,7 +101,7 @@ public class ExternalContentPathValidator {
             throw new ExternalMessageBodyException("Path was not absolute: " + extPath);
         }
         if (!ALLOWED_SCHEMES.contains(uri.getScheme())) {
-            throw new ExternalMessageBodyException("Path did not provide an accept scheme: " + extPath);
+            throw new ExternalMessageBodyException("Path did not provide an allowed scheme: " + extPath);
         }
 
         if (allowedList.stream().anyMatch(allowed -> path.startsWith(allowed))) {
@@ -143,9 +143,9 @@ public class ExternalContentPathValidator {
     }
 
     /**
-     * Loads the allowed list
+     * Loads the allowed list.
      *
-     * @throws IOException
+     * @throws IOException thrown if the allowed list configuration file cannot be read.
      */
     private synchronized void loadAllowedPaths() throws IOException {
         try (final Stream<String> stream = Files.lines(Paths.get(configPath))) {
@@ -243,25 +243,16 @@ public class ExternalContentPathValidator {
     /**
      * Set the file path for the allowed external path configuration
      *
-     * @param configPath
+     * @param configPath file path for configuration
      */
     public void setConfigPath(final String configPath) {
         this.configPath = configPath;
     }
 
     /**
-     * Get the file path for the configuration file
-     *
-     * @return
-     */
-    public String getConfigPath() {
-        return configPath;
-    }
-
-    /**
      * Set whether to monitor the configuration file for changes
      *
-     * @param monitorForChanges
+     * @param monitorForChanges flag controlling if to enable configuration monitoring
      */
     public void setMonitorForChanges(final boolean monitorForChanges) {
         this.monitorForChanges = monitorForChanges;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api;
+
+import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
+
+/**
+ * Validates external content paths to ensure that they are within a configured allowed list of paths.
+ *
+ * @author bbpennel
+ */
+public class ExternalContentPathValidator {
+
+    private String allowListPath;
+
+    /**
+     * Validates that an external path is valid. The path must be an HTTP or file URI within the allow list of paths,
+     * be absolute, and contain no relative modifier.
+     *
+     * @param extPath
+     * @throws ExternalMessageBodyException
+     */
+    public void validate(final String extPath) throws ExternalMessageBodyException {
+
+    }
+
+    /**
+     * Initialize the allow list
+     */
+    public void init() {
+
+    }
+
+    public void setAllowListPath(final String allowListPath) {
+        this.allowListPath = allowListPath;
+    }
+}

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -17,7 +17,23 @@
  */
 package org.fcrepo.http.api;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
+import org.slf4j.Logger;
 
 /**
  * Validates external content paths to ensure that they are within a configured allowed list of paths.
@@ -26,7 +42,13 @@ import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
  */
 public class ExternalContentPathValidator {
 
-    private String allowListPath;
+    private static final Logger LOGGER = getLogger(ExternalContentPathValidator.class);
+
+    private final Set<String> ALLOWED_SCHEMES = new HashSet<>(Arrays.asList("file", "http", "https"));
+
+    private String allowedListPath;
+
+    private List<String> allowedList;
 
     /**
      * Validates that an external path is valid. The path must be an HTTP or file URI within the allow list of paths,
@@ -36,17 +58,72 @@ public class ExternalContentPathValidator {
      * @throws ExternalMessageBodyException
      */
     public void validate(final String extPath) throws ExternalMessageBodyException {
+        if (allowedList == null || allowedList.size() == 0) {
+            throw new ExternalMessageBodyException("External content is disallowed by the server");
+        }
 
+        if (isEmpty(extPath)) {
+            throw new ExternalMessageBodyException("External content path was empty");
+        }
+
+        if (extPath.contains("../")) {
+            throw new ExternalMessageBodyException("Path was not absolute: " + extPath);
+        }
+
+        final URI uri;
+        try {
+            uri = new URI(extPath);
+        } catch (final URISyntaxException e) {
+            throw new ExternalMessageBodyException("Path was not a valid URI: " + extPath);
+        }
+        if (!uri.isAbsolute()) {
+            throw new ExternalMessageBodyException("Path was not absolute: " + extPath);
+        }
+        if (!ALLOWED_SCHEMES.contains(uri.getScheme())) {
+            throw new ExternalMessageBodyException("Path did not provide an accept scheme: " + extPath);
+        }
+
+        if (allowedList.stream().anyMatch(allowed -> extPath.startsWith(allowed))) {
+            return;
+        }
+        throw new ExternalMessageBodyException("Path did not match any allowed external content paths: " + extPath);
     }
 
     /**
      * Initialize the allow list
      */
-    public void init() {
+    public void init() throws IOException {
+        loadAllowedPaths();
+    }
 
+    private void loadAllowedPaths() throws IOException {
+        if (isEmpty(allowedListPath)) {
+            return;
+        }
+        try (final Stream<String> stream = Files.lines(Paths.get(allowedListPath))) {
+            allowedList = stream.map(line -> line.trim())
+                .filter(line -> {
+                    if (line.contains("../")) {
+                        return false;
+                    }
+                    final URI uri;
+                    try {
+                        uri = new URI(line);
+                    } catch (final URISyntaxException e) {
+                        LOGGER.error("Invalid URL {} provided in allowed external path configuration", line);
+                        return false;
+                    }
+                    if (!uri.isAbsolute() || !ALLOWED_SCHEMES.contains(uri.getScheme())) {
+                        LOGGER.error("Invalid URL or scheme {} provided in allowed external path configuration",
+                                line);
+                        return false;
+                    }
+                    return true;
+                }).collect(Collectors.toList());
+        }
     }
 
     public void setAllowListPath(final String allowListPath) {
-        this.allowListPath = allowListPath;
+        this.allowedListPath = allowListPath;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -419,7 +419,7 @@ public class FedoraLdp extends ContentExposingResource {
         try {
 
             final Collection<String> checksums = parseDigestHeader(digest);
-            final ExternalContentHandler extContent = ExternalContentHandler.createFromLinks(links);
+            final ExternalContentHandler extContent = extContentHandlerFactory.createFromLinks(links);
 
             final MediaType contentType =  getSimpleContentType(
                     extContent != null ? extContent.getContentType() : requestContentType);
@@ -633,7 +633,7 @@ public class FedoraLdp extends ContentExposingResource {
         final String interactionModel = checkInteractionModel(links);
 
         // If request is an external binary, verify link header before proceeding
-        final ExternalContentHandler extContent = ExternalContentHandler.createFromLinks(links);
+        final ExternalContentHandler extContent = extContentHandlerFactory.createFromLinks(links);
 
         if (!(resource() instanceof Container)) {
             throw new ClientErrorException("Object cannot have child nodes", CONFLICT);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -203,7 +203,7 @@ public class FedoraVersioning extends ContentExposingResource {
                                 binaryResource, mementoInstant, storagePolicyDecisionPoint);
                     } else {
                         final List<String> links = unpackLinks(rawLinks);
-                        final ExternalContentHandler extContent = ExternalContentHandler.createFromLinks(links);
+                        final ExternalContentHandler extContent = extContentHandlerFactory.createFromLinks(links);
 
                         memento = createBinaryMementoFromRequest(binaryResource, mementoInstant,
                                 requestBodyStream, extContent, digest);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api;
+
+import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Link;
+import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ExternalContentHandlerFactoryTest {
+
+    @Mock
+    private ExternalContentPathValidator validator;
+
+    private ExternalContentHandlerFactory factory;
+
+    @Before
+    public void init() {
+        factory = new ExternalContentHandlerFactory();
+        factory.setValidator(validator);
+    }
+
+    @Test
+    public void testValidLinkHeader() throws Exception {
+        final ExternalContentHandler handler = factory.createFromLinks(
+                makeLinks("http://test.com"));
+
+        assertEquals("http://test.com", handler.getURL());
+        assertEquals("text/plain", handler.getContentType().toString());
+        assertEquals("proxy", handler.getHandling());
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testValidationFailure() throws Exception {
+        doThrow(new ExternalMessageBodyException("")).when(validator).validate(anyString());
+
+        factory.createFromLinks(makeLinks("http://test.com"));
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testMultipleExtLinkHeaders() throws Exception {
+        final List<String> links = makeLinks("http://test.com", "http://test2.com");
+
+        factory.createFromLinks(links);
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testGetWithExternalMessageMissingURLBinary() throws Exception {
+        final List<String> links = makeLinks("http://test.com");
+        links.set(0, links.get(0).replaceAll("<.*>", "< >"));
+
+        factory.createFromLinks(links);
+    }
+
+    private List<String> makeLinks(final String... uris) {
+        return Arrays.stream(uris)
+                .map(uri -> Link.fromUri(uri)
+                        .rel(EXTERNAL_CONTENT.toString())
+                        .param("handling", "proxy")
+                        .type("text/plain")
+                        .build()
+                        .toString())
+                .collect(Collectors.toList());
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -50,7 +50,7 @@ public class ExternalContentPathValidatorTest {
         allowListFile = tmpDir.newFile();
 
         validator = new ExternalContentPathValidator();
-        validator.setAllowListPath(allowListFile.getAbsolutePath());
+        validator.setConfigPath(allowListFile.getAbsolutePath());
     }
 
     @After
@@ -60,7 +60,7 @@ public class ExternalContentPathValidatorTest {
 
     @Test(expected = ExternalMessageBodyException.class)
     public void testValidateWithNoAllowList() throws Exception {
-        validator.setAllowListPath(null);
+        validator.setConfigPath(null);
         validator.init();
 
         final String extPath = "file:///this/path/file.txt";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -71,7 +71,7 @@ public class ExternalContentPathValidatorTest {
 
     @Test
     public void testValidHttpUri() throws Exception {
-        final String goodPath = "http:///example.com/";
+        final String goodPath = "http://example.com/";
         final String extPath = goodPath + "file.txt";
 
         addAllowedPath(goodPath);
@@ -102,7 +102,7 @@ public class ExternalContentPathValidatorTest {
 
     @Test
     public void testMultipleSchemes() throws Exception {
-        final String httpPath = "http:///example.com/";
+        final String httpPath = "http://example.com/";
         final String filePath = "file:///this/path/is/good/";
         final String extPath = filePath + "file.txt";
 
@@ -124,8 +124,8 @@ public class ExternalContentPathValidatorTest {
 
     @Test(expected = ExternalMessageBodyException.class)
     public void testInvalidHttpUri() throws Exception {
-        final String goodPath = "http:///good.example.com/";
-        final String extPath = "http:///bad.example.com/file.txt";
+        final String goodPath = "http://good.example.com/";
+        final String extPath = "http://bad.example.com/file.txt";
 
         addAllowedPath(goodPath);
 
@@ -173,6 +173,30 @@ public class ExternalContentPathValidatorTest {
         allowListFile.delete();
 
         validator.init();
+    }
+
+    @Test
+    public void testAllowAny() throws Exception {
+        addAllowedPath("file:///");
+        addAllowedPath("http://");
+        addAllowedPath("https://");
+
+        final String path1 = "file:///this/path/is/good/file";
+        validator.validate(path1);
+        final String path2 = "http://example.com/file";
+        validator.validate(path2);
+        final String path3 = "https://example.com/file";
+        validator.validate(path3);
+    }
+
+    @Test
+    public void testCaseInsensitive() throws Exception {
+        final String goodPath = "FILE:///this/path/";
+        final String extPath = "file:///this/path/file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
     }
 
     private void addAllowedPath(final String allowed) throws Exception {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.nio.file.Files;
+
+import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author bbpennel
+ */
+public class ExternalContentPathValidatorTest {
+
+    private ExternalContentPathValidator validator;
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    private File allowListFile;
+
+    @Before
+    public void init() throws Exception {
+        allowListFile = tmpDir.newFile();
+
+        validator = new ExternalContentPathValidator();
+        validator.setAllowListPath(allowListFile.getAbsolutePath());
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testValidateWithNoAllowList() throws Exception {
+        validator.setAllowListPath(null);
+
+        final String extPath = "file:///this/path/file.txt";
+        validator.validate(extPath);
+    }
+
+    @Test
+    public void testValidFileUri() throws Exception {
+        final String goodPath = "file:///this/path/is/good/";
+        final String extPath = goodPath + "file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test
+    public void testValidHttpUri() throws Exception {
+        final String goodPath = "http:///example.com/";
+        final String extPath = goodPath + "file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test
+    public void testExactFileUri() throws Exception {
+        final String goodPath = "file:///this/path/is/good/file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(goodPath);
+    }
+
+    @Test
+    public void testMultipleMatches() throws Exception {
+        final String goodPath = "file:///this/path/is/good/";
+        final String extPath = goodPath + "file.txt";
+        final String anotherPath = "file:///this/path/";
+
+        addAllowedPath(anotherPath);
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test
+    public void testMultipleSchemes() throws Exception {
+        final String httpPath = "http:///example.com/";
+        final String filePath = "file:///this/path/is/good/";
+        final String extPath = filePath + "file.txt";
+
+        addAllowedPath(httpPath);
+        addAllowedPath(filePath);
+
+        validator.validate(extPath);
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testInvalidFileUri() throws Exception {
+        final String goodPath = "file:///this/path/is/good/";
+        final String extPath = "file:///a/different/path/file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testInvalidHttpUri() throws Exception {
+        final String goodPath = "http:///good.example.com/";
+        final String extPath = "http:///bad.example.com/file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testRelativeModifier() throws Exception {
+        final String goodPath = "file:///this/path/";
+        final String extPath = goodPath + "../sneaky/file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testNoScheme() throws Exception {
+        final String goodPath = "file:///this/path/is/good/";
+        final String extPath = "/this/path/is/good/file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testEmptyPath() throws Exception {
+        final String goodPath = "file:///this/path/is/good/";
+        addAllowedPath(goodPath);
+
+        validator.validate("");
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
+    public void testNullPath() throws Exception {
+        final String goodPath = "file:///this/path/is/good/";
+        addAllowedPath(goodPath);
+
+        validator.validate(null);
+    }
+
+    private void addAllowedPath(final String allowed) throws Exception {
+        try (BufferedWriter writer = Files.newBufferedWriter(allowListFile.toPath(), APPEND)) {
+            writer.write(allowed + System.lineSeparator());
+        }
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -207,6 +207,28 @@ public class ExternalContentPathValidatorTest {
         validator.validate(extPath);
     }
 
+    @Test
+    public void testFileSlashes() throws Exception {
+        addAllowedPath("file:/one/slash/");
+        addAllowedPath("file://two/slash/");
+        addAllowedPath("file:///three/slash/");
+        addAllowedPath("file:////toomany/slash/");
+
+        validator.validate("file:/one/slash/file");
+        validator.validate("file://one/slash/file");
+        validator.validate("file:///one/slash/file");
+
+        validator.validate("file:/two/slash/file");
+        validator.validate("file://two/slash/file");
+        validator.validate("file:///two/slash/file");
+
+        validator.validate("file:/three/slash/file");
+        validator.validate("file://three/slash/file");
+        validator.validate("file:///three/slash/file");
+
+        validator.validate("file:////toomany/slash/file");
+    }
+
     /*
      * Test ignored because it takes around 10+ seconds to poll for events on MacOS:
      * https://bugs.openjdk.java.net/browse/JDK-7133447 Can be enabled for one off testing

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -21,6 +21,7 @@ import static java.nio.file.StandardOpenOption.APPEND;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 
 import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
@@ -52,6 +53,7 @@ public class ExternalContentPathValidatorTest {
     @Test(expected = ExternalMessageBodyException.class)
     public void testValidateWithNoAllowList() throws Exception {
         validator.setAllowListPath(null);
+        validator.init();
 
         final String extPath = "file:///this/path/file.txt";
         validator.validate(extPath);
@@ -166,9 +168,17 @@ public class ExternalContentPathValidatorTest {
         validator.validate(null);
     }
 
+    @Test(expected = IOException.class)
+    public void testListFileDoesNotExist() throws Exception {
+        allowListFile.delete();
+
+        validator.init();
+    }
+
     private void addAllowedPath(final String allowed) throws Exception {
         try (BufferedWriter writer = Files.newBufferedWriter(allowListFile.toPath(), APPEND)) {
             writer.write(allowed + System.lineSeparator());
         }
+        validator.init();
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -60,6 +60,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -217,6 +218,9 @@ public class FedoraLdpTest {
     @Mock
     private PreferTag preferTag;
 
+    @Mock
+    private ExternalContentHandlerFactory extContentHandlerFactory;
+
     private static final Logger log = getLogger(FedoraLdpTest.class);
 
 
@@ -243,6 +247,7 @@ public class FedoraLdpTest {
         setField(testObj, "lockManager", mockLockManager);
         setField(testObj, "context", mockServletContext);
         setField(testObj, "prefer", prefer);
+        setField(testObj, "extContentHandlerFactory", extContentHandlerFactory);
 
         when(mockHttpConfiguration.putRequiresIfMatch()).thenReturn(false);
 
@@ -789,6 +794,9 @@ public class FedoraLdpTest {
 
     @Test(expected = ExternalMessageBodyException.class)
     public void testGetWithExternalMessageMissingURLBinary() throws Exception {
+        when(extContentHandlerFactory.createFromLinks(anyListOf(String.class)))
+                .thenThrow(new ExternalMessageBodyException(""));
+
         final String badExternal = Link.fromUri("http://test.com")
                 .rel(EXTERNAL_CONTENT.toString())
                 .param("handling", "proxy")
@@ -797,11 +805,14 @@ public class FedoraLdpTest {
                 .toString()
                 .replaceAll("<.*>", "< >");
 
-        final Response actual = testObj.createObject(null, null, null, null, Arrays.asList(badExternal), null);
+        testObj.createObject(null, null, null, null, Arrays.asList(badExternal), null);
     }
 
     @Test(expected = ExternalMessageBodyException.class)
     public void testPostWithExternalMessageBadHandling() throws Exception {
+        when(extContentHandlerFactory.createFromLinks(anyListOf(String.class)))
+                .thenThrow(new ExternalMessageBodyException(""));
+
          final String badExternal = Link.fromUri("http://test.com")
             .rel(EXTERNAL_CONTENT.toString()).param("handling", "boogie").type("text/plain").build().toString();
         final Response actual = testObj.createObject(null, null, null, null, Arrays.asList(badExternal), null);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -815,7 +815,7 @@ public class FedoraLdpTest {
 
          final String badExternal = Link.fromUri("http://test.com")
             .rel(EXTERNAL_CONTENT.toString()).param("handling", "boogie").type("text/plain").build().toString();
-        final Response actual = testObj.createObject(null, null, null, null, Arrays.asList(badExternal), null);
+        testObj.createObject(null, null, null, null, Arrays.asList(badExternal), null);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_LOCATION;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.nio.file.Files;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+/**
+ * @author bbpennel
+ */
+public class ExternalContentPathValidatorIT extends AbstractResourceIT {
+
+    private static final Logger LOGGER = getLogger(ExternalContentPathValidatorIT.class);
+
+    private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
+
+    static {
+        try {
+            final File allowedFile = File.createTempFile("allowed", "txt");
+            allowedFile.deleteOnExit();
+            addAllowedPath(allowedFile, serverAddress);
+
+            System.setProperty("fcrepo.external.content.allowed", allowedFile.getAbsolutePath());
+            LOGGER.warn("fcrepo.external.content.allowed = {}", allowedFile.getAbsolutePath());
+        } catch (final Exception e) {
+            LOGGER.error("Failed to setup allowed configuration file", e);
+        }
+    }
+
+    private static void addAllowedPath(final File allowedFile, final String allowed) throws Exception {
+        try (BufferedWriter writer = Files.newBufferedWriter(allowedFile.toPath(), APPEND)) {
+            writer.write(allowed + System.lineSeparator());
+        }
+    }
+
+    @Test
+    public void testAllowedPath() throws Exception {
+        final HttpPost method = postObjMethod();
+        method.addHeader(CONTENT_TYPE, "text/plain");
+        method.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        method.setEntity(new StringEntity("xyz"));
+        final String externalLocation;
+
+        // Make an external remote URI.
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(SC_CREATED, getStatus(response));
+            externalLocation = getLocation(response);
+        }
+
+        final String id = getRandomUniqueId();
+
+        final HttpPut put = putObjMethod(id);
+        put.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "proxy", null));
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(SC_CREATED, getStatus(response));
+        }
+        // Get the external content proxy resource.
+        try (final CloseableHttpResponse response = execute(getObjMethod(id))) {
+            assertEquals(SC_OK, getStatus(response));
+            assertEquals("text/plain", response.getFirstHeader(CONTENT_TYPE).getValue());
+            assertEquals(externalLocation, response.getFirstHeader(CONTENT_LOCATION).getValue());
+        }
+    }
+
+    @Test
+    public void testDisallowedPath() throws Exception {
+        final String externalLocation = "http://example.com/";
+
+        final String id = getRandomUniqueId();
+        final String uri = serverAddress + id;
+
+        final HttpPut put = putObjMethod(uri);
+        put.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "proxy", null));
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(SC_BAD_REQUEST, getStatus(response));
+        }
+    }
+}

--- a/fcrepo-http-api/src/test/resources/allowed_external_paths.txt
+++ b/fcrepo-http-api/src/test/resources/allowed_external_paths.txt
@@ -1,0 +1,3 @@
+http://
+https://
+file:///

--- a/fcrepo-http-api/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-http-api/src/test/resources/spring-test/rest.xml
@@ -24,7 +24,7 @@
   <!-- External content configuration -->
   <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
       init-method="init">
-    <property name="configPath" value="src/test/resources/allowed_external_paths.txt" />
+    <property name="configPath" value="${fcrepo.external.content.allowed:src/test/resources/allowed_external_paths.txt}" />
     <property name="monitorForChanges" value="false" />
   </bean>
 

--- a/fcrepo-http-api/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-http-api/src/test/resources/spring-test/rest.xml
@@ -21,4 +21,15 @@
 
   <context:component-scan base-package="org.fcrepo"/>
 
+  <!-- External content configuration -->
+  <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
+      init-method="init">
+    <property name="configPath" value="src/test/resources/allowed_external_paths.txt" />
+    <property name="monitorForChanges" value="false" />
+  </bean>
+
+  <bean name="externalContentHandlerFactory" class="org.fcrepo.http.api.ExternalContentHandlerFactory">
+    <property name="validator" ref="externalContentPathValidator" />
+  </bean>
+
 </beans>

--- a/fcrepo-integration-rdf/src/test/resources/allowed_external_paths.txt
+++ b/fcrepo-integration-rdf/src/test/resources/allowed_external_paths.txt
@@ -1,0 +1,3 @@
+http://
+https://
+file:///

--- a/fcrepo-integration-rdf/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-integration-rdf/src/test/resources/spring-test/rest.xml
@@ -21,7 +21,7 @@
   <context:component-scan base-package="org.fcrepo"/>
   
   <!-- External content configuration -->
-    <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
+  <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
       init-method="init">
     <property name="configPath" value="src/test/resources/allowed_external_paths.txt" />
     <property name="monitorForChanges" value="false" />

--- a/fcrepo-integration-rdf/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-integration-rdf/src/test/resources/spring-test/rest.xml
@@ -19,5 +19,16 @@
   <context:annotation-config/>
 
   <context:component-scan base-package="org.fcrepo"/>
+  
+  <!-- External content configuration -->
+    <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
+      init-method="init">
+    <property name="configPath" value="src/test/resources/allowed_external_paths.txt" />
+    <property name="monitorForChanges" value="false" />
+  </bean>
+
+  <bean name="externalContentHandlerFactory" class="org.fcrepo.http.api.ExternalContentHandlerFactory">
+    <property name="validator" ref="externalContentPathValidator" />
+  </bean>
 
 </beans>

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoader.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoader.java
@@ -112,11 +112,8 @@ public class DefaultPropertiesLoader {
         }
 
         for (final PROPERTIES prop : PROPERTIES.values()) {
-            final String name = prop.getValue();
-            final String val = getProperty(name);
-            if (val != null) {
-                LOGGER.info("{} = {}", name, val);
-            }
+            final String val = prop.getValue();
+            LOGGER.info("{} = {}", val, getProperty(val));
         }
     }
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoader.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoader.java
@@ -55,16 +55,27 @@ public class DefaultPropertiesLoader {
         BINARY_STORE("fcrepo.binary.directory"),
         MODE_INDEX("fcrepo.modeshape.index.directory"),
         ACTIVE_MQ("fcrepo.activemq.directory"),
-        ALLOWED_EXTERNAL_CONTENT("fcrepo.external.content.allowed");
+        ALLOWED_EXTERNAL_CONTENT("fcrepo.external.content.allowed", false);
 
         private String text;
 
+        private boolean setDefaultValue;
+
         private PROPERTIES(final String text) {
+            this(text, true);
+        }
+
+        private PROPERTIES(final String text, final boolean setDefaultValue) {
             this.text = text;
+            this.setDefaultValue = setDefaultValue;
         }
 
         public String getValue() {
             return text;
+        }
+
+        public boolean getSetDefaultValue() {
+            return setDefaultValue;
         }
     }
 
@@ -91,7 +102,9 @@ public class DefaultPropertiesLoader {
             for (final PROPERTIES prop : PROPERTIES.values()) {
                 final String value = getProperty(prop.getValue());
                 if (value == null) {
-                    setProperty(prop.getValue(), baseDir);
+                    if (prop.getSetDefaultValue()) {
+                        setProperty(prop.getValue(), baseDir);
+                    }
                 } else {
                     updateRelativePropertyPath(prop.getValue(), value, baseDir);
                 }
@@ -99,8 +112,11 @@ public class DefaultPropertiesLoader {
         }
 
         for (final PROPERTIES prop : PROPERTIES.values()) {
-            final String val = prop.getValue();
-            LOGGER.info("{} = {}", val, getProperty(val));
+            final String name = prop.getValue();
+            final String val = getProperty(name);
+            if (val != null) {
+                LOGGER.info("{} = {}", name, val);
+            }
         }
     }
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoader.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoader.java
@@ -54,7 +54,8 @@ public class DefaultPropertiesLoader {
         OBJECT_STORE("fcrepo.object.directory"),
         BINARY_STORE("fcrepo.binary.directory"),
         MODE_INDEX("fcrepo.modeshape.index.directory"),
-        ACTIVE_MQ("fcrepo.activemq.directory");
+        ACTIVE_MQ("fcrepo.activemq.directory"),
+        ALLOWED_EXTERNAL_CONTENT("fcrepo.external.content.allowed");
 
         private String text;
 

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoaderTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoaderTest.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.modeshape.spring;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
@@ -36,6 +38,8 @@ public class DefaultPropertiesLoaderTest {
     private static final String PROP_TEST = "fcrepo.binary.directory";
     private static final String HOME_PROP = "fcrepo.home";
 
+    private static final String NO_DEFAULT_PROP = "fcrepo.external.content.allowed";
+
     @Before
     public void setUp() {
         loader = new DefaultPropertiesLoader();
@@ -50,6 +54,7 @@ public class DefaultPropertiesLoaderTest {
         System.clearProperty(PROP_FLAG);
         System.clearProperty(PROP_TEST);
         System.clearProperty(HOME_PROP);
+        System.clearProperty(NO_DEFAULT_PROP);
     }
 
     @Test
@@ -113,6 +118,28 @@ public class DefaultPropertiesLoaderTest {
 
         Assert.assertEquals(new File(new File("test"), "sub"),
                 new File(System.getProperty(PROP_TEST)));
+        clearProps();
+    }
+
+    @Test
+    public void testNoDefault() {
+        loader.loadSystemProperties();
+
+        assertNull("No default should be set for property", System.getProperty(NO_DEFAULT_PROP));
+
+        clearProps();
+    }
+
+    @Test
+    public void testValueSetForNoDefault() {
+        final String value = "/absolute/path";
+        System.setProperty(NO_DEFAULT_PROP, value);
+
+        loader.loadSystemProperties();
+
+        assertEquals("Value must be set for property with no default",
+                value, System.getProperty(NO_DEFAULT_PROP));
+
         clearProps();
     }
 

--- a/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
+++ b/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
@@ -220,7 +220,7 @@
     <!-- External content configuration -->
     <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
         init-method="init" destroy-method="shutdown">
-        <property name="configPath" value="${fcrepo.external.content.allowed:}" />
+        <property name="configPath" value="${fcrepo.external.content.allowed:#{null}}" />
         <property name="monitorForChanges" value="true" />
     </bean>
     

--- a/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
+++ b/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
@@ -217,6 +217,16 @@
     <!-- Fedora's lightweight internal event bus. Currently memory-resident.-->
     <bean name="fedoraInternalEventBus" class="com.google.common.eventbus.EventBus"/>
 
+    <!-- External content configuration -->
+    <bean name="externalContentPathValidator" class="org.fcrepo.http.api.ExternalContentPathValidator"
+        init-method="init" destroy-method="shutdown">
+        <property name="configPath" value="${fcrepo.external.content.allowed:}" />
+        <property name="monitorForChanges" value="true" />
+    </bean>
+    
+    <bean name="externalContentHandlerFactory" class="org.fcrepo.http.api.ExternalContentHandlerFactory">
+        <property name="validator" ref="externalContentPathValidator" />
+    </bean>
 
     <!-- ***********************************
             Internal system configuration

--- a/fcrepo-webapp/src/main/webapp/static/constraints/ExternalMessageBodyException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/ExternalMessageBodyException.rdf
@@ -17,9 +17,9 @@
     <owl:Ontology rdf:about="static/constraints/ExternalMessageBodyException">
         <rdfs:label xml:lang="en">External Message Body Constraint</rdfs:label>
         <rdfs:comment xml:lang="en">Part of the request for creating/updating an External Message Body was missing
-            or malformed. Link header must include a URI reference to an external resource from an allowed path,
-            a link relation type ('rel') that is set to "http://fedora.info/definitions/fcrepo#ExternalContent";',
-            a 'handling' attribute set to one of the following three values: proxy, redirect, or copy,
+            or malformed. Link header must include a URI reference to an external resource from an allowed path;
+            a link relation type ('rel') that is set to "http://fedora.info/definitions/fcrepo#ExternalContent";
+            a 'handling' attribute set to one of the following three values: proxy, redirect, or copy;
             and an optional 'type' attribute representing the content type of the external body.
         </rdfs:comment>
     </owl:Ontology>

--- a/fcrepo-webapp/src/main/webapp/static/constraints/ExternalMessageBodyException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/ExternalMessageBodyException.rdf
@@ -17,10 +17,10 @@
     <owl:Ontology rdf:about="static/constraints/ExternalMessageBodyException">
         <rdfs:label xml:lang="en">External Message Body Constraint</rdfs:label>
         <rdfs:comment xml:lang="en">Part of the request for creating/updating an External Message Body was missing
-            or malformed. Link header should include a URI reference to the external resource, a link relation
-            type ('rel') that's set to "http://fedora.info/definitions/fcrepo#ExternalContent";',
-            a 'handling' attribute set to one of these three things: proxy, redirect, or copy, and an optional
-            attribute of 'type' representing the content type of the external body.
+            or malformed. Link header must include a URI reference to an external resource from an allowed path,
+            a link relation type ('rel') that is set to "http://fedora.info/definitions/fcrepo#ExternalContent";',
+            a 'handling' attribute set to one of the following three values: proxy, redirect, or copy,
+            and an optional 'type' attribute representing the content type of the external body.
         </rdfs:comment>
     </owl:Ontology>
 </rdf:RDF>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2835

# What does this Pull Request do?
Adds an optional configuration file for specifying what URIs external content may be created from. If no configuration is provided, then external binary creation is disabled.

# What's new?
* Adds java startup parameter "fcrepo.external.content.allowed" which allows users to optionally specify where the allowed list configuration file is.
* Introduces a ExternalContentPathValidator which verifies that a path is from the allowed list and does not contain relative modifiers.
* Introduces ExternalContentHandlerFactory which constructors ExternalContentHandlers and performs validation of links prior to returning the handler
* Validator configured by default to reload configuration file if it is modified (assuming it was provided at startup time)
* Updates tests accordingly

Example format for the configuration file:
```
file:///allowed/path/
file:/another/allowed/path/
file:///exact/match/file.txt
https://duraspace.com/
http://example.com/
```

# How should this be tested?
Adds tests for new functional, but should also be tested as follows:
```
# Start jetty without allowed list
mvn jetty:run

# Try to create external binaries, should fail with 400 status
curl -v -X PUT -H "Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/allow_http -ufedoraAdmin:fedoraAdmin

# Try to create external binaries, should fail with 400 status
curl -v -X PUT -H "Link: <file:///Users/bbpennel/git/fcrepo4/NOTICE>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/allow_file -ufedoraAdmin:fedoraAdmin

# Create allowed list, very permissive
echo "http://
file:/" > allowed.txt

# Stop jetty

# Restart jetty with allowed list configuration
mvn jetty:run -Dfcrepo.external.content.allowed=/Users/bbpennel/git/fcrepo4/allowed.txt

# Should succeed
curl -v -X PUT -H "Link: <file:///Users/bbpennel/git/fcrepo4/NOTICE>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/allow_file -ufedoraAdmin:fedoraAdmin

# Should fail because of ".."
curl -v -X PUT -H "Link: <file:///Users/bbpennel/git/fcrepo4/fcrepo-auth-webac/../NOTICE>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/allow_file -ufedoraAdmin:fedoraAdmin

# Should fail because https was not permitted
curl -v -X PUT -H "Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/allow_http -ufedoraAdmin:fedoraAdmin

# Add a new line to the allowed list WITHOUT restarting jetty
echo "https://duraspace.org/wp-content/" >> allowed.txt

# After a few seconds to wait for config to reload, this should now succeed
curl -v -X PUT -H "Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/allow_http -ufedoraAdmin:fedoraAdmin
```

# Additional Notes:
Not sure if documentation exists for external content yet, but this will definitely need to be documented. Will also need to update the fcrepo configuration options page.

# Interested parties
@awoods @whikloj @bseeger 
