### PR TITLE
Added acl:default statement to the default root ACL

### DIFF
--- a/fcrepo-http-api/src/main/resources/root-authorization.ttl
+++ b/fcrepo-http-api/src/main/resources/root-authorization.ttl
@@ -7,4 +7,5 @@
    rdfs:label "Root Authorization" ;
    rdfs:comment "By default, all non-Admin agents (foaf:Agent) are denied access (no acl:mode is specified) to all resources." ;
    acl:agentClass foaf:Agent ;
-   acl:accessToClass fedora:Resource .
+   acl:accessToClass fedora:Resource ;
+   acl:default <.> .

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -30,6 +30,7 @@ import static org.fcrepo.http.api.FedoraAcl.ROOT_AUTHORIZATION_PROPERTY;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_NAMESPACE_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -201,6 +202,11 @@ public class FedoraAclIT extends AbstractResourceIT {
                                       createURI(rootAclUri),
                                       createURI("http://www.w3.org/2000/01/rdf-schema#label"),
                                       createLiteral("Root Authorization")));
+
+            assertTrue(graph.contains(ANY,
+                                      createURI(rootAclUri),
+                                      createURI(WEBAC_NAMESPACE_VALUE + "default"),
+                                      createURI(serverAddress)));
         }
     }
 
@@ -214,7 +220,12 @@ public class FedoraAclIT extends AbstractResourceIT {
                                       createURI(rootAclUri),
                                       createURI("http://www.w3.org/2000/01/rdf-schema#label"),
                                       createLiteral("(Test) Root ACL")));
-        }
+
+            assertTrue(graph.contains(ANY,
+                                      createURI(rootAclUri),
+                                      createURI(WEBAC_NAMESPACE_VALUE + "default"),
+                                      createURI(serverAddress)));
+            }
     }
 
     @Test

--- a/fcrepo-http-api/src/test/resources/test-root-authorization.ttl
+++ b/fcrepo-http-api/src/test/resources/test-root-authorization.ttl
@@ -7,4 +7,5 @@
    rdfs:comment "Provide read access to all resources to the testAdminUser agent." ;
    acl:agent "testAdminUser" ;
    acl:mode acl:Read ;
-   acl:accessToClass fedora:Resource .
+   acl:accessToClass fedora:Resource ;
+   acl:default <.> .


### PR DESCRIPTION
Added acl:default statement to the default root ACL

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2824

# How should this be tested?
```
Verify that the acl:default statement presented in the root acl and linking to repository root <http://localhost:8080/rest/>:
$ curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/fcr:acl
HTTP/1.1 200 OK
Date: Wed, 22 Aug 2018 20:40:31 GMT
Set-Cookie: JSESSIONID=1wqg64680h5bj1skmofk8fsk0i;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Tue, 21-Aug-2018 20:40:31 GMT
Content-Type: text/turtle;charset=utf-8
Content-Length: 1402
Server: Jetty(9.3.1.v20150714)

@prefix premis:  <http://www.loc.gov/premis/rdf/v1#> .
@prefix test:  <info:fedora/test/> .
@prefix memento:  <http://mementoweb.org/ns#> .
@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
@prefix webac:  <http://fedora.info/definitions/v4/webac#> .
@prefix acl:  <http://www.w3.org/ns/auth/acl#> .
@prefix ns001:  <http://purl.org/dc/terms/> .
@prefix xsi:  <http://www.w3.org/2001/XMLSchema-instance> .
@prefix xmlns:  <http://www.w3.org/2000/xmlns/> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix xml:  <http://www.w3.org/XML/1998/namespace> .
@prefix ebucore:  <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .
@prefix xs:  <http://www.w3.org/2001/XMLSchema> .
@prefix fedoraconfig:  <http://fedora.info/definitions/v4/config#> .
@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@prefix dc:  <http://purl.org/dc/elements/1.1/> .

<http://localhost:8080/rest/fcr:acl>
        acl:default        <http://localhost:8080/rest/> ;
        acl:accessToClass  fedora:Resource ;
        acl:agentClass     foaf:Agent ;
        rdfs:comment       "By default, all non-Admin agents (foaf:Agent) are denied access (no acl:mode is specified) to all resources." ;
        rdfs:label         "Root Authorization" ;
        rdf:type           acl:Authorization .

```
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
