### PR TITLE
Change error message to reference `5x` documentation

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/FedoraContextLoaderListener.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/FedoraContextLoaderListener.java
@@ -47,7 +47,7 @@ public class FedoraContextLoaderListener extends ContextLoaderListener {
                     "You must configure a 'repository.json'\n" +
                     "\n" +
                     "See documentation specific to your version of Fedora\n" +
-                    "https://wiki.duraspace.org/display/FEDORA4x/Application+Configuration\n" +
+                    "https://wiki.duraspace.org/display/FEDORA5x/Application+Configuration\n" +
                     "\n" +
                     "=====================================================================\n" +
                     "=====================================================================\n";


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2885

# What does this Pull Request do?
Changes a single character in documentation URL from `4x` to `5x`:
- From: `https://wiki.duraspace.org/display/FEDORA4x/Application+Configuration`
- To: `https://wiki.duraspace.org/display/FEDORA5x/Application+Configuration`

# How should this be tested?
1. Comment out the local JAVA_OPTS value of `-Dfcrepo.modeshape.configuration`
1. Observe in the Tomcat logs a message that now references the `5x` documentation

# Interested parties
@fcrepo4/committers
