### PR TITLE
Don't create a timemap when trying to create a Memento

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -160,11 +160,7 @@ public class FedoraVersioning extends ContentExposingResource {
             throws InvalidChecksumException, MementoDatetimeFormatException {
 
         final FedoraResource resource = resource();
-        final FedoraResource timeMap = resource.findOrCreateTimeMap();
-        // If the timemap was created in this request, commit it.
-        if (timeMap.isNew()) {
-            session.commit();
-        }
+        final FedoraResource timeMap = resource.getTimeMap();
 
         final AcquiredLock lock = lockManager.lockForWrite(timeMap.getPath(),
             session.getFedoraSession(), nodeService);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1122,7 +1122,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals("fcr:metadata/fcr:versions must be available after enabling versioning",
                 OK.getStatusCode(), getStatus(new HttpGet(versionsDescUri)));
 
-        final String mementoUri = createMemento(subjectUri, null, null, null);
+        final String mementoUri = createMemento(binaryUri, null, null, null);
         assertEquals("Memento must be created",
                 OK.getStatusCode(), getStatus(new HttpGet(mementoUri)));
     }
@@ -1546,6 +1546,17 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertEquals(OK.getStatusCode(), getStatus(getResponse));
             final String content = EntityUtils.toString(getResponse.getEntity());
             assertEquals("Binary doesn't match expected content", newContent, content);
+        }
+    }
+
+    @Test
+    public void createVersionOnNonVersionedResource() throws Exception {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String timemap = id + "/" + FCR_VERSIONS;
+        final HttpPost versionPost = postObjMethod(timemap);
+        try (final CloseableHttpResponse response = execute(versionPost)) {
+            assertEquals(NOT_FOUND.getStatusCode(), getStatus(response));
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2846

# What does this Pull Request do?
Stops generating a timemap if one doesn't exist.

# How should this be tested?

Internal test or
```
curl -i -X PUT --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/versioning/v3
curl -i --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/versioning/v3
curl -i -X POST --user fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/versioning/v3/fcr:versions"
curl -i --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/versioning/v3
```
The third step should success (201 Created) before this PR and fail (404 Not Found) after.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers @kefo
