### PR TITLE
Remove the dead and redundant code from fcrepo-auth-common.

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/AbstractPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/AbstractPrincipalProvider.java
@@ -54,7 +54,7 @@ abstract class AbstractPrincipalProvider implements PrincipalProvider {
     private static final String REALM_NAME = "org.fcrepo.auth.webac.WebACAuthorizingRealm";
 
     @Override
-    public void init(final FilterConfig filterConfig) throws ServletException {
+    public void init(final FilterConfig filterConfig) {
         // this method intentionally left empty
     }
 

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/BypassSecurityServletAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/BypassSecurityServletAuthenticationProvider.java
@@ -61,7 +61,7 @@ public class BypassSecurityServletAuthenticationProvider implements
     public static class AnonymousAdminSecurityContext implements
             SecurityContext {
 
-        private String userName;
+        private final String userName;
 
         /**
          * Create a new security context with the given user name

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerAuthToken.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerAuthToken.java
@@ -36,9 +36,9 @@ public class ContainerAuthToken implements AuthenticationToken {
 
     public static final String AUTHORIZED = "AUTHORIZED";
 
-    private BasicUserPrincipal servletUser;
+    private final BasicUserPrincipal servletUser;
 
-    private Set<ContainerRolesPrincipal> servletRoles;
+    private final Set<ContainerRolesPrincipal> servletRoles;
 
     /**
      * @param servletUsername username returned from servlet container authentication

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthFilter.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthFilter.java
@@ -57,7 +57,7 @@ public class ServletContainerAuthFilter implements Filter {
     private static final String[] ROLE_NAMES = { FEDORA_ADMIN_ROLE, FEDORA_USER_ROLE };
 
     @Override
-    public void init(final FilterConfig filterConfig) throws ServletException {
+    public void init(final FilterConfig filterConfig) {
         // this method intentionally left empty
     }
 

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroSecurityContext.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ShiroSecurityContext.java
@@ -72,10 +72,9 @@ public class ShiroSecurityContext implements SecurityContext {
             return true;
         } else if ("write".equals(roleName)) {
             return true;
-        } else if ("admin".equals(roleName)) {
-            return true;
+        } else {
+            return "admin".equals(roleName);
         }
-        return false;
     }
 
     @Override

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProviderTest.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.auth.common;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -42,10 +41,6 @@ public class DelegateHeaderPrincipalProviderTest {
 
     @Mock
     private HttpServletRequest request;
-
-    @Before
-    public void setUp() {
-    }
 
     @Test
     public void testGetDelegate0() {

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
@@ -20,9 +20,7 @@ package org.fcrepo.auth.integration;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.junit.Before;
@@ -33,8 +31,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.UUID;
 
 /**
  * <p>Abstract AbstractResourceIT class.</p>
@@ -45,22 +41,22 @@ import java.util.UUID;
 @ContextConfiguration("/spring-test/test-container.xml")
 public abstract class AbstractResourceIT {
 
-    protected Logger logger;
+    private Logger logger;
 
     @Before
     public void setLogger() {
         logger = LoggerFactory.getLogger(this.getClass());
     }
 
-    protected static final int SERVER_PORT = Integer.parseInt(System
+    private static final int SERVER_PORT = Integer.parseInt(System
             .getProperty("fcrepo.dynamic.test.port", "8080"));
 
-    protected static final String HOSTNAME = "localhost";
+    private static final String HOSTNAME = "localhost";
 
-    protected static final String serverAddress = "http://" + HOSTNAME +
+    private static final String serverAddress = "http://" + HOSTNAME +
             ":" + SERVER_PORT + "/";
 
-    protected static HttpClient client;
+    private static HttpClient client;
 
     public AbstractResourceIT() {
         client =
@@ -72,10 +68,6 @@ public abstract class AbstractResourceIT {
         return new HttpPost(serverAddress + pid);
     }
 
-    protected static HttpPut putObjMethod(final String pid) {
-        return new HttpPut(serverAddress + pid);
-    }
-
     protected static HttpPost postObjMethod(final String pid,
             final String query) {
         if (query.equals("")) {
@@ -84,28 +76,7 @@ public abstract class AbstractResourceIT {
         return new HttpPost(serverAddress + pid + "?" + query);
     }
 
-    protected static HttpPost postDSMethod(final String pid,
-            final String ds, final String content)
-            throws UnsupportedEncodingException {
-        final HttpPost post =
-                new HttpPost(serverAddress + pid + "/" + ds +
-                        "/jcr:content");
-        post.setEntity(new StringEntity(content));
-        return post;
-    }
-
-    protected static HttpPut putDSMethod(final String pid,
-            final String ds, final String content)
-            throws UnsupportedEncodingException {
-        final HttpPut put =
-                new HttpPut(serverAddress + pid + "/" + ds +
-                        "/jcr:content");
-
-        put.setEntity(new StringEntity(content));
-        return put;
-    }
-
-    protected HttpResponse execute(final HttpUriRequest method)
+    private HttpResponse execute(final HttpUriRequest method)
             throws IOException {
         logger.debug("Executing: " + method.getMethod() + " to " +
                 method.getURI());
@@ -120,15 +91,5 @@ public abstract class AbstractResourceIT {
             logger.warn(EntityUtils.toString(response.getEntity()));
         }
         return result;
-    }
-
-    /**
-     * Gets a random (but valid) pid for use in testing. This pid is guaranteed
-     * to be unique within runs of this application.
-     *
-     * @return  A string containing the new Pid
-     */
-    protected static String getRandomUniquePid() {
-        return UUID.randomUUID().toString();
     }
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/RootTestResource.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/RootTestResource.java
@@ -54,7 +54,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class RootTestResource extends AbstractResource {
 
     @Inject
-    protected HttpSession session;
+    private HttpSession session;
 
     private static final Logger LOGGER = getLogger(RootTestResource.class);
 
@@ -79,7 +79,7 @@ public class RootTestResource extends AbstractResource {
         return Response.created(location).build();
     }
 
-    protected IdentifierConverter<Resource,FedoraResource> translator() {
+    private IdentifierConverter<Resource,FedoraResource> translator() {
         return new HttpResourceConverter(session,
                     uriInfo.getBaseUriBuilder().clone().path(RootTestResource.class));
     }


### PR DESCRIPTION
Additionally, tighten method and field qualifiers.

Resolves: https://jira.duraspace.org/browse/FCREPO-2900

# What does this Pull Request do?
Non-functional clean-up of fcrepo-auth-common

# How should this be tested?
Successful build, deployment and one-click

# Interested parties
@fcrepo4/committers
