### PR TITLE
Fcrepo 2869 - Memento datetime negotiation with exact dates

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1184,6 +1184,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             FMT.format(ISO_INSTANT.parse("2016-06-17T11:41:00Z", Instant::from));
         final String version2Uri = createLDPRSMementoWithExistingBody(memento2);
 
+        // Request datetime between memento1 and memento2
         final String request1Datetime =
             FMT.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
         final HttpGet getMemento = getObjMethod(id);
@@ -1196,6 +1197,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertEquals("Did not get Content-Length == 0", "0", response.getFirstHeader(CONTENT_LENGTH).getValue());
         }
 
+        // Request datetime more recent than both mementos
         final String request2Datetime =
             FMT.format(ISO_INSTANT.parse("2018-01-10T00:00:00Z", Instant::from));
         final HttpGet getMemento2 = getObjMethod(id);
@@ -1205,6 +1207,19 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertEquals("Did not get FOUND response", FOUND.getStatusCode(), getStatus(response));
             assertNoMementoDatetimeHeaderPresent(response);
             assertEquals("Did not get Location header", version1Uri, response.getFirstHeader(LOCATION).getValue());
+            assertEquals("Did not get Content-Length == 0", "0", response.getFirstHeader(CONTENT_LENGTH).getValue());
+        }
+
+        // Request datetime older than either mementos
+        final String request3Datetime =
+                FMT.format(ISO_INSTANT.parse("2014-01-01T00:00:00Z", Instant::from));
+        final HttpGet getMemento3 = getObjMethod(id);
+        getMemento3.addHeader(ACCEPT_DATETIME, request3Datetime);
+
+        try (final CloseableHttpResponse response = customClient.execute(getMemento3)) {
+            assertEquals("Did not get FOUND response", FOUND.getStatusCode(), getStatus(response));
+            assertNoMementoDatetimeHeaderPresent(response);
+            assertEquals("Did not get Location header", version2Uri, response.getFirstHeader(LOCATION).getValue());
             assertEquals("Did not get Content-Length == 0", "0", response.getFirstHeader(CONTENT_LENGTH).getValue());
         }
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -1258,12 +1258,13 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
             final FedoraResource timemap = this.getTimeMap();
             if (timemap != null) {
                 final Stream<FedoraResource> mementos = timemap.getChildren();
-                final Optional<FedoraResource> closest =
-                    mementos.filter(t -> t.getMementoDatetime().compareTo(mementoDatetime) <= 0)
-                        .reduce((a,
-                            b) -> dateTimeDifference(a.getMementoDatetime(), mementoDatetime,
-                                ChronoUnit.SECONDS) <= dateTimeDifference(b.getMementoDatetime(), mementoDatetime,
-                                    ChronoUnit.SECONDS) ? a : b);
+                // Filter to mementos prior to mementoDatetime, then reduce to the nearest one
+                final Optional<FedoraResource> closest = mementos
+                        .filter(t -> dateTimeDifference(mementoDatetime, t.getMementoDatetime()) <= 0)
+                        .reduce((a, b) ->
+                                dateTimeDifference(a.getMementoDatetime(), mementoDatetime)
+                                <= dateTimeDifference(b.getMementoDatetime(), mementoDatetime) ?
+                                        a : b);
                 if (closest.isPresent()) {
                     // Return the closest version older than the requested date.
                     return closest.get();
@@ -1285,11 +1286,10 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
      *
      * @param d1 first datetime
      * @param d2 second datetime
-     * @param unit unit to compare down to
      * @return the difference
      */
-  static long dateTimeDifference(final Temporal d1, final Temporal d2, final ChronoUnit unit) {
-      return unit.between(d1, d2);
+  static long dateTimeDifference(final Temporal d1, final Temporal d2) {
+      return ChronoUnit.SECONDS.between(d1, d2);
   }
 
   @Override


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2869

# What does this Pull Request do?
Fixes issue where requesting a memento by its exact memento datetime returns an older memento if available.

# What's new?
During negotiation, when filtering mementos to just those older or the same age as the `Accept-datetime` header, ensure that the header value is being compared against the memento datetime to the same level of precision. The issue was caused by the request header being accurate to the second, while system generated memento-datetimes are to the millisecond. As a result, the memento was technically after the header.

Also added an integration test to verify the behavior when submitting a Accept-datetime older than the first memento, to make sure no unrelated side effects occurred from this change.

# How should this be tested?

Integration tests.

It can also be verifed with the following commands (output is for running against master)
```
curl -ufedoraAdmin:fedoraAdmin -vi -XPUT -H"Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" http://localhost:8080/rest/nego_test 

curl -ufedoraAdmin:fedoraAdmin -vi -XPOST http://localhost:8080/rest/nego_test/fcr:versions
# http://localhost:8080/rest/nego_test/fcr:versions/20180920131323
curl -ufedoraAdmin:fedoraAdmin -vi -XPOST http://localhost:8080/rest/nego_test/fcr:versions
# http://localhost:8080/rest/nego_test/fcr:versions/20180920131336

curl -I --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/nego_test/fcr:versions/20180920131323
# Memento-Datetime: Thu, 20 Sep 2018 13:13:23 GMT

curl -I --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/nego_test/fcr:versions/20180920131336
# Memento-Datetime: Thu, 20 Sep 2018 13:13:36 GMT

# Request the first memento by its exact datetime
curl -I --user fedoraAdmin:fedoraAdmin -H "Accept-datetime: Thu, 20 Sep 2018 13:13:23 GMT" http://localhost:8080/rest/nego_test
# Location: http://localhost:8080/rest/nego_test/fcr:versions/20180920131323
 
# Request the exact datetime of the newer memento (this is the bug)
curl -I --user fedoraAdmin:fedoraAdmin -H "Accept-datetime: Thu, 20 Sep 2018 13:13:36 GMT" http://localhost:8080/rest/nego_test
#Location: http://localhost:8080/rest/nego_test/fcr:versions/20180920131323
 
# Request one second after the newer memento
curl -I --user fedoraAdmin:fedoraAdmin -H "Accept-datetime: Thu, 20 Sep 2018 13:13:37 GMT" http://localhost:8080/rest/nego_test
#Location: http://localhost:8080/rest/nego_test/fcr:versions/20180920131336
```

# Interested parties
@fcrepo4/committers
