### PR TITLE
Remove extra slash from tombstone URI

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 
 import java.net.URI;
 import java.security.Principal;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
@@ -52,6 +53,8 @@ abstract public class FedoraBaseResource extends AbstractResource {
     private static final Logger LOGGER = getLogger(FedoraBaseResource.class);
 
     static final String JMS_BASEURL_PROP = "fcrepo.jms.baseUrl";
+
+    private static final Pattern TRAILING_SLASH_REGEX = Pattern.compile("/+$");
 
     @Inject
     protected HttpSession session;
@@ -91,7 +94,8 @@ abstract public class FedoraBaseResource extends AbstractResource {
         final FedoraResource fedoraResource = translator().convert(resource);
 
         if (fedoraResource instanceof Tombstone) {
-            throw new TombstoneException(fedoraResource, resource.getURI() + "/fcr:tombstone");
+            final String resourceURI = TRAILING_SLASH_REGEX.matcher(resource.getURI()).replaceAll("");
+            throw new TombstoneException(fedoraResource, resourceURI + "/fcr:tombstone");
         }
 
         return fedoraResource;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -753,6 +753,31 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testTrailingSlashTombstoneLink() throws IOException {
+        final String id = getRandomUniqueId();
+        final URI expectedTombstone = URI.create(serverAddress + id + "/fcr:tombstone");
+        createObjectAndClose(id);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(serverAddress + id)));
+        assertDeleted(id);
+        final HttpGet get1 = getObjMethod(id);
+        final Link tombstone;
+        try (final CloseableHttpResponse response = execute(get1)) {
+            tombstone = Link.valueOf(response.getFirstHeader(LINK).getValue());
+        }
+        assertEquals("hasTombstone", tombstone.getRel());
+        assertEquals(expectedTombstone, tombstone.getUri());
+        // Now with a trailing slash
+        final HttpGet get2 = getObjMethod(id + "/");
+        final Link tombstone2;
+        try (final CloseableHttpResponse response = execute(get2)) {
+            tombstone2 = Link.valueOf(response.getFirstHeader(LINK).getValue());
+        }
+        assertEquals("hasTombstone", tombstone2.getRel());
+        assertEquals(expectedTombstone, tombstone2.getUri());
+
+    }
+
+    @Test
     public void testEmptyPatch() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2861

# What does this Pull Request do?
Tombstone URI is generated based on the request URI, this ensures the created URI doesn't have a `//` in it.

# How should this be tested?

1.
     ```
     > curl -i -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/deleteMe
     HTTP/1.1 201 Created
     Date: Fri, 14 Sep 2018 15:00:31 GMT
     Set-Cookie: JSESSIONID=s0o2t4mivfb61xf1ugfajiy0n;Path=/
     Expires: Thu, 01 Jan 1970 00:00:00 GMT
     Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 13-Sep-2018 15:00:31 GMT
     ETag: W/"860f0238f8fec8e94215b2305948ff37cc5f0c94"
     Last-Modified: Fri, 14 Sep 2018 15:00:31 GMT
     Link: <http://localhost:8080/static/constraints/ContainerConstraints.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
     Link: <http://localhost:8080/rest/deleteMe/fcr:acl>; rel="acl"
     Location: http://localhost:8080/rest/deleteMe
     Content-Type: text/plain
     Content-Length: 35
     Server: Jetty(9.3.1.v20150714)

     http://localhost:8080/rest/deleteMe
     ```
1. 
     ```
     > curl -i -ufedoraAdmin:fedoraAdmin -XDELETE http://localhost:8080/rest/deleteMe
     HTTP/1.1 204 No Content
     Date: Fri, 14 Sep 2018 15:00:56 GMT
     Set-Cookie: JSESSIONID=qpzj5n6hlofp1ou74048iz74;Path=/
     Expires: Thu, 01 Jan 1970 00:00:00 GMT
     Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 13-Sep-2018 15:00:56 GMT
     Server: Jetty(9.3.1.v20150714)
     ```

The tombstone in the `Link` header should be the same regardless of request.
Before the PR.

*
     ```
     > curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/deleteMe         
     HTTP/1.1 410 Gone
     Date: Fri, 14 Sep 2018 15:01:01 GMT
     Set-Cookie: JSESSIONID=1kjr9h72tfjenvshyuq11qea0;Path=/
     Expires: Thu, 01 Jan 1970 00:00:00 GMT
     Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 13-Sep-2018 15:01:01 GMT
     Link: <http://localhost:8080/rest/deleteMe/fcr:tombstone>; rel="hasTombstone"
     Content-Type: text/plain
     Content-Length: 83
     Server: Jetty(9.3.1.v20150714)

     Discovered tombstone resource at /deleteMe, departed: 2018-09-14T10:00:56.267-05:00
     ```
* 
     ```
     > curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/deleteMe/
     HTTP/1.1 410 Gone
     Date: Fri, 14 Sep 2018 15:01:06 GMT
     Set-Cookie: JSESSIONID=1e2lsw4qi21bxcisrmv56woo1;Path=/
     Expires: Thu, 01 Jan 1970 00:00:00 GMT
     Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 13-Sep-2018 15:01:06 GMT
     Link: <http://localhost:8080/rest/deleteMe//fcr:tombstone>; rel="hasTombstone"
     Content-Type: text/plain
     Content-Length: 83
     Server: Jetty(9.3.1.v20150714)

     Discovered tombstone resource at /deleteMe, departed: 2018-09-14T10:00:56.267-05:00
     ```

After the PR

*
     ```
     > curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/deleteMe 
     HTTP/1.1 410 Gone
     Date: Fri, 14 Sep 2018 16:02:02 GMT
     Set-Cookie: JSESSIONID=uamzzfk80wkat2123hatpl13;Path=/
     Expires: Thu, 01 Jan 1970 00:00:00 GMT
     Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 13-Sep-2018 16:02:02 GMT
     Link: <http://localhost:8080/rest/deleteMe/fcr:tombstone>; rel="hasTombstone"
     Content-Type: text/plain
     Content-Length: 83
     Server: Jetty(9.3.1.v20150714)

     Discovered tombstone resource at /deleteMe, departed: 2018-09-14T10:00:56.267-05:00%                                                                          
     ```
*
     ```
     > curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/deleteMe/
     HTTP/1.1 410 Gone
     Date: Fri, 14 Sep 2018 16:02:05 GMT
     Set-Cookie: JSESSIONID=12g2ks0ktv6l5vsxy4rb239h3;Path=/
     Expires: Thu, 01 Jan 1970 00:00:00 GMT
     Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 13-Sep-2018 16:02:05 GMT
     Link: <http://localhost:8080/rest/deleteMe/fcr:tombstone>; rel="hasTombstone"
     Content-Type: text/plain
     Content-Length: 83
     Server: Jetty(9.3.1.v20150714)

     Discovered tombstone resource at /deleteMe, departed: 2018-09-14T10:00:56.267-05:00
     ```

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
