### PR TITLE
Enable versioning, creation of Mementos and view Mementos in HTML UI

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -86,6 +86,7 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RequiredRdfContext.MINIMAL;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -98,7 +99,6 @@ import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -481,7 +481,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (resource.isMemento()) {
             final Instant mementoInstant = resource.getMementoDatetime();
             if (mementoInstant != null) {
-                final String mementoDatetime = DateTimeFormatter.RFC_1123_DATE_TIME
+                final String mementoDatetime = MEMENTO_RFC_1123_FORMATTER
                         .format(mementoInstant.atZone(ZoneOffset.UTC));
                 servletResponse.addHeader(MEMENTO_DATETIME_HEADER, mementoDatetime);
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -64,6 +64,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.FedoraExternalContent.COPY;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -72,7 +73,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -322,7 +322,7 @@ public class FedoraLdp extends ContentExposingResource {
      */
     private Response getMemento(final String datetimeHeader, final FedoraResource resource) {
         try {
-            final Instant mementoDatetime = Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(datetimeHeader));
+            final Instant mementoDatetime = Instant.from(MEMENTO_RFC_1123_FORMATTER.parse(datetimeHeader));
             final FedoraResource memento = resource.findMementoByDatetime(mementoDatetime);
             final Response builder;
             if (memento != null) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -72,6 +72,7 @@ import org.fcrepo.http.commons.session.HttpSession;
 import org.fcrepo.http.commons.session.SessionFactory;
 import org.fcrepo.kernel.api.RdfLexicon;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.glassfish.jersey.uri.UriTemplate;
 import org.slf4j.Logger;
@@ -92,29 +93,18 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
     UriInfo uriInfo;
 
     @javax.ws.rs.core.Context
-    private SessionFactory sessionFactory;
+    SessionFactory sessionFactory;
 
     @javax.ws.rs.core.Context
-    private HttpServletRequest request;
-
-    private HttpSession session;
+    HttpServletRequest request;
 
     private HttpSession session() {
-        if (session == null) {
-            session = sessionFactory.getSession(request);
-        }
-        return session;
+        return sessionFactory.getSession(request);
     }
 
-    protected IdentifierConverter<Resource, FedoraResource> idTranslator;
-
-    protected IdentifierConverter<Resource, FedoraResource> translator() {
-        if (idTranslator == null) {
-            idTranslator = new HttpResourceConverter(session(),
+    private IdentifierConverter<Resource, FedoraResource> translator() {
+        return new HttpResourceConverter(session(),
                 uriInfo.getBaseUriBuilder().clone().path(FedoraLdp.class));
-        }
-
-        return idTranslator;
     }
 
     private static EscapeTool escapeTool = new EscapeTool();
@@ -202,6 +192,8 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
         final FedoraResource resource = getResourceFromSubject(subject.toString());
         context.put("isVersionable", (resource != null ? resource.isVersioned() : false));
         context.put("isVersion", (resource != null ? resource.isMemento() : false));
+        context.put("isLDPNR", (resource != null
+            ? resource instanceof FedoraBinary || !resource.getDescribedResource().equals(resource) : false));
 
         // the contract of MessageBodyWriter<T> is _not_ to close the stream
         // after writing to it

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -3,32 +3,32 @@
 #set ($isRoot = $helpers.isRootResource($rdf, $topic))
 
 #if ($isVersion == true)
-<div class="alert alert-warning">
+  <div class="alert alert-warning">
     <span class="glyphicon glyphicon-warning-sign"></span>
     This is a <strong>historic version</strong> and cannot be modified.
-</div>
-<form id="action_remove_version" method="DELETE" action="$uriInfo.getAbsolutePath().toString()" data-redirect-after-submit="$helpers.getVersionSubjectUrl($uriInfo, $topic)/fcr:versions" >
+  </div>
+  <form id="action_remove_version" method="DELETE" action="$uriInfo.getAbsolutePath().toString()" data-redirect-after-submit="$helpers.getVersionSubjectUrl($uriInfo, $topic)/fcr:versions" >
     <button type="submit" class="btn btn-danger standalone">Delete this Version</button>
-</form>
+  </form>
 #else
-#if ($helpers.isRdfResource($rdf, $content, "http://fedora.info/definitions/v4/repository#", "Binary"))
+  #if ($helpers.isRdfResource($rdf, $content, "http://fedora.info/definitions/v4/repository#", "Binary"))
     <a href="$content" class="btn btn-success btn-lg"><span class="glyphicon glyphicon-download"></span> Download Content</a><br/><br/>
 	<a href="$content/fcr:fixity" class="btn btn-success btn-lg">Fixity</a>
     #if ($writable == true)
-    <h3>Update Content</h3>
-    <form id="action_update_file">
-      <div class="form-group">
-        <label for="update_file" class="control-label">File</label>
-        <input type="file" id="update_file"/>
-      </div>
-      <input type="submit" id="binary_update_content" class="btn btn-primary" value="Update">
-    </form>
+      <h3>Update Content</h3>
+      <form id="action_update_file">
+        <div class="form-group">
+          <label for="update_file" class="control-label">File</label>
+          <input type="file" id="update_file"/>
+        </div>
+        <input type="submit" id="binary_update_content" class="btn btn-primary" value="Update">
+      </form>
     #end
     <hr />
-#end
+  #end
 
-#if ($writable == true)
-<form id="action_create" name="action_create" method="POST" enctype="multipart/form-data">
+  #if ($writable == true)
+  <form id="action_create" name="action_create" method="POST" enctype="multipart/form-data">
     <h3>Create New Child Resource</h3>
     <div class="form-group">
     <label for="new_mixin" class="control-label">
@@ -65,10 +65,10 @@
     
     <button id="btn_action_create" class="btn btn-primary">Add</button>
     <hr />
-</form>
+  </form>
 
 
-<form id="action_sparql_update" method="POST">
+  <form id="action_sparql_update" method="POST">
     <input type="hidden" name="_method" value="PATCH" />
     <h3>Update Properties</h3>
     <div class="form-group">
@@ -81,34 +81,34 @@ WHERE { }
     </div>
     <button type="submit" class="btn btn-primary">Update</button>
     <hr />
-</form>
+  </form>
 
-#if ( !$isRoot )
+  #if ( !$isRoot )
 	#if ( $isLDPNR )
-	<h3>Versioning</h3>
-	<p>Versioning of binary resources is not currently available through the HTML UI.</p>
-	<hr />
+	  <h3>Versioning</h3>
+	  <p>Versioning of binary resources is not currently available through the HTML UI.</p>
+	  <hr />
 	#elseif ($isVersionable == true)
-<form id="action_create_version" name="action_create_version" method="POST">
-    <h3>Create Version Snapshot</h3>
-    <button id="create-version-button" type="submit" class="btn btn-primary">Create Version</button>
-    <h4><a href="$topic/fcr:versions">View Mementos</a></h4>
-    <hr />
-</form>
+      <form id="action_create_version" name="action_create_version" method="POST">
+        <h3>Create Version Snapshot</h3>
+        <button id="create-version-button" type="submit" class="btn btn-primary">Create Version</button>
+        <h4><a href="$topic/fcr:versions">View Mementos</a></h4>
+        <hr />
+      </form>
 	#else
-<form id="action_enable_version" name="action_enable_version" method="POST">
-    <h3>Versioning</h3>
-    <button id="enable-version-button" type="submit" class="btn btn-primary">Enable Versioning</button>
-    <hr />
-</form>
-#end
+      <form id="action_enable_version" name="action_enable_version" method="POST">
+        <h3>Versioning</h3>
+        <button id="enable-version-button" type="submit" class="btn btn-primary">Enable Versioning</button>
+        <hr />
+      </form>
+    #end
 
-<form id="action_delete" name="action_delete">
-    <h3>Delete Resource</h3>
-    <button name="delete-button" type="submit" class="btn btn-danger">Delete</button>
-    <hr />
-</form>
-	#end
+    <form id="action_delete" name="action_delete">
+      <h3>Delete Resource</h3>
+      <button name="delete-button" type="submit" class="btn btn-danger">Delete</button>
+      <hr />
+    </form>
+  #end
 #end
 
 #end

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -85,10 +85,13 @@ WHERE { }
 #if ($isVersionable == true)
 <form id="action_create_version" name="action_create_version" method="POST">
     <h3>Create Version Snapshot</h3>
-    <div class="form-group">
-    <input type="text" id="version_id" placeholder="(auto-generated name)" name="version_name" class="form-control"/>
-    </div>
     <button id="create-version-button" type="submit" class="btn btn-primary">Create Version</button>
+    <hr />
+</form>
+#else
+<form id="action_enable_version" name="action_enable_version" method="POST">
+    <h3>Versioning</h3>
+    <button id="create-version-button" type="submit" class="btn btn-primary">Enable Versioning</button>
     <hr />
 </form>
 #end

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -1,15 +1,11 @@
 #set ($content = $helpers.getContentNode($topic))
 #set ($writable = $helpers.isWritable($rdf, $topic))
-#set ($frozen = $helpers.isVersionedNode($rdf, $topic))
 
-#if ($frozen == true)
+#if ($isVersion == true)
 <div class="alert alert-warning">
     <span class="glyphicon glyphicon-warning-sign"></span>
     This is a <strong>historic version</strong> and cannot be modified.
 </div>
-<form id="action_revert" method="PATCH" action="$uriInfo.getAbsolutePath().toString()" data-redirect-after-submit="$helpers.getVersionSubjectUrl($uriInfo, $topic)/fcr:versions" >
-    <button type="submit" class="btn btn-primary standalone">Revert to this Version</button>
-</form>
 <form id="action_remove_version" method="DELETE" action="$uriInfo.getAbsolutePath().toString()" data-redirect-after-submit="$helpers.getVersionSubjectUrl($uriInfo, $topic)/fcr:versions" >
     <button type="submit" class="btn btn-danger standalone">Delete this Version</button>
 </form>
@@ -86,6 +82,7 @@ WHERE { }
     <hr />
 </form>
 
+#if ($isVersionable == true)
 <form id="action_create_version" name="action_create_version" method="POST">
     <h3>Create Version Snapshot</h3>
     <div class="form-group">
@@ -94,6 +91,7 @@ WHERE { }
     <button id="create-version-button" type="submit" class="btn btn-primary">Create Version</button>
     <hr />
 </form>
+#end
 
 <form id="action_delete" name="action_delete">
     <h3>Delete Resource</h3>

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -86,6 +86,7 @@ WHERE { }
 <form id="action_create_version" name="action_create_version" method="POST">
     <h3>Create Version Snapshot</h3>
     <button id="create-version-button" type="submit" class="btn btn-primary">Create Version</button>
+    <h4><a href="$topic/fcr:versions">View Mementos</a></h4>
     <hr />
 </form>
 #else

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -1,5 +1,6 @@
 #set ($content = $helpers.getContentNode($topic))
 #set ($writable = $helpers.isWritable($rdf, $topic))
+#set ($isRoot = $helpers.isRootResource($rdf, $topic))
 
 #if ($isVersion == true)
 <div class="alert alert-warning">
@@ -82,17 +83,22 @@ WHERE { }
     <hr />
 </form>
 
-#if ($isVersionable == true)
+#if ( !$isRoot )
+	#if ( $isLDPNR )
+	<h3>Versioning</h3>
+	<p>Versioning of binary resources is not currently available through the HTML UI.</p>
+	<hr />
+	#elseif ($isVersionable == true)
 <form id="action_create_version" name="action_create_version" method="POST">
     <h3>Create Version Snapshot</h3>
     <button id="create-version-button" type="submit" class="btn btn-primary">Create Version</button>
     <h4><a href="$topic/fcr:versions">View Mementos</a></h4>
     <hr />
 </form>
-#else
+	#else
 <form id="action_enable_version" name="action_enable_version" method="POST">
     <h3>Versioning</h3>
-    <button id="create-version-button" type="submit" class="btn btn-primary">Enable Versioning</button>
+    <button id="enable-version-button" type="submit" class="btn btn-primary">Enable Versioning</button>
     <hr />
 </form>
 #end
@@ -102,6 +108,7 @@ WHERE { }
     <button name="delete-button" type="submit" class="btn btn-danger">Delete</button>
     <hr />
 </form>
+	#end
 #end
 
 #end

--- a/fcrepo-http-api/src/main/resources/views/fcr-versions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/fcr-versions.vsl
@@ -21,7 +21,7 @@
         <div class="panel-group" id="accordion">
             #foreach($subject in $helpers.getVersions($rdf, $topic))
                 <div class="panel panel-default" resource="$subject.getURI()">
-                    #set($label = $helpers.getVersionLabel($rdf, $subject).orElse("Unlabeled Version"))
+                    #set($label = $helpers.getVersionLabel($rdf, $subject))
                     <div class="panel-heading collapsed" data-toggle="collapse" data-target="#$helpers.parameterize($subject.getURI())_triples" >
                         <div class="ctitle panel-title"><a href="$subject.getURI()" class="version_link">$esc.html($label)</a></div>
                     </div>

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProviderTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProviderTest.java
@@ -51,6 +51,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.http.commons.responses.HtmlTemplate;
@@ -64,7 +65,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
@@ -94,6 +94,9 @@ public class StreamingBaseHtmlProviderTest {
     @Mock
     private NamespaceRegistry mockNamespaceRegistry;
 
+    @Mock
+    private UriInfo mockUriInfo;
+
     @Before
     public void setup() throws RepositoryException {
         when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
@@ -112,11 +115,13 @@ public class StreamingBaseHtmlProviderTest {
         testData = new RdfNamespacedStream(stream, getNamespaces(mockSession));
 
         testData2 = new RdfNamespacedStream(stream2, getNamespaces(mockSession));
-        final UriInfo info = Mockito.mock(UriInfo.class);
-        final URI baseUri = URI.create("http://localhost:8080/rest/");
-        when(info.getBaseUri()).thenReturn(baseUri);
 
-        setField(testProvider, "uriInfo", info);
+        final URI baseUri = URI.create("http://localhost:8080/rest/");
+        final UriBuilder baseUriBuilder = UriBuilder.fromUri(baseUri);
+        when(mockUriInfo.getBaseUri()).thenReturn(baseUri);
+        when(mockUriInfo.getBaseUriBuilder()).thenReturn(baseUriBuilder);
+
+        setField(testProvider, "uriInfo", mockUriInfo);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -18,7 +18,6 @@
 package org.fcrepo.integration.http.api;
 
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Arrays.sort;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
@@ -64,6 +63,8 @@ import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.SERVER_MANAGED_PROPERTIES_MODE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEMAP_TYPE;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -77,9 +78,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
@@ -129,9 +128,6 @@ import org.junit.rules.TemporaryFolder;
  */
 public class FedoraVersioningIT extends AbstractResourceIT {
 
-    public static final DateTimeFormatter MEMENTO_DATETIME_ID_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.of("GMT"));
-
     private static final String VERSIONED_RESOURCE_LINK_HEADER = "<" + VERSIONED_RESOURCE.getURI() + ">; rel=\"type\"";
     private static final String BINARY_CONTENT = "binary content";
     private static final String BINARY_UPDATED = "updated content";
@@ -144,7 +140,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     private static final Property TEST_PROPERTY = createProperty("info:test#label");
 
     private final String MEMENTO_DATETIME =
-            RFC_1123_DATE_TIME.format(LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC));
+        MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC));
     private final List<String> rdfTypes = new ArrayList<>(Arrays.asList(POSSIBLE_RDF_RESPONSE_VARIANTS_STRING));
 
     private String subjectUri;
@@ -190,11 +186,11 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testGetTimeMapResponseMultipleMementos() throws Exception {
         createVersionedContainer(id);
         final String memento1 =
-            RFC_1123_DATE_TIME.format(LocalDateTime.of(2000, 1, 1, 00, 00, 00).atOffset(ZoneOffset.UTC));
+            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 00, 00, 00).atOffset(ZoneOffset.UTC));
         final String memento2 =
-            RFC_1123_DATE_TIME.format(LocalDateTime.of(2015, 8, 13, 18, 30, 0).atOffset(ZoneOffset.UTC));
+            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2015, 8, 13, 18, 30, 0).atOffset(ZoneOffset.UTC));
         final String memento3 =
-            RFC_1123_DATE_TIME.format(LocalDateTime.of(1980, 5, 31, 9, 15, 30).atOffset(ZoneOffset.UTC));
+            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(1980, 5, 31, 9, 15, 30).atOffset(ZoneOffset.UTC));
         createContainerMementoWithBody(subjectUri, memento1);
         createContainerMementoWithBody(subjectUri, memento2);
         createContainerMementoWithBody(subjectUri, memento3);
@@ -249,10 +245,10 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             createVersionedContainer(id);
 
             // this results in a time which has .86 in the ms area. This is key for this test.
-            final String createdDate = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(
+            final String createdDate = MEMENTO_RFC_1123_FORMATTER.format(
                     LocalDateTime.of(2018, 9, 21, 5, 30, 01, 860000000).atZone(ZoneOffset.UTC));
 
-            final String lastModified = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(
+            final String lastModified = MEMENTO_RFC_1123_FORMATTER.format(
                     LocalDateTime.of(2018, 9, 21, 5, 30, 03, 500000000).atZone(ZoneOffset.UTC));
 
             // patch the resource with timestamps that trigger millisecond truncation in modeshape 5.0
@@ -559,11 +555,10 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     @Test
     public void testHeadOnMemento() throws Exception {
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
         createVersionedContainer(id);
         final String mementoDateTime =
-            FMT.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: HEAD request on existing memento
@@ -582,11 +577,10 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     @Test
     public void testGetOnMemento() throws Exception {
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
         createVersionedContainer(id);
         final String mementoDateTime =
-            FMT.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: GET request on existing memento
@@ -605,11 +599,10 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     @Test
     public void testOptionsOnMemento() throws Exception {
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
         createVersionedContainer(id);
         final String mementoDateTime =
-            FMT.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: OPTIONS request on existing memento
@@ -819,8 +812,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         listLinks.add(selfLink.build());
         if (mementoDateTime != null) {
             for (final String memento : mementoDateTime) {
-                final TemporalAccessor instant = RFC_1123_DATE_TIME.parse(memento);
-                listLinks.add(Link.fromUri(ldpcvUri + "/" + MEMENTO_DATETIME_ID_FORMATTER.format(instant))
+                final TemporalAccessor instant = MEMENTO_RFC_1123_FORMATTER.parse(memento);
+                listLinks.add(Link.fromUri(ldpcvUri + "/" + MEMENTO_LABEL_FORMATTER.format(instant))
                               .rel("memento")
                     .param("datetime", memento)
                               .build());
@@ -1221,19 +1214,18 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testDatetimeNegotiationLDPRv() throws Exception {
         final CloseableHttpClient customClient = createClient(true);
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
         createVersionedContainer(id);
         final String memento1 =
-            FMT.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
         final String memento2 =
-            FMT.format(ISO_INSTANT.parse("2016-06-17T11:41:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2016-06-17T11:41:00Z", Instant::from));
         final String version2Uri = createLDPRSMementoWithExistingBody(memento2);
 
         // Request datetime between memento1 and memento2
         final String request1Datetime =
-            FMT.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
         final HttpGet getMemento = getObjMethod(id);
         getMemento.addHeader(ACCEPT_DATETIME, request1Datetime);
 
@@ -1246,7 +1238,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         // Request datetime more recent than both mementos
         final String request2Datetime =
-            FMT.format(ISO_INSTANT.parse("2018-01-10T00:00:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2018-01-10T00:00:00Z", Instant::from));
         final HttpGet getMemento2 = getObjMethod(id);
         getMemento2.addHeader(ACCEPT_DATETIME, request2Datetime);
 
@@ -1259,7 +1251,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         // Request datetime older than either mementos
         final String request3Datetime =
-                FMT.format(ISO_INSTANT.parse("2014-01-01T00:00:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2014-01-01T00:00:00Z", Instant::from));
         final HttpGet getMemento3 = getObjMethod(id);
         getMemento3.addHeader(ACCEPT_DATETIME, request3Datetime);
 
@@ -1274,21 +1266,21 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testDatetimeNegotiationExactMatch() throws Exception {
         final CloseableHttpClient customClient = createClient(true);
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
         final String originalUri = createVersionedContainer(id);
 
         // Create a current memento
         final String version1Uri = createMemento(originalUri, null, "text/turtle", null);
         final HttpHead httpHead = new HttpHead(version1Uri);
-        String version1Datetime;
+        final String version1Datetime;
         try (final CloseableHttpResponse response = customClient.execute(httpHead)) {
             version1Datetime = response.getFirstHeader(MEMENTO_DATETIME_HEADER).getValue();
         }
 
         // Create a slightly older memento
-        final Instant version2Instant = Instant.from(FMT.parse(version1Datetime)).minus(5, ChronoUnit.SECONDS);
-        final String version2Datetime = FMT.format(version2Instant);
+        final Instant version2Instant =
+            Instant.from(MEMENTO_RFC_1123_FORMATTER.parse(version1Datetime)).minus(5, ChronoUnit.SECONDS);
+        final String version2Datetime = MEMENTO_RFC_1123_FORMATTER.format(version2Instant);
         final String version2Uri = createLDPRSMementoWithExistingBody(version2Datetime);
 
         // Attempt to retrieve older memento
@@ -1317,11 +1309,10 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testDatetimeNegotiationNoMementos() throws Exception {
         final CloseableHttpClient customClient = createClient(true);
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
         createVersionedContainer(id);
         final String requestDatetime =
-            FMT.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-01-12T00:00:00Z", Instant::from));
         final HttpGet getMemento = getObjMethod(id);
         getMemento.addHeader(ACCEPT_DATETIME, requestDatetime);
 
@@ -1336,9 +1327,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testGetWithDateTimeNegotiation() throws Exception {
         final CloseableHttpClient customClient = createClient(true);
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
         final String mementoDateTime =
-            FMT.format(ISO_INSTANT.parse("2017-08-29T15:47:50Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-08-29T15:47:50Z", Instant::from));
 
         createVersionedContainer(id);
 
@@ -1475,11 +1465,10 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     @Test
     public void testGetLDPRSMementoHeaders() throws Exception {
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
         createVersionedContainer(id);
 
         final String memento1 =
-            FMT.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
         final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
         final HttpGet getRequest = new HttpGet(version1Uri);
 
@@ -1499,11 +1488,10 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     @Test
     public void testGetLDPNRMementoHeaders() throws Exception {
-        final DateTimeFormatter FMT = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
         createVersionedBinary(id, "text/plain", "This is some versioned content");
 
         final String memento1 =
-            FMT.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
         final String version1Uri = createLDPNRMementoWithExistingBody(memento1);
         final HttpGet getRequest = new HttpGet(version1Uri);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -79,6 +79,7 @@ import java.io.StringWriter;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
@@ -239,16 +240,18 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testCreateVersionWithLastModifiedDateTimestamp() throws Exception {
         try {
+            final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
             // relaxing the server managed mode here so lastModifiedDate can be set
             System.setProperty(SERVER_MANAGED_PROPERTIES_MODE, "relaxed");
 
             createVersionedContainer(id);
 
             // this results in a time which has .86 in the ms area. This is key for this test.
-            final String createdDate = MEMENTO_RFC_1123_FORMATTER.format(
+            final String createdDate = FMT.format(
                     LocalDateTime.of(2018, 9, 21, 5, 30, 01, 860000000).atZone(ZoneOffset.UTC));
 
-            final String lastModified = MEMENTO_RFC_1123_FORMATTER.format(
+            final String lastModified = FMT.format(
                     LocalDateTime.of(2018, 9, 21, 5, 30, 03, 500000000).atZone(ZoneOffset.UTC));
 
             // patch the resource with timestamps that trigger millisecond truncation in modeshape 5.0

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ViewHelpers.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ViewHelpers.java
@@ -26,7 +26,6 @@ import static org.apache.jena.vocabulary.DC.title;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.apache.jena.vocabulary.RDFS.label;
 import static org.apache.jena.vocabulary.SKOS.prefLabel;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.time.Instant.now;
 import static java.time.ZoneId.of;
 import static java.util.Arrays.asList;
@@ -40,10 +39,11 @@ import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.WRITABLE;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -159,7 +159,7 @@ public class ViewHelpers {
      */
     public String getVersionLabel(final Graph graph, final Node subject) {
         final Instant datetime = getVersionDate(graph, subject);
-        return RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC")).format(datetime);
+        return MEMENTO_RFC_1123_FORMATTER.format(datetime);
     }
 
     /**
@@ -171,8 +171,7 @@ public class ViewHelpers {
      */
     public Instant getVersionDate(final Graph graph, final Node subject) {
         final String[] pathParts = subject.getURI().split("/");
-        final Instant datetime = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.of("UTC"))
-            .parse(pathParts[pathParts.length - 1], Instant::from);
+        final Instant datetime = MEMENTO_LABEL_FORMATTER.parse(pathParts[pathParts.length - 1], Instant::from);
         return datetime;
     }
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
@@ -32,7 +32,8 @@ import static org.fcrepo.http.commons.test.util.TestHelpers.getUriInfoImpl;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBES;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
+import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.WRITABLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -160,11 +161,20 @@ public class ViewHelpersTest {
     }
 
     @Test
+    @Ignore("This function is probably useless now.")
+    public void testIsVersionableNode() {
+        final Graph mem = createDefaultModel().getGraph();
+        mem.add(new Triple(createURI("a/b/c"), type.asNode(), createURI(VERSIONED_RESOURCE.toString())));
+        // assertTrue("Node is a versionable node.", testObj.isVersionableNode(mem, createURI("a/b/c")));
+    }
+
+    @Test
     public void testIsVersionedNode() {
         final Graph mem = createDefaultModel().getGraph();
-        mem.add(new Triple(createURI("a/b/c"), type.asNode(), createURI(REPOSITORY_NAMESPACE + "Version")));
+        mem.add(new Triple(createURI("a/b/c"), type.asNode(), createURI(MEMENTO_TYPE.toString())));
         assertTrue("Node is a versioned node.", testObj.isVersionedNode(mem, createURI("a/b/c")));
     }
+
 
     @Test
     public void testRdfResource() {

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
@@ -38,13 +38,12 @@ import static org.fcrepo.kernel.api.RdfLexicon.WRITABLE;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_REPOSITORY_ROOT;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static java.time.ZoneId.of;
-
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -74,12 +73,6 @@ public class ViewHelpersTest {
 
     private ViewHelpers testObj;
 
-    private final DateTimeFormatter RFC_1123_PATTERN =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(of("GMT"));
-
-    private final DateTimeFormatter DATE_PATTERN =
-        DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(of("GMT"));
-
     private static final String REPOSITORY_ROOT_URI =
         FEDORA_REPOSITORY_ROOT.replaceAll("fedora:", REPOSITORY_NAMESPACE);
 
@@ -93,9 +86,9 @@ public class ViewHelpersTest {
         final Graph mem = createDefaultModel().getGraph();
         final String resource_version = "http://localhost/fcrepo/abc/" + FCR_VERSIONS;
         final Instant recent = Instant.now();
-        final Node version = createURI(resource_version + "/" + DATE_PATTERN.format(recent));
+        final Node version = createURI(resource_version + "/" + MEMENTO_LABEL_FORMATTER.format(recent));
         mem.add(new Triple(createURI(resource_version), CONTAINS.asNode(), version));
-        mem.add(new Triple(version, CREATED_DATE.asNode(), createLiteral(RFC_1123_PATTERN.format(recent))));
+        mem.add(new Triple(version, CREATED_DATE.asNode(), createLiteral(MEMENTO_RFC_1123_FORMATTER.format(recent))));
         assertEquals("Version should be available.",
             version, testObj.getVersions(mem, createURI(resource_version)).next());
     }
@@ -106,17 +99,20 @@ public class ViewHelpersTest {
         final Instant recent = Instant.now();
         final Instant past = recent.minus(3, java.time.temporal.ChronoUnit.DAYS);
         final Instant way_past = recent.minus(60, java.time.temporal.ChronoUnit.DAYS);
-        final Node v1 = createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + DATE_PATTERN.format(recent));
-        final Node v2 = createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + DATE_PATTERN.format(past));
-        final Node v3 = createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + DATE_PATTERN.format(way_past));
+        final Node v1 =
+            createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + MEMENTO_LABEL_FORMATTER.format(recent));
+        final Node v2 =
+            createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + MEMENTO_LABEL_FORMATTER.format(past));
+        final Node v3 =
+            createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + MEMENTO_LABEL_FORMATTER.format(way_past));
 
         final Graph mem = createDefaultModel().getGraph();
         mem.add(new Triple(resource_version, CONTAINS.asNode(), v1));
         mem.add(new Triple(resource_version, CONTAINS.asNode(), v2));
         mem.add(new Triple(resource_version, CONTAINS.asNode(), v3));
-        mem.add(new Triple(v1, CREATED_DATE.asNode(), createLiteral(RFC_1123_PATTERN.format(recent))));
-        mem.add(new Triple(v2, CREATED_DATE.asNode(), createLiteral(RFC_1123_PATTERN.format(past))));
-        mem.add(new Triple(v3, CREATED_DATE.asNode(), createLiteral(RFC_1123_PATTERN.format(way_past))));
+        mem.add(new Triple(v1, CREATED_DATE.asNode(), createLiteral(MEMENTO_RFC_1123_FORMATTER.format(recent))));
+        mem.add(new Triple(v2, CREATED_DATE.asNode(), createLiteral(MEMENTO_RFC_1123_FORMATTER.format(past))));
+        mem.add(new Triple(v3, CREATED_DATE.asNode(), createLiteral(MEMENTO_RFC_1123_FORMATTER.format(way_past))));
 
         final Iterator<Node> versions = testObj.getOrderedVersions(mem, resource_version, CONTAINS);
         assertTrue(versions.hasNext());
@@ -212,9 +208,9 @@ public class ViewHelpersTest {
         final Graph mem = createDefaultModel().getGraph();
         final String date_str = "20011231050505";
         final Node subject = createURI("a/b/c/" + date_str);
-        final Instant date = Instant.from(DATE_PATTERN.parse(date_str));
+        final Instant date = Instant.from(MEMENTO_LABEL_FORMATTER.parse(date_str));
         mem.add(new Triple(subject, CREATED_DATE.asNode(),
-            createLiteral(RFC_1123_PATTERN.format(date))));
+            createLiteral(MEMENTO_RFC_1123_FORMATTER.format(date))));
 
         assertEquals("Date should be available.", date, testObj.getVersionDate(mem, subject));
     }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
@@ -33,14 +33,18 @@ import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBES;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
-import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.WRITABLE;
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_REPOSITORY_ROOT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static java.time.Instant.now;
+import static java.time.ZoneId.of;
 
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +54,6 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Triple;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.jena.graph.Node;
@@ -71,46 +74,58 @@ public class ViewHelpersTest {
 
     private ViewHelpers testObj;
 
+    private final DateTimeFormatter RFC_1123_PATTERN =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(of("GMT"));
+
+    private final DateTimeFormatter DATE_PATTERN =
+        DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(of("GMT"));
+
+    private static final String REPOSITORY_ROOT_URI =
+        FEDORA_REPOSITORY_ROOT.replaceAll("fedora:", REPOSITORY_NAMESPACE);
+
     @Before
     public void setUp() {
         testObj = ViewHelpers.getInstance();
     }
 
     @Test
-    @Ignore("Until Mementos have been implemented!")
     public void testGetVersions() {
         final Graph mem = createDefaultModel().getGraph();
-        final Node version = createURI("http://localhost/fcrepo/abc/fcr:version/adcd");
-//        mem.add(new Triple(createURI("http://localhost/fcrepo/abc"), HAS_VERSION.asNode(),
-//                version));
-        mem.add(new Triple(version, CREATED_DATE.asNode(), createLiteral(now().toString())));
+        final String resource_version = "http://localhost/fcrepo/abc/" + FCR_VERSIONS;
+        final Instant recent = Instant.now();
+        final Node version = createURI(resource_version + "/" + DATE_PATTERN.format(recent));
+        mem.add(new Triple(createURI(resource_version), CONTAINS.asNode(), version));
+        mem.add(new Triple(version, CREATED_DATE.asNode(), createLiteral(RFC_1123_PATTERN.format(recent))));
         assertEquals("Version should be available.",
-                version, testObj.getVersions(mem, createURI("http://localhost/fcrepo/abc")).next());
+            version, testObj.getVersions(mem, createURI(resource_version)).next());
     }
 
     @Test
-    @Ignore("Until Mementos have been implemented!")
     public void testGetOrderedVersions() {
-        final Node resource = createURI("http://localhost/fcrepo/abc");
-        final Node v1 = createURI("http://localhost/fcrepo/abc/fcr:version/1");
-        final Node v2 = createURI("http://localhost/fcrepo/abc/fcr:version/2");
-        final Node v3 = createURI("http://localhost/fcrepo/abc/fcr:version/3");
-        final Instant date = now();
+        final Node resource_version = createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS);
+        final Instant recent = Instant.now();
+        final Instant past = recent.minus(3, java.time.temporal.ChronoUnit.DAYS);
+        final Instant way_past = recent.minus(60, java.time.temporal.ChronoUnit.DAYS);
+        final Node v1 = createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + DATE_PATTERN.format(recent));
+        final Node v2 = createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + DATE_PATTERN.format(past));
+        final Node v3 = createURI("http://localhost/fcrepo/abc/" + FCR_VERSIONS + "/" + DATE_PATTERN.format(way_past));
 
         final Graph mem = createDefaultModel().getGraph();
-//        mem.add(new Triple(resource, HAS_VERSION.asNode(), v1));
-//        mem.add(new Triple(v1, CREATED_DATE.asNode(), createLiteral(date.toString())));
-//        mem.add(new Triple(resource, HAS_VERSION.asNode(), v2));
-//        mem.add(new Triple(v2, CREATED_DATE.asNode(), createLiteral(date.toString())));
-//        mem.add(new Triple(resource, HAS_VERSION.asNode(), v3));
-        mem.add(new Triple(v3, CREATED_DATE.asNode(),
-                createLiteral(date.plusMillis(10000l).toString())));
+        mem.add(new Triple(resource_version, CONTAINS.asNode(), v1));
+        mem.add(new Triple(resource_version, CONTAINS.asNode(), v2));
+        mem.add(new Triple(resource_version, CONTAINS.asNode(), v3));
+        mem.add(new Triple(v1, CREATED_DATE.asNode(), createLiteral(RFC_1123_PATTERN.format(recent))));
+        mem.add(new Triple(v2, CREATED_DATE.asNode(), createLiteral(RFC_1123_PATTERN.format(past))));
+        mem.add(new Triple(v3, CREATED_DATE.asNode(), createLiteral(RFC_1123_PATTERN.format(way_past))));
 
-//        final Iterator<Node> versions = testObj.getOrderedVersions(mem, resource, HAS_VERSION);
-//        versions.next();
-//        versions.next();
-//        final Node r3 = versions.next();
-//        assertEquals("Latest version should be last.", v3, r3);
+        final Iterator<Node> versions = testObj.getOrderedVersions(mem, resource_version, CONTAINS);
+        assertTrue(versions.hasNext());
+        final Node r1 = versions.next();
+        assertEquals("Version is out of order", v3, r1);
+        final Node r2 = versions.next();
+        assertEquals("Version is out of order", v2, r2);
+        final Node r3 = versions.next();
+        assertEquals("Latest version should be last.", v1, r3);
     }
 
     @Test
@@ -161,14 +176,6 @@ public class ViewHelpersTest {
     }
 
     @Test
-    @Ignore("This function is probably useless now.")
-    public void testIsVersionableNode() {
-        final Graph mem = createDefaultModel().getGraph();
-        mem.add(new Triple(createURI("a/b/c"), type.asNode(), createURI(VERSIONED_RESOURCE.toString())));
-        // assertTrue("Node is a versionable node.", testObj.isVersionableNode(mem, createURI("a/b/c")));
-    }
-
-    @Test
     public void testIsVersionedNode() {
         final Graph mem = createDefaultModel().getGraph();
         mem.add(new Triple(createURI("a/b/c"), type.asNode(), createURI(MEMENTO_TYPE.toString())));
@@ -203,16 +210,13 @@ public class ViewHelpersTest {
     @Test
     public void testGetVersionDate() {
         final Graph mem = createDefaultModel().getGraph();
-        final String date = now().toString();
-        mem.add(new Triple(createURI("a/b/c"), CREATED_DATE.asNode(),
-                createLiteral(date)));
-        assertEquals("Date should be available.", date, testObj.getVersionDate(mem, createURI("a/b/c")).get());
-    }
+        final String date_str = "20011231050505";
+        final Node subject = createURI("a/b/c/" + date_str);
+        final Instant date = Instant.from(DATE_PATTERN.parse(date_str));
+        mem.add(new Triple(subject, CREATED_DATE.asNode(),
+            createLiteral(RFC_1123_PATTERN.format(date))));
 
-    @Test
-    public void testGetMissingVersionDate() {
-        final Graph mem = createDefaultModel().getGraph();
-        assertFalse("Date should not be available.", testObj.getVersionDate(mem, createURI("a/b/c")).isPresent());
+        assertEquals("Date should be available.", date, testObj.getVersionDate(mem, subject));
     }
 
     @Test
@@ -369,9 +373,18 @@ public class ViewHelpersTest {
     }
 
     @Test
-    public void testGetNumChildrenNone() {
-        final Graph mem = createDefaultModel().getGraph();
-        assertEquals(0, testObj.getNumChildren(mem, createURI("a/b/c")));
-    }
+    public void testIsRepositoryRoot() {
+        final Model model = createDefaultModel();
+        model.setNsPrefix("fedora", REPOSITORY_NAMESPACE);
+        final Graph mem = model.getGraph();
+        final Node root = createURI("http://localhost/root");
+        final Node child = createURI("http://localhost/not_root");
 
+        mem.add(new Triple(root, type.asNode(), BASIC_CONTAINER.asNode()));
+        mem.add(new Triple(root, type.asNode(), createURI(REPOSITORY_ROOT_URI)));
+        mem.add(new Triple(child, type.asNode(), BASIC_CONTAINER.asNode()));
+
+        assertTrue("Root should be a Repository Root", testObj.isRootResource(mem, root));
+        assertFalse("Child should not be a Repository Root", testObj.isRootResource(mem, child));
+    }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -17,9 +17,13 @@
  */
 package org.fcrepo.kernel.api.services;
 
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+
 import java.io.InputStream;
 import java.net.URI;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 
 import org.apache.jena.rdf.model.Resource;
@@ -39,6 +43,17 @@ import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
  * @since Feb 19, 2014
  */
 public interface VersionService {
+
+    /**
+     * To format a datetime for use as a Memento path.
+     */
+    public static final DateTimeFormatter MEMENTO_LABEL_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+            .withZone(ZoneId.of("UTC"));
+
+    /**
+     * To format a datetime as RFC-1123 with correct timezone.
+     */
+    public static final DateTimeFormatter MEMENTO_RFC_1123_FORMATTER = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
     /**
      * Explicitly creates a version for the resource at the path provided.

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -46,7 +46,6 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.GregorianCalendar;
@@ -101,9 +100,6 @@ import com.google.common.annotations.VisibleForTesting;
 public class VersionServiceImpl extends AbstractService implements VersionService {
 
     private static final Logger LOGGER = getLogger(VersionService.class);
-
-    private static final DateTimeFormatter MEMENTO_DATETIME_ID_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyyMMddHHmmss").withZone(ZoneId.of("GMT"));
 
     @VisibleForTesting
     public static final Set<TripleCategory> VERSION_TRIPLES = new HashSet<>(asList(
@@ -345,7 +341,7 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     }
 
     private String makeMementoPath(final FedoraResource resource, final Instant datetime) {
-        return resource.getPath() + "/" + LDPCV_TIME_MAP + "/" + MEMENTO_DATETIME_ID_FORMATTER.format(datetime);
+        return resource.getPath() + "/" + LDPCV_TIME_MAP + "/" + MEMENTO_LABEL_FORMATTER.format(datetime);
     }
 
     protected String getUri(final FedoraResource resource,

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -268,10 +268,13 @@
 
   function enableVersioning(e) {
       const url = document.getElementById('main').getAttribute('resource');
+      const d = new Date();
+      const expires = (new Date(d - 1000000)).toUTCString();
       const get_headers = [
           ['Prefer', 'return=representation; omit="http://fedora.info/definitions/v4/repository#ServerManaged"'],
           ['Accept', 'application/ld+json'],
-          ['Cache-Control', 'no-cache']
+          ['Cache-Control', 'no-cache, no-store, max-age=0'],
+          ['Expires', expires]
       ];
       const put_headers = [
           ['Prefer', 'handling=lenient; received="minimal"'],

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -70,9 +70,6 @@
       });
     }
 
-    //both ldp-rs and ldp-nr resources should be created as versionable resources.
-    headers.push(['Link', '<http://mementoweb.org/ns#OriginalResource>; rel=\"type\"']);
-
     if (mixin == 'binary') {
       const update_file = document.getElementById('binary_payload').files[0];
       const reader = new FileReader();
@@ -192,6 +189,8 @@
 
   function createVersionSnapshot(e) {
       const uri = document.getElementById('main').getAttribute('resource');
+      const d = new Date();
+      const name = 'version.' + d.getFullYear().toString() + (d.getMonth()+1).toString() + d.getDate().toString() + d.getHours() + d.getMinutes() + d.getSeconds();
 
       http('POST', uri + '/fcr:versions', function(res) {
         if (res.status == 201) {
@@ -267,6 +266,34 @@
       (document.getElementById('binary_update_content') || {}).disabled = false;
   }
 
+  function enableVersioning(e) {
+      const url = document.getElementById('main').getAttribute('resource');
+      const get_headers = [
+          ['Prefer', 'return=representation; omit="http://fedora.info/definitions/v4/repository#ServerManaged"'],
+          ['Accept', 'application/ld+json']
+      ];
+      const put_headers = [
+          ['Prefer', 'handling=lenient; received="minimal"'],
+          ['Content-Type', 'application/ld+json'],
+          ['Link', '<http://mementoweb.org/ns#OriginalResource>; rel="type"']
+      ];
+      http('GET', url, get_headers, function(res) {
+          if (res.status == 200) {
+              var body = res.responseText; 
+              http('PUT', url, put_headers, body, function(res) {
+                  if (res.status == 204) {
+                      window.location.reload(true);
+                  } else {
+                      ajaxErrorHandler(res, 'Error');
+                  }
+              });
+          } else {
+              ajaxErrorHandler(res, 'Error');
+          }
+      });
+      e.preventDefault();
+  }
+
   ready(function() {
       listen('new_mixin', 'change', function(e) {
         document.getElementById('binary_payload_container').style.display = e.target.value == 'binary' ? 'block' : 'none';
@@ -294,6 +321,7 @@
       listen('action_revert', 'submit', patchAndReload);
       listen('action_remove_version', 'submit', removeVersion);
       listen('action_create_version', 'submit', createVersionSnapshot);
+      listen('action_enable_version', 'submit', enableVersioning);
       listen('action_update_file', 'submit', updateFile);
       listen('update_rbacl', 'submit', updateAccessRoles);
 

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -270,7 +270,8 @@
       const url = document.getElementById('main').getAttribute('resource');
       const get_headers = [
           ['Prefer', 'return=representation; omit="http://fedora.info/definitions/v4/repository#ServerManaged"'],
-          ['Accept', 'application/ld+json']
+          ['Accept', 'application/ld+json'],
+          ['Cache-Control', 'no-cache']
       ];
       const put_headers = [
           ['Prefer', 'handling=lenient; received="minimal"'],
@@ -279,7 +280,7 @@
       ];
       http('GET', url, get_headers, function(res) {
           if (res.status == 200) {
-              var body = res.responseText; 
+              var body = res.responseText;
               http('PUT', url, put_headers, body, function(res) {
                   if (res.status == 204) {
                       window.location.reload(true);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2730

# What does this Pull Request do?
Make the HTML UI work (mostly) with versions.

# What's new?
* Checks if an item is:
    * the repository root or 
    * a Memento or 
    * is Versionable (has /fcr:versions container) or
    *  is an a LDP-NR or its description.

It then changes the HTML interface based on the above to

* Allows you to enable versioning on LDP-RSes (but not LDP-NRs or LDP-RSs acting as descriptions)
* Allows you to make a version.
* Allows you to view the versions (but the triples appear under Other Resources, AND if you click the URL or dc:title instead of the plus sign you move away from the Memento).

# How should this be tested?

Build it and play with the HTML UI.

# Additional Notes:

Example:
* Does this change require documentation to be updated? Probably
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
