### PR TITLE
Adding rdf:type memento:* - whether via PUT, POST or PATCH -

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -71,7 +71,9 @@ import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
@@ -202,6 +204,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     static final Node WEBAC_ACCESS_TO_CLASS_URI = createURI(WEBAC_ACCESS_TO_CLASS);
 
     static final Property WEBAC_ACCESS_TO_PROPERTY = createProperty(WEBAC_ACCESS_TO);
+
+    static final Node RDF_TYPE_URI = createURI(RDF_NAMESPACE + "type");
 
     @Context protected Request request;
     @Context protected HttpServletResponse servletResponse;
@@ -951,7 +955,22 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
         ensureValidACLAuthorization(resource, inputModel);
 
+        ensureNoMementoNamespaceTypes(inputModel);
+
         resource.replaceProperties(translator(), inputModel, resourceTriples);
+    }
+
+    private void ensureNoMementoNamespaceTypes(final Model inputModel) throws MalformedRdfException {
+        inputModel.listStatements().forEachRemaining((final Statement s) -> {
+            LOGGER.debug("statement: s={}, p={}, o={}", s.getSubject(), s.getPredicate(), s.getObject());
+            final RDFNode object = s.getObject();
+            if (s.getObject().isURIResource() && s.getPredicate().getURI().equals(RDF_TYPE_URI.getURI()) &&
+                object.asResource().getURI().startsWith(MEMENTO_NAMESPACE)) {
+                throw new MalformedRdfException(
+                    "The " + RDF_TYPE_URI.getURI() + " predicate may not take an object in the memento namespace (" +
+                    MEMENTO_NAMESPACE + ").");
+            }
+        });
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -960,13 +960,13 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         resource.replaceProperties(translator(), inputModel, resourceTriples);
     }
 
-    private void ensureNoMementoNamespaceTypes(final Model inputModel) throws MalformedRdfException {
+    private void ensureNoMementoNamespaceTypes(final Model inputModel) {
         inputModel.listStatements().forEachRemaining((final Statement s) -> {
             LOGGER.debug("statement: s={}, p={}, o={}", s.getSubject(), s.getPredicate(), s.getObject());
             final RDFNode object = s.getObject();
             if (s.getObject().isURIResource() && s.getPredicate().getURI().equals(RDF_TYPE_URI.getURI()) &&
                 object.asResource().getURI().startsWith(MEMENTO_NAMESPACE)) {
-                throw new MalformedRdfException(
+                throw new ServerManagedPropertyException(
                     "The " + RDF_TYPE_URI.getURI() + " predicate may not take an object in the memento namespace (" +
                     MEMENTO_NAMESPACE + ").");
             }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -3906,7 +3906,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createMethod.setEntity(new StringEntity("<> a <" + MEMENTO_TYPE + "> ."));
         try (final CloseableHttpResponse response = execute(createMethod)) {
             assertEquals("Must not be able to POST RDF that contains an \"<> a  <" + MEMENTO_TYPE + ">\"",
-                         BAD_REQUEST.getStatusCode(),
+                         CONFLICT.getStatusCode(),
                          getStatus(response));
         }
     }
@@ -3919,7 +3919,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         putMethod.setEntity(new StringEntity("<> a <" + MEMENTO_TYPE + "> ."));
         try (final CloseableHttpResponse response = execute(putMethod)) {
             assertEquals("Must not be able to PUT RDF that contains an \"<> a  <" + MEMENTO_TYPE + ">\"",
-                         BAD_REQUEST.getStatusCode(),
+                         CONFLICT.getStatusCode(),
                          getStatus(response));
         }
     }
@@ -3935,7 +3935,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         try (CloseableHttpResponse response = execute(patch)) {
             assertEquals("Must not be able to INSERT  \"<>  <\" + RDF_NAMESPACE + \"type> <" + MEMENTO_TYPE + ">\"",
-                         BAD_REQUEST.getStatusCode(), getStatus(patch));
+                         CONFLICT.getStatusCode(), getStatus(patch));
         }
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -94,6 +94,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
@@ -3896,4 +3897,45 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Test
+    public void testPostCreateRDFSourceWithMementoNamespaceTriple() throws IOException {
+        final String subjectURI = getRandomUniqueId();
+        final HttpPost createMethod = new HttpPost(serverAddress);
+        createMethod.addHeader(CONTENT_TYPE, "text/turtle");
+        createMethod.addHeader("Slug", subjectURI);
+        createMethod.setEntity(new StringEntity("<> a <" + MEMENTO_TYPE + "> ."));
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            assertEquals("Must not be able to POST RDF that contains an \"<> a  <" + MEMENTO_TYPE + ">\"",
+                         BAD_REQUEST.getStatusCode(),
+                         getStatus(response));
+        }
+    }
+
+    @Test
+    public void testPutCreateRDFSourceWithMementoNamespaceTriple() throws IOException {
+        final String subjectURI = serverAddress + getRandomUniqueId();
+        final HttpPut putMethod = new HttpPut(subjectURI);
+        putMethod.addHeader(CONTENT_TYPE, "text/turtle");
+        putMethod.setEntity(new StringEntity("<> a <" + MEMENTO_TYPE + "> ."));
+        try (final CloseableHttpResponse response = execute(putMethod)) {
+            assertEquals("Must not be able to PUT RDF that contains an \"<> a  <" + MEMENTO_TYPE + ">\"",
+                         BAD_REQUEST.getStatusCode(),
+                         getStatus(response));
+        }
+    }
+
+    @Test
+    public void testPatchInsertMementoNamespaceTriple() throws IOException {
+        final String pid =  getRandomUniqueId();
+        final String subjectURI = serverAddress + pid;
+        createObjectAndClose(pid);
+        final HttpPatch patch = new HttpPatch(subjectURI);
+        patch.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patch.setEntity(new StringEntity("INSERT { <> a <" + MEMENTO_TYPE + "> . } WHERE {} "));
+
+        try (CloseableHttpResponse response = execute(patch)) {
+            assertEquals("Must not be able to INSERT  \"<>  <\" + RDF_NAMESPACE + \"type> <" + MEMENTO_TYPE + ">\"",
+                         BAD_REQUEST.getStatusCode(), getStatus(patch));
+        }
+    }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -36,6 +36,7 @@ import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedNamespace;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
@@ -174,6 +175,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     public static final String LDPCV_TIME_MAP = "fedora:timemap";
 
     public static final String CONTAINER_WEBAC_ACL = "fedora:acl";
+
+    static final String RDF_TYPE_URI = RDF_NAMESPACE + "type";
 
     // A curried type accepting resource, translator, and "minimality", returning triples.
     protected static interface RdfGenerator extends Function<FedoraResource,
@@ -813,6 +816,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
         checkInteractionModel(request);
 
+        checkForDisallowedTriples(request);
+
         final FilteringJcrPropertyStatementListener listener = new FilteringJcrPropertyStatementListener(
                 idTranslator, getSession(), idTranslator.reverse().convert(described).asNode());
 
@@ -881,6 +886,42 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
                             + ixn + " is not allowed!");
                 }
             });
