### PR TITLE
Map inbound reference events to ActivityStreams Follow

### DIFF
--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -218,7 +218,7 @@ abstract class AbstractJmsIT implements MessageListener {
     }
 
     @Test(timeout = TIMEOUT)
-    public void testInboundReference() throws RepositoryException {
+    public void testInboundReference() {
         final String uri1 = "/testInboundReference-" + randomUUID().toString();
         final String uri2 = "/testInboundReference-" + randomUUID().toString();
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/observer/EventType.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/observer/EventType.java
@@ -30,7 +30,8 @@ public enum EventType {
     RESOURCE_CREATION("create resource", "Create"),
     RESOURCE_DELETION("delete resource", "Delete"),
     RESOURCE_MODIFICATION("update resource", "Update"),
-    RESOURCE_RELOCATION("move resource", "Move");
+    RESOURCE_RELOCATION("move resource", "Move"),
+    INBOUND_REFERENCE("refer to resource", "Follow");
 
     private final String eventName;
     private final String eventType;

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraJcrConstants.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraJcrConstants.java
@@ -48,6 +48,9 @@ public final class FedoraJcrConstants {
 
     public static final String FIELD_DELIMITER = "\30^^\30";
 
+    // Fake JCR event type to allow mapping inbound references to an ActivityStreams FOLLOW activity.
+    public static final int FEDORA_JCR_REFERENCE = 88;
+
     private FedoraJcrConstants() {
         // Prevent instantiation
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/FedoraEventImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/FedoraEventImpl.java
@@ -22,6 +22,8 @@ import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_RELOCATION;
+import static org.fcrepo.kernel.api.observer.EventType.INBOUND_REFERENCE;
+import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FEDORA_JCR_REFERENCE;
 import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
 import static org.fcrepo.kernel.api.observer.OptionalValues.USER_AGENT;
 import static javax.jcr.observation.Event.NODE_ADDED;
@@ -93,7 +95,7 @@ public class FedoraEventImpl implements FedoraEvent {
     private final Set<EventType> eventTypes = new HashSet<>();
 
     private static final List<Integer> PROPERTY_TYPES = asList(Event.PROPERTY_ADDED,
-            Event.PROPERTY_CHANGED, Event.PROPERTY_REMOVED);
+        Event.PROPERTY_CHANGED, Event.PROPERTY_REMOVED, FEDORA_JCR_REFERENCE);
 
     /**
      * Create a new FedoraEvent
@@ -221,7 +223,8 @@ public class FedoraEventImpl implements FedoraEvent {
             .put(PROPERTY_ADDED, RESOURCE_MODIFICATION)
             .put(PROPERTY_REMOVED, RESOURCE_MODIFICATION)
             .put(PROPERTY_CHANGED, RESOURCE_MODIFICATION)
-            .put(NODE_MOVED, RESOURCE_RELOCATION).build();
+            .put(NODE_MOVED, RESOURCE_RELOCATION)
+            .put(FEDORA_JCR_REFERENCE, INBOUND_REFERENCE).build();
 
     /**
      * Get the Fedora event type for a JCR type
@@ -287,7 +290,8 @@ public class FedoraEventImpl implements FedoraEvent {
      * @return the types recorded on the resource associated to this event
      */
     public static Stream<String> getResourceTypes(final Event event) {
-        if (event instanceof org.modeshape.jcr.api.observation.Event) {
+        if (event instanceof org.modeshape.jcr.api.observation.Event ||
+            event instanceof org.fcrepo.kernel.modeshape.observer.WrappedJcrEvent) {
             try {
                 final org.modeshape.jcr.api.observation.Event modeEvent =
                         (org.modeshape.jcr.api.observation.Event) event;

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/WrappedJcrEvent.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/WrappedJcrEvent.java
@@ -25,7 +25,7 @@ import javax.jcr.nodetype.NodeType;
 import org.modeshape.jcr.api.observation.Event;
 
 /**
- * Wrap a JCR Event so we can modify its event type.
+ * Wrap a Modeshape JCR Event so we can modify its event type.
  *
  * @author whikloj
  * @since 2018-09-13
@@ -37,7 +37,7 @@ public class WrappedJcrEvent implements Event {
     private final int eventType;
 
     /**
-     * Construct a wrapped JCR Event
+     * Construct a wrapped Modeshape JCR Event
      *
      * @param event The original event.
      * @param type The new event type.

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/WrappedJcrEvent.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/WrappedJcrEvent.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.modeshape.observer;
+
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.nodetype.NodeType;
+
+import org.modeshape.jcr.api.observation.Event;
+
+/**
+ * Wrap a JCR Event so we can modify its event type.
+ *
+ * @author whikloj
+ * @since 2018-09-13
+ */
+public class WrappedJcrEvent implements Event {
+
+    private final Event wrappedEvent;
+
+    private final int eventType;
+
+    /**
+     * Construct a wrapped JCR Event
+     *
+     * @param event The original event.
+     * @param type The new event type.
+     */
+    public WrappedJcrEvent(final Event event, final int type) {
+        this.wrappedEvent = event;
+        this.eventType = type;
+    }
+
+    @Override
+    public int getType() {
+        return this.eventType;
+    }
+
+    @Override
+    public String getPath() throws RepositoryException {
+        return wrappedEvent.getPath();
+    }
+
+    @Override
+    public String getUserID() {
+        return wrappedEvent.getUserID();
+    }
+
+    @Override
+    public String getIdentifier() throws RepositoryException {
+        return wrappedEvent.getIdentifier();
+    }
+
+    @Override
+    public Map getInfo() throws RepositoryException {
+        return wrappedEvent.getInfo();
+    }
+
+    @Override
+    public String getUserData() throws RepositoryException {
+        return wrappedEvent.getUserData();
+    }
+
+    @Override
+    public long getDate() throws RepositoryException {
+        return wrappedEvent.getDate();
+    }
+
+    @Override
+    public NodeType getPrimaryNodeType() throws RepositoryException {
+        return wrappedEvent.getPrimaryNodeType();
+    }
+
+    @Override
+    public NodeType[] getMixinNodeTypes() throws RepositoryException {
+        return wrappedEvent.getMixinNodeTypes();
+    }
+
+}

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/eventmappings/AllNodeEventsOneEvent.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/observer/eventmappings/AllNodeEventsOneEvent.java
@@ -63,14 +63,14 @@ public class AllNodeEventsOneEvent implements InternalExternalEventMapper {
      * @param ev The list of events to check.
      * @return The original list or a list with the altered event.
      */
-    private static final List<Event> AlterReferenceEvents(final List<Event> ev) {
+    private static List<Event> AlterReferenceEvents(final List<Event> ev) {
         try {
             if (ev.size() == 1 && ev.get(0).getPath().endsWith("/" + JCR_LASTMODIFIED) &&
                 ev.get(0).getType() == PROPERTY_CHANGED) {
                 final Event original = ev.get(0);
                 final Event tempEv =
                     new WrappedJcrEvent((org.modeshape.jcr.api.observation.Event) original, FEDORA_JCR_REFERENCE);
-                final List<Event> list = new ArrayList<Event>();
+                final List<Event> list = new ArrayList<>();
                 list.add(tempEv);
                 return list;
             }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
@@ -210,10 +210,8 @@ public class SimpleObserverIT extends AbstractIT {
         awaitEvent("/object6/object7", RESOURCE_DELETION);
         awaitEvent("/object6/object7/child1", RESOURCE_DELETION);
         awaitEvent("/object6/object7/child2", RESOURCE_DELETION);
-        // should produce two of these
-        awaitEvent("/object6", RESOURCE_MODIFICATION);
 
-        assertEquals("Move operation didn't generate additional events", (Integer) 12, eventBusMessageCount);
+        assertEquals("Move operation didn't generate additional events", (Integer) 10, eventBusMessageCount);
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.integration.kernel.modeshape.observer;
 
+import static java.util.UUID.randomUUID;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static com.jayway.awaitility.Awaitility.await;
@@ -30,6 +31,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_DESCRIPTION;
 import static org.fcrepo.kernel.api.RdfLexicon.NT_LEAF_NODE;
 import static org.fcrepo.kernel.api.RdfLexicon.NT_VERSION_FILE;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
+import static org.fcrepo.kernel.api.observer.EventType.INBOUND_REFERENCE;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
@@ -210,8 +212,10 @@ public class SimpleObserverIT extends AbstractIT {
         awaitEvent("/object6/object7", RESOURCE_DELETION);
         awaitEvent("/object6/object7/child1", RESOURCE_DELETION);
         awaitEvent("/object6/object7/child2", RESOURCE_DELETION);
+        // should produce two of these
+        awaitEvent("/object6", RESOURCE_MODIFICATION);
 
-        assertEquals("Move operation didn't generate additional events", (Integer) 10, eventBusMessageCount);
+        assertEquals("Move operation didn't generate additional events", (Integer) 12, eventBusMessageCount);
     }
 
     @Test
@@ -371,6 +375,43 @@ public class SimpleObserverIT extends AbstractIT {
         awaitEvent("/object13", RESOURCE_MODIFICATION);
 
         assertEquals("Where are my events?", (Integer) 14, eventBusMessageCount);
+    }
+
+    @Test
+    public void testInboundReferenceEvents() throws RepositoryException {
+        final FedoraSession session = repository.login();
+        final Session se = getJcrSession(session);
+        final DefaultIdentifierTranslator subjects = new DefaultIdentifierTranslator(se);
+
+        final String path1 = "/" + randomUUID();
+        final String path2 = "/" + randomUUID();
+
+        final Container obj1 = containerService.findOrCreate(session, path1);
+        final Container obj2 = containerService.findOrCreate(session, path2);
+
+        final Resource subject2 = subjects.reverse().convert(obj2);
+
+        try {
+            session.commit();
+
+            awaitEvent(path1, RESOURCE_CREATION);
+            awaitEvent(path1, RESOURCE_MODIFICATION);
+            awaitEvent(path2, RESOURCE_CREATION);
+
+            assertEquals("Where are my events?", (Integer) 3, eventBusMessageCount);
+
+            obj1.updateProperties(subjects, "PREFIX ore: <http://www.openarchives.org/ore/terms/>\n" +
+                "INSERT { <> ore:proxyFor <" + subject2 + "> } WHERE {}", obj1.getTriples(subjects, PROPERTIES));
+            session.commit();
+
+            awaitEvent(path1, RESOURCE_MODIFICATION);
+            awaitEvent(path2, INBOUND_REFERENCE);
+
+            assertEquals("Where are my events?", (Integer) 5, eventBusMessageCount);
+        } finally {
+            session.expire();
+        }
+
     }
 
     private void awaitEvent(final String id, final EventType eventType, final String resourceType) {

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/observer/eventmappings/AllNodeEventsOneEventTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/observer/eventmappings/AllNodeEventsOneEventTest.java
@@ -155,4 +155,18 @@ public class AllNodeEventsOneEventTest {
         assertEquals("Got the wrong number of events with Inbound Reference", 1,
             list.stream().filter(e -> e.getTypes().contains(INBOUND_REFERENCE)).count());
     }
+
+    @Test
+    public void testNotAlterEvents() {
+        // Three events attached to 2 paths, one is a node add and a jcr:lastModified property change.
+        // So we should NOT alter it to an INBOUND_REFERENCE.
+        final Stream<Event> mockStream = of(mockEvent3, mockEvent4, mockEvent6);
+
+        final Stream<FedoraEvent> stream = testMapping.apply(mockStream);
+        assertNotNull(stream);
+        final List<FedoraEvent> list = stream.collect(toList());
+        assertEquals("Got the wrong number of events.", 2, list.size());
+        assertEquals("Got the wrong number of events with Inbound Reference", 0,
+            list.stream().filter(e -> e.getTypes().contains(INBOUND_REFERENCE)).count());
+    }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2804

# What does this Pull Request do?
When an inbound reference happens it causes the `jcr:lastModified` of the JCR node to be changed. This is the only change to that node, so we can alter them. 

# What's new?

A new predicate to check for a List of 1 Event with a type of PROPERTY_CHANGED and path that ends in `jcr:lastModified`.
The Modeshape event is wrapped so that we can return our fake event type and map that to the ActivityStreams Follow Activity.

# How should this be tested?

Internal tests are in place, but you can also stick a consumer on the activemq topic and check for any events when you POST with a reference to an existing Resource.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? Yes
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? Could affect client workflow, hence the documentation changes.

# Interested parties
@fcrepo4/committers
