### PR TITLE
fcrepo-2887 - Remove unused namespace prefixes from responses

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/RdfStreamStreamingOutput.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/RdfStreamStreamingOutput.java
@@ -30,18 +30,27 @@ import static org.apache.jena.riot.system.StreamRDFWriter.defaultSerialization;
 import static org.apache.jena.riot.system.StreamRDFWriter.getWriterStream;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
 
 import com.google.common.util.concurrent.AbstractFuture;
 import org.apache.jena.riot.RiotException;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.NsIterator;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
@@ -63,6 +72,8 @@ public class RdfStreamStreamingOutput extends AbstractFuture<Void> implements
     private static final String JSONLD_COMPACTED = "http://www.w3.org/ns/json-ld#compacted";
 
     private static final String JSONLD_FLATTENED = "http://www.w3.org/ns/json-ld#flattened";
+
+    public static final String RDF_TYPE = RDF_NAMESPACE + "type";
 
     private final Lang format;
 
@@ -125,17 +136,35 @@ public class RdfStreamStreamingOutput extends AbstractFuture<Void> implements
         // For formats that can be block-streamed (n-triples, turtle)
         if (format != null) {
             LOGGER.debug("Stream-based serialization of {}", dataFormat.toString());
+            final Set<String> namespacesPresent = new HashSet<>();
+
             final StreamRDF stream = new SynchonizedStreamRDFWrapper(getWriterStream(output, format));
             stream.start();
-            nsPrefixes.forEach(stream::prefix);
-            rdfStream.forEach(stream::triple);
+            // Must read the rdf stream before writing out ns prefixes, otherwise the prefixes come after the triples
+            final List<Triple> tripleList = rdfStream.peek(t -> {
+                // Collect the namespaces present in the RDF stream, using the same
+                // criteria for where to look that jena's model.listNameSpaces() does
+                namespacesPresent.add(t.getPredicate().getNameSpace());
+                if (RDF_TYPE.equals(t.getPredicate().getURI()) && t.getObject().isURI()) {
+                    namespacesPresent.add(t.getObject().getNameSpace());
+                }
+            }).collect(Collectors.toList());
+
+            nsPrefixes.forEach((prefix, uri) -> {
+                // Only add namespace prefixes if the namespace is present in the rdf stream
+                if (namespacesPresent.contains(uri)) {
+                    stream.prefix(prefix, uri);
+                }
+            });
+            tripleList.forEach(stream::triple);
             stream.finish();
 
         // For formats that require analysis of the entire model and cannot be streamed directly (rdfxml, n3)
         } else {
             LOGGER.debug("Non-stream serialization of {}", dataFormat.toString());
             final Model model = rdfStream.collect(toModel());
-            model.setNsPrefixes(nsPrefixes);
+
+            model.setNsPrefixes(filterNamespacesToPresent(model, nsPrefixes));
             // use block output streaming for RDFXML
             if (RDFXML.equals(dataFormat)) {
                 RDFDataMgr.write(output, model.getGraph(), RDFXML_PLAIN);
@@ -146,6 +175,33 @@ public class RdfStreamStreamingOutput extends AbstractFuture<Void> implements
                 RDFDataMgr.write(output, model.getGraph(), dataFormat);
             }
         }
