### PR TITLE
Fixed the ACL link header URL for repository root

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -472,7 +472,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     protected void addAclHeader(final FedoraResource resource) {
         if (!(resource instanceof FedoraWebacAcl) && !resource.isMemento()) {
-            servletResponse.addHeader(LINK, buildLink(getUri(resource.getDescribedResource()) + "/" + FCR_ACL, "acl"));
+            final String resourceUri = getUri(resource.getDescribedResource()).toString();
+            final String aclLocation =  resourceUri + (resourceUri.endsWith("/") ? "" : "/") + FCR_ACL;
+            servletResponse.addHeader(LINK, buildLink(aclLocation, "acl"));
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -216,9 +216,12 @@ public class FedoraLdpIT extends AbstractResourceIT {
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
     @Test
-    public void testHeadRepositoryGraph() {
+    public void testHeadRepositoryGraph() throws IOException {
         final HttpHead headObjMethod = new HttpHead(serverAddress);
-        assertEquals(OK.getStatusCode(), getStatus(headObjMethod));
+        try (final CloseableHttpResponse response = execute(headObjMethod)) {
+          assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
+          checkForLinkHeader(response, serverAddress + FCR_ACL, "acl");
+        }
     }
 
     @Test


### PR DESCRIPTION
Fix the ACL URL for the repository root.

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2826

# What does this Pull Request do?
Corrected the double slash in the ACL link header URL for the repository root.

# How should this be tested?
```
1. Verify the ACL URL with HEAH on repository root
curl -i -XHEAD http://localhost:8080/rest
HTTP/1.1 200 OK
Date: Wed, 08 Aug 2018 22:35:18 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Accept-Patch: application/sparql-update
Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json
Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
Link: <http://localhost:8080/rest/fcr:acl>; rel="acl"
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 0
Server: Jetty(9.2.3.v20140905)

2. Verify the ACL URL with GET on repository root
curl -i http://localhost:8080/rest
HTTP/1.1 200 OK
Date: Wed, 08 Aug 2018 22:37:33 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Accept-Patch: application/sparql-update
Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json
Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
Link: <http://localhost:8080/rest/fcr:acl>; rel="acl"
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Content-Type: text/turtle;charset=utf-8
Content-Length: 1439
Server: Jetty(9.2.3.v20140905)

@prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
@prefix test:  <info:fedora/test/> .
@prefix memento:  <http://mementoweb.org/ns#> .
@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
@prefix webac:  <http://fedora.info/definitions/v4/webac#> .
@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
@prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
@prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix xml:  <http://www.w3.org/XML/1998/namespace> .
@prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .
@prefix xs:  <http://www.w3.org/2001/XMLSchema> .
@prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@prefix dc:  <http://purl.org/dc/elements/1.1/> .

<http://localhost:8080/rest/>
        rdf:type                       ldp:RDFSource ;
        rdf:type                       ldp:Container ;
        rdf:type                       ldp:BasicContainer ;
        fedora:writable                true ;
        rdf:type                       fedora:RepositoryRoot ;
        rdf:type                       fedora:Resource ;
        rdf:type                       fedora:Container ;
        fedora:hasTransactionProvider  <http://localhost:8080/rest/fcr:tx> .
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
