### PR TITLE
Add different container types to HTML UI dropdown.

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -35,7 +35,9 @@
         Type
     </label>
     <select id="new_mixin" class="form-control">
-        <option value="container">container</option>
+        <option value="basic container">basic container</option>
+        <option value="direct container">direct container</option>
+        <option value="indirect container">indirect container</option>
         <option value="binary">binary</option>
     </select>
         </div>

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -81,7 +81,16 @@
       };
       reader.readAsArrayBuffer(update_file);
     } else {
-      headers.push(['Link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"']);
+      if (mixin == 'basic container') {
+        headers.push(['Link', '<http://www.w3.org/ns/ldp#BasicContainer>; rel=\"type\"']);
+      } else if (mixin == 'direct container') {
+        headers.push(['Link', '<http://www.w3.org/ns/ldp#DirectContainer>; rel=\"type\"']);
+      } else if (mixin == 'indirect container') {
+        headers.push(['Link', '<http://www.w3.org/ns/ldp#IndirectContainer>; rel=\"type\"']);
+      } else {
+        alert("Unrecognized type: " + mixin);
+        return;
+      }
       const turtle = document.getElementById('turtle_payload');
       if (turtle && turtle.value) {
         headers.push(['Content-Type', 'text/turtle']);

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
@@ -154,13 +154,11 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
     @Test
     public void testCreateNewBasicContainer() throws IOException {
         final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "basic container");
-        System.err.println(newPage.asText());
         assertTrue("Set container type to ldp:BasicContainer", newPage.asText().contains(
                 "http://www.w3.org/ns/ldp#BasicContainer"));
     }
 
     @Test
-    @Ignore
     public void testCreateNewDirectContainer() throws IOException {
         final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "direct container");
         assertTrue("Set container type to ldp:DirectContainer", newPage.asText().contains(
@@ -168,7 +166,6 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore
     public void testCreateNewIndirectContainer() throws IOException {
         final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "indirect container");
         assertTrue("Set container type to ldp:IndirectContainer", newPage.asText().contains(

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
@@ -103,14 +103,23 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
 
     @Test
     public void testCreateNewNodeWithProvidedId() throws IOException {
-        createAndVerifyObjectWithIdFromRootPage(randomUUID().toString());
+        createAndVerifyObjectWithIdFromRootPage(newPid());
+    }
+
+    private String newPid() {
+        return randomUUID().toString();
     }
 
     private HtmlPage createAndVerifyObjectWithIdFromRootPage(final String pid) throws IOException {
+        return createAndVerifyObjectWithIdFromRootPage(pid, "basic container");
+    }
+
+    private HtmlPage createAndVerifyObjectWithIdFromRootPage(final String pid, final String containerType)
+            throws IOException {
         final HtmlPage page = webClient.getPage(serverAddress);
         final HtmlForm form = (HtmlForm)page.getElementById("action_create");
         final HtmlSelect type = (HtmlSelect)page.getElementById("new_mixin");
-        type.getOptionByValue("container").setSelected(true);
+        type.getOptionByValue(containerType).setSelected(true);
 
         final HtmlInput new_id = (HtmlInput)page.getElementById("new_id");
         new_id.setValueAttribute(pid);
@@ -134,12 +143,36 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
         final HtmlPage page = webClient.getPage(serverAddress);
         final HtmlForm form = (HtmlForm)page.getElementById("action_create");
         final HtmlSelect type = (HtmlSelect)page.getElementById("new_mixin");
-        type.getOptionByValue("container").setSelected(true);
+        type.getOptionByValue("basic container").setSelected(true);
         final HtmlButton button = form.getFirstByXPath("button");
         button.click();
 
         final HtmlPage page1 = javascriptlessWebClient.getPage(serverAddress);
         assertTrue("Didn't see new information in page!", !page1.asText().equals(page.asText()));
+    }
+
+    @Test
+    public void testCreateNewBasicContainer() throws IOException {
+        final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "basic container");
+        System.err.println(newPage.asText());
+        assertTrue("Set container type to ldp:BasicContainer", newPage.asText().contains(
+                "http://www.w3.org/ns/ldp#BasicContainer"));
+    }
+
+    @Test
+    @Ignore
+    public void testCreateNewDirectContainer() throws IOException {
+        final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "direct container");
+        assertTrue("Set container type to ldp:DirectContainer", newPage.asText().contains(
+                "http://www.w3.org/ns/ldp#DirectContainer"));
+    }
+
+    @Test
+    @Ignore
+    public void testCreateNewIndirectContainer() throws IOException {
+        final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "indirect container");
+        assertTrue("Set container type to ldp:IndirectContainer", newPage.asText().contains(
+                "http://www.w3.org/ns/ldp#IndirectContainer"));
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2896

# What does this Pull Request do?
Add different container types to HTML UI dropdown.

# What's new?
* Removes the "container" entry from the create new object dropdown in the HTML UI
* Adds the 3 different container types to the dropdown ("basic container", "direct container", and "indirect container")
* Adds integration tests that ensure the containers created through the HTML UI this way have the correct RDF type

# How should this be tested?
* Use `mvn clean install` to run the tests.
* Manual testing can be done by running the webapp via jetty:run, creating containers of the 3 types, and observing that the resulting objects have the correct RDF type.

# Additional Notes:
* Does this change require documentation to be updated? If we refer to "Create a container" anywhere in the docs, that will need to be changed to be "basic container", or other type as appropriate.

# Interested parties
@fcrepo4/committers