### PR TITLE
Added tests to verify HEAD and GET requests to External Content with Want-Digest header are correctly responded.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -206,6 +206,12 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final String DIGEST = "Digest";
 
+    private static final String TEST_BINARY_CONTENT = "01234567890123456789012345678901234567890123456789";
+
+    private static final String TEST_SHA_DIGEST_HEADER_VALUE = "sha=9578f951955d37f20b601c26591e260c1e5389bf";
+
+    private static final String TEST_MD5_DIGEST_HEADER_VALUE = "md5=baed005300234f3d1503c50a48ce8e6f";
+
     private static final Logger LOGGER = getLogger(FedoraLdpIT.class);
 
     private static DateTimeFormatter headerFormat =
@@ -390,7 +396,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testHeadDatastreamWithWantDigest() throws IOException, ParseException {
         final String id = getRandomUniqueId();
-        createDatastream(id, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(id, "x", TEST_BINARY_CONTENT);
 
         final HttpHead headObjMethod = headObjMethod(id + "/x");
         headObjMethod.addHeader(WANT_DIGEST, "SHA");
@@ -400,14 +406,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue(response.getHeaders(DIGEST).length > 0);
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("Fixity Checksum doesn't match",
-                    digesterHeaderValue.equals("sha=9578f951955d37f20b601c26591e260c1e5389bf"));
+                    digesterHeaderValue.equals(TEST_SHA_DIGEST_HEADER_VALUE));
         }
     }
 
     @Test
     public void testHeadDatastreamWithWantDigestMultiple() throws IOException, ParseException {
         final String id = getRandomUniqueId();
-        createDatastream(id, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(id, "x", TEST_BINARY_CONTENT);
 
         final HttpHead headObjMethod = headObjMethod(id + "/x");
         headObjMethod.addHeader(WANT_DIGEST, "SHA, md5;q=0.3");
@@ -418,16 +424,16 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf("sha=9578f951955d37f20b601c26591e260c1e5389bf") >= 0);
+                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
+                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
         }
     }
 
     @Test
     public void testExternalDatastreamProxyWithWantDigestForLocalFile() throws IOException, ParseException {
 
-        final File externalFile = createExternalLocalFile("01234567890123456789012345678901234567890123456789");
+        final File externalFile = createExternalLocalFile(TEST_BINARY_CONTENT);
 
         final String fileUri = externalFile.toURI().toString();
 
@@ -436,7 +442,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         put.addHeader(LINK, getExternalContentLinkHeader(fileUri, "proxy", "text/plain"));
         assertEquals(CREATED.getStatusCode(), getStatus(put));
 
-        final String expectedDigestHeaderValue = "sha=9578f951955d37f20b601c26591e260c1e5389bf";
+        final String expectedDigestHeaderValue = TEST_SHA_DIGEST_HEADER_VALUE;
 
         // HEAD request with Want-Digest
         final HttpHead headObjMethod = headObjMethod(id);
@@ -452,7 +458,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testExternalDatastreamCopyWithWantDigestForLocalFile() throws IOException, ParseException {
 
-        final File externalFile = createExternalLocalFile("01234567890123456789012345678901234567890123456789");
+        final File externalFile = createExternalLocalFile(TEST_BINARY_CONTENT);
 
         final String fileUri = externalFile.toURI().toString();
 
@@ -461,7 +467,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         put.addHeader(LINK, getExternalContentLinkHeader(fileUri, "copy", "text/plain"));
         assertEquals(CREATED.getStatusCode(), getStatus(put));
 
-        final String expectedDigestHeaderValue = "sha=9578f951955d37f20b601c26591e260c1e5389bf";
+        final String expectedDigestHeaderValue = TEST_SHA_DIGEST_HEADER_VALUE;
 
         // HEAD request with Want-Digest
         final HttpHead headObjMethod = headObjMethod(id);
@@ -478,7 +484,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testExternalDatastreamProxyWithWantDigest() throws IOException, ParseException {
 
         final String dsId = getRandomUniqueId();
-        createDatastream(dsId, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(dsId, "x", TEST_BINARY_CONTENT);
 
         final String dsUrl = serverAddress + dsId + "/x";
 
@@ -487,7 +493,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         put.addHeader(LINK, getExternalContentLinkHeader(dsUrl, "proxy", "text/plain"));
         assertEquals(CREATED.getStatusCode(), getStatus(put));
 
-        final String expectedDigestHeaderValue = "sha=9578f951955d37f20b601c26591e260c1e5389bf";
+        final String expectedDigestHeaderValue = TEST_SHA_DIGEST_HEADER_VALUE;
 
         // HEAD request with Want-Digest
         final HttpHead headObjMethod = headObjMethod(id);
@@ -504,7 +510,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testExternalDatastreamCopyWithWantDigest() throws IOException, ParseException {
 
         final String dsId = getRandomUniqueId();
-        createDatastream(dsId, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(dsId, "x", TEST_BINARY_CONTENT);
 
         final String dsUrl = serverAddress + dsId + "/x";
 
@@ -513,7 +519,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         put.addHeader(LINK, getExternalContentLinkHeader(dsUrl, "copy", "text/plain"));
         assertEquals(CREATED.getStatusCode(), getStatus(put));
 
-        final String expectedDigestHeaderValue = "sha=9578f951955d37f20b601c26591e260c1e5389bf";
+        final String expectedDigestHeaderValue = TEST_SHA_DIGEST_HEADER_VALUE;
 
         // HEAD request with Want-Digest
         final HttpHead headObjMethod = headObjMethod(id);
@@ -529,7 +535,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testExternalDatastreamProxyWithWantDigestMultipleForLocalFile() throws IOException, ParseException {
 
-        final File externalFile = createExternalLocalFile("01234567890123456789012345678901234567890123456789");
+        final File externalFile = createExternalLocalFile(TEST_BINARY_CONTENT);
 
         final String fileUri = externalFile.toURI().toString();
 
@@ -548,9 +554,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf("sha=9578f951955d37f20b601c26591e260c1e5389bf") >= 0);
+                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
+                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
         }
 
         // GET request with Want-Digest
@@ -563,9 +569,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf("sha=9578f951955d37f20b601c26591e260c1e5389bf") >= 0);
+                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
+                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
         }
     }
 
@@ -649,7 +655,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testHeadExternalDatastreamWithWantDigest() throws IOException, ParseException {
 
         final String dsId = getRandomUniqueId();
-        createDatastream(dsId, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(dsId, "x", TEST_BINARY_CONTENT);
 
         final String dsUrl = serverAddress + dsId + "/x";
 
@@ -671,7 +677,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals(dsUrl, getLocation(response));
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("Fixity Checksum doesn't match",
-                    digesterHeaderValue.equals("sha=9578f951955d37f20b601c26591e260c1e5389bf"));
+                    digesterHeaderValue.equals(TEST_SHA_DIGEST_HEADER_VALUE));
         }
     }
 
@@ -680,7 +686,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testHeadExternalDatastreamWithWantDigestMultiple() throws IOException, ParseException {
 
         final String dsId = getRandomUniqueId();
-        createDatastream(dsId, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(dsId, "x", TEST_BINARY_CONTENT);
 
         final String dsUrl = serverAddress + dsId + "/x";
 
@@ -703,9 +709,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf("sha=9578f951955d37f20b601c26591e260c1e5389bf") >= 0);
+                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
+                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
         }
     }
 
