### PR TITLE
PrincipalProvider and Authorization Refactor

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProvider.java
@@ -35,6 +35,43 @@ public class DelegateHeaderPrincipalProvider extends HttpHeaderPrincipalProvider
     private static final String SEP = "no-separator";
     protected static final String DELEGATE_HEADER = "On-Behalf-Of";
 
+    public static class DelegatedHeaderPrincipal implements Principal {
+
+        private final String name;
+
+        protected DelegatedHeaderPrincipal(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (o instanceof DelegatedHeaderPrincipal) {
+                return ((DelegatedHeaderPrincipal) o).getName().equals(
+                        this.getName());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            if (name == null) {
+                return 0;
+            }
+            return name.hashCode();
+        }
+
+    }
+
     /**
      * Default Constructor
      */
@@ -62,6 +99,11 @@ public class DelegateHeaderPrincipalProvider extends HttpHeaderPrincipalProvider
         }
 
         throw new RepositoryConfigurationException("Too many delegates! " + principals);
+    }
+
+    @Override
+    protected Principal createPrincipal(final String name) {
+        return new DelegatedHeaderPrincipal(name.trim());
     }
 
 }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/HttpHeaderPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/HttpHeaderPrincipalProvider.java
@@ -37,11 +37,11 @@ import java.util.Set;
  */
 public class HttpHeaderPrincipalProvider extends AbstractPrincipalProvider {
 
-    protected static class HttpHeaderPrincipal implements Principal {
+    public static class HttpHeaderPrincipal implements Principal {
 
         private final String name;
 
-        HttpHeaderPrincipal(final String name) {
+        protected HttpHeaderPrincipal(final String name) {
             this.name = name;
         }
 
@@ -128,11 +128,15 @@ public class HttpHeaderPrincipalProvider extends AbstractPrincipalProvider {
 
         for (final String name : names) {
             LOGGER.debug("Adding HTTP header-provided principal: {}", name.trim());
-            principals.add(new HttpHeaderPrincipal(name.trim()));
+            principals.add(createPrincipal(name));
         }
 
         return principals;
 
+    }
+
+    protected Principal createPrincipal(final String name) {
+        return new HttpHeaderPrincipal(name.trim());
     }
 
 }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroSecurityContext.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroSecurityContext.java
@@ -40,13 +40,17 @@ public class ShiroSecurityContext implements SecurityContext {
      * @param user subject to create the security context for
      */
     public ShiroSecurityContext(final Subject user) {
-        this.user = user;
-        final PrincipalCollection principals = user.getPrincipals();
-        final BasicUserPrincipal userPrincipal = principals.oneByType(BasicUserPrincipal.class);
-        if (userPrincipal != null) {
-            this.userName = userPrincipal.getName();
-        } else {
-            this.userName = null;
+        if (user != null) {
+            this.user = user;
+            final PrincipalCollection principals = user.getPrincipals();
+            if (principals != null) {
+                final BasicUserPrincipal userPrincipal = principals.oneByType(BasicUserPrincipal.class);
+                if (userPrincipal != null) {
+                    this.userName = userPrincipal.getName();
+                } else {
+                    this.userName = null;
+                }
+            }
         }
     }
 

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -234,11 +234,9 @@ public class WebACRecipesIT extends AbstractResourceIT {
         final String idDark = "/rest/dark/archive";
         final String idLight = "/rest/dark/archive/sunshine";
         final String testObj = ingestObj(idDark);
-        final String testObj2 = ingestObj(idLight);
+        final String testObj2 = ingestObjWithACL(idLight, "/acls/03/acl.ttl");
         final String aclDark =
                 ingestAcl("fedoraAdmin", "/acls/03/acl.ttl", testObj + "/fcr:acl");
-        final String aclLight =
-            ingestAcl("fedoraAdmin", "/acls/03/acl.ttl", testObj2 + "/fcr:acl");
 
         logger.debug("Anonymous can't read " + testObj);
         final HttpGet requestGet = getObjMethod(idDark);
@@ -264,8 +262,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     @Test
     public void scenario4() throws IOException {
         final String id = "/rest/public_collection";
-        final String testObj = ingestObj(id);
-        final String acl4 = ingestAcl("fedoraAdmin", "/acls/04/acl.ttl", testObj + "/fcr:acl");
+        final String testObj = ingestObjWithACL(id, "/acls/04/acl.ttl");
 
         logger.debug("Anonymous can read " + testObj);
         final HttpGet requestGet = getObjMethod(id);
@@ -343,12 +340,10 @@ public class WebACRecipesIT extends AbstractResourceIT {
     public void scenario5() throws IOException {
         final String idPublic = "/rest/mixedCollection/publicObj";
         final String idPrivate = "/rest/mixedCollection/privateObj";
-        final String testObj = ingestObj("/rest/mixedCollection");
+        final String testObj = ingestObjWithACL("/rest/mixedCollection", "/acls/05/acl.ttl");
         final String publicObj = ingestObj(idPublic);
         final String privateObj = ingestObj(idPrivate);
         final HttpPatch patch = patchObjMethod(idPublic);
-        final String acl5TestObj =
-                ingestAcl("fedoraAdmin", "/acls/05/acl.ttl", testObj + "/fcr:acl");
 
         setAuth(patch, "fedoraAdmin");
         patch.setHeader("Content-type", "application/sparql-update");
@@ -618,13 +613,12 @@ public class WebACRecipesIT extends AbstractResourceIT {
     @Test
     public void scenario21TestACLNotForInheritance() throws IOException {
         final String parentPath = "/rest/resource_acl_no_inheritance";
-        final String parentObj = ingestObj(parentPath);
+        // Ingest ACL with no acl:default statement to the parent resource
+        final String parentObj = ingestObjWithACL(parentPath, "/acls/21/acl.ttl");
 
         final String id = parentPath + "/" + getRandomUniqueId();
         final String testObj = ingestObj(id);
 
-        // Ingest ACL with no acl:default statement to the parent resource
-        ingestAcl("fedoraAdmin", "/acls/21/acl.ttl", parentObj + "/fcr:acl");
 
         // Test the parent ACL with no acl:default is applied for the parent resource authorization.
         final HttpGet requestGet1 = getObjMethod(parentPath);

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -198,7 +198,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void scenario2() throws IOException {
         final String id = "/rest/box/bag/collection";
         final String testObj = ingestObj(id);
@@ -231,16 +230,15 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void scenario3() throws IOException {
         final String idDark = "/rest/dark/archive";
         final String idLight = "/rest/dark/archive/sunshine";
         final String testObj = ingestObj(idDark);
         final String testObj2 = ingestObj(idLight);
         final String aclDark =
-                ingestAcl("fedoraAdmin", "/acls/03/acl.ttl", idDark + "/fcr:acl");
+                ingestAcl("fedoraAdmin", "/acls/03/acl.ttl", testObj + "/fcr:acl");
         final String aclLight =
-            ingestAcl("fedoraAdmin", "/acls/03/acl.ttl", idLight + "/fcr:acl");
+            ingestAcl("fedoraAdmin", "/acls/03/acl.ttl", testObj2 + "/fcr:acl");
 
         logger.debug("Anonymous can't read " + testObj);
         final HttpGet requestGet = getObjMethod(idDark);
@@ -264,11 +262,10 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void scenario4() throws IOException {
         final String id = "/rest/public_collection";
         final String testObj = ingestObj(id);
-        final String acl4 = ingestAcl("fedoraAdmin", "/acls/04/acl.ttl", id + "/fcr:acl");
+        final String acl4 = ingestAcl("fedoraAdmin", "/acls/04/acl.ttl", testObj + "/fcr:acl");
 
         logger.debug("Anonymous can read " + testObj);
         final HttpGet requestGet = getObjMethod(id);
@@ -343,24 +340,21 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void scenario5() throws IOException {
         final String idPublic = "/rest/mixedCollection/publicObj";
         final String idPrivate = "/rest/mixedCollection/privateObj";
         final String testObj = ingestObj("/rest/mixedCollection");
         final String publicObj = ingestObj(idPublic);
+        final String privateObj = ingestObj(idPrivate);
         final HttpPatch patch = patchObjMethod(idPublic);
-        final String acl5Public =
-                ingestAcl("fedoraAdmin", "/acls/05/acl.ttl", idPublic + "/fcr:acl");
-        final String acl5Private =
-            ingestAcl("fedoraAdmin", "/acls/05/acl.ttl", idPrivate + "/fcr:acl");
+        final String acl5TestObj =
+                ingestAcl("fedoraAdmin", "/acls/05/acl.ttl", testObj + "/fcr:acl");
 
         setAuth(patch, "fedoraAdmin");
         patch.setHeader("Content-type", "application/sparql-update");
         patch.setEntity(new StringEntity("INSERT { <> a <http://example.com/terms#publicImage> . } WHERE {}"));
         assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(patch));
 
-        final String privateObj = ingestObj(idPrivate);
 
         logger.debug("Anonymous can see eg:publicImage " + publicObj);
         final HttpGet requestGet = getObjMethod(idPublic);
@@ -755,7 +749,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("needs principal providers config: https://jira.duraspace.org/browse/FCREPO-2778")
     public void testDelegatedUserAccess() throws IOException {
         logger.debug("testing delegated authentication");
         final String targetPath = "/rest/foo";

--- a/fcrepo-auth-webac/src/test/resources/acls/04/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/04/acl.ttl
@@ -9,4 +9,5 @@
 <#auth2> a acl:Authorization ;
   acl:agent "Editors" ;
   acl:mode acl:Read, acl:Write ;
+  acl:default </rest/public_collection> ;
   acl:accessTo </rest/public_collection> .

--- a/fcrepo-auth-webac/src/test/resources/acls/05/acl.ttl
+++ b/fcrepo-auth-webac/src/test/resources/acls/05/acl.ttl
@@ -5,9 +5,11 @@
 <#open> a acl:Authorization ;
    acl:agentClass foaf:Agent ;
    acl:mode acl:Read ;
+   acl:default </rest/mixedCollection> ;
    acl:accessToClass eg:publicImage .
 
 <#restricted> a acl:Authorization ;
    acl:agent 'Admins' ;
    acl:mode acl:Read ;
+   acl:default </rest/mixedCollection> ;
    acl:accessTo </rest/mixedCollection> .

--- a/fcrepo-auth-webac/src/test/resources/spring-test/security.xml
+++ b/fcrepo-auth-webac/src/test/resources/spring-test/security.xml
@@ -7,6 +7,13 @@
  
   <context:property-placeholder/>
     <!-- Shiro config -->
+
+   <bean name="headerProvider" class="org.fcrepo.auth.common.HttpHeaderPrincipalProvider">
+      <property name="headerName" value="some-header"/>
+      <property name="separator" value=","/>
+  </bean>
+
+  <bean name="delegatedPrincipalProvider" class="org.fcrepo.auth.common.DelegateHeaderPrincipalProvider"/>
   
   <bean id="testAuthFilter" class="org.fcrepo.http.commons.test.util.TestAuthenticationRequestFilter"/>
   <bean id="webACFilter" class="org.fcrepo.auth.webac.WebACFilter"/>
@@ -16,7 +23,7 @@
     <property name="securityManager" ref="securityManager"/>
     <property name="filterChainDefinitions">
       <value>
-        /** = testAuthFilter, servletAuthFilter, webACFilter
+        /** = testAuthFilter, servletAuthFilter, delegatedPrincipalProvider, headerProvider, webACFilter
       </value>
     </property>
   </bean>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2778

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
- Refactor to make PrincipalProviders work with Shiro Authorization.
- Refactor WebACFilter to allow authorization checks for unauthenticated requests.
- Configure PrincipalProviders in fcrepo-auth-webac test spring configuration.
- Reenable ignored tests and refactor for `acl:default` changes

# What's new?
## PrincipalProvider Refactor
Shiro does provide a direct way to add/update the current user principals. The refactor utilizes the runAs principal Shiro functionality to add the header provided principals to the BasicUserPrincipal obtained for the servlet authentication.

The WebACAuthorizingRealm is refactored to inspect all available principals instead of just the BasicUserPrincipal.

## Authorization checks for unauthenticated requests
When the WebACFilter requests authorization checks for unauthenticated requests Shiro denies authorization without actually consulting the WebACAuthorizingRealm when there are no principals associated with the current subject. A static foaf agent Subject (with a dummy everyone principal) is added to WebACFilter to do authentication checks for unauthenticated requests.

The WebACAuthorizingRealm is refactored to add `WEBAC_AUTHENTICATED_AGENT_VALUE` roles to all authenticated requests and `FOAF_AGENT_VALUE` roles to all requests inconsiderate of their authentication status.

# How should this be tested?
Verify that all the fcrepo-auth-webac tests pass.

# Interested parties
@fcrepo4/committers
