### PR TITLE
Referencing acl:group lists using Hash URIs now works properly.

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -27,7 +27,7 @@ import static java.util.stream.Stream.empty;
 import static java.util.stream.Stream.of;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.auth.webac.URIConstants.FOAF_AGENT_VALUE;
-import static org.fcrepo.auth.webac.URIConstants.VCARD_GROUP;
+import static org.fcrepo.auth.webac.URIConstants.VCARD_GROUP_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.VCARD_MEMBER_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESSTO_CLASS_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESSTO_VALUE;
@@ -99,6 +99,8 @@ public class WebACRolesProvider implements AccessRolesProvider {
     private static final String FEDORA_INTERNAL_PREFIX = "info:fedora";
 
     private static final String JCR_VERSIONABLE_UUID_PROPERTY = "jcr:versionableUuid";
+
+    private static final org.apache.jena.graph.Node RDF_TYPE_NODE = createURI(RDF_NAMESPACE + "type");
 
     @Inject
     private NodeService nodeService;
@@ -298,9 +300,15 @@ public class WebACRolesProvider implements AccessRolesProvider {
 
         final List<String> members = agentGroups.stream().flatMap(agentGroup -> {
             if (agentGroup.startsWith(FEDORA_INTERNAL_PREFIX)) {
+                //strip off trailing hash.
+                final int hashIndex = agentGroup.indexOf("#");
+                final String agentGroupNoHash = hashIndex > 0 ?
+                                         agentGroup.substring(0, hashIndex) :
+                                         agentGroup;
+                final String hashedSuffix = hashIndex > 0 ? agentGroup.substring(hashIndex) : null;
                 final FedoraResource resource = nodeService.find(
-                    internalSession, agentGroup.substring(FEDORA_INTERNAL_PREFIX.length()));
-                return getAgentMembers(translator, resource);
+                    internalSession, agentGroupNoHash.substring(FEDORA_INTERNAL_PREFIX.length()));
+                return getAgentMembers(translator, resource, hashedSuffix);
             } else if (agentGroup.equals(FOAF_AGENT_VALUE)) {
                 return of(agentGroup);
             } else {
@@ -317,12 +325,26 @@ public class WebACRolesProvider implements AccessRolesProvider {
     }
 
     /**
-     *  Given a FedoraResource, return a list of agents.
+     * Given a FedoraResource, return a list of agents.
      */
     private static Stream<String> getAgentMembers(final IdentifierConverter<Resource, FedoraResource> translator,
-            final FedoraResource resource) {
-        return resource.getTriples(translator, PROPERTIES).filter(memberTestFromTypes.apply(resource.getTypes()))
-            .map(Triple::getObject).flatMap(WebACRolesProvider::nodeToStringStream);
+                                                  final FedoraResource resource, final String hashPortion) {
+
+        //resolve list of triples, accounting for hash-uris.
+        final List<Triple> triples = resource.getTriples(translator, PROPERTIES).filter(
+            triple -> hashPortion == null || triple.getSubject().getURI().endsWith(hashPortion)).collect(toList());
+        //determine if there is a rdf:type vcard:Group
+        final boolean hasVcardGroup = triples.stream().filter(
+            triple -> triple.predicateMatches(RDF_TYPE_NODE) &&
+                      triple.getObject().getURI().equals(VCARD_GROUP_VALUE)).count() > 0;
+        //return members only if there is an associated vcard:Group
+        if (hasVcardGroup) {
+            return triples.stream()
+                          .filter(triple -> triple.predicateMatches(createURI(VCARD_MEMBER_VALUE)))
+                          .map(Triple::getObject).flatMap(WebACRolesProvider::nodeToStringStream);
+        } else {
+            return empty();
+        }
     }
 
     /**
@@ -339,11 +361,6 @@ public class WebACRolesProvider implements AccessRolesProvider {
         }
     }
 
-    /**
-     * A simple predicate for filtering out any non-vcard:hasMember properties
-     */
-    private static final Function<List<URI>, Predicate<Triple>> memberTestFromTypes = types -> triple -> types
-            .contains(VCARD_GROUP) && triple.predicateMatches(createURI(VCARD_MEMBER_VALUE));
 
     /**
      *  A simple predicate for filtering out any non-acl triples.

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Optional;
-
 import javax.ws.rs.core.Link;
 
 import org.apache.commons.codec.binary.Base64;
@@ -1203,5 +1202,38 @@ public class WebACRecipesIT extends AbstractResourceIT {
         final HttpGet darkReq = new HttpGet(path);
         setAuth(darkReq, username);
         assertEquals(HttpStatus.SC_OK, getStatus(darkReq));
+    }
+
+    public void testAgentGroupWithHashUris() throws Exception {
+        ingestTurtleResource("fedoraAdmin", "/acls/agent-group-list.ttl",
+                             serverAddress + "/rest/agent-group-list");
+        //check that the authorized are authorized.
+        final String authorized = ingestObj("/rest/agent-group-with-hash-uri-authorized");
+        ingestAcl("fedoraAdmin", "/acls/agent-group-with-hash-uri-authorized.ttl", authorized + "/fcr:acl");
+
+        final HttpGet getAuthorized = new HttpGet(authorized);
+        setAuth(getAuthorized, "testuser");
+        assertEquals(HttpStatus.SC_OK, getStatus(getAuthorized));
+
+        //check that the unauthorized are unauthorized.
+        final String unauthorized = ingestObj("/rest/agent-group-with-hash-uri-unauthorized");
+        ingestAcl("fedoraAdmin", "/acls/agent-group-with-hash-uri-unauthorized.ttl", unauthorized + "/fcr:acl");
+
+        final HttpGet getUnauthorized = new HttpGet(unauthorized);
+        setAuth(getUnauthorized, "testuser");
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(getUnauthorized));
+    }
+
+    @Test
+    public void testAgentGroup() throws Exception {
+        ingestTurtleResource("fedoraAdmin", "/acls/agent-group-list-flat.ttl",
+                             serverAddress + "/rest/agent-group-list-flat");
+        //check that the authorized are authorized.
+        final String flat = ingestObj("/rest/agent-group-flat");
+        ingestAcl("fedoraAdmin", "/acls/agent-group-flat.ttl", flat + "/fcr:acl");
+
+        final HttpGet getFlat = new HttpGet(flat);
+        setAuth(getFlat, "testuser");
+        assertEquals(HttpStatus.SC_OK, getStatus(getFlat));
     }
 }

--- a/fcrepo-auth-webac/src/test/resources/acls/agent-group-flat.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/agent-group-flat.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<#authorization>    a               acl:Authorization;
+    acl:accessTo    </rest/agent-group-flat>;
+    acl:mode        acl:Read; 
+    acl:agentGroup  </rest/agent-group-list-flat>.

--- a/fcrepo-auth-webac/src/test/resources/acls/agent-group-list-flat.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/agent-group-list-flat.ttl
@@ -1,0 +1,4 @@
+@prefix    acl:  <http://www.w3.org/ns/auth/acl#>.
+@prefix  vcard:  <http://www.w3.org/2006/vcard/ns#>.
+<> a vcard:Group ;
+          vcard:hasMember  "testuser" .

--- a/fcrepo-auth-webac/src/test/resources/acls/agent-group-list.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/agent-group-list.ttl
@@ -1,0 +1,6 @@
+@prefix    acl:  <http://www.w3.org/ns/auth/acl#>.
+@prefix  vcard:  <http://www.w3.org/2006/vcard/ns#>.
+<#authorized> a vcard:Group ;
+          vcard:hasMember  "testuser" .
+<#unauthorized> a vcard:Group ;
+          vcard:hasMember  "anotheruser" .

--- a/fcrepo-auth-webac/src/test/resources/acls/agent-group-with-hash-uri-authorized.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/agent-group-with-hash-uri-authorized.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<#authorization>    a               acl:Authorization;
+    acl:accessTo    </rest/agent-group-with-hash-uri-authorized>;
+    acl:mode        acl:Read; 
+    acl:agentGroup  </rest/agent-group-list#authorized>.

--- a/fcrepo-auth-webac/src/test/resources/acls/agent-group-with-hash-uri-unauthorized.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/agent-group-with-hash-uri-unauthorized.ttl
@@ -1,0 +1,6 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+
+<#authorization>    a               acl:Authorization;
+    acl:accessTo    </rest/agent-group-with-hash-uri-unauthorized>;
+    acl:mode        acl:Read;
+    acl:agentGroup  </rest/agent-group-list#unauthorized>.


### PR DESCRIPTION
**ACLs that reference group list resource using a hash URI  in acl:agentGroup triples was not authorizing correctly.  This PR addresses the bug.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2864

# What does this Pull Request do?
Now it is possible to use hash URIs as the object of an acl:agentGroup predicate.  Two integration tests were added to confirm that the functionality works. The first test ensures that members defined in hash-URI blocks are respected while acls referencing an unauthorized block within the same resource results in a 403.  The second test ensures that non-hash URIs work as expected.

# How should this be tested?
Integration tests cover the new functionality and provides missing testing for existing functionality.  

# Additional Notes:
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? Possibly, but unlikely.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