@@ -929,7 +935,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testGetNonRDFSourceWithWantDigest() throws IOException {
         final String id = getRandomUniqueId();
-        createDatastream(id, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(id, "x", TEST_BINARY_CONTENT);
 
         final HttpGet getMethod = getDSMethod(id, "x");
         getMethod.addHeader(WANT_DIGEST, "SHA");
@@ -937,18 +943,18 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final HttpEntity entity = response.getEntity();
             final String content = EntityUtils.toString(entity);
             assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
-            assertEquals("01234567890123456789012345678901234567890123456789", content);
+            assertEquals(TEST_BINARY_CONTENT, content);
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("Fixity Checksum doesn't match",
-                    digesterHeaderValue.equals("sha=9578f951955d37f20b601c26591e260c1e5389bf"));
+                    digesterHeaderValue.equals(TEST_SHA_DIGEST_HEADER_VALUE));
         }
     }
 
     @Test
     public void testGetNonRDFSourceWithWantDigestMultiple() throws IOException {
         final String id = getRandomUniqueId();
-        createDatastream(id, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(id, "x", TEST_BINARY_CONTENT);
 
         final HttpGet getMethod = getDSMethod(id, "x");
         getMethod.addHeader(WANT_DIGEST, "SHA,md5;q=0.3,sha-256;q=0.2");
@@ -956,13 +962,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final HttpEntity entity = response.getEntity();
             final String content = EntityUtils.toString(entity);
             assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
-            assertEquals("01234567890123456789012345678901234567890123456789", content);
+            assertEquals(TEST_BINARY_CONTENT, content);
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf("sha=9578f951955d37f20b601c26591e260c1e5389bf") >= 0);
+                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
+                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
             assertTrue("SHA-256 fixity checksum doesn't match",
                 digesterHeaderValue
                     .indexOf("sha256=fb871ff8cce8fea83dfaeab41784305a1461e008dc02a371ed26d856c766c903") >= 0);
@@ -972,7 +978,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testGetExternalDatastreamWithWantDigest() throws IOException, ParseException {
         final String dsId = getRandomUniqueId();
-        createDatastream(dsId, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(dsId, "x", TEST_BINARY_CONTENT);
         final String dsUrl = serverAddress + dsId + "/x";
 
         final String id = getRandomUniqueId();
@@ -993,7 +999,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue(response.getHeaders(DIGEST).length > 0);
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("Fixity Checksum doesn't match",
-                    digesterHeaderValue.equals("sha=9578f951955d37f20b601c26591e260c1e5389bf"));
+                    digesterHeaderValue.equals(TEST_SHA_DIGEST_HEADER_VALUE));
         }
     }
 
