### PR TITLE
Allow HEAD when there is acl:Read permission

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -164,6 +164,7 @@ public class WebACFilter implements Filter {
         final WebACPermission toAppend = new WebACPermission(WEBAC_MODE_APPEND, requestURI);
 
         switch (httpRequest.getMethod()) {
+        case "HEAD":
         case "GET":
             return currentUser.isPermitted(toRead);
         case "PUT":

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
@@ -214,6 +214,15 @@ public class WebACFilterTest {
     }
 
     @Test
+    public void testAdminUserHead() throws ServletException, IOException {
+        setupAdminUser();
+        // HEAD => 200
+        request.setMethod("HEAD");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_OK, response.getStatus());
+    }
+
+    @Test
     public void testAdminUserGet() throws ServletException, IOException {
         setupAdminUser();
         // GET => 200
@@ -259,6 +268,15 @@ public class WebACFilterTest {
     }
 
     @Test
+    public void testAuthUserNoPermsHead() throws ServletException, IOException {
+        setupAuthUserNoPerms();
+        // HEAD => 403
+        request.setMethod("HEAD");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_FORBIDDEN, response.getStatus());
+    }
+
+    @Test
     public void testAuthUserNoPermsGet() throws ServletException, IOException {
         setupAuthUserNoPerms();
         // GET => 403
@@ -301,6 +319,15 @@ public class WebACFilterTest {
         request.setMethod("DELETE");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
+    }
+
+    @Test
+    public void testAuthUserReadOnlyHead() throws ServletException, IOException {
+        setupAuthUserReadOnly();
+        // HEAD => 200
+        request.setMethod("HEAD");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_OK, response.getStatus());
     }
 
     @Test
@@ -491,6 +518,15 @@ public class WebACFilterTest {
         // POST => 200
         request.setRequestURI(testPath);
         request.setMethod("POST");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_OK, response.getStatus());
+    }
+
+    @Test
+    public void testAuthUserReadWriteHead() throws ServletException, IOException {
+        setupAuthUserReadWrite();
+        // HEAD => 200
+        request.setMethod("HEAD");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2843

# What does this Pull Request do?
Allow HEAD when there is acl:Read permission on a resource.

# What's new?
HEAD requests are authorized identically to GET requests.

# How should this be tested?

Follow the procedure outlined by @awoods in the JIRA ticket:
The issue can be reproduced as follows:
1. Create a resource:
  ```
  curl -u fedoraAdmin:fedoraAdmin -v -X PUT http://localhost:8080/rest/test
  ```
2. Give 'testuser' READ access to the above resource:
  ```
  curl -u fedoraAdmin:fedoraAdmin -v -X PUT http://localhost:8080/rest/test/fcr:acl \
      --data-binary "@acl.ttl" -H "Content-Type: text/turtle"
  ```
  where "acl.ttl" is:
  ```
@prefix acl: <http://www.w3.org/ns/auth/acl#> .
@prefix foaf: <http://xmlns.com/foaf/0.1/> .

<#restricted> a acl:Authorization ;
acl:agent "testuser" ;
acl:mode acl:Read ;
acl:accessTo </rest/test> .
  ```
3. Notice success on GET
  ```
  curl -i -u testuser:testpass -X GET http://localhost:8080/rest/test
  ```
4. Notice success on HEAD
  ```
  curl -i -u testuser:testpass -I http://localhost:8080/rest/test
  ```

# Interested parties
@awoods, @dbernstein, @fcrepo4/committers
