### PR TITLE
Suppress ldp contains on omit smt

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -77,7 +77,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEMAP_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_NAMESPACE_VALUE;
-import static org.fcrepo.kernel.api.RdfLexicon.isManagedLDPType;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedNamespace;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
 import static org.fcrepo.kernel.api.RequiredRdfContext.EMBED_RESOURCES;
@@ -230,8 +229,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected ExternalContentHandlerFactory extContentHandlerFactory;
 
     private static final Predicate<Triple> IS_MANAGED_TYPE = t -> t.getPredicate().equals(type.asNode()) &&
-            (isManagedNamespace.test(t.getObject().getNameSpace()) ||
-            isManagedLDPType.test(createResource(t.getObject().getURI())));
+            (isManagedNamespace.test(t.getObject().getNameSpace()));
     private static final Predicate<Triple> IS_MANAGED_TRIPLE = IS_MANAGED_TYPE
         .or(t -> isManagedPredicate.test(createProperty(t.getPredicate().getURI())));
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -229,7 +229,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected ExternalContentHandlerFactory extContentHandlerFactory;
 
     private static final Predicate<Triple> IS_MANAGED_TYPE = t -> t.getPredicate().equals(type.asNode()) &&
-            (isManagedNamespace.test(t.getObject().getNameSpace()));
+            isManagedNamespace.test(t.getObject().getNameSpace());
     private static final Predicate<Triple> IS_MANAGED_TRIPLE = IS_MANAGED_TYPE
         .or(t -> isManagedPredicate.test(createProperty(t.getPredicate().getURI())));
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -77,6 +77,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEMAP_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_NAMESPACE_VALUE;
+import static org.fcrepo.kernel.api.RdfLexicon.isManagedLDPType;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedNamespace;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
 import static org.fcrepo.kernel.api.RequiredRdfContext.EMBED_RESOURCES;
@@ -229,7 +230,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected ExternalContentHandlerFactory extContentHandlerFactory;
 
     private static final Predicate<Triple> IS_MANAGED_TYPE = t -> t.getPredicate().equals(type.asNode()) &&
-            isManagedNamespace.test(t.getObject().getNameSpace());
+            (isManagedNamespace.test(t.getObject().getNameSpace()) ||
+            isManagedLDPType.test(createResource(t.getObject().getURI())));
     private static final Predicate<Triple> IS_MANAGED_TRIPLE = IS_MANAGED_TYPE
         .or(t -> isManagedPredicate.test(createProperty(t.getPredicate().getURI())));
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1381,8 +1381,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
         // Create the DirectContainer
         final HttpPut createContainer = new HttpPut(serverAddress + members);
         createContainer.addHeader(CONTENT_TYPE, "text/turtle");
-        final String membersRDF = "<> a <http://www.w3.org/ns/ldp#DirectContainer>; "
-            + "<http://www.w3.org/ns/ldp#hasMemberRelation> <http://pcdm.org/models#hasMember>; "
+        createContainer.addHeader(LINK, "<http://www.w3.org/ns/ldp#DirectContainer>;rel=type");
+        final String membersRDF = "<> <http://www.w3.org/ns/ldp#hasMemberRelation> <http://pcdm.org/models#hasMember>; "
             + "<http://www.w3.org/ns/ldp#membershipResource> <" + serverAddress + id + "> . ";
         createContainer.setEntity(new StringEntity(membersRDF));
         assertEquals("Membership container not created!", CREATED.getStatusCode(), getStatus(createContainer));
@@ -1417,8 +1417,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
         // Create the IndirectContainer
         final HttpPut createContainer = new HttpPut(serverAddress + members);
         createContainer.addHeader(CONTENT_TYPE, "text/turtle");
-        final String membersRDF = "<> a <http://www.w3.org/ns/ldp#IndirectContainer>; "
-            + "<http://www.w3.org/ns/ldp#hasMemberRelation> <info:fedora/test/hasTitle> ; "
+        createContainer.addHeader(LINK, "<http://www.w3.org/ns/ldp#IndirectContainer>;rel=type");
+        final String membersRDF = "<> <http://www.w3.org/ns/ldp#hasMemberRelation> <info:fedora/test/hasTitle> ; "
             + "<http://www.w3.org/ns/ldp#insertedContentRelation> <http://www.w3.org/2004/02/skos/core#prefLabel>; "
             + "<http://www.w3.org/ns/ldp#membershipResource> <" + serverAddress + id + "> . ";
         createContainer.setEntity(new StringEntity(membersRDF));