+    }
+
+    /**
+     * Filters the map of namespace prefix mappings to just those containing namespace URIs present in the model
+     *
+     * @param model model
+     * @param nsPrefixes map of namespace to uris
+     * @return nsPrefixes filtered to namespaces found in the model
+     */
+    private static Map<String, String> filterNamespacesToPresent(final Model model,
+            final Map<String, String> nsPrefixes) {
+        final Map<String, String> resultNses = new HashMap<>();
+        final Set<Entry<String, String>> nsSet = nsPrefixes.entrySet();
+        final NsIterator nsIt = model.listNameSpaces();
+        while (nsIt.hasNext()) {
+            final String ns = nsIt.next();
+
+            final Optional<Entry<String, String>> nsOpt = nsSet.stream()
+                    .filter(nsEntry -> nsEntry.getValue().equals(ns))
+                    .findFirst();
+            if (nsOpt.isPresent()) {
+                final Entry<String, String> nsMatch = nsOpt.get();
+                resultNses.put(nsMatch.getKey(), nsMatch.getValue());
+            }
+        }
+
+        return resultNses;
     }
 
     private static RDFFormat getFormatFromMediaType(final MediaType mediaType) {

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/RdfStreamStreamingOutputTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/RdfStreamStreamingOutputTest.java
@@ -120,12 +120,12 @@ public class RdfStreamStreamingOutputTest {
     @Test
     public void testWriteWithNamespace() throws IOException {
         final Map<String, String> namespaces = new HashMap<>();
-        namespaces.put("a", "info:a");
+        namespaces.put("a", "info:");
         try (final RdfStream input = new DefaultRdfStream(triple.getSubject(), of(triple));
                 final ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             new RdfStreamStreamingOutput(input, namespaces, TURTLE_TYPE).write(output);
             final String s = output.toString("UTF-8");
-            assertTrue(s.replaceAll("\\s+", " ").contains("@prefix a: <info:a>"));
+            assertTrue(s.replaceAll("\\s+", " ").contains("@prefix a: <info:>"));
         }
     }
 

--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/RdfNamespaceMappingIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/RdfNamespaceMappingIT.java
@@ -26,32 +26,17 @@ import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.integration.http.api.AbstractResourceIT;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  * @author bbpennel
  */
 public class RdfNamespaceMappingIT extends AbstractResourceIT {
-
-    private Map<String, String> namespaces = new HashMap<>();
-
-    @Before
-    public void init() {
-        namespaces.put("ldp", "http://www.w3.org/ns/ldp#");
-        namespaces.put("memento", "http://mementoweb.org/ns#");
-        namespaces.put("unused", "http://example.com/ns#");
-        namespaces.put("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
-        namespaces.put("fedora", "http://fedora.info/definitions/v4/repository#");
-    }
 
     @Test
     public void testUnregisteredNamespace() throws Exception {
@@ -104,22 +89,32 @@ public class RdfNamespaceMappingIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testAllNamespacesReturned() throws Exception {
+    public void testUnusedNamespaceNotReturned() throws Exception {
+        verifyUnusedNamespaceNotReturned("text/turtle", "TURTLE");
+    }
+
+    // Testing a serialization that cannot be block streamed
+    @Test
+    public void testUnusedNamespaceNotReturnedRdfXML() throws Exception {
+        verifyUnusedNamespaceNotReturned("application/rdf+xml", "RDF/XML");
+    }
+
+    private void verifyUnusedNamespaceNotReturned(final String acceptType, final String rdfLang) throws Exception {
         final String pid = getRandomUniqueId();
         final String subjectURI = serverAddress + pid;
         createObject(pid);
 
         final HttpGet httpGet = getObjMethod(pid);
-        httpGet.addHeader(ACCEPT, "text/turtle");
+        httpGet.addHeader(ACCEPT, acceptType);
         final Model model = createDefaultModel();
         try (final CloseableHttpResponse response = execute(httpGet)) {
-            model.read(response.getEntity().getContent(), subjectURI, "TURTLE");
+            model.read(response.getEntity().getContent(), subjectURI, rdfLang);
 
-            for (final Entry<String, String> namespace : namespaces.entrySet()) {
-                assertTrue("Must contain " + namespace.getKey() + " namespace prefix",
-                        model.getNsPrefixMap().containsKey(namespace.getKey()));
-                assertEquals(namespace.getValue(), model.getNsPrefixMap().get(namespace.getKey()));
-            }
+            assertTrue("Should contain fedora namespace prefix",
+                    model.getNsPrefixMap().containsKey("fedora"));
+
+            assertFalse("Must not contain prefix for registered but unused namespace",
+                    model.getNsPrefixMap().containsKey("unused"));
         }
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2887

# What does this Pull Request do?
Filters namespace prefixes in serialized RDF responses to just those which are present in the RDF being returned.

# What's new?
Filters the configured set of namespace prefixes down to just those present in either the predicates or rdf:type objects in the set of triples being serialized.
This applies to both block-streamed and serializations that require analysis of the entire model (rdf+xml, jsonld)

# How should this be tested?

```
curl -ufedoraAdmin:fedoraAdmin -i -XPUT -H"Content-Type: text/turtle" http://localhost:8080/rest/ns_test1

curl -ufedoraAdmin:fedoraAdmin -i -H"Accept: text/turtle"  http://localhost:8080/rest/ns_test1
# @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
# @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
# @prefix ldp:  <http://www.w3.org/ns/ldp#> .
# 
# <http://localhost:8080/rest/ns_test1>
#         rdf:type               fedora:Container ;
#         rdf:type               fedora:Resource ;
#         fedora:lastModifiedBy  "fedoraAdmin" ;
#         fedora:createdBy       "fedoraAdmin" ;
#         fedora:created         "2018-10-04T19:53:30.459Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
#         fedora:lastModified    "2018-10-04T19:53:30.459Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
#         rdf:type               ldp:RDFSource ;
#         rdf:type               ldp:Container ;
#         fedora:writable        true .

curl -ufedoraAdmin:fedoraAdmin -i -H"Accept: application/rdf+xml"  http://localhost:8080/rest/ns_test1
# <rdf:RDF
#     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
#     xmlns:fedora="http://fedora.info/definitions/v4/repository#"
#     xmlns:ldp="http://www.w3.org/ns/ldp#" > 
#   <rdf:Description rdf:about="http://localhost:8080/rest/ns_test1">
#     <fedora:writable rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</fedora:writable>
# ...

echo "INSERT { <> <http://purl.org/dc/terms/title> 'some title' } WHERE { }" | curl -ufedoraAdmin:fedoraAdmin --data-binary "@-" -i -XPATCH -H"Content-Type: application/sparql-update" http://localhost:8080/rest/ns_test1

curl -ufedoraAdmin:fedoraAdmin -i -H"Accept: text/turtle"  http://localhost:8080/rest/ns_test1

# @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
# @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
# @prefix ldp:  <http://www.w3.org/ns/ldp#> .
# @prefix dcterms:  <http://purl.org/dc/terms/> .
# 
# <http://localhost:8080/rest/ns_test1>
#         ...
#         dcterms:title          "some title" ;
#         rdf:type               ldp:RDFSource ;
#         ...
```

# Additional Notes:
I'm not entirely happy with this PR since it involves reading the RDF stream into a list. Its actually possible to skip that, but the triples would have to appear before the namespace prefixes, which looks a bit weird but appears to be valid according to Jena. 

This problem is because the stream of triples must be read in order to determine what namespaces it contains, which we need to know before filtering the set of namespace prefixes, but there is no point from retrieving to serializing where the triples could be read first.

Since this is reading the stream into memory, it may also be reasonable to send the triples into a Model for all serialization types. I left them separate since I figured the resource footprint of a list of triples was probably slightly smaller than having to construct a model.

One other note: the jsonld serialization doesn't return namespaces, so we could actually skip doing anything with namespace prefixes for that serialization if we want.

# Interested parties
@fcrepo4/committers, @awoods 
