### PR TITLE
Prevents an UnavailableSecurityManagerException by simply rejecting at…

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroAuthenticationProvider.java
@@ -37,6 +37,10 @@ public class ShiroAuthenticationProvider implements AuthenticationProvider {
             final String workspaceName, final ExecutionContext repositoryContext,
             final Map<String, Object> sessionAttributes) {
 
+        if (credentials == null) {
+            return null;
+        }
+
         return repositoryContext.with(new ShiroSecurityContext(SecurityUtils.getSubject()));
     }
 


### PR DESCRIPTION
…tempts to authenticate

against ShiroAuthenticationProvider without credentials.

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2798


* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Prevents an UnavailableSecurityManagerException when running ```mvn jetty:run```.

# What's new?

# How should this be tested?

1. Run: 
```
mvn jetty:run

```
2. Verify that the stack trace doesn't appear in the console
3. Login, create some resources.  Verify that fedora:createdBy property is correct.


# Interested parties
@peichman-umd , @awoods 