### PR TITLE
FCREPO-2849: Added some documentation about memento TimeGate interact…

### DIFF
--- a/fcrepo-webapp/src/main/webapp/static/constraints/ContainerConstraints.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/ContainerConstraints.rdf
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="owl2html.xsl"?>
 
 <!DOCTYPE rdf:RDF [
@@ -30,5 +30,11 @@
         <rdfs:comment xml:lang="en">Properties in the &lt;http://fedora.info/definitions/v4/repository#&gt;
           namespace, and types in the &lt;http://fedora.info/definitions/v4/repository#&gt; and
           &lt;http://www.w3.org/ns/ldp#&gt; namespace can only be modified by the repository.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Fedora will create resources that are of the type 
+          &gt;http://mementoweb.org/ns#TimeMap&gt;.  When DELETE operations are made against the TimeMap, 
+          the original resource will no longer be versioned (and no longer be a memento TimeGate and no longer provide 
+          to the RFC-7089 Memento TimeGate interaction model.  POST operations to the TimeMap will result in 
+          new version creation.
+        </rdfs:comment>
     </owl:Ontology>
 </rdf:RDF>


### PR DESCRIPTION
…ion model, and how fcrepo allows version creation.

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2849

# What does this Pull Request do?
This pull request updates the documentation that is the result of the ldp:constrainedBy link header to include some information about the Memento TimeGate and timemap interaction models.

# What's new?
More text, references to Memento, and a cursory explanation of how to create versions.

# How should this be tested?

View http://localhost:8080/static/constraints/ContainerConstraints.rdf

# Additional Notes:
The LDP spec indicates that we must present some documentation (any format) referenced in an ldp:constrainedBy link header when a request fails due to a constraint.  It says we may provide that information for other requests.  This update adds a little bit more information.  It seemed a reasonable place to put information about how this particular Fedora implementation allows version creation since the spec (memento) doesn't speak to that.