@@ -2209,11 +2209,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertTrue(getLinkHeaders(getObjMethod(pid + "/b")).contains(DIRECT_CONTAINER_LINK_HEADER));
 
         // successful update the properties with the interaction mode
-        final String ttla = "<> a <" + DIRECT_CONTAINER.getURI()
-                + "> ; <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
+        final String ttla = "<> <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
                 + "<" + HAS_MEMBER_RELATION + "> <info:some/relation> .\n";
         final HttpPut puta = putObjMethod(pid + "/b", "text/turtle", ttla);
         puta.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
+        puta.addHeader(LINK, "<http://www.w3.org/ns/ldp#DirectContainer>;rel=type");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(puta));
 
         // attempt to change direct container to basic container
@@ -2323,8 +2323,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
         // create an indirect container
         final HttpPut createContainer = new HttpPut(serverAddress + pid1 + "/members");
         createContainer.addHeader(CONTENT_TYPE, "text/turtle");
-        final String membersRDF = "<> a <http://www.w3.org/ns/ldp#IndirectContainer>; "
-            + "<http://www.w3.org/ns/ldp#hasMemberRelation> <" + memberRelation + ">; "
+        createContainer.addHeader(LINK, "<http://www.w3.org/ns/ldp#IndirectContainer>;rel=type");
+        final String membersRDF = "<> <http://www.w3.org/ns/ldp#hasMemberRelation> <" + memberRelation + ">; "
             + "<http://www.w3.org/ns/ldp#insertedContentRelation> <http://www.openarchives.org/ore/terms/proxyFor>; "
             + "<http://www.w3.org/ns/ldp#membershipResource> <" + serverAddress + pid1 + "> . ";
         createContainer.setEntity(new StringEntity(membersRDF));
@@ -3707,8 +3707,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final long lastmod3;
         final HttpPut createContainer = new HttpPut(objURI + "/members");
         createContainer.addHeader(CONTENT_TYPE, "text/turtle");
