### PR TITLE
Configured maven filter exclusions for binary files.

### DIFF
--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -292,6 +292,11 @@
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
           <attachClasses>true</attachClasses>
+          <nonFilteredFileExtensions>
+            <nonFilteredFileExtension>ico</nonFilteredFileExtension>
+            <nonFilteredFileExtension>ttf</nonFilteredFileExtension>
+            <nonFilteredFileExtension>woff</nonFilteredFileExtension>
+          </nonFilteredFileExtensions>
           <webResources>
             <resource>
               <directory>src/main/webapp</directory>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2695

# What does this Pull Request do?
Adds a list of binary file extensions to be excluded from maven-war-plugin filtering to prevent corruption.

Maven filtering (resources plugin / war plugin) corrupts binary files. Some of the common image extensions are excluded by default and we can configure a list of file extensions to be excluded.

- https://stackoverflow.com/questions/32690418/i-cant-load-fonts-while-using-tomcat
- https://maven.apache.org/plugins/maven-resources-plugin/examples/binaries-filtering.html
- https://maven.apache.org/plugins/maven-war-plugin/examples/adding-filtering-webresources.html


# How should this be tested?
1. Checkout the PR changes and build
2. Run the fcrepo-webapp in tomcat
  - Switch to fcrepo-webapp directory
  - Create a Dockerfile with following content
     ```
     FROM tomcat:8-jre8
     COPY target/fcrepo-webapp-5.0.0-SNAPSHOT /usr/local/tomcat/webapps/fcrepo
     COPY src/main/jetty-console/WEB-INF/web.xml /usr/local/tomcat/webapps/fcrepo/WEB-INF/
     ENV fcrepo.modeshape.configuration="file:/usr/local/tomcat/webapps/fcrepo/WEB-INF/classes/config/file-simple/repository.json"

     ```
  - Run the docker commands to bring up the container
    ```
    docker build -t fcrepo . && docker run -it --rm -p 8080:8080 --name=fcrepo fcrepo
    ```
3. Webapp should be accessible at: http://localhost:8080/fcrepo/rest
4. Upload a binary file and verify that the download icon appears correctly.

# Interested parties
@fcrepo4/committers
