### PR TITLE
Fcrepo 2819 - POST create External Content

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -119,7 +119,6 @@ import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
-import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InteractionModelViolationException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
@@ -673,10 +672,6 @@ public class FedoraLdp extends ContentExposingResource {
                         replaceResourceWithStream(resource, requestBodyStream, contentType, resourceTriples);
                     } else if (resource instanceof FedoraBinary) {
                         LOGGER.trace("Created a datastream and have a binary payload.");
-
-                        if (requestBodyStream != null && extContent != null) {
-                            throw new ExternalMessageBodyException("Body included in request.");
-                        }
 
                         InputStream stream = requestBodyStream;
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -674,17 +674,20 @@ public class FedoraLdp extends ContentExposingResource {
                         LOGGER.trace("Created a datastream and have a binary payload.");
 
                         InputStream stream = requestBodyStream;
+                        MediaType type = requestContentType;
 
                         if (extContent != null) {
                             if (extContent.isCopy()) {
                                 LOGGER.debug("POST copying data {} ", externalPath);
                                 stream = extContent.fetchExternalContent();
                             }
+
+                            type = contentType; // if external, then this already holds the correct value
                         }
 
                         final String handling = extContent != null ? extContent.getHandling() : null;
                         replaceResourceBinaryWithStream((FedoraBinary) resource,
-                            stream, contentDisposition, requestContentType, checksum,
+                                stream, contentDisposition, type, checksum,
                             handling != null && !handling.equals(COPY) ? handling : null,
                             extContent != null ? extContent.getURL() : null);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -3196,7 +3196,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpPost httpPost = postObjMethod();
         httpPost.addHeader("Slug", id);
         httpPost.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
-        httpPost.addHeader(LINK, getExternalContentLinkHeader(origLocation, "proxy", null));
+        httpPost.addHeader(LINK, getExternalContentLinkHeader(origLocation, "proxy", "text/plain"));
 
         try (final CloseableHttpResponse response = execute(httpPost)) {
             assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
@@ -3204,6 +3204,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
             try (final CloseableHttpResponse getResponse = execute(get)) {
                 assertEquals(OK.getStatusCode(), getStatus(getResponse));
                 assertEquals(origLocation, getContentLocation(getResponse));
+
+                final String contentType = getResponse.getFirstHeader("Content-Type").getValue();
+                assertEquals("text/plain", contentType);
+
                 final String content = EntityUtils.toString(getResponse.getEntity());
                 assertEquals("Entity Data doesn't match original object!", entityStr, content);
             }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2819

# What does this Pull Request do?
* Allows users to create external content binaries with post requests
* Fixes bonus bug that prevented mimetype from getting set when creating external binary via POST.

# What's new?
* Removes a check for null request bodies when creating external content
* Adds integration test for creating external content binaries with post.

# How should this be tested?

```
# Start fcrepo with external content enabled
mvn jetty:run -Dfcrepo.external.content.allowed=/Users/bbpennel/git/fcrepo4/fcrepo-http-api/src/test/resources/allowed_external_paths.txt 

# Create external content with POST
curl -i -XPOST -H "Slug:post_ext" -H "Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" "http://localhost:8080/rest/" -ufedoraAdmin:fedoraAdmin

# 201 Created response

# visiting http://localhost:8080/rest/post_ext should return the file

```

# Additional Notes:
N/A

# Interested parties
@bseeger @awoods @whikloj 
