### PR TITLE
Disallow PATCH of "ldp:contains" as (In)Direct ldp:hasMemberRelation

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2231,6 +2231,74 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPatchWithLdpContainsIndirectContainer() throws IOException {
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id);
+        put.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        executeAndClose(put);
+
+        final HttpPatch patch = patchObjMethod(id);
+        patch.setHeader(CONTENT_TYPE, "application/sparql-update");
+        final String updateString =
+                "INSERT DATA { <> <" + MEMBERSHIP_RESOURCE.getURI() +
+                        "> <> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "contains> .}";
+        patch.setEntity(new StringEntity(updateString));
+        assertEquals("Patch with sparql update allowed ldp:contains in indirect container!",
+                CONFLICT.getStatusCode(), getStatus(patch));
+    }
+
+    @Test
+    public void testPatchWithoutLdpContainsIndirectContainer() throws IOException {
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id);
+        put.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        executeAndClose(put);
+
+        final HttpPatch patch = patchObjMethod(id);
+        patch.setHeader(CONTENT_TYPE, "application/sparql-update");
+        final String updateString =
+                "INSERT DATA { <> <" + MEMBERSHIP_RESOURCE.getURI() +
+                        "> <> ; <" + HAS_MEMBER_RELATION + "> <info:some/relation> .}";
+        patch.setEntity(new StringEntity(updateString));
+        assertEquals("Patch with sparql update did not allow non SMT relation in indirect container!",
+                NO_CONTENT.getStatusCode(), getStatus(patch));
+    }
+
+    @Test
+    public void testPatchWithLdpContainsDirectContainer() throws IOException {
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        executeAndClose(put);
+
+        final HttpPatch patch = patchObjMethod(id);
+        patch.setHeader(CONTENT_TYPE, "application/sparql-update");
+        final String updateString =
+                "INSERT DATA { <> <" + MEMBERSHIP_RESOURCE.getURI() +
+                        "> <> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "contains> .}";
+        patch.setEntity(new StringEntity(updateString));
+        assertEquals("Patch with sparql update allowed ldp:contains in direct container!",
+                CONFLICT.getStatusCode(), getStatus(patch));
+    }
+
+    @Test
+    public void testPatchWithoutDirectContainer() throws IOException {
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        executeAndClose(put);
+
+        final HttpPatch patch = patchObjMethod(id);
+        patch.setHeader(CONTENT_TYPE, "application/sparql-update");
+        final String updateString =
+                "INSERT DATA { <> <" + MEMBERSHIP_RESOURCE.getURI() +
+                        "> <> ; <" + HAS_MEMBER_RELATION + "> <info:some/relation> .}";
+        patch.setEntity(new StringEntity(updateString));
+        assertEquals("Patch with sparql update did not allow non SMT relation in direct container!",
+                NO_CONTENT.getStatusCode(), getStatus(patch));
+    }
+
+    @Test
     public void testPatchToDeleteNonRdfSourceInteractionModel() throws IOException {
         final String pid = getRandomUniqueId();
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -33,6 +33,8 @@ import static org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral;
 import static org.apache.jena.update.UpdateAction.execute;
 import static org.apache.jena.update.UpdateFactory.create;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
@@ -913,6 +915,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
         quads.stream().forEach(e -> {
            ensureNoMementNamespacedObjects(e.asTriple());
+           ensureValidMemberRelation(e.asTriple());
         });
     }
 
@@ -923,6 +926,16 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
             throw new ServerManagedTypeException(
                 "The " + RDF_TYPE_URI + " predicate may not take an object in the memento namespace (" +
                 MEMENTO_NAMESPACE + ").");
+        }
+    }
+
+    private void ensureValidMemberRelation(final Triple triple) {
+        final org.apache.jena.graph.Node object = triple.getObject();
+        if (object.isURI() && triple.getPredicate().getURI().equals(HAS_MEMBER_RELATION.toString()) &&
+            object.getURI().equals(CONTAINS.toString())) {
+            throw new ServerManagedTypeException(
+                "The " + HAS_MEMBER_RELATION + " predicate may not take the ldp:contains type. (" +
+                CONTAINS + ").");
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2895

# What does this Pull Request do?
Validate PATCH request to ensure LDP Membership relation triple does not allow "ldp:contains" as the relationship.

# How should this be tested?
1. Verify the new tests cover all the validation cases and they pass.
2. Follow the instructions on the Jira issue description to reproduce the problem and note that the PATCH request now correctly fails with 409 response.

# Interested parties
@fcrepo4/committers
