### PR TITLE
Respond with a 400 if a PUT/POST request has a rel="acl" Link header.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -127,6 +127,7 @@ import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.RequestWithAclLinkHeaderException;
 import org.fcrepo.kernel.api.exception.UnsupportedAccessTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.Container;
@@ -410,6 +411,8 @@ public class FedoraLdp extends ContentExposingResource {
 
         final String interactionModel = checkInteractionModel(links);
 
+        checkAclLinkHeader(links);
+
         final FedoraResource resource;
 
         final String path = toPath(translator(), externalPath);
@@ -631,6 +634,8 @@ public class FedoraLdp extends ContentExposingResource {
         }
 
         final String interactionModel = checkInteractionModel(links);
+
+        checkAclLinkHeader(links);
 
         // If request is an external binary, verify link header before proceeding
         final ExternalContentHandler extContent = ExternalContentHandler.createFromLinks(links);
@@ -1013,6 +1018,13 @@ public class FedoraLdp extends ContentExposingResource {
                 throw new ClientErrorException("Invalid 'Want-Digest' header value: " + wantDigest + "\n", BAD_REQUEST);
             }
             throw e;
+        }
+    }
+
+    private void checkAclLinkHeader(final List<String> links) throws RequestWithAclLinkHeaderException {
+        if (links != null && links.stream().anyMatch(l -> Link.valueOf(l).getRel().equals("acl"))) {
+            throw new RequestWithAclLinkHeaderException(
+                    "Unable to handle request with the specified LDP-RS as the ACL.");
         }
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -615,7 +615,7 @@ public abstract class AbstractResourceIT {
 
     protected static void assertConstrainedByPresent(final CloseableHttpResponse response) {
         final Collection<String> linkHeaders = getLinkHeaders(response);
-        assertTrue("Constrained by link header no present",
+        assertTrue("Constrained by link header not present",
                 linkHeaders.stream().map(Link::valueOf)
                         .anyMatch(l -> l.getRel().equals(CONSTRAINED_BY.getURI())));
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -33,6 +33,7 @@ import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
+import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
@@ -42,6 +43,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -610,4 +612,12 @@ public abstract class AbstractResourceIT {
         }
         return link;
     }
+
+    protected static void assertConstrainedByPresent(final CloseableHttpResponse response) {
+        final Collection<String> linkHeaders = getLinkHeaders(response);
+        assertTrue("Constrained by link header no present",
+                linkHeaders.stream().map(Link::valueOf)
+                        .anyMatch(l -> l.getRel().equals(CONSTRAINED_BY.getURI())));
+    }
+
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4008,7 +4008,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createMethod.addHeader("Slug", subjectURI);
         createMethod.setEntity(new StringEntity("test body"));
 
-        checkReponseForMethodWithAcl(createMethod);
+        checkResponseForMethodWithAcl(createMethod);
     }
 
 @Test
@@ -4021,7 +4021,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createMethod.addHeader("Slug", subjectURI);
         createMethod.setEntity(new StringEntity("<> <info:test#label> \"foo\""));
 
-        checkReponseForMethodWithAcl(createMethod);
+        checkResponseForMethodWithAcl(createMethod);
 }
 
     @Test
@@ -4033,7 +4033,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         putMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
         putMethod.setEntity(new StringEntity("test body"));
 
-        checkReponseForMethodWithAcl(putMethod);
+        checkResponseForMethodWithAcl(putMethod);
     }
 
     @Test
@@ -4045,10 +4045,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
         putMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
         putMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
 
-        checkReponseForMethodWithAcl(putMethod);
+        checkResponseForMethodWithAcl(putMethod);
     }
 
