### PR TITLE
acl:agentClass foaf:Agent and acl:AuthenticatedAgent are now respected.

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/URIConstants.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/URIConstants.java
@@ -139,6 +139,11 @@ final public class URIConstants {
     public static final URI WEBAC_MODE = URI.create(WEBAC_MODE_VALUE);
 
     /**
+     * WebAC AuthenticatedAgent
+     */
+    public static final String WEBAC_AUTHENTICATED_AGENT_VALUE = WEBAC_NAMESPACE_VALUE + "AuthenticatedAgent";
+
+    /**
      * FOAF Namespace
      */
     public static final String FOAF_NAMESPACE_VALUE = "http://xmlns.com/foaf/0.1/";

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -166,11 +166,9 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
             modes.addAll(foafAgentModes);
         }
 
-        if (userPrincipal != null) {
-            final Collection<String> authenticatedAgentRoles = roles.get(WEBAC_AUTHENTICATED_AGENT_VALUE);
-            if (authenticatedAgentRoles != null) {
-                modes.addAll(authenticatedAgentRoles);
-            }
+        final Collection<String> authenticatedAgentRoles = roles.get(WEBAC_AUTHENTICATED_AGENT_VALUE);
+        if (authenticatedAgentRoles != null) {
+            modes.addAll(authenticatedAgentRoles);
         }
 
         return modes;

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -19,13 +19,16 @@ package org.fcrepo.auth.webac;
 
 import static org.fcrepo.auth.common.ServletContainerAuthFilter.FEDORA_ADMIN_ROLE;
 import static org.fcrepo.auth.common.ServletContainerAuthFilter.FEDORA_USER_ROLE;
+import static org.fcrepo.auth.webac.URIConstants.FOAF_AGENT_VALUE;
+import static org.fcrepo.auth.webac.URIConstants.WEBAC_AUTHENTICATED_AGENT_VALUE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
 import java.security.Principal;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
-
+import java.util.Set;
 import javax.inject.Inject;
 import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
@@ -131,7 +134,7 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
                 final Principal userPrincipal = principals.oneByType(BasicUserPrincipal.class);
                 if (userPrincipal != null) {
                     log.debug("Basic user principal username: {}", userPrincipal.getName());
-                    final Collection<String> modesForUser = roles.get(userPrincipal.getName());
+                    final Collection<String> modesForUser = getModesForUser(roles, userPrincipal);
                     if (modesForUser != null) {
                         // add WebACPermission instance for each mode in the Authorization
                         final URI fullRequestURI = URI.create(request.getRequestURL().toString());
@@ -148,6 +151,29 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
         }
 
         return authzInfo;
+    }
+
+    private Collection<String> getModesForUser(final Map<String, Collection<String>> roles,
+                                               final Principal userPrincipal) {
+        final Set<String> modes = new HashSet<>();
+        final Collection<String> userModes = roles.get(userPrincipal.getName());
+        if (userModes != null) {
+            modes.addAll(userModes);
+        }
+
+        final Collection<String> foafAgentModes = roles.get(FOAF_AGENT_VALUE);
+        if (foafAgentModes != null) {
+            modes.addAll(foafAgentModes);
+        }
+
+        if (userPrincipal != null) {
+            final Collection<String> authenticatedAgentRoles = roles.get(WEBAC_AUTHENTICATED_AGENT_VALUE);
+            if (authenticatedAgentRoles != null) {
+                modes.addAll(authenticatedAgentRoles);
+            }
+        }
+
+        return modes;
     }
 
     /**

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
@@ -371,6 +370,62 @@ public class WebACRolesProviderTest {
         assertEquals("There should be exactly one agent", 1, roles.size());
         assertEquals("The agent should have one mode", 1, roles.get(agent).size());
         assertTrue("The agent should be able to read", roles.get(agent).contains(WEBAC_MODE_READ_VALUE));
+    }
+
+    @Test
+    public void foafAgentTest() throws RepositoryException {
+        final String agent = "http://xmlns.com/foaf/0.1/Agent";
+        final String accessTo = "/foaf-agent";
+        final String acl = "/acls/03/foaf-agent.ttl";
+
+        when(mockNodeService.find(any(FedoraSession.class), eq(acl))).thenReturn(mockAclResource);
+        when(mockNodeService.find(any(FedoraSession.class), eq(accessTo))).thenReturn(mockResource);
+        when(mockNode.getPath()).thenReturn(accessTo);
+        when(mockAclNode.getPath()).thenReturn(acl);
+        when(mockResource.getAcl()).thenReturn(mockAclResource);
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockAclResource.isAcl()).thenReturn(true);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
+        when(mockAclResource.getTriples(anyObject(), eq(PROPERTIES)))
+            .thenReturn(getRdfStreamFromResource(acl, TTL));
+
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be only one valid role", 1, roles.size());
+        assertEquals("The foaf:Agent should have exactly one valid mode", 1,
+                     roles.get(agent).size());
+        assertTrue("The foaf:Agent should be able to write",
+                   roles.get(agent).contains(WEBAC_MODE_READ_VALUE));
+    }
+
+    @Test
+    public void authenticatedAgentTest() throws RepositoryException {
+        final String aclAuthenticatedAgent = "http://www.w3.org/ns/auth/acl#AuthenticatedAgent";
+        final String accessTo = "/authenticated-agent";
+        final String acl = "/acls/03/authenticated-agent.ttl";
+
+        when(mockNodeService.find(any(FedoraSession.class), eq(acl))).thenReturn(mockAclResource);
+        when(mockNodeService.find(any(FedoraSession.class), eq(accessTo))).thenReturn(mockResource);
+        when(mockNode.getPath()).thenReturn(accessTo);
+        when(mockAclNode.getPath()).thenReturn(acl);
+        when(mockResource.getAcl()).thenReturn(mockAclResource);
+        when(mockNodeService.find(mockSession, acl)).thenReturn(mockAclResource);
+        when(mockAclResource.getPath()).thenReturn(acl);
+        when(mockAclResource.isAcl()).thenReturn(true);
+        when(mockResource.getPath()).thenReturn(accessTo);
+        when(mockResource.getOriginalResource()).thenReturn(mockResource);
+        when(mockAclResource.getTriples(anyObject(), eq(PROPERTIES)))
+            .thenReturn(getRdfStreamFromResource(acl, TTL));
+
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
+
+        assertEquals("There should be only one valid role", 1, roles.size());
+        assertEquals("The acl:AuthenticatedAgent should have exactly one valid mode", 1,
+                     roles.get(aclAuthenticatedAgent).size());
+        assertTrue("The acl:AuthenticatedAgent should be able to write",
+                   roles.get(aclAuthenticatedAgent).contains(WEBAC_MODE_READ_VALUE));
     }
 
     @Test

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -1180,18 +1180,24 @@ public class WebACRecipesIT extends AbstractResourceIT {
     @Test
     public void testFoafAgent() throws IOException {
         final String path = ingestObj("/rest/foaf-agent");
-        ingestAcl("fedoraAdmin", "/acls/03/foaf-agent.ttl", path + "/fcr:acl");
+        ingestAcl("fedoraAdmin", "/acls/26/foaf-agent.ttl", path + "/fcr:acl");
         final String username = "user1";
 
         final HttpGet req = new HttpGet(path);
+
+        //NB: Actually no authentication headers should be set for this test
+        //since the point of foaf:Agent is to allow unauthenticated access for everyone.
+        //However at this time the test integration test server requires callers to
+        //authenticate.
         setAuth(req, username);
+
         assertEquals(HttpStatus.SC_OK, getStatus(req));
     }
 
     @Test
     public void testAuthenticatedAgent() throws IOException {
         final String path = ingestObj("/rest/authenticated-agent");
-        ingestAcl("fedoraAdmin", "/acls/03/authenticated-agent.ttl", path + "/fcr:acl");
+        ingestAcl("fedoraAdmin", "/acls/26/authenticated-agent.ttl", path + "/fcr:acl");
         final String username = "user1";
 
         final HttpGet darkReq = new HttpGet(path);

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -1177,4 +1177,25 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(postReq));
     }
 
+    @Test
+    public void testFoafAgent() throws IOException {
+        final String path = ingestObj("/rest/foaf-agent");
+        ingestAcl("fedoraAdmin", "/acls/03/foaf-agent.ttl", path + "/fcr:acl");
+        final String username = "user1";
+
+        final HttpGet req = new HttpGet(path);
+        setAuth(req, username);
+        assertEquals(HttpStatus.SC_OK, getStatus(req));
+    }
+
+    @Test
+    public void testAuthenticatedAgent() throws IOException {
+        final String path = ingestObj("/rest/authenticated-agent");
+        ingestAcl("fedoraAdmin", "/acls/03/authenticated-agent.ttl", path + "/fcr:acl");
+        final String username = "user1";
+
+        final HttpGet darkReq = new HttpGet(path);
+        setAuth(darkReq, username);
+        assertEquals(HttpStatus.SC_OK, getStatus(darkReq));
+    }
 }

--- a/fcrepo-auth-webac/src/test/resources/acls/03/authenticated-agent.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/03/authenticated-agent.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<#authenticated_agent> a acl:Authorization ;
+   acl:agentClass acl:AuthenticatedAgent ;
+   acl:mode acl:Read ;
+   acl:accessTo </rest/authenticated-agent> .

--- a/fcrepo-auth-webac/src/test/resources/acls/03/foaf-agent.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/03/foaf-agent.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#authenticated_agent> a acl:Authorization ;
+   acl:agentClass foaf:Agent ;
+   acl:mode acl:Read ;
+   acl:accessTo </rest/foaf-agent> .

--- a/fcrepo-auth-webac/src/test/resources/acls/26/authenticated-agent.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/26/authenticated-agent.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<#authenticated_agent> a acl:Authorization ;
+   acl:agentClass acl:AuthenticatedAgent ;
+   acl:mode acl:Read ;
+   acl:accessTo </rest/authenticated-agent> .

--- a/fcrepo-auth-webac/src/test/resources/acls/26/foaf-agent.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/26/foaf-agent.ttl
@@ -1,0 +1,7 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<#authenticated_agent> a acl:Authorization ;
+   acl:agentClass foaf:Agent ;
+   acl:mode acl:Read ;
+   acl:accessTo </rest/foaf-agent> .


### PR DESCRIPTION

**acl:agentClass foaf:Agent and acl:AuthenticatedAgent are now respected.**
* * *

**JIRA Ticket**:  https://jira.duraspace.org/browse/FCREPO-2863

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Ensures that acl:AuthenticatedAgent and foaf:Agent are respected.

# How should this be tested?
Includes unit as well as integration tests.
For manual testing: 
Create a foaf-agent.ttl :
```
@prefix acl: <http://www.w3.org/ns/auth/acl#> .
@prefix foaf: <http://xmlns.com/foaf/0.1/> .

<#foafAgent> a acl:Authorization ;
              acl:agentClass foaf:Agent;
              acl:mode acl:Read;
              acl:accessTo </rest/foaf-agent> .
```

Create foaf resource and acl and perform GET verifying a 200 response.
```
curl -v -u fedoraAdmin:fedoraAdmin -X PUT  http://localhost:8080/rest/foaf-agent;
curl -v -u fedoraAdmin:fedoraAdmin -X PUT --data-binary  "@foaf-agent.ttl" -H "Content-Type: text/turtle" http://localhost:8080/rest/foaf-agent/fcr:acl;
curl -v -u testuser:testpass -X GET  http://localhost:8080/rest/foaf-agent;

```
Create authenticated-agent.ttl
```
@prefix acl: <http://www.w3.org/ns/auth/acl#> .

<#authenticated> a acl:Authorization ;
              acl:agentClass acl:AuthenticatedAgent;
              acl:mode acl:Read;
              acl:accessTo </rest/authenticated-agent> .
```
Create authenticated-agent resource and  acl, perform GET and verify 200
```
curl -v -u fedoraAdmin:fedoraAdmin -X PUT  http://localhost:8080/rest/authenticated-agent
curl -v -u fedoraAdmin:fedoraAdmin -X PUT --data-binary  "@authenticated-agent.ttl" -H "Content-Type: text/turtle" http://localhost:8080/rest/authenticated-agent/fcr:acl
curl -v -u testuser:testpass -X GET  http://localhost:8080/rest/authenticated-agent
```


# Additional Notes:
Once https://github.com/fcrepo/Fedora-API-Test-Suite/pull/181 is merged in, the two related tests that were failing, 5.0-D and 5.0-E, should now pass. 

* Does this change require documentation to be updated? yes
* Does this change add any new dependencies? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
