### PR TITLE
Allow OPTIONS when there is an acl:Read permission.

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -164,6 +164,7 @@ public class WebACFilter implements Filter {
         final WebACPermission toAppend = new WebACPermission(WEBAC_MODE_APPEND, requestURI);
 
         switch (httpRequest.getMethod()) {
+        case "OPTIONS":
         case "HEAD":
         case "GET":
             return currentUser.isPermitted(toRead);

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
@@ -223,6 +223,15 @@ public class WebACFilterTest {
     }
 
     @Test
+    public void testAdminUserOptions() throws ServletException, IOException {
+        setupAdminUser();
+        // GET => 200
+        request.setMethod("OPTIONS");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_OK, response.getStatus());
+    }
+
+    @Test
     public void testAdminUserGet() throws ServletException, IOException {
         setupAdminUser();
         // GET => 200
@@ -277,6 +286,15 @@ public class WebACFilterTest {
     }
 
     @Test
+    public void testAuthUserNoPermsOptions() throws ServletException, IOException {
+        setupAuthUserNoPerms();
+        // GET => 403
+        request.setMethod("OPTIONS");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_FORBIDDEN, response.getStatus());
+    }
+
+    @Test
     public void testAuthUserNoPermsGet() throws ServletException, IOException {
         setupAuthUserNoPerms();
         // GET => 403
@@ -326,6 +344,15 @@ public class WebACFilterTest {
         setupAuthUserReadOnly();
         // HEAD => 200
         request.setMethod("HEAD");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_OK, response.getStatus());
+    }
+
+    @Test
+    public void testAuthUserReadOnlyOptions() throws ServletException, IOException {
+        setupAuthUserReadOnly();
+        // GET => 200
+        request.setMethod("OPTIONS");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
     }
@@ -527,6 +554,15 @@ public class WebACFilterTest {
         setupAuthUserReadWrite();
         // HEAD => 200
         request.setMethod("HEAD");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_OK, response.getStatus());
+    }
+
+    @Test
+    public void testAuthUserReadWriteOptions() throws ServletException, IOException {
+        setupAuthUserReadWrite();
+        // GET => 200
+        request.setMethod("OPTIONS");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_OK, response.getStatus());
     }

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -42,6 +42,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -870,6 +871,16 @@ public class WebACRecipesIT extends AbstractResourceIT {
         final HttpHead headReq = new HttpHead(testObj);
         setAuth(headReq, "user19");
         assertEquals(HttpStatus.SC_OK, getStatus(headReq));
+    }
+
+    @Test
+    public void testOptionsWithReadOnlyUser() throws IOException {
+        final String testObj = ingestObj("/rest/test_options");
+        final String acl = ingestAcl("fedoraAdmin", "/acls/20/acl.ttl", testObj + "/fcr:acl");
+
+        final HttpOptions optionsReq = new HttpOptions(testObj);
+        setAuth(optionsReq, "user20");
+        assertEquals(HttpStatus.SC_OK, getStatus(optionsReq));
     }
 
 }

--- a/fcrepo-auth-webac/src/test/resources/acls/20/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/20/acl.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<#readonly> a acl:Authorization ;
+    acl:agent "user20" ;
+    acl:mode acl:Read ;
+    acl:accessTo </rest/test_options> .


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2847

# What does this Pull Request do?
Allow OPTIONS when there is an acl:Read permission.

# What's new?
Permit OPTIONS requests when the current user has acl:Read mode permissions to the requested resource.

# How should this be tested?

Includes unit and integration tests, so the standard `mvn clean test` should test.

# Interested parties
@awoods, @fcrepo4/committers