-    private void checkReponseForMethodWithAcl(final HttpUriRequest req) throws IOException {
+    private void checkResponseForMethodWithAcl(final HttpUriRequest req) throws IOException {
         try (final CloseableHttpResponse response = execute(req)) {
             assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
             assertConstrainedByPresent(response);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -140,6 +140,7 @@ import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.FileEntity;
@@ -3994,6 +3995,63 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(httpDelete)) {
             assertEquals("Must not be able to DELETE with fedora namespaced path!", CONFLICT.getStatusCode(),
                 getStatus(response));
+        }
+    }
+
+    @Test
+    public void testPostCreateNonRDFSourceWithAcl() throws IOException {
+        final String aclURI = createAcl();
+        final String subjectURI = getRandomUniqueId();
+        final HttpPost createMethod = new HttpPost(serverAddress);
+        createMethod.addHeader(CONTENT_TYPE, "text/plain");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.addHeader("Slug", subjectURI);
+        createMethod.setEntity(new StringEntity("test body"));
+
+        checkReponseForMethodWithAcl(createMethod);
+    }
+
+@Test
+    public void testPostCreateRDFSourceWithAcl() throws IOException {
+        final String aclURI = createAcl();
+        final String subjectURI = getRandomUniqueId();
+        final HttpPost createMethod = new HttpPost(serverAddress);
+        createMethod.addHeader(CONTENT_TYPE, "text/n3");
+        createMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        createMethod.addHeader("Slug", subjectURI);
+        createMethod.setEntity(new StringEntity("<> <info:test#label> \"foo\""));
+
+        checkReponseForMethodWithAcl(createMethod);
+}
+
+    @Test
+    public void testPutCreateNonRDFSourceWithAcl() throws IOException {
+        final String aclURI = createAcl();
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut putMethod = new HttpPut(subjectURI);
+        putMethod.addHeader(CONTENT_TYPE, "text/plain");
+        putMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        putMethod.setEntity(new StringEntity("test body"));
+
+        checkReponseForMethodWithAcl(putMethod);
+    }
+
+    @Test
+    public void testPutCreateRDFSourceWithAcl() throws IOException {
+        final String aclURI = createAcl();
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut putMethod = new HttpPut(subjectURI);
+        putMethod.addHeader(CONTENT_TYPE, "text/n3");
+        putMethod.addHeader("Link", "<" + aclURI + ">; rel=\"acl\"");
+        putMethod.setEntity(new StringEntity("<" + subjectURI + "> <info:test#label> \"foo\""));
+
+        checkReponseForMethodWithAcl(putMethod);
+    }
+
+    private void checkReponseForMethodWithAcl(final HttpUriRequest req) throws IOException {
+        try (final CloseableHttpResponse response = execute(req)) {
+            assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
+            assertConstrainedByPresent(response);
         }
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -49,7 +49,6 @@ import static org.fcrepo.kernel.api.FedoraTypes.FCR_FIXITY;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
-import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBED_BY;
@@ -80,7 +79,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -1618,13 +1616,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertMementoDatetimeHeaderPresent(response);
         assertEquals("Response memento datetime did not match expected value",
                 expected, response.getFirstHeader(MEMENTO_DATETIME_HEADER).getValue());
-    }
-
-    private static void assertConstrainedByPresent(final CloseableHttpResponse response) {
-        final Collection<String> linkHeaders = getLinkHeaders(response);
-        assertTrue("Constrained by link header no present",
-                linkHeaders.stream().map(Link::valueOf)
-                        .anyMatch(l -> l.getRel().equals(CONSTRAINED_BY.getURI())));
     }
 
     private static void enableVersioning(final String uri) throws Exception {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RequestWithAclLinkHeaderExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RequestWithAclLinkHeaderExceptionMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.fcrepo.kernel.api.exception.RequestWithAclLinkHeaderException;
+import org.slf4j.Logger;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+/**
+ * @author lsitu
+ * @since 2018-07-25
+ */
+@Provider
+public class RequestWithAclLinkHeaderExceptionMapper
+        extends ConstraintExceptionMapper<RequestWithAclLinkHeaderException>
+    implements ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(RequestWithAclLinkHeaderExceptionMapper.class);
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Context
+    private ServletContext context;
+
+    @Override
+    public Response toResponse(final RequestWithAclLinkHeaderException e) {
+        debugException(this, e, LOGGER);
+        final Link link = buildConstraintLink(e, context, uriInfo);
+        final String msg = e.getMessage();
+        return status(BAD_REQUEST).entity(msg).links(link).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/RequestWithAclLinkHeaderException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/RequestWithAclLinkHeaderException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Request failed with ACL link header
+ *
+ * @author lsitu
+ * @since 2018-07-25
+ */
+public class RequestWithAclLinkHeaderException extends ConstraintViolationException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     */
+    public RequestWithAclLinkHeaderException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param rootCause the root cause
+     */
+    public RequestWithAclLinkHeaderException(final Throwable rootCause) {
+        super(rootCause);
+    }
+
+}

--- a/fcrepo-webapp/src/main/webapp/static/constraints/RequestWithAclLinkHeaderException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/RequestWithAclLinkHeaderException.rdf
@@ -15,9 +15,10 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
     <owl:Ontology rdf:about="static/constraints/CannotCreateResourceWithAclException">
-        <rdfs:label xml:lang="en">Request With Acl Link Header Exception</rdfs:label>
+        <rdfs:label xml:lang="en">Request With ACL Link Header Exception</rdfs:label>
         <rdfs:comment xml:lang="en">
-          Fedora will not handle request with the specified LDP-RS as the ACL in the request.
+          Fedora cannot handle requests containing Link headers where rel="acl".
+          ACL locations are system-defined and cannot be altered.
         </rdfs:comment>
     </owl:Ontology>
 </rdf:RDF>

--- a/fcrepo-webapp/src/main/webapp/static/constraints/RequestWithAclLinkHeaderException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/RequestWithAclLinkHeaderException.rdf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="owl2html.xsl"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+]>
+
+
+<rdf:RDF
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="static/constraints/CannotCreateResourceWithAclException">
+        <rdfs:label xml:lang="en">Request With Acl Link Header Exception</rdfs:label>
+        <rdfs:comment xml:lang="en">
+          Fedora will not handle request with the specified LDP-RS as the ACL in the request.
+        </rdfs:comment>
+    </owl:Ontology>
+</rdf:RDF>


### PR DESCRIPTION
Respond with a 400 when a PUT/POST request has a rel="acl" Link header.

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2822

# How should this be tested?
```
1. Test POST with link header rel="acl"
$ curl -i -XPOST -H "Slug: newResource" -H "Link: <http://localhost:8080/rest/anyResource/fcr:acl>; rel=\"acl\"" "http://localhost:8080/rest"
HTTP/1.1 400 Bad Request
Date: Wed, 25 Jul 2018 22:25:02 GMT
Link: <http://localhost:8080/static/constraints/RequestWithAclLinkHeaderException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 62
Server: Jetty(9.2.3.v20140905)

Unable to handle request with the specified LDP-RS as the ACL.

2. Test PUT with link header rel="acl"
$ curl -i -XPUT -H "Link: <http://localhost:8080/rest/anyResource/fcr:acl>; rel=\"acl\"" "http://localhost:8080/rest/newResource"
HTTP/1.1 400 Bad Request
Date: Wed, 25 Jul 2018 22:25:39 GMT
Link: <http://localhost:8080/static/constraints/RequestWithAclLinkHeaderException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 62
Server: Jetty(9.2.3.v20140905)

Unable to handle request with the specified LDP-RS as the ACL. 
```
# Interested parties
@peichman-umd  @fcrepo4/committers
