### PR TITLE
Allow charset in content-type

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -41,6 +41,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.query.QueryParseException;
@@ -62,6 +63,8 @@ import org.slf4j.Logger;
 public class WebACFilter implements Filter {
 
     private static final Logger log = getLogger(WebACFilter.class);
+
+    private static MediaType sparqlUpdate = MediaType.valueOf(contentTypeSPARQLUpdate);
 
     private FedoraSession session;
 
@@ -297,7 +300,12 @@ public class WebACFilter implements Filter {
     }
 
     private boolean isSparqlUpdate(final HttpServletRequest request) {
-        return request.getMethod().equals("PATCH") &&
-                contentTypeSPARQLUpdate.equalsIgnoreCase(request.getContentType());
+        try {
+            return request.getMethod().equals("PATCH") &&
+                    request.getContentType() != null && sparqlUpdate.isCompatible(MediaType.valueOf(request
+                            .getContentType()));
+        } catch (final IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -461,6 +461,10 @@ public class WebACRecipesIT extends AbstractResourceIT {
         logger.debug("user18 can patch - SPARQL INSERTs (ACL append): {}", id);
         assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(requestPatch));
 
+        requestPatch.setHeader("Content-type", "application/sparql-update; charset=UTF-8");
+        logger.debug("user18 can patch - SPARQL INSERTs (ACL append with charset): {}", id);
+        assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(requestPatch));
+
         logger.debug("user18 still can't delete (ACL append): {}", id);
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(requestDelete));
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2866

# What does this Pull Request do?
Does better Content-type matching to allow `; charset=` suffixes

# How should this be tested?

Modified one of the ITs to try PATCHing with charset too. But

Make a LDP-RS that has an Acl then try to PATCH that resource using Content-type with and without a charset with a non-admin user with permissions

ie.
* `Content-type: application/sparql-update`
* `Content-type: application/sparql-update; charset=UTF-8`

Before the PR you'll get a 204 for the first and 403 for the second.
After this PR you'll get 204s for both.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