-        final String membersRDF = "<> a <http://www.w3.org/ns/ldp#DirectContainer>; "
-            + "<http://www.w3.org/ns/ldp#hasMemberRelation> <http://pcdm.org/models#hasMember>; "
+        createContainer.addHeader(LINK, "<http://www.w3.org/ns/ldp#DirectContainer>;rel=type");
+        final String membersRDF = "<> <http://www.w3.org/ns/ldp#hasMemberRelation> <http://pcdm.org/models#hasMember>; "
             + "<http://www.w3.org/ns/ldp#membershipResource> <" + objURI + "> . ";
         createContainer.setEntity(new StringEntity(membersRDF));
         try (final CloseableHttpResponse response = execute(createContainer)) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2133,6 +2133,64 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testGetLDPRmOmitServerManaged() throws IOException {
+        final String versionedResourceURI = createVersionedRDFResource();
+        final String mementoResourceURI = getLocation(new HttpPost(versionedResourceURI + "/fcr:versions"));
+
+        final HttpGet mementoGetMethod = new HttpGet(mementoResourceURI);
+        mementoGetMethod.addHeader("Prefer",
+                "return=representation; omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"");
+        try (final CloseableDataset dataset = getDataset(mementoGetMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(versionedResourceURI);
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CREATED_BY.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_BY.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
+    public void testGetLDPRmWithoutOmitServerManager() throws IOException {
+        final String versionedResourceURI = createVersionedRDFResource();
+        final String mementoResourceURI = getLocation(new HttpPost(versionedResourceURI + "/fcr:versions"));
+
+        final HttpGet mementoGetMethod = new HttpGet(mementoResourceURI);
+        try (final CloseableDataset dataset = getDataset(mementoGetMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(versionedResourceURI);
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, CREATED_BY.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_BY.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
     public void testPatchToCreateDirectContainerInSparqlUpdate() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2110,7 +2110,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final DatasetGraph graph = dataset.asDatasetGraph();
             final Node resource = createURI(serverAddress + id);
             assertTrue("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
-            assertTrue("Didn't find contained", graph.find(ANY, resource,  CONTAINS.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
             assertFalse("Expected nothing server managed",
                     graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
             assertFalse("Expected nothing server managed",

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -77,15 +77,19 @@ import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
+import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_CHILD;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
@@ -2028,6 +2032,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testGetObjectOmitMembership() throws IOException {
         final String id = getRandomUniqueId();
+        final Node resource = createURI(serverAddress + id);
         createObjectAndClose(id);
         addMixin(id, BASIC_CONTAINER.getURI());
         createObjectAndClose(id + "/a");
@@ -2036,6 +2041,16 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 + "omit=\"http://www.w3.org/ns/ldp#PreferContainment http://www.w3.org/ns/ldp#PreferMembership\"");
         try (final CloseableDataset dataset = getDataset(getObjMethod)) {
             final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, BASIC_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, CREATED_BY.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, LAST_MODIFIED_BY.asNode(), ANY).hasNext());
             assertFalse("Didn't expect inlined member resources", graph.find(ANY,
                     createURI(serverAddress + id), HAS_CHILD.asNode(), ANY).hasNext());
         }
@@ -2061,7 +2076,59 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final DatasetGraph graph = dataset.asDatasetGraph();
             final Node resource = createURI(serverAddress + id);
             assertTrue("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, BASIC_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, CREATED_BY.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, LAST_MODIFIED_BY.asNode(), ANY).hasNext());
             assertFalse("Expected nothing contained", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
+    public void testGetObjectOmitServerManaged() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String location = serverAddress + id;
+        final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+        final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals(CREATED.getStatusCode(), getStatus(put));
+        assertTrue(getLinkHeaders(getObjMethod(id + "/a")).contains(DIRECT_CONTAINER_LINK_HEADER));
+        createObject(id + "/a/1");
+
+        final HttpGet getObjMethod = getObjMethod(id);
+        getObjMethod.addHeader("Prefer",
+                "return=representation; omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"");
+        try (final CloseableDataset dataset = getDataset(getObjMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(serverAddress + id);
+            assertTrue("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
+            assertTrue("Didn't find contained", graph.find(ANY, resource,  CONTAINS.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, BASIC_CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CREATED_BY.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_BY.asNode(), ANY).hasNext());
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2134,6 +2134,30 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testGetObjectIncludeContainmentAndOmitServerManaged() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String location = serverAddress + id;
+        final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+        final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals(CREATED.getStatusCode(), getStatus(put));
+        assertTrue(getLinkHeaders(getObjMethod(id + "/a")).contains(DIRECT_CONTAINER_LINK_HEADER));
+        createObject(id + "/a/1");
+
+        final HttpGet getObjMethod = getObjMethod(id);
+        getObjMethod.addHeader("Prefer",
+                "return=representation; omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"; " +
+                "include=\"http://www.w3.org/ns/ldp#PreferContainment\"");
+        try (final CloseableDataset dataset = getDataset(getObjMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(serverAddress + id);
+            assertTrue("Didn't find ldp containment", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
     public void testGetLDPRmOmitServerManaged() throws IOException {
         final String versionedResourceURI = createVersionedRDFResource();
         final String mementoResourceURI = getLocation(new HttpPost(versionedResourceURI + "/fcr:versions"));

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
@@ -68,8 +68,8 @@ public class LdpPreferTag extends PreferTag {
         membership = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferMembership")) ||
                 includes.contains(LDP_NAMESPACE + "PreferMembership");
 
-        containment = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferContainment")) ||
-                includes.contains(LDP_NAMESPACE + "PreferContainment");
+        containment = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferContainment") &&
+                !omits.contains(SERVER_MANAGED.toString())) || includes.contains(LDP_NAMESPACE + "PreferContainment");
 
         references = includes.contains(INBOUND_REFERENCES.toString());
 

--- a/fcrepo-integration-ldp/src/test/java/org/fcrepo/integration/ldp/LdpTestSuiteIT.java
+++ b/fcrepo-integration-ldp/src/test/java/org/fcrepo/integration/ldp/LdpTestSuiteIT.java
@@ -20,6 +20,7 @@ package org.fcrepo.integration.ldp;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.parseInt;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -103,10 +104,8 @@ public class LdpTestSuiteIT {
         final String pid = "ldp-test-basic-" + UUID.randomUUID().toString();
 
         final HttpPut request = new HttpPut(serverAddress + pid);
-        final BasicHttpEntity entity = new BasicHttpEntity();
-        entity.setContent(IOUtils.toInputStream("<> a <" + BASIC_CONTAINER + "> ."));
-        request.setEntity(entity);
         request.setHeader(CONTENT_TYPE, "text/turtle");
+        request.setHeader(LINK, "<" + BASIC_CONTAINER + ">;rel=type");
         try (final CloseableHttpResponse response = executeWithBasicAuth(request)) {
             assertEquals(CREATED.getStatusCode(), response.getStatusLine().getStatusCode());
 
@@ -129,11 +128,11 @@ public class LdpTestSuiteIT {
 
         final HttpPut request = new HttpPut(serverAddress + pid);
         final BasicHttpEntity entity = new BasicHttpEntity();
-        entity.setContent(IOUtils.toInputStream("<> a <" + DIRECT_CONTAINER + "> ;" +
-                "    <" + LDP_NAMESPACE + "membershipResource> <> ;" +
+        entity.setContent(IOUtils.toInputStream("<> <" + LDP_NAMESPACE + "membershipResource> <> ;" +
                 "    <" + LDP_NAMESPACE + "hasMemberRelation> <" + LDP_NAMESPACE + "member> ."));
         request.setEntity(entity);
         request.setHeader(CONTENT_TYPE, "text/turtle");
+        request.setHeader(LINK, "<" + DIRECT_CONTAINER + ">;rel=type");
         try (final CloseableHttpResponse response = executeWithBasicAuth(request)) {
             assertEquals(CREATED.getStatusCode(), response.getStatusLine().getStatusCode());
 
@@ -155,12 +154,12 @@ public class LdpTestSuiteIT {
 
         final HttpPut request = new HttpPut(serverAddress + pid);
         final BasicHttpEntity entity = new BasicHttpEntity();
-        entity.setContent(IOUtils.toInputStream("<> a <" + INDIRECT_CONTAINER + ">;" +
-                "    <" + LDP_NAMESPACE + "membershipResource> <> ;" +
+        entity.setContent(IOUtils.toInputStream("<> <" + LDP_NAMESPACE + "membershipResource> <> ;" +
                 "    <" + LDP_NAMESPACE + "insertedContentRelation> <" + LDP_NAMESPACE + "MemberSubject> ;" +
                 "    <" + LDP_NAMESPACE + "hasMemberRelation> <" + LDP_NAMESPACE + "member> ."));
         request.setEntity(entity);
         request.setHeader(CONTENT_TYPE, "text/turtle");
+        request.setHeader(LINK, "<" + INDIRECT_CONTAINER + ">;rel=type");
         try (final CloseableHttpResponse response = executeWithBasicAuth(request)) {
             assertEquals(CREATED.getStatusCode(), response.getStatusLine().getStatusCode());
 

--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/AbstractIntegrationRdfIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/AbstractIntegrationRdfIT.java
@@ -59,10 +59,20 @@ import static org.junit.Assert.assertTrue;
 public abstract class AbstractIntegrationRdfIT extends AbstractResourceIT {
 
     protected HttpResponse createLDPRSAndCheckResponse(final String pid, final String body) {
+        return createLDPRSAndCheckResponse(pid, body, null);
+    }
+
+    protected HttpResponse createLDPRSAndCheckResponse(final String pid, final String body,
+            final Map<String, String> headers) {
         try {
             final HttpPut httpPut = new HttpPut(serverAddress + pid);
-            httpPut.addHeader("Slug", pid);
-            httpPut.addHeader(CONTENT_TYPE, "text/turtle");
+            if (headers != null && !headers.isEmpty()) {
+                headers.keySet().stream().forEach(k -> httpPut.addHeader(k, headers.get(k)));
+            }
+            if (httpPut.getFirstHeader(CONTENT_TYPE) == null) {
+                httpPut.addHeader(CONTENT_TYPE, "text/turtle");
+            }
+            httpPut.setHeader("Slug", pid);
             final BasicHttpEntity e = new BasicHttpEntity();
             e.setContent(IOUtils.toInputStream(body, UTF_8));
             httpPut.setEntity(e);

--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/LdpIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/LdpIT.java
@@ -24,6 +24,8 @@ import org.apache.http.client.methods.HttpPost;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static org.junit.Assert.assertFalse;
@@ -42,12 +44,13 @@ public class LdpIT extends AbstractIntegrationRdfIT {
                 "@prefix ldp: <http://www.w3.org/ns/ldp#>.\n" +
                 "@prefix dcterms: <http://purl.org/dc/terms/>.\n" +
                 "@prefix o: <http://example.org/ontology#>.\n" +
-                "<> a ldp:DirectContainer ;" +
-                "   dcterms:title \"The liabilities of JohnZSmith\";\n" +
+                "<> dcterms:title \"The liabilities of JohnZSmith\";\n" +
                 "   ldp:membershipResource <" + location + ">;\n" +
                 "   ldp:hasMemberRelation o:liability;\n";
 
-        createLDPRSAndCheckResponse(pid + "/liabilities", body);
+        final Map<String, String> headers = new HashMap();
+        headers.put("Link", "<http://www.w3.org/ns/ldp#DirectContainer>;rel=type");
+        createLDPRSAndCheckResponse(pid + "/liabilities", body, headers);
 
         final HttpPost httpPost1 = new HttpPost(serverAddress + pid + "/liabilities");
         httpPost1.setHeader("Slug", "l1");

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -177,6 +177,8 @@ public final class RdfLexicon {
 
     private static final Set<Property> ldpManagedProperties = of(CONTAINS);
 
+    private static final Set<Resource> ldpManagedTypes = of(CONTAINER, BASIC_CONTAINER, RDF_SOURCE);
+
     // REPOSITORY INFORMATION
     public static final Property HAS_OBJECT_COUNT =
             createProperty(REPOSITORY_NAMESPACE + "objectCount");
@@ -279,6 +281,11 @@ public final class RdfLexicon {
      */
     public static final Predicate<Property> isManagedPredicate =
         hasFedoraNamespace.or(p -> managedProperties.contains(p));
+
+    /**
+     * Detects whether an RDF resource is a managed LDP Type.
+     */
+    public static final Predicate<Resource> isManagedLDPType = p -> ldpManagedTypes.contains(p);
 
     /**
      * Fedora defined JCR node type with supertype of nt:file with two nt:folder named fedora:timemap and

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -178,8 +178,6 @@ public final class RdfLexicon {
 
     private static final Set<Property> ldpManagedProperties = of(CONTAINS);
 
-    private static final Set<Resource> ldpManagedTypes = of(CONTAINER, BASIC_CONTAINER, RDF_SOURCE);
-
     // REPOSITORY INFORMATION
     public static final Property HAS_OBJECT_COUNT =
             createProperty(REPOSITORY_NAMESPACE + "objectCount");

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -90,7 +90,8 @@ public final class RdfLexicon {
     /**
      * Is this namespace one that the repository manages?
      */
-    public static final Predicate<String> isManagedNamespace = p -> p.equals(REPOSITORY_NAMESPACE);
+    public static final Predicate<String> isManagedNamespace = p -> p.equals(REPOSITORY_NAMESPACE) ||
+            p.equals(LDP_NAMESPACE);
 
     // MEMBERSHIP
     public static final Property HAS_PARENT =
@@ -281,11 +282,6 @@ public final class RdfLexicon {
      */
     public static final Predicate<Property> isManagedPredicate =
         hasFedoraNamespace.or(p -> managedProperties.contains(p));
-
-    /**
-     * Detects whether an RDF resource is a managed LDP Type.
-     */
-    public static final Predicate<Resource> isManagedLDPType = p -> ldpManagedTypes.contains(p);
 
     /**
      * Fedora defined JCR node type with supertype of nt:file with two nt:folder named fedora:timemap and


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2879

Depends on: https://github.com/fcrepo4/fcrepo4/pull/1424

# What does this Pull Request do?
Suppress LDP Containment triples on omit server-managed-triples header unless if there is an explicit include prefer-containment header

# How should this be tested?
FedoraLdpIT includes tests to verify that:
- PreferContainment triples are suppressed on `omit` ServerManaged Prefer header
- PreferContainment triples are NOT suppressed on `omit` ServerManaged and `include` PreferContainment Prefer header.

#### Verify that you can `PUT` a resource that you retrieved using `GET` with `omit` SMT header
```
# Create a Direct Container
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test-dc" -X PUT -H 'Link: <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"' -H 'Content-Type: text/turtle' --data-binary '<> <http://purl.org/dc/elements/1.1/title> "Test"'
# Create a child resource
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test-dc" -X POST
# Get the Direct Container resouce with omit SMT
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test-dc" -o output_turtle -H "Accept: text/turtle" -H'Prefer: return=representation; omit="http://fedora.info/definitions/v4/repository#ServerManaged"'
# Put it back
curl -i -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test-dc" -X PUT -d "@output_turtle" -H "Content-type: text/turtle" -H "Prefer: handling=lenient; received=minimal"
```

# Interested parties
@whikloj, @fcrepo4/committers