@@ -1002,7 +1008,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public void testGetExternalDatastreamWithWantDigestMultiple() throws IOException, ParseException {
 
         final String dsId = getRandomUniqueId();
-        createDatastream(dsId, "x", "01234567890123456789012345678901234567890123456789");
+        createDatastream(dsId, "x", TEST_BINARY_CONTENT);
 
         final String dsUrl = serverAddress + dsId + "/x";
 
@@ -1025,9 +1031,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf("sha=9578f951955d37f20b601c26591e260c1e5389bf") >= 0);
+                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf("md5=baed005300234f3d1503c50a48ce8e6f") >= 0);
+                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
         }
     }
 
@@ -3692,10 +3698,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpPatch delPatch = new HttpPatch(location);
 
         final String longLiteral =   // minimumBinaryInByteSize is currently 40 bytes
-                "01234567890123456789012345678901234567890123456789" +
-                        "01234567890123456789012345678901234567890123456789" +
-                        "01234567890123456789012345678901234567890123456789" +
-                        "01234567890123456789012345678901234567890123456789";
+                TEST_BINARY_CONTENT +
+                        TEST_BINARY_CONTENT +
+                        TEST_BINARY_CONTENT +
+                        TEST_BINARY_CONTENT;
 
         LOGGER.info("BINARY LITERAL TEST");
 


### PR DESCRIPTION
Verify HEAD and GET requests to External Content with Want-Digest header are correctly responded.

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2752

# What does this Pull Request do?
Added tests for external resource (URL and local file) with different handling (redirect, proxy, copy) to verify HEAD and GET requests to External Content with Want-Digest header are correctly responded and contains the required headers.

