### PR TITLE
Ensure ldp:RDFSource type is on LDP-RSs

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -69,6 +69,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEMAP_TYPE;
@@ -577,7 +578,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @param relation the relation string.
      * @return the string version of the link.
      */
-    private static String buildLink(final String linkUri, final String relation) {
+    public static final String buildLink(final String linkUri, final String relation) {
         return buildLink(URI.create(linkUri), relation);
     }
 
@@ -641,6 +642,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             servletResponse.addHeader(LINK, "<" + LDP_NAMESPACE + "NonRDFSource>;rel=\"type\"");
         } else if (resource instanceof Container || resource instanceof FedoraTimeMap) {
             servletResponse.addHeader(LINK, "<" + CONTAINER.getURI() + ">;rel=\"type\"");
+            servletResponse.addHeader(LINK, buildLink(RDF_SOURCE.getURI(), "type"));
             if (resource.hasType(LDP_BASIC_CONTAINER)) {
                 servletResponse.addHeader(LINK, "<" + BASIC_CONTAINER.getURI() + ">;rel=\"type\"");
             } else if (resource.hasType(LDP_DIRECT_CONTAINER)) {
@@ -651,7 +653,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 servletResponse.addHeader(LINK, "<" + BASIC_CONTAINER.getURI() + ">;rel=\"type\"");
             }
         } else {
-            servletResponse.addHeader(LINK, "<" + LDP_NAMESPACE + "RDFSource>;rel=\"type\"");
+            servletResponse.addHeader(LINK, buildLink(RDF_SOURCE.getURI(), "type"));
         }
         if (httpHeaderInject != null) {
             httpHeaderInject.addHttpHeaderToResponseStream(servletResponse, uriInfo, resource);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -578,7 +578,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @param relation the relation string.
      * @return the string version of the link.
      */
-    public static final String buildLink(final String linkUri, final String relation) {
+    protected static String buildLink(final String linkUri, final String relation) {
         return buildLink(URI.create(linkUri), relation);
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -36,6 +36,7 @@ import static javax.ws.rs.core.Response.Status.TEMPORARY_REDIRECT;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
+import static org.fcrepo.http.api.ContentExposingResource.buildLink;
 import static org.fcrepo.http.api.ContentExposingResource.getSimpleContentType;
 import static org.fcrepo.http.api.FedoraBaseResource.JMS_BASEURL_PROP;
 import static org.fcrepo.http.api.FedoraLdp.HTTP_HEADER_ACCEPT_PATCH;
@@ -53,6 +54,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
 import static org.junit.Assert.assertEquals;
@@ -470,8 +472,8 @@ public class FedoraLdpTest {
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
-        assertTrue("Should be an LDP RDFSource", mockResponse.getHeaders(LINK).contains("<" + LDP_NAMESPACE +
-                "RDFSource>;rel=\"type\""));
+        assertTrue("Should be an LDP RDFSource",
+            mockResponse.getHeaders(LINK).contains(buildLink(RDF_SOURCE.getURI(), "type")));
         assertShouldNotAdvertiseAcceptPostFlavors();
         assertShouldAdvertiseAcceptPatchFlavors();
         assertShouldContainLinkToTheBinary();
@@ -834,8 +836,9 @@ public class FedoraLdpTest {
                     (createURI("mockBinary"), createURI("called"), createURI("child:properties")))));
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
+
         assertTrue("Should be an LDP RDFSource",
-                mockResponse.getHeaders(LINK).contains("<" + LDP_NAMESPACE + "RDFSource>;rel=\"type\""));
+            mockResponse.getHeaders(LINK).contains(buildLink(RDF_SOURCE.getURI(), "type")));
         assertShouldNotAdvertiseAcceptPostFlavors();
         assertShouldAdvertiseAcceptPatchFlavors();
         assertShouldContainLinkToTheBinary();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -550,7 +550,7 @@ public abstract class AbstractResourceIT {
      * @param uri the URI not to exist in the LINK header
      * @param rel the rel argument to check for
      */
-    protected static void assertNoLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+    protected static void assertNoLinkHeader(final HttpResponse response, final String uri, final String rel) {
         assertEquals(0, countLinkHeader(response, uri, rel));
     }
 
@@ -561,7 +561,7 @@ public abstract class AbstractResourceIT {
      * @param uri the URI expected in the LINK header
      * @param rel the rel argument to check for
      */
-    protected static void checkForLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+    protected static void checkForLinkHeader(final HttpResponse response, final String uri, final String rel) {
         assertEquals(1, countLinkHeader(response, uri, rel));
     }
 
@@ -573,7 +573,7 @@ public abstract class AbstractResourceIT {
      * @param rel the rel argument to check for
      * @param count how many LINK headers should exist
      */
-    protected static void checkForNLinkHeaders(final CloseableHttpResponse response, final String uri, final String rel,
+    protected static void checkForNLinkHeaders(final HttpResponse response, final String uri, final String rel,
         final int count) {
         assertEquals(count, countLinkHeader(response, uri, rel));
     }
@@ -586,7 +586,7 @@ public abstract class AbstractResourceIT {
      * @param rel the rel argument to check for
      * @return the count of LINK headers.
      */
-    private static int countLinkHeader(final CloseableHttpResponse response, final String uri, final String rel) {
+    private static int countLinkHeader(final HttpResponse response, final String uri, final String rel) {
         final Link linkA = Link.valueOf("<" + uri + ">; rel=" + rel);
         return (int) Arrays.asList(response.getHeaders(LINK)).stream().filter(x -> {
             final Link linkB = Link.valueOf(x.getValue());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -88,6 +88,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
@@ -234,6 +235,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createObject(id).close();
         final HttpHead headObjMethod = headObjMethod(id);
         try (final CloseableHttpResponse response = execute(headObjMethod)) {
+            checkForLinkHeader(response, RDF_SOURCE.getURI(), "type");
             assertTrue("Didn't find LDP container link header!", getLinkHeaders(response).contains(
                     BASIC_CONTAINER_LINK_HEADER));
         }
@@ -249,6 +251,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpHead headObjMethod = headObjMethod(id);
         try (final CloseableHttpResponse response = execute(headObjMethod)) {
             final Collection<String> links = getLinkHeaders(response);
+            checkForLinkHeader(response, RDF_SOURCE.getURI(), "type");
             assertTrue("Didn't find LDP container link header!", links.contains(BASIC_CONTAINER_LINK_HEADER));
         }
     }
@@ -347,6 +350,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpHead headObjMethod = headObjMethod(id);
         try (final CloseableHttpResponse response = execute(headObjMethod)) {
             final Collection<String> links = getLinkHeaders(response);
+            checkForLinkHeader(response, RDF_SOURCE.getURI(), "type");
             assertTrue("Didn't find LDP container link header!", links.contains(DIRECT_CONTAINER_LINK_HEADER));
             testHeadVaryAndPreferHeaders(response);
         }
@@ -550,6 +554,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(new HttpGet(serverAddress + id))) {
             assertEquals(OK.getStatusCode(), getStatus(response));
             checkForLinkHeader(response, location + "/" + FCR_ACL, "acl");
+            checkForLinkHeader(response, RDF_SOURCE.getURI(), "type");
             final HttpEntity entity = response.getEntity();
             final String contentType = parse(entity.getContentType().getValue()).getMimeType();
             assertNotNull("Entity is not an RDF serialization!", contentTypeToLang(contentType));
@@ -1003,6 +1008,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String subjectURI = createVersionedRDFResource();
         try (final CloseableHttpResponse response = execute(new HttpGet(subjectURI))) {
             verifyVersionedResourceResponseHeaders(subjectURI, response);
+            checkForLinkHeader(response, RDF_SOURCE.getURI(), "type");
         }
     }
 
@@ -1867,6 +1873,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(getObjMethod)) {
             assertEquals(OK.getStatusCode(), getStatus(response));
             assertResourceOptionsHeaders(response);
+            checkForLinkHeader(response, RDF_SOURCE.getURI(), "type");
             assertTrue("Didn't find LDP link header!", getLinkHeaders(response).contains(LDP_RESOURCE_LINK_HEADER));
             checkForLinkHeader(response, location + "/" + FCR_ACL, "acl");
             try (final CloseableDataset dataset = getDataset(response)) {
@@ -3736,4 +3743,5 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertConstrainedByPresent(response);
         }
     }
+
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -792,6 +792,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String ldpcvUri = uri + "/" + FCR_VERSIONS;
         checkForLinkHeader(response, RESOURCE.toString(), "type");
         checkForLinkHeader(response, CONTAINER.toString(), "type");
+        checkForLinkHeader(response, RDF_SOURCE.getURI(), "type");
         checkForLinkHeader(response, uri, "original");
         checkForLinkHeader(response, uri, "timegate");
         checkForLinkHeader(response, uri + "/" + FCR_VERSIONS, "timemap");
@@ -1366,6 +1367,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             checkForLinkHeader(response, subjectUri, "timegate");
             checkForLinkHeader(response, subjectUri + "/" + FCR_VERSIONS, "timemap");
             checkForLinkHeader(response, RESOURCE.toString(), "type");
+            checkForLinkHeader(response, RDF_SOURCE.toString(), "type");
             assertNoLinkHeader(response, VERSIONED_RESOURCE.toString(), "type");
             assertNoLinkHeader(response, VERSIONING_TIMEMAP_TYPE.toString(), "type");
             assertNoLinkHeader(response, version1Uri + "/" + FCR_ACL, "acl");


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2862

# What does this Pull Request do?
Adds the `http://www.w3.org/ns/ldp#RDFSource` Link header with `rel="type"` to all LDP-RSs. 

# How should this be tested?

Put a LDP-RS and when you GET or HEAD it see the new type, same with TimeMaps and Binary descriptions.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
