### PR TITLE
Suppress ldp contains on omit smt

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2110,7 +2110,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final DatasetGraph graph = dataset.asDatasetGraph();
             final Node resource = createURI(serverAddress + id);
             assertTrue("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
-            assertTrue("Didn't find contained", graph.find(ANY, resource,  CONTAINS.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
             assertFalse("Expected nothing server managed",
                     graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
             assertFalse("Expected nothing server managed",

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2134,6 +2134,30 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testGetObjectIncludeContainmentAndOmitServerManaged() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String location = serverAddress + id;
+        final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+        final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals(CREATED.getStatusCode(), getStatus(put));
+        assertTrue(getLinkHeaders(getObjMethod(id + "/a")).contains(DIRECT_CONTAINER_LINK_HEADER));
+        createObject(id + "/a/1");
+
+        final HttpGet getObjMethod = getObjMethod(id);
+        getObjMethod.addHeader("Prefer",
+                "return=representation; omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"; " +
+                "include=\"http://www.w3.org/ns/ldp#PreferContainment\"");
+        try (final CloseableDataset dataset = getDataset(getObjMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(serverAddress + id);
+            assertTrue("Didn't find ldp containment", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
     public void testGetLDPRmOmitServerManaged() throws IOException {
         final String versionedResourceURI = createVersionedRDFResource();
         final String mementoResourceURI = getLocation(new HttpPost(versionedResourceURI + "/fcr:versions"));

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
@@ -68,8 +68,8 @@ public class LdpPreferTag extends PreferTag {
         membership = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferMembership")) ||
                 includes.contains(LDP_NAMESPACE + "PreferMembership");
 
-        containment = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferContainment")) ||
-                includes.contains(LDP_NAMESPACE + "PreferContainment");
+        containment = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferContainment") &&
+                !omits.contains(SERVER_MANAGED.toString())) || includes.contains(LDP_NAMESPACE + "PreferContainment");
 
         references = includes.contains(INBOUND_REFERENCES.toString());
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2879

# What does this Pull Request do?
Suppress LDP Containment triples on omit server-managed-triples header unless if there is an explicit include prefer-containment header

# How should this be tested?
FedoraLdpIT includes tests to verify that:
- PreferContainment triples are suppressed on `omit` ServerManaged Prefer header
- PreferContainment triples are NOT suppressed on `omit` ServerManaged and `include` PreferContainment Prefer header.

#### Verify that you can `PUT` a resource that you retrieved using `GET` with `omit` SMT header
```
# Create a Direct Container
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test-dc" -X PUT -H 'Link: <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"' -H 'Content-Type: text/turtle' --data-binary '<> <http://purl.org/dc/elements/1.1/title> "Test"'
# Create a child resource
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test-dc" -X POST
# Get the Direct Container resouce with omit SMT
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test-dc" -o output_turtle -H "Accept: text/turtle" -H'Prefer: return=representation; omit="http://fedora.info/definitions/v4/repository#ServerManaged"'
# Put it back
curl -i -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test-dc" -X PUT -d "@output_turtle" -H "Content-type: text/turtle" -H "Prefer: handling=lenient; received=minimal"
```

# Interested parties
@whikloj, @fcrepo4/committers