# How should this be tested?
```
0. Start the server with external content enabled: 
$ mvn jetty:run -Dfcrepo.external.content.allowed=/Users/danny/code/fcrepo4/fcrepo-http-api/src/test/resources/allowed_external_paths.txt

1. Create external resource (URL resource) and verify that Want-Digest header is presented for HEAD and GET
$ curl -i -ufedoraAdmin:fedoraAdmin -XPUT -H"Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/externalContent

$ curl -i -ufedoraAdmin:fedoraAdmin -XHEAD -H"Want-Digest: sha" http://localhost:8080/rest/externalContent
HTTP/1.1 200 OK
Date: Wed, 01 Aug 2018 23:35:13 GMT
Set-Cookie: JSESSIONID=olbdo4tcnfky1vssss8qffqw5;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Tue, 31-Jul-2018 23:35:13 GMT
ETag: "1c74e1e7dff63ac5b2ef080ecdd80fa720bf0935"
Last-Modified: Wed, 01 Aug 2018 23:31:00 GMT
Content-Type: image/png
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Wed, 01 Aug 2018 23:31:00 GMT"; modification-date="Wed, 01 Aug 2018 23:31:00 GMT"; size=3361
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8080/rest/externalContent/fcr:metadata>; rel="describedby"
Link: <http://localhost:8080/static/constraints/NonRDFSourceConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Accept-External-Content-Handling: copy,redirect,proxy
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Link: <http://localhost:8080/rest/externalContent/fcr:acl>; rel="acl"
Content-Location: https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png
Digest: sha=2b171d756295d1e9ae81e24355fe1cf92b14fdb8
Content-Length: 3361
Server: Jetty(9.3.1.v20150714)


$ curl -i -ufedoraAdmin:fedoraAdmin -H"Want-Digest: sha" http://localhost:8080/rest/externalContent
< HTTP/1.1 200 OK
< Date: Wed, 01 Aug 2018 23:37:32 GMT
< Set-Cookie: JSESSIONID=90mqz8fmcfdlqdthlhqnugv8;Path=/
< Expires: Thu, 01 Jan 1970 00:00:00 GMT
< Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Tue, 31-Jul-2018 23:37:32 GMT
< ETag: "1c74e1e7dff63ac5b2ef080ecdd80fa720bf0935"
< Last-Modified: Wed, 01 Aug 2018 23:31:00 GMT
< Content-Type: image/png
< Accept-Ranges: bytes
< Content-Disposition: attachment; filename=""; creation-date="Wed, 01 Aug 2018 23:31:00 GMT"; modification-date="Wed, 01 Aug 2018 23:31:00 GMT"; size=3361
< Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
< Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
< Link: <http://localhost:8080/rest/externalContent/fcr:metadata>; rel="describedby"
< Link: <http://localhost:8080/static/constraints/NonRDFSourceConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
< Accept-External-Content-Handling: copy,redirect,proxy
< Allow: DELETE,HEAD,GET,PUT,OPTIONS
< Link: <http://localhost:8080/rest/externalContent/fcr:acl>; rel="acl"
< Content-Location: https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png
< Digest: sha=2b171d756295d1e9ae81e24355fe1cf92b14fdb8
< Content-Length: 3361
< Server: Jetty(9.3.1.v20150714)


2. Create external resource (local file) and verify that Want-Digest header is presented for HEAD and GET
$ "external content" > binary.txt
$ curl -i -ufedoraAdmin:fedoraAdmin -XPUT -H"Link: <file:///[path/to]/binary.txt>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/externalLocalFile

$ curl -i -ufedoraAdmin:fedoraAdmin -XHEAD -H"Want-Digest: sha" http://localhost:8080/rest/externalLocalFile
HTTP/1.1 200 OK
Date: Wed, 01 Aug 2018 23:39:49 GMT
Set-Cookie: JSESSIONID=9cu3t09nspf7l4nm16gg4naw;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Tue, 31-Jul-2018 23:39:49 GMT
ETag: "d936229314d22a18e601bdee88853664ac755b6b"
Last-Modified: Wed, 01 Aug 2018 23:39:37 GMT
Content-Type: text/plain
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Wed, 01 Aug 2018 23:39:37 GMT"; modification-date="Wed, 01 Aug 2018 23:39:37 GMT"; size=5
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8080/rest/externalLocalFile/fcr:metadata>; rel="describedby"
Link: <http://localhost:8080/static/constraints/NonRDFSourceConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Accept-External-Content-Handling: copy,redirect,proxy
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Link: <http://localhost:8080/rest/externalLocalFile/fcr:acl>; rel="acl"
Content-Location: file:/tmp/binary.txt
Digest: sha=4e1243bd22c66e76c2ba9eddc1f91394e57f9f83
Content-Length: 5
Server: Jetty(9.3.1.v20150714)

$ curl -i -ufedoraAdmin:fedoraAdmin -H"Want-Digest: sha" http://localhost:8080/rest/externalLocalFile
HTTP/1.1 200 OK
Date: Wed, 01 Aug 2018 23:40:25 GMT
Set-Cookie: JSESSIONID=sk1f7kzafshu16z6pmdbygnqx;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Tue, 31-Jul-2018 23:40:25 GMT
ETag: "d936229314d22a18e601bdee88853664ac755b6b"
Last-Modified: Wed, 01 Aug 2018 23:39:37 GMT
Digest: sha=4e1243bd22c66e76c2ba9eddc1f91394e57f9f83
Content-Type: text/plain
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Wed, 01 Aug 2018 23:39:37 GMT"; modification-date="Wed, 01 Aug 2018 23:39:37 GMT"; size=5
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8080/rest/externalLocalFile/fcr:metadata>; rel="describedby"
Link: <http://localhost:8080/static/constraints/NonRDFSourceConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Accept-External-Content-Handling: copy,redirect,proxy
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Link: <http://localhost:8080/rest/externalLocalFile/fcr:acl>; rel="acl"
Content-Location: file:/tmp/binary.txt
Cache-Control: no-transform, must-revalidate, max-age=0
Content-Length: 5
Server: Jetty(9.3.1.v20150714)

```

# Interested parties
@dbernstein , @fcrepo4/committers
