### PR TITLE
Fix the 500 error stacktrace for PUTing ACL with bad RDF content

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -143,8 +143,6 @@ public class FedoraAcl extends ContentExposingResource {
                          created ? new DefaultRdfStream(asNode(aclResource)) : getResourceTriples(aclResource)) {
                     replaceResourceWithStream(aclResource, requestBodyStream, contentType, resourceTriples);
 
-                } catch (final Exception e) {
-                    throw new RuntimeException(e);
                 }
             } else {
                 throw new BadRequestException("Content-Type (" + requestContentType + ") is invalid. Try text/turtle " +

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -162,6 +162,16 @@ public class FedoraAclIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPutACLBadRdf() throws IOException {
+        createObjectAndClose(id);
+
+        final HttpPut put = new HttpPut(subjectUri + "/" + FCR_ACL);
+        put.setHeader(CONTENT_TYPE, "text/turtle");
+        put.setEntity(new StringEntity("<> a junk:Object ;"));
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(put));
+    }
+
+    @Test
     public void testDeleteAcl() throws Exception {
         createObjectAndClose(id);
 


### PR DESCRIPTION
Fix the 500 error stacktrace while PUTing ACL with bad RDF content

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2844

# What does this Pull Request do?
PUTing ACL with bad RDF content will produce a stacktrace with 500 error. The PR will fix it to return status 400 bad request.

# How should this be tested?
```
1. Create resource:
$ curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test -XPUT

2. Create ACL with bad RDF and verify status 400 returned:
$ echo -e '<> a junk:Object ;' | curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test/fcr:acl -XPUT -H"Content-Type: text/turtle" --data-binary @-
HTTP/1.1 400 Bad Request
Date: Wed, 29 Aug 2018 18:04:23 GMT
Set-Cookie: JSESSIONID=9qlvnhmcfpyz1by05yixj2ols;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Tue, 28-Aug-2018 18:04:23 GMT
Content-Type: text/plain;charset=utf-8
Content-Length: 63
Server: Jetty(9.3.1.v20150714)

RDF was not parsable: [line: 1, col: 6 ] Undefined prefix: junk
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
