### PR TITLE
Fcrepo-2876 - Changed from sha256 to sha-256 when returning digests

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -1119,8 +1119,8 @@ public class FedoraLdpTest {
         try (final InputStream content = toInputStream("x", UTF_8)) {
             final MediaType requestContentType = MediaType.valueOf("some/mime-type; with=some; param=s");
             final String sha = "73cb3858a687a8494ca3323053016282f3dad39d42cf62ca4e79dda2aac7d9ac";
-            final String requestSHA = "sha256=" + sha;
-            final Set<URI> shaURI = singleton(URI.create("urn:sha256:" + sha));
+            final String requestSHA = "sha-256=" + sha;
+            final Set<URI> shaURI = singleton(URI.create("urn:sha-256:" + sha));
             final Response actual = testObj.createObject(null, requestContentType, "b", content, nonRDFSourceLink,
                 requestSHA);
             assertEquals(CREATED.getStatusCode(), actual.getStatus());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -207,6 +207,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final String TEST_MD5_DIGEST_HEADER_VALUE = "md5=baed005300234f3d1503c50a48ce8e6f";
 
+    private static final String TEST_SHA256_DIGEST_HEADER_VALUE =
+            "sha-256=fb871ff8cce8fea83dfaeab41784305a1461e008dc02a371ed26d856c766c903";
+
     private static final Logger LOGGER = getLogger(FedoraLdpIT.class);
 
     private static DateTimeFormatter headerFormat =
@@ -428,7 +431,23 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Test
+    public void testHeadDatastreamWithWantDigestSha256() throws IOException, ParseException {
+        final String id = getRandomUniqueId();
+        createDatastream(id, "x", TEST_BINARY_CONTENT);
 
+        final HttpHead headObjMethod = headObjMethod(id + "/x");
+        headObjMethod.addHeader(WANT_DIGEST, "sha-256");
+        try (final CloseableHttpResponse response = execute(headObjMethod)) {
+            assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
+            assertEquals(TEXT_PLAIN, response.getFirstHeader(CONTENT_TYPE).getValue());
+            assertTrue(response.getHeaders(DIGEST).length > 0);
+
+            final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
+            assertTrue("SHA-256 Fixity Checksum doesn't match",
+                    digesterHeaderValue.indexOf(TEST_SHA256_DIGEST_HEADER_VALUE) >= 0);
+        }
+    }
 
     @Test
     public void testHeadRdfResourceHeaders() throws IOException {
@@ -692,7 +711,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
             assertTrue("SHA-256 fixity checksum doesn't match",
                 digesterHeaderValue
-                    .indexOf("sha256=fb871ff8cce8fea83dfaeab41784305a1461e008dc02a371ed26d856c766c903") >= 0);
+                            .indexOf(
+                                    "sha-256=fb871ff8cce8fea83dfaeab41784305a1461e008dc02a371ed26d856c766c903") >= 0);
         }
     }
 
@@ -1687,7 +1707,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final File img = new File("src/test/resources/test-objects/img.png");
         method.addHeader(CONTENT_TYPE, "application/octet-stream");
         method.addHeader("Digest", "md5=6668675a91f39ca1afe46c084e8406ba," +
-                " sha256=7b115a72978fe138287c1a6dfe6cc1afce4720fb3610a81d32e4ad518700c923");
+                " sha-256=7b115a72978fe138287c1a6dfe6cc1afce4720fb3610a81d32e4ad518700c923");
         method.setEntity(new FileEntity(img));
         method.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
@@ -39,7 +39,7 @@ public final class ContentDigest {
     private static final Logger LOGGER = getLogger(ContentDigest.class);
 
     public enum DIGEST_ALGORITHM {
-        SHA1("SHA", "urn:sha1"), SHA256("SHA-256", "urn:sha256"), MD5("MD5", "urn:md5"), MISSING("NONE", "missing");
+        SHA1("SHA", "urn:sha1"), SHA256("SHA-256", "urn:sha-256"), MD5("MD5", "urn:md5"), MISSING("NONE", "missing");
 
         final public String algorithm;
         final private String scheme;

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
@@ -53,7 +53,7 @@ public class ContentDigestTest {
     @Test
     public void testSHA256() {
         assertEquals("Failed to produce a proper content digest URI!",
-                create("urn:sha256:fake"), asURI("SHA-256", "fake"));
+                create("urn:sha-256:fake"), asURI("SHA-256", "fake"));
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2876

# What does this Pull Request do?
Returning `sha-256` in Digest responses instead of sha256

# What's new?
Updates name of content digest and updates tests accordingly

# How should this be tested?
```
echo -n "01234567890123456789012345678901234567890123456789" | curl -ufedoraAdmin:fedoraAdmin -XPUT --data "@-" http://localhost:8080/rest/sha256_test

curl -I -ufedoraAdmin:fedoraAdmin -H"Want-Digest: sha-256" http://localhost:8080/rest/sha256_test
# Digest: sha-256=fb871ff8cce8fea83dfaeab41784305a1461e008dc02a371ed26d856c766c903
```

# Interested parties
@dbernstein 
