### PR TITLE
Updated OPTIONS response to advertise support for external content.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -446,6 +446,13 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         servletResponse.addHeader("Accept-Post", rdfTypes);
     }
 
+    /**
+     * Add the standard Accept-External-Content-Handling header, for reuse.
+     */
+    protected void addAcceptExternalHeader() {
+        servletResponse.addHeader(ACCEPT_EXTERNAL_CONTENT, COPY + "," + REDIRECT + "," + PROXY);
+    }
+
     protected void addMementoHeaders(final FedoraResource resource) {
         if (resource.isMemento()) {
             final Instant mementoInstant = resource.getMementoDatetime();
@@ -541,24 +548,21 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected void addLinkAndOptionsHttpHeaders(final FedoraResource resource) {
         // Add Link headers
         addResourceLinkHeaders(resource);
+        addAcceptExternalHeader();
 
         // Add Options headers
         final String options;
         if (resource.isMemento()) {
             options = "GET,HEAD,OPTIONS,DELETE";
-
         } else if (resource instanceof FedoraTimeMap) {
             options = "POST,HEAD,GET,OPTIONS,DELETE";
             servletResponse.addHeader("Vary-Post", MEMENTO_DATETIME_HEADER);
             addAcceptPostHeader();
         } else if (resource instanceof FedoraBinary) {
             options = "DELETE,HEAD,GET,PUT,OPTIONS";
-            servletResponse.addHeader(ACCEPT_EXTERNAL_CONTENT, COPY + "," + REDIRECT + "," + PROXY);
-
         } else if (resource instanceof NonRdfSourceDescription) {
             options = "HEAD,GET,DELETE,PUT,PATCH,OPTIONS";
             servletResponse.addHeader(HTTP_HEADER_ACCEPT_PATCH, contentTypeSPARQLUpdate);
-
         } else if (resource instanceof Container) {
             options = "MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS";
             servletResponse.addHeader(HTTP_HEADER_ACCEPT_PATCH, contentTypeSPARQLUpdate);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -438,11 +438,6 @@ public class FedoraLdpTest {
                 mockResponse.getHeader(FedoraLdp.ACCEPT_EXTERNAL_CONTENT));
     }
 
-    private void assertShouldNotHaveAcceptExternalContentHandlingHeader() {
-        assertFalse("Should not have Accept-External-Content-Handling header",
-                mockResponse.containsHeader(FedoraLdp.ACCEPT_EXTERNAL_CONTENT));
-    }
-
     @Test
     public void testHeadWithExternalBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
@@ -494,17 +489,17 @@ public class FedoraLdpTest {
         final Response actual = testObj.options();
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should have an Allow header", mockResponse.containsHeader("Allow"));
-        assertShouldNotHaveAcceptExternalContentHandlingHeader();
+        assertShouldHaveAcceptExternalContentHandlingHeader();
     }
 
     @Test
-    public void testOptionWithObject() throws Exception {
+    public void testOptionWithLDPRS() throws Exception {
         setResource(Container.class);
         final Response actual = testObj.options();
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should advertise Accept-Post flavors", mockResponse.containsHeader("Accept-Post"));
         assertShouldAdvertiseAcceptPatchFlavors();
-        assertShouldNotHaveAcceptExternalContentHandlingHeader();
+        assertShouldHaveAcceptExternalContentHandlingHeader();
     }
 
     @Test
@@ -531,7 +526,7 @@ public class FedoraLdpTest {
         assertShouldNotAdvertiseAcceptPostFlavors();
         assertShouldAdvertiseAcceptPatchFlavors();
         assertShouldContainLinkToTheBinary();
-        assertShouldNotHaveAcceptExternalContentHandlingHeader();
+        assertShouldHaveAcceptExternalContentHandlingHeader();
     }
 
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -67,6 +67,9 @@ import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_VARIANTS;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.fcrepo.kernel.api.FedoraExternalContent.COPY;
+import static org.fcrepo.kernel.api.FedoraExternalContent.PROXY;
+import static org.fcrepo.kernel.api.FedoraExternalContent.REDIRECT;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
@@ -511,6 +514,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertTrue("POST should support text/n3", postTypes.contains(contentTypeN3Alt2));
         assertTrue("POST should support application/rdf+xml", postTypes.contains(contentTypeRDFXML));
         assertTrue("POST should support application/n-triples", postTypes.contains(contentTypeNTriples));
+
+        final List<String> externalTypes = headerValues(httpResponse, "Accept-External-Content-Handling");
+        assertTrue("COPY should be advertised for accepted external content.", externalTypes.contains(COPY));
+        assertTrue("PROXY should be advertised for accepted external content.", externalTypes.contains(PROXY));
+        assertTrue("REDIRECT should be advertised for accepted external content.", externalTypes.contains(REDIRECT));
     }
 
     private static void assertRdfOptionsHeaders(final HttpResponse httpResponse) {


### PR DESCRIPTION

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2814

# What does this Pull Request do?
Updates the code to advertise external content support whenever an options request is made against an LDPR (any resource in fedora).

# What's new?
* All OPTIONS requests now include the response: "Accept-External-Content-Handling: copy, redirect, proxy"

# How should this be tested?

Make OPTIONS requests against each type of resource in Fedora.

