### PR TITLE
Implemented support for acl:default

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/LinkHeaderProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/LinkHeaderProvider.java
@@ -74,7 +74,7 @@ public class LinkHeaderProvider implements UriAwareHttpHeaderFactory {
 
         LOGGER.debug("Adding WebAC Link Header for Resource: {}", resource.getPath());
         // Get the correct Acl for this resource
-        WebACRolesProvider.getEffectiveAcl(resource).ifPresent(acls -> {
+        WebACRolesProvider.getEffectiveAcl(resource, false).ifPresent(acls -> {
             // If the Acl is present we need to use the internal session to get its URI
             nodeService.find(internalSession, acls.resource.getPath())
             .getTriples(translator, PROPERTIES)

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -50,7 +50,9 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.message.AbstractHttpMessage;
 import org.fcrepo.integration.http.api.AbstractResourceIT;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +64,9 @@ import org.slf4j.LoggerFactory;
 public class WebACRecipesIT extends AbstractResourceIT {
 
     private static final Logger logger = LoggerFactory.getLogger(WebACRecipesIT.class);
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     /**
      * Convenience method to create an ACL with 0 or more authorization resources in the respository.
@@ -588,6 +593,35 @@ public class WebACRecipesIT extends AbstractResourceIT {
         final HttpGet requestGet7 = getObjMethod(id);
         setAuth(requestGet7, "user06b");
         assertEquals(HttpStatus.SC_OK, getStatus(requestGet7));
+    }
+
+    @Test
+    public void scenario20TestACLNotForInheritance() throws IOException {
+        final String parentPath = "/rest/resource_acl_no_inheritance";
+        final String parentObj = ingestObj(parentPath);
+
+        final String id = parentPath + "/" + getRandomUniqueId();
+        final String testObj = ingestObj(id);
+
+        // Ingest ACL with no acl:default statement to the parent resource
+        ingestAcl("fedoraAdmin", "/acls/20/acl.ttl", parentObj + "/fcr:acl");
+
+        // Test the parent ACL with no acl:default is applied for the parent resource authorization.
+        final HttpGet requestGet1 = getObjMethod(parentPath);
+        setAuth(requestGet1, "user20");
+        assertEquals("Agent user20 can't read resource " + parentPath + " with its own ACL!",
+                HttpStatus.SC_OK, getStatus(requestGet1));
+
+        final HttpGet requestGet2 = getObjMethod(id);
+        assertEquals("Agent user20 inherits read permission from parent ACL to read resource " + testObj + "!",
+                HttpStatus.SC_FORBIDDEN, getStatus(requestGet2));
+
+        // Test the default root ACL is inherited for authorization while the parent ACL with no acl:default is ignored
+        System.setProperty(ROOT_AUTHORIZATION_PROPERTY, "./target/test-classes/test-root-authorization2.ttl");
+        final HttpGet requestGet3 = getObjMethod(id);
+        setAuth(requestGet3, "user06a");
+        assertEquals("Agent user06a can't inherit read persmssion from root ACL to read resource " + testObj + "!",
+                HttpStatus.SC_OK, getStatus(requestGet3));
     }
 
     @Test

--- a/fcrepo-auth-webac/src/test/resources/acls/06/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/06/acl.ttl
@@ -1,5 +1,7 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 
+<> acl:default <.> .
+
 <#authorization> a acl:Authorization ;
    acl:agent "user06a" ;
    acl:mode acl:Read, acl:Write ;

--- a/fcrepo-auth-webac/src/test/resources/acls/07/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/07/acl.ttl
@@ -1,5 +1,7 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 
+<> acl:default <.> .
+
 <#authorization> a acl:Authorization ;
    acl:agent "user07" ;
    acl:mode acl:Read, acl:Write ;

--- a/fcrepo-auth-webac/src/test/resources/acls/09/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/09/acl.ttl
@@ -1,5 +1,7 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 
+<> acl:default <.> .
+
 <#authorization> a acl:Authorization ;
    acl:agentGroup </rest/group/foo> ;
    acl:mode acl:Read, acl:Write ;

--- a/fcrepo-auth-webac/src/test/resources/acls/13/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/13/acl.ttl
@@ -1,5 +1,7 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 
+<> acl:default <.> .
+
 <#authorization> a acl:Authorization ;
    acl:agent "user13" ;
    acl:mode acl:Read, acl:Write ;

--- a/fcrepo-auth-webac/src/test/resources/acls/14/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/14/acl.ttl
@@ -1,5 +1,7 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 
+<> acl:default <.> .
+
 <#authorization> a acl:Authorization ;
    acl:agent "user14" ;
    acl:mode acl:Read, acl:Write ;

--- a/fcrepo-auth-webac/src/test/resources/acls/15/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/15/acl.ttl
@@ -1,5 +1,7 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 
+<> acl:default <.> .
+
 <#authorization> a acl:Authorization ;
    acl:agent "user15" ;
    acl:mode acl:Read, acl:Write ;

--- a/fcrepo-auth-webac/src/test/resources/acls/18/append-only-acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/18/append-only-acl.ttl
@@ -1,6 +1,8 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
+<> acl:default <.> .
+
 <#appendOnly> a acl:Authorization ;
    acl:agent "user18" ;
    acl:mode acl:Append ;

--- a/fcrepo-auth-webac/src/test/resources/acls/18/read-append-acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/18/read-append-acl.ttl
@@ -1,6 +1,7 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
+<> acl:default <.> .
 
 <#readAppend> a acl:Authorization ;
    acl:agent "user18" ;

--- a/fcrepo-auth-webac/src/test/resources/acls/18/read-append-write-acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/18/read-append-write-acl.ttl
@@ -1,6 +1,8 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
+<> acl:default <.> .
+
 <#readAppendWrite> a acl:Authorization ;
    acl:agent "user18" ;
    acl:mode acl:Read, acl:Append, acl:Write ;

--- a/fcrepo-auth-webac/src/test/resources/acls/20/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/20/acl.ttl
@@ -1,8 +1,6 @@
 @prefix acl: <http://www.w3.org/ns/auth/acl#> .
 
-<> acl:default <.> .
-
 <> a acl:Authorization ;
-   acl:agent "user01" ;
+   acl:agent "user20" ;
    acl:mode acl:Read, acl:Write ;
-   acl:accessTo </rest/webacl_box1> .
+   acl:accessTo </rest/resource_acl_no_inheritance> .

--- a/fcrepo-auth-webac/src/test/resources/test-root-authorization.ttl
+++ b/fcrepo-auth-webac/src/test/resources/test-root-authorization.ttl
@@ -7,4 +7,5 @@
    rdfs:comment "Provide read access to all resources to the testAdminUser agent." ;
    acl:agent "testAdminUser" ;
    acl:mode acl:Read ;
-   acl:accessToClass fedora:Resource .
+   acl:accessToClass fedora:Resource ;
+   acl:default <.> .

--- a/fcrepo-auth-webac/src/test/resources/test-root-authorization2.ttl
+++ b/fcrepo-auth-webac/src/test/resources/test-root-authorization2.ttl
@@ -7,4 +7,5 @@
    rdfs:comment "Provide read access to all resources to the user06a agent." ;
    acl:agent "user06a" ;
    acl:mode acl:Read ;
-   acl:accessTo <info:fedora/> .
+   acl:accessTo <info:fedora/> ;
+   acl:default <.> .

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
@@ -100,4 +100,6 @@ public interface FedoraTypes {
     String LDP_IS_MEMBER_OF_RELATION = "ldp:isMemberOfRelation";
 
     String LDP_MEMBER_RESOURCE = "ldp:membershipResource";
+
+    String ACL_DEFAULT = "acl:default";
 }

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -105,6 +105,7 @@
  * A Fedora webac:Acl mixin.
  */
 [webac:Acl] > fedora:Resource mixin
+  - acl:default (REFERENCE)
 
 /*
  * Some content that can have a checksum


### PR DESCRIPTION
Implement support with acl:default for parent ACL inheritance.

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2698

# What does this Pull Request do?
Apply parent/ancestor ACLs to a resource only if it contains an acl:default statement that is used for inheritance as defined in https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm.

# What's new?
Those parent ACLs with no acl:default statement will be ignored for child resource authorization.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
