### PR TITLE
Return 406 when no mementos exist

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -36,8 +36,8 @@ import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.FOUND;
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.jena.atlas.web.ContentType.create;
@@ -324,7 +324,7 @@ public class FedoraLdp extends ContentExposingResource {
                 builder =
                     status(FOUND).header(LOCATION, translator().reverse().convert(memento).toString()).build();
             } else {
-                builder = status(NOT_FOUND).build();
+                builder = status(NOT_ACCEPTABLE).build();
             }
             addResourceHttpHeaders(resource);
             setVaryAndPreferenceAppliedHeaders(servletResponse, prefer, resource);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1131,7 +1131,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         getMemento.addHeader(ACCEPT_DATETIME, requestDatetime);
 
         try (final CloseableHttpResponse response = customClient.execute(getMemento)) {
-            assertEquals("Did not get NOT_FOUND response", NOT_FOUND.getStatusCode(), getStatus(response));
+            assertEquals("Did not get NOT_ACCEPTABLE response", NOT_ACCEPTABLE.getStatusCode(), getStatus(response));
             assertNull("Did not expect a Location header", response.getFirstHeader(LOCATION));
             assertNotEquals("Did not get Content-Length > 0", 0, response.getFirstHeader(CONTENT_LENGTH).getValue());
         }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2812

# What does this Pull Request do?
Change response from 404 to 406

# How should this be tested?

Before this PR
Create new versioned resource
```
curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/empty_version -XPUT -H"Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\""
```
Do GET with an `Accept-Datetime` header and see the 404
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/empty_version -H"Accept-Datetime: Thu, 1 Jan 1970 00:00:00 GMT"
HTTP/1.1 404 Not Found
Date: Thu, 09 Aug 2018 17:23:45 GMT
Set-Cookie: JSESSIONID=iicku0de4hnt17vf44kwmeeaa;Path=/
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 08-Aug-2018 17:23:45 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://localhost:8080/rest/empty_version>; rel="timegate"
Link: <http://localhost:8080/rest/empty_version>; rel="original"
Link: <http://localhost:8080/rest/empty_version/fcr:versions>; rel="timemap"
Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
Accept-Patch: application/sparql-update
Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json
Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
Link: <http://localhost:8080/rest/empty_version/fcr:acl>; rel="acl"
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Vary: Accept-Datetime
Content-Type: text/html;charset=iso-8859-1
Cache-Control: must-revalidate,no-cache,no-store
Content-Length: 334
Server: Jetty(9.3.1.v20150714)

<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 404 Not Found</title>
</head>
<body><h2>HTTP ERROR 404</h2>
<p>Problem accessing /rest/empty_version. Reason:
<pre>    Not Found</pre></p><hr><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.1.v20150714</a><hr/>

</body>
</html>
```

Apply this PR
Do the GET again and see the 406
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/empty_version -H"Accept-Datetime: Thu, 1 Jan 1970 00:00:00 GMT"
HTTP/1.1 406 Not Acceptable
Date: Thu, 09 Aug 2018 17:47:30 GMT
Set-Cookie: JSESSIONID=1835ckgulb6c4og8c2ztu4rad;Path=/
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 08-Aug-2018 17:47:30 GMT
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://localhost:8080/rest/empty_version>; rel="timegate"
Link: <http://localhost:8080/rest/empty_version>; rel="original"
Link: <http://localhost:8080/rest/empty_version/fcr:versions>; rel="timemap"
Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
Accept-Patch: application/sparql-update
Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json
Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
Link: <http://localhost:8080/rest/empty_version/fcr:acl>; rel="acl"
Preference-Applied: return=representation
Vary: Prefer
Vary: Accept
Vary: Range
Vary: Accept-Encoding
Vary: Accept-Language
Vary: Accept-Datetime
Content-Type: text/html;charset=iso-8859-1
Cache-Control: must-revalidate,no-cache,no-store
Content-Length: 344
Server: Jetty(9.3.1.v20150714)

<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 406 Not Acceptable</title>
</head>
<body><h2>HTTP ERROR 406</h2>
<p>Problem accessing /rest/empty_version. Reason:
<pre>    Not Acceptable</pre></p><hr><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.1.v20150714</a><hr/>

</body>
</html>
```

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
