### PR TITLE
Remove dead and redundant code from fcrepo-jms

### DIFF
--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/AbstractJMSPublisher.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/AbstractJMSPublisher.java
@@ -19,8 +19,6 @@ package org.fcrepo.jms;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.io.IOException;
-
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
@@ -49,21 +47,21 @@ import com.google.common.eventbus.Subscribe;
 abstract class AbstractJMSPublisher {
 
     @Inject
-    protected EventBus eventBus;
+    private EventBus eventBus;
 
     @Inject
-    protected ActiveMQConnectionFactory connectionFactory;
+    private ActiveMQConnectionFactory connectionFactory;
 
     @Inject
-    protected JMSEventMessageFactory eventFactory;
+    private JMSEventMessageFactory eventFactory;
 
-    protected Connection connection;
+    private Connection connection;
 
     protected Session jmsSession;
 
-    protected MessageProducer producer;
+    private MessageProducer producer;
 
-    protected static final Logger LOGGER = getLogger(AbstractJMSPublisher.class);
+    private static final Logger LOGGER = getLogger(AbstractJMSPublisher.class);
 
     protected abstract Destination createDestination() throws JMSException;
 
@@ -73,10 +71,9 @@ abstract class AbstractJMSPublisher {
      *
      * @param fedoraEvent the fedora event
      * @throws JMSException if JMS exception occurred
-     * @throws IOException if IO exception occurred
      */
     @Subscribe
-    public void publishJCREvent(final FedoraEvent fedoraEvent) throws JMSException, IOException {
+    public void publishJCREvent(final FedoraEvent fedoraEvent) throws JMSException {
         LOGGER.debug("Received an event from the internal bus.");
         final Message tm =
                 eventFactory.getMessage(fedoraEvent, jmsSession);

--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/DefaultMessageFactory.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/DefaultMessageFactory.java
@@ -45,7 +45,7 @@ import org.slf4j.Logger;
  */
 public class DefaultMessageFactory implements JMSEventMessageFactory {
 
-    public static final String JMS_NAMESPACE = "org.fcrepo.jms.";
+    private static final String JMS_NAMESPACE = "org.fcrepo.jms.";
 
     public static final String TIMESTAMP_HEADER_NAME = JMS_NAMESPACE
             + "timestamp";

--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/JMSEventMessageFactory.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/JMSEventMessageFactory.java
@@ -17,8 +17,6 @@
  */
 package org.fcrepo.jms;
 
-import java.io.IOException;
-
 import javax.jms.JMSException;
 import javax.jms.Message;
 
@@ -38,9 +36,8 @@ public interface JMSEventMessageFactory {
      * @param jcrEvent the jcr event
      * @param jmsSession the jms session
      * @return JMS message created from a JCR event
-     * @throws IOException if IO exception occurred
      * @throws JMSException if JMS exception occurred
      */
     Message getMessage(final FedoraEvent jcrEvent,
-            final javax.jms.Session jmsSession) throws IOException, JMSException;
+            final javax.jms.Session jmsSession) throws JMSException;
 }

--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/JMSQueuePublisher.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/JMSQueuePublisher.java
@@ -29,7 +29,7 @@ import javax.jms.JMSException;
  */
 public class JMSQueuePublisher extends AbstractJMSPublisher {
 
-    private String queueName;
+    private final String queueName;
 
     /**
      * Create a JMS Topic with the default name of "fedora"
@@ -43,7 +43,7 @@ public class JMSQueuePublisher extends AbstractJMSPublisher {
      *
      * @param queueName the name of the queue
      */
-    public JMSQueuePublisher(final String queueName) {
+    private JMSQueuePublisher(final String queueName) {
         this.queueName = queueName;
     }
 

--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/JMSTopicPublisher.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/JMSTopicPublisher.java
@@ -29,7 +29,7 @@ import javax.jms.JMSException;
  */
 public class JMSTopicPublisher extends AbstractJMSPublisher {
 
-    private String topicName;
+    private final String topicName;
 
     /**
      * Create a JMS Topic with the default name of "fedora"
@@ -43,7 +43,7 @@ public class JMSTopicPublisher extends AbstractJMSPublisher {
      *
      * @param topicName the name of the topic
      */
-    public JMSTopicPublisher(final String topicName) {
+    private JMSTopicPublisher(final String topicName) {
         this.topicName = topicName;
     }
 

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -42,7 +42,6 @@ import java.io.ByteArrayInputStream;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import javax.inject.Inject;
-import javax.jcr.RepositoryException;
 import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.JMSException;
@@ -111,14 +110,14 @@ abstract class AbstractJmsIT implements MessageListener {
 
     private MessageConsumer consumer;
 
-    private volatile Set<Message> messages = new CopyOnWriteArraySet<>();
+    private final Set<Message> messages = new CopyOnWriteArraySet<>();
 
     private static final Logger LOGGER = getLogger(AbstractJmsIT.class);
 
     protected abstract Destination createDestination() throws JMSException;
 
     @Test(timeout = TIMEOUT)
-    public void testIngestion() throws RepositoryException {
+    public void testIngestion() {
 
         LOGGER.debug("Expecting a {} event", RESOURCE_CREATION.getType());
 
@@ -136,7 +135,7 @@ abstract class AbstractJmsIT implements MessageListener {
     }
 
     @Test(timeout = TIMEOUT)
-    public void testFileEvents() throws InvalidChecksumException, RepositoryException {
+    public void testFileEvents() throws InvalidChecksumException {
 
         final FedoraSession session = repository.login();
         session.addSessionData(BASE_URL, TEST_BASE_URL);
@@ -162,7 +161,7 @@ abstract class AbstractJmsIT implements MessageListener {
     }
 
     @Test(timeout = TIMEOUT)
-    public void testMetadataEvents() throws RepositoryException {
+    public void testMetadataEvents() {
 
         final FedoraSession session = repository.login();
         session.addSessionData(BASE_URL, TEST_BASE_URL);
@@ -199,7 +198,7 @@ abstract class AbstractJmsIT implements MessageListener {
     }
 
     @Test(timeout = TIMEOUT)
-    public void testRemoval() throws RepositoryException {
+    public void testRemoval() {
 
         LOGGER.debug("Expecting a {} event", RESOURCE_DELETION.getType());
         final FedoraSession session = repository.login();


### PR DESCRIPTION
- Tighten method and field qualifiers.

Resolves: https://jira.duraspace.org/browse/FCREPO-2907

# What does this Pull Request do?
Non-functional clean-up of fcrepo-jms

# How should this be tested?
- Successful build, deployment and one-click
- Consume and check messages produced while interacting with the repository
** https://wiki.duraspace.org/display/FEDORA5x/How+to+Inspect+Event+Messages+Generated+by+Fedora
** https://jsonformatter.org/json-pretty-print

# Interested parties
@fcrepo4/committers