+        }
+    }
+
+    /**
+     * Check sparql statements for disallowed modifications
+     * @param request
+     */
+    private void checkForDisallowedTriples(final UpdateRequest request) {
+        final List<Quad> quads = new ArrayList<>();
+
+        for (final Update operation : request.getOperations()) {
+            if (operation instanceof UpdateModify) {
+                final UpdateModify op = (UpdateModify) operation;
+                quads.addAll(op.getDeleteQuads());
+                quads.addAll(op.getInsertQuads());
+            } else if (operation instanceof UpdateData) {
+                final UpdateData op = (UpdateData) operation;
+                quads.addAll(op.getQuads());
+            } else if (operation instanceof UpdateDeleteWhere) {
+                final UpdateDeleteWhere op = (UpdateDeleteWhere) operation;
+                quads.addAll(op.getQuads());
+            }
+        }
+
+        quads.stream().forEach(e -> {
+           ensureNoMementNamespacedObjects(e.asTriple());
+        });
+    }
+
+    private void ensureNoMementNamespacedObjects(final Triple triple) {
+        final org.apache.jena.graph.Node object = triple.getObject();
+        if (object.isURI() && triple.getPredicate().getURI().equals(RDF_TYPE_URI) &&
+            object.getURI().startsWith(MEMENTO_NAMESPACE)) {
+            throw new MalformedRdfException(
+                "The " + RDF_TYPE_URI + " predicate may not take an object in the memento namespace (" +
+                MEMENTO_NAMESPACE + ").");
         }
     }
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -127,6 +127,7 @@ import org.fcrepo.kernel.api.exception.InvalidPrefixException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.FedoraTimeMap;
@@ -919,7 +920,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         final org.apache.jena.graph.Node object = triple.getObject();
         if (object.isURI() && triple.getPredicate().getURI().equals(RDF_TYPE_URI) &&
             object.getURI().startsWith(MEMENTO_NAMESPACE)) {
-            throw new MalformedRdfException(
+            throw new ServerManagedTypeException(
                 "The " + RDF_TYPE_URI + " predicate may not take an object in the memento namespace (" +
                 MEMENTO_NAMESPACE + ").");
         }


### PR DESCRIPTION
no longer causes resources to disappear.
Instead a MalformedRdfException is thrown.

**Adding rdf:type memento:* - whether via PUT, POST or PATCH - no longer causes resources to disappear.**


**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2884

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Adding `<> a memento:*` should result in a constraint exception since there are simply no cases where that should be allowed.  Furthermore,  we use the triple internally to and thus adding it to resources through the API wreaks havoc in the form of mysteriously disappearing resources.

This PR ensures that a constraint error is thrown whenever a client attempts to add such a triple via PUT, POST, or PATCH.

Integration tests cover the three cases.


# How should this be tested?

1. POST a resource  and verify 400 response: 
` curl -i -u fedoraAdmin:fedoraAdmin -X POST http://localhost:8080/rest/test -H "Content-Type: text/turtle"  --data "<> a <http://mementoweb.org/ns#Memento> ."`

2. PUT a resource  and verify 400 response: 
` curl -i -u fedoraAdmin:fedoraAdmin -X PUT http://localhost:8080/rest/test -H "Content-Type: text/turtle"  --data "<> a <http://mementoweb.org/ns#Memento> ."`

3. Create a resource, PATCH,   and verify 400 response: 
```
curl -i -u fedoraAdmin:fedoraAdmin -X PUT  http://localhost:8080/rest/test;
curl -i -u fedoraAdmin:fedoraAdmin -X PATCH  http://localhost:8080/rest/test -H "Content-Type: application/sparql-update"  --data "INSERT { <> a <http://mementoweb.org/ns#Memento> . } WHERE {}"
```

Example:
* Does this change require documentation to be updated?  Yes
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? Never say never.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
