### PR TITLE
Fcrepo 2840

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -163,13 +163,6 @@ public class ExternalContentHandler {
         final Link realLink = Link.valueOf(link);
 
         try {
-            final String url = realLink.getUri().toString().toLowerCase();
-            // see if it's a legit url, if it's not an error will be thrown
-            realLink.getUri().toURL();
-            if (url.isEmpty() || (!url.startsWith("http") && !url.startsWith("file"))) {
-                throw new ExternalMessageBodyException("Link header formatted incorrectly: URI incorrectly formatted");
-            }
-
             final String handling = realLink.getParams().get(HANDLING);
             if (handling == null || !handling.matches("(?i)" + PROXY + "|" + COPY + "|" + REDIRECT)) {
                 // error

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
@@ -75,14 +75,6 @@ public class ExternalContentHandlerFactoryTest {
         factory.createFromLinks(links);
     }
 
-    @Test(expected = ExternalMessageBodyException.class)
-    public void testGetWithExternalMessageMissingURLBinary() throws Exception {
-        final List<String> links = makeLinks("http://test.com");
-        links.set(0, links.get(0).replaceAll("<.*>", "< >"));
-
-        factory.createFromLinks(links);
-    }
-
     private List<String> makeLinks(final String... uris) {
         return Arrays.stream(uris)
                 .map(uri -> Link.fromUri(uri)

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/DirtyContextBeforeAndAfterClassTestExecutionListener.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/DirtyContextBeforeAndAfterClassTestExecutionListener.java
@@ -23,7 +23,10 @@ import org.springframework.test.context.TestContext;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
 /**
- * @author Sam Brannen
+ * TestExecutionListener which marks the context as dirty before and after the test class.
+ * Based on example from https://stackoverflow.com/questions/39277040/
+ *
+ * @author bbpennel
  */
 public class DirtyContextBeforeAndAfterClassTestExecutionListener
         extends AbstractTestExecutionListener {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/DirtyContextBeforeAndAfterClassTestExecutionListener.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/DirtyContextBeforeAndAfterClassTestExecutionListener.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import org.springframework.core.Ordered;
+import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+/**
+ * @author Sam Brannen
+ */
+public class DirtyContextBeforeAndAfterClassTestExecutionListener
+        extends AbstractTestExecutionListener {
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    @Override
+    public void beforeTestClass(final TestContext testContext) throws Exception {
+        testContext.markApplicationContextDirty(HierarchyMode.EXHAUSTIVE);
+    }
+
+    @Override
+    public void afterTestClass(final TestContext testContext) throws Exception {
+        testContext.markApplicationContextDirty(HierarchyMode.EXHAUSTIVE);
+    }
+
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
@@ -30,29 +30,59 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.net.ConnectException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.slf4j.Logger;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
 /**
  * @author bbpennel
  */
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
+@TestExecutionListeners(listeners = { DirtiesContextBeforeModesTestExecutionListener.class,
+    DependencyInjectionTestExecutionListener.class, DirtiesContextTestExecutionListener.class })
 public class ExternalContentPathValidatorIT extends AbstractResourceIT {
 
     private static final Logger LOGGER = getLogger(ExternalContentPathValidatorIT.class);
 
     private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
 
+    private static File disallowedDir;
+    private static File allowedDir;
+
     static {
         try {
-            final File allowedFile = File.createTempFile("allowed", "txt");
+            final File allowedFile = File.createTempFile("allowed", ".txt");
             allowedFile.deleteOnExit();
             addAllowedPath(allowedFile, serverAddress);
+
+            final Path disallowedPath = Files.createTempDirectory("disallowed");
+            disallowedPath.toFile().deleteOnExit();
+            disallowedDir = disallowedPath.toFile();
+            allowedDir = Files.createTempDirectory(disallowedPath, "data").toFile();
+            addAllowedPath(allowedFile, allowedDir.toURI().toString());
 
             System.setProperty("fcrepo.external.content.allowed", allowedFile.getAbsolutePath());
             LOGGER.warn("fcrepo.external.content.allowed = {}", allowedFile.getAbsolutePath());
@@ -64,6 +94,26 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
     private static void addAllowedPath(final File allowedFile, final String allowed) throws Exception {
         try (BufferedWriter writer = Files.newBufferedWriter(allowedFile.toPath(), APPEND)) {
             writer.write(allowed + System.lineSeparator());
+        }
+    }
+
+    @Before
+    public void init() throws Exception {
+        // Because of the dirtied context, need to wait for fedora to restart before testing
+        int triesRemaining = 50;
+        while (true) {
+            final HttpGet get = new HttpGet(serverAddress);
+            try (final CloseableHttpResponse response = execute(get)) {
+                assertEquals(SC_OK, getStatus(response));
+                break;
+            } catch (final NoHttpResponseException | ConnectException e) {
+                if (triesRemaining-- > 0) {
+                    LOGGER.debug("Waiting for fedora to become available");
+                    Thread.sleep(50);
+                } else {
+                    throw new Exception("Fedora instance did not become available in allowed time");
+                }
+            }
         }
     }
 
@@ -101,12 +151,72 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
         final String externalLocation = "http://example.com/";
 
         final String id = getRandomUniqueId();
-        final String uri = serverAddress + id;
 
-        final HttpPut put = putObjMethod(uri);
+        final HttpPut put = putObjMethod(id);
         put.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "proxy", null));
         try (final CloseableHttpResponse response = execute(put)) {
             assertEquals(SC_BAD_REQUEST, getStatus(response));
+        }
+    }
+
+    @Test
+    public void testAllowedFilePath() throws Exception {
+        final String fileContent = "content";
+        final File permittedFile = new File(allowedDir, "test.txt");
+        FileUtils.writeStringToFile(permittedFile, fileContent, "UTF-8");
+        final String fileUri = permittedFile.toURI().toString();
+
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id);
+        put.addHeader(LINK, getExternalContentLinkHeader(fileUri, "proxy", "text/plain"));
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(SC_CREATED, getStatus(response));
+        }
+        // Get the external content proxy resource.
+        try (final CloseableHttpResponse response = execute(getObjMethod(id))) {
+            assertEquals(SC_OK, getStatus(response));
+            assertEquals("text/plain", response.getFirstHeader(CONTENT_TYPE).getValue());
+            assertEquals(fileUri, response.getFirstHeader(CONTENT_LOCATION).getValue());
+            assertEquals(fileContent, IOUtils.toString(response.getEntity().getContent(), "UTF-8"));
+        }
+    }
+
+    @Test
+    public void testDisallowedFilePath() throws Exception {
+        final String fileContent = "content";
+        final File permittedFile = new File(disallowedDir, "test.txt");
+        FileUtils.writeStringToFile(permittedFile, fileContent, "UTF-8");
+        final String fileUri = permittedFile.toURI().toString();
+
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id);
+        put.addHeader(LINK, getExternalContentLinkHeader(fileUri, "proxy", "text/plain"));
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(SC_BAD_REQUEST, getStatus(response));
+        }
+    }
+
+    @Test
+    public void testPathModifiers() throws Exception {
+        // Creating file in disallowed path
+        final String fileContent = "content";
+        final File permittedFile = new File(disallowedDir, "test.txt");
+        FileUtils.writeStringToFile(permittedFile, fileContent, "UTF-8");
+
+        // Variations of path modifiers that should be rejected or fail to find file.
+        final List<String> modifiers = Arrays.asList("../", "%2e%2e%2f", "%2e%2e/", "..%2f",
+                "%252e%252e%255c", "%2e%2e%5c", "%2e%2e%5c%2f", "..%c0%af");
+
+        for (final String modifier : modifiers) {
+            // Attempt to address file with escaped uri modifiers
+            final String externalLocation = allowedDir.toURI().toString() + modifier + "test.txt";
+
+            final String id = getRandomUniqueId();
+            final HttpPut put = putObjMethod(id);
+            put.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "proxy", "text/plain"));
+            try (final CloseableHttpResponse response = execute(put)) {
+                assertEquals("Path " + externalLocation + " must be rejected", SC_BAD_REQUEST, getStatus(response));
+            }
         }
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
@@ -186,9 +186,9 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
     @Test
     public void testDisallowedFilePath() throws Exception {
         final String fileContent = "content";
-        final File permittedFile = new File(disallowedDir, "test.txt");
-        FileUtils.writeStringToFile(permittedFile, fileContent, "UTF-8");
-        final String fileUri = permittedFile.toURI().toString();
+        final File disallowedFile = new File(disallowedDir, "test.txt");
+        FileUtils.writeStringToFile(disallowedFile, fileContent, "UTF-8");
+        final String fileUri = disallowedFile.toURI().toString();
 
         final String id = getRandomUniqueId();
         final HttpPut put = putObjMethod(id);
@@ -202,8 +202,8 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
     public void testPathModifiers() throws Exception {
         // Creating file in disallowed path
         final String fileContent = "content";
-        final File permittedFile = new File(disallowedDir, "test.txt");
-        FileUtils.writeStringToFile(permittedFile, fileContent, "UTF-8");
+        final File disallowedFile = new File(disallowedDir, "test.txt");
+        FileUtils.writeStringToFile(disallowedFile, fileContent, "UTF-8");
 
         // Variations of path modifiers that should be rejected or fail to find file.
         final List<String> modifiers = Arrays.asList("../", "%2e%2e%2f", "%2e%2e/", "..%2f",

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
@@ -51,18 +51,18 @@ import org.slf4j.Logger;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestExecutionListeners.MergeMode;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
-import org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener;
-import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
 /**
  * @author bbpennel
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
-@TestExecutionListeners(listeners = { DirtiesContextBeforeModesTestExecutionListener.class,
-    DependencyInjectionTestExecutionListener.class, DirtiesContextTestExecutionListener.class })
+@TestExecutionListeners(listeners = { DependencyInjectionTestExecutionListener.class,
+    DirtyContextBeforeAndAfterClassTestExecutionListener.class },
+        mergeMode = MergeMode.MERGE_WITH_DEFAULTS)
 public class ExternalContentPathValidatorIT extends AbstractResourceIT {
 
     private static final Logger LOGGER = getLogger(ExternalContentPathValidatorIT.class);
@@ -115,6 +115,8 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
                 }
             }
         }
+        // Now that fedora has started, clear the property so it won't impact other tests
+        System.clearProperty("fcrepo.external.content.allowed");
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2840

# What does this Pull Request do?
Adds additional external content uri checks

# What's new?
* Decodes uris before validating
* Verifies that external content files exist
* Fixes issue with existing ExternalContentPathValidatorIT test due to a typo, resulting in needing to restart test fedora instance before the test to change allowed list file
* Adds integration and unit tests
* Moves a few validity checks over to the validator from the ExternalContentHandler

# How should this be tested?

```
# Create allowed list file
echo "https://
file:///Users/bbpennel/git/fcrepo4/fcrepo-http-api/" > allowed_list.txt

mvn jetty:run -Dfcrepo.external.content.allowed=allowed_list.txt


# Path modifier
curl -v -X PUT -H "Link: <file:///Users/bbpennel/git/fcrepo4/fcrepo-http-api/../LICENSE>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/blocked1 -ufedoraAdmin:fedoraAdmin

# 400
# Path was not absolute

# Encoded modifier
curl -v -X PUT -H "Link: <file:///Users/bbpennel/git/fcrepo4/fcrepo-http-api/%2e%2e%2fLICENSE>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/blocked1 -ufedoraAdmin:fedoraAdmin

# 400
# Path was not absolute

# Double encoded modifier
curl -v -X PUT -H "Link: <file:///Users/bbpennel/git/fcrepo4/fcrepo-http-api/%252e%252e%255cLICENSE>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/blocked1 -ufedoraAdmin:fedoraAdmin

# 400
# Path did not match any allowed external content paths

# http uri with encoded modifier
curl -v -X PUT -H "Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/%2e%2e%2fwhitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/blocked2 -ufedoraAdmin:fedoraAdmin

# 400
# Path was not absolute

# Verify normal functionality works
curl -v -X PUT -H "Link: <file:///Users/bbpennel/git/fcrepo4/fcrepo-http-api/LICENSE.txt>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/blocked1 -ufedoraAdmin:fedoraAdmin

# 201 Created

curl -v -X PUT -H "Link: <https://duraspace.org/wp-content/themes/duraspace/assets/images/whitedura.png>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"image/png\"" http://localhost:8080/rest/allowed2 -ufedoraAdmin:fedoraAdmin

# 201 Created
```

# Interested parties
@bseeger @awoods 
