### PR TITLE
Fcrepo-2850 - Improve error message for empty memento creation

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -409,6 +409,23 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testCreateVersionWithDatetimeAndEmptyBody() throws Exception {
+        createVersionedContainer(id);
+
+        final HttpPost createVersionMethod = new HttpPost(subjectUri + "/" + FCR_VERSIONS);
+        createVersionMethod.setEntity(new StringEntity(""));
+        createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, MEMENTO_DATETIME);
+
+        // Create new memento of resource with updated body
+        try (final CloseableHttpResponse response = execute(createVersionMethod)) {
+            assertEquals("Didn't get a BAD_REQUEST response!", BAD_REQUEST.getStatusCode(), getStatus(response));
+            final String responseMsg = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+            assertTrue("Expected error message indicating empty body provided, received: " + responseMsg,
+                    responseMsg.contains("Cannot create historic memento from an empty body"));
+        }
+    }
+
+    @Test
     public void testDeleteAndPostContainerMemento() throws Exception {
         createVersionedContainer(id);
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -70,6 +70,7 @@ import org.apache.jena.riot.Lang;
 import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
@@ -148,6 +149,11 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
         } else {
             final Model inputModel = ModelFactory.createDefaultModel();
             inputModel.read(rdfInputStream, mementoUri, rdfFormat.getName());
+
+            if (inputModel.isEmpty()) {
+                throw new ConstraintViolationException(
+                        "Cannot create historic memento from an empty body");
+            }
 
             // Validate server managed triples are provided
             if (resource instanceof Container) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2850

# What does this Pull Request do?
Provides a message explicitly stating that empty models are disallowed when creating historic mementos

# What's new?
Added check for empty body when creating memento, and integration test

# How should this be tested?

```
curl -i -XPUT --user fedoraAdmin:fedoraAdmin -H"Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\""  http://localhost:8080/rest/test_resc

curl -i -XPOST --user fedoraAdmin:fedoraAdmin -H "Memento-Datetime: Wed, 30 May 2018 23:02:44 GMT" -H "Content-Type: text/turtle" http://localhost:8080/rest/test_resc/fcr:versions

< HTTP/1.1 400 Bad Request
< Cannot create historic memento from an empty body
```

# Interested parties
@fcrepo4/committers
