### PR TITLE
Removes support for LDPCv DELETE.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -21,7 +21,6 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
-import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.Response.ok;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
@@ -56,7 +55,6 @@ import javax.jcr.ItemExistsException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.OPTIONS;
@@ -123,18 +121,6 @@ public class FedoraVersioning extends ContentExposingResource {
     @VisibleForTesting
     public FedoraVersioning(final String externalPath) {
         this.externalPath = externalPath;
-    }
-
-    /**
-     * Disable versioning
-     * @return the response
-     */
-    @DELETE
-    public Response disableVersioning() {
-        LOGGER.debug("Disable versioning for '{}'", externalPath);
-        resource().disableVersioning();
-        session.commit();
-        return noContent().build();
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -27,6 +27,7 @@ import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.FOUND;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -157,22 +158,13 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testDeleteTimeMapForContainer() throws Exception {
+    public void testDeleteTimeMapNotAllowed() throws Exception {
         createVersionedContainer(id);
-
-        final String mementoUri = createMemento(subjectUri, null, null, null);
-        assertEquals(200, getStatus(new HttpGet(mementoUri)));
-
         final String timeMapUri = subjectUri + "/" + FCR_VERSIONS;
         assertEquals(200, getStatus(new HttpGet(timeMapUri)));
-
         // disabled versioning to delete TimeMap
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(serverAddress + id + "/" + FCR_VERSIONS)));
-
-        // validate that the memento version is gone
-        assertEquals(404, getStatus(new HttpGet(mementoUri)));
-        // validate that the LDPCv is gone
-        assertEquals(404, getStatus(new HttpGet(timeMapUri)));
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(),
+                     getStatus(new HttpDelete(serverAddress + id + "/" + FCR_VERSIONS)));
     }
 
     @Test


### PR DESCRIPTION
**Removes support for LDPCv DELETE**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2889

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://jira.duraspace.org/browse/FCREPO-2890

# What does this Pull Request do?
The PR simply removes the endpoint for LDPCv DELETE and updates the corresponding integration test to confirm that delete is not allowed.
# How should this be tested?
Create a versioned resource: 
`curl -X POST -H "Link: <http://mementoweb.org/ns#OriginalResource>; rel=\"type\"" http://localhost:8080/rest/ -H "slug: testxyz" -u fedoraAdmin:fedoraAdmin`
Try deleting the timemap
`curl -X DELETE http://localhost:8080/rest/testxyz/fcr:versions -u fedoraAdmin:fedoraAdmin`
Verify 405 response

# Additional Notes:
The code for enabling, disabling, and checking the versionability of resource has been left intact in case we wish to revert during the release candidate testing.
Example:
* Does this change require documentation to be updated? Yes
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
