### PR TITLE
Prevent PATCH containing server managed predicates and objects

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -400,7 +400,7 @@ public abstract class AbstractResourceIT {
         return createObjectWithLinkHeader(pid, null);
     }
 
-    protected CloseableHttpResponse createObjectWithLinkHeader(final String pid, final String linkHeader) {
+    private CloseableHttpResponse createObjectWithLinkHeader(final String pid, final String linkHeader) {
         final HttpPost httpPost = postObjMethod("/");
         if (isNotEmpty(pid)) {
             httpPost.addHeader("Slug", pid);
@@ -481,16 +481,6 @@ public abstract class AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(createTx)) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             return getLocation(response);
-        }
-    }
-
-    protected static void addMixin(final String pid, final String mixinUrl) throws IOException {
-        final HttpPatch updateObjectGraphMethod = new HttpPatch(serverAddress + pid);
-        updateObjectGraphMethod.addHeader(CONTENT_TYPE, "application/sparql-update");
-        updateObjectGraphMethod.setEntity(new StringEntity(
-                "INSERT DATA { <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <" + mixinUrl + "> . } "));
-        try (final CloseableHttpResponse response = execute(updateObjectGraphMethod)) {
-            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -31,6 +31,7 @@ import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
@@ -396,9 +397,16 @@ public abstract class AbstractResourceIT {
     }
 
     protected CloseableHttpResponse createObject(final String pid) {
+        return createObjectWithLinkHeader(pid, null);
+    }
+
+    protected CloseableHttpResponse createObjectWithLinkHeader(final String pid, final String linkHeader) {
         final HttpPost httpPost = postObjMethod("/");
-        if (pid.length() > 0) {
+        if (isNotEmpty(pid)) {
             httpPost.addHeader("Slug", pid);
+        }
+        if (isNotEmpty(linkHeader)) {
+            httpPost.addHeader(LINK, linkHeader);
         }
         try {
             final CloseableHttpResponse response = execute(httpPost);
@@ -412,6 +420,14 @@ public abstract class AbstractResourceIT {
     protected void createObjectAndClose(final String pid) {
         try {
             createObject(pid).close();
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void createObjectAndClose(final String pid, final String linkHeader) {
+        try {
+            createObjectWithLinkHeader(pid, linkHeader).close();
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -18,7 +18,6 @@
 package org.fcrepo.integration.http.api;
 
 import static org.apache.commons.lang3.StringUtils.contains;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
@@ -75,7 +74,6 @@ public class FedoraHtmlIT extends AbstractResourceIT {
     public void testGetContainerTemplate() throws IOException {
         final String pid = getRandomUniqueId();
         createObject(pid);
-        addMixin(pid, REPOSITORY_NAMESPACE + "Container");
 
         final HttpGet method = new HttpGet(serverAddress + pid);
         method.addHeader(ACCEPT, "text/html");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4069,7 +4069,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             "> \"Thu, 21 Jan 2010 00:09:40 GMT\". } WHERE {}"));
         try (CloseableHttpResponse response = execute(patch)) {
             assertEquals("Must not be able to PATCH RDF that contains a memento namespace predicate",
-                         CONFLICT.getStatusCode(), getStatus(patch));
+                         CONFLICT.getStatusCode(), getStatus(response));
         }
     }
 
@@ -4092,7 +4092,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     "ldp:insertedContentRelation ore:proxyFor. } WHERE {}"));
         try (CloseableHttpResponse response = execute(patch)) {
             assertEquals("Must not be able to PATCH IndirectContainer updating Server Managed triples",
-                         CONFLICT.getStatusCode(), getStatus(patch));
+                         CONFLICT.getStatusCode(), getStatus(response));
         }
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -91,7 +91,7 @@ public final class RdfLexicon {
      * Is this namespace one that the repository manages?
      */
     public static final Predicate<String> isManagedNamespace = p -> p.equals(REPOSITORY_NAMESPACE) ||
-            p.equals(LDP_NAMESPACE);
+            p.equals(LDP_NAMESPACE) || p.equals(MEMENTO_NAMESPACE);
 
     // MEMBERSHIP
     public static final Property HAS_PARENT =
@@ -271,6 +271,9 @@ public final class RdfLexicon {
     private static Predicate<Property> hasFedoraNamespace =
         p -> !p.isAnon() && p.getNameSpace().startsWith(REPOSITORY_NAMESPACE);
 
+    private static Predicate<Property> hasMementoNamespace =
+        p -> !p.isAnon() && p.getNameSpace().startsWith(MEMENTO_NAMESPACE);
+
     public static final Predicate<Property> isRelaxed =
             p -> relaxableProperties.contains(p)
                     && ("relaxed".equals(System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)));
@@ -279,7 +282,7 @@ public final class RdfLexicon {
      * Detects whether an RDF property is managed by the repository.
      */
     public static final Predicate<Property> isManagedPredicate =
-        hasFedoraNamespace.or(p -> managedProperties.contains(p));
+        hasFedoraNamespace.or(hasMementoNamespace).or(p -> managedProperties.contains(p));
 
     /**
      * Fedora defined JCR node type with supertype of nt:file with two nt:folder named fedora:timemap and
@@ -316,8 +319,8 @@ public final class RdfLexicon {
     /**
      * This is an internal RDF type for versionable resources, this may be replaced by a Memento type.
      */
-    public static final Property VERSIONED_RESOURCE =
-        createProperty(MEMENTO_NAMESPACE + "OriginalResource");
+    public static final Resource VERSIONED_RESOURCE =
+        createResource(MEMENTO_NAMESPACE + "OriginalResource");
 
     /*
      * Interaction Models.

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -33,7 +33,6 @@ import static org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral;
 import static org.apache.jena.update.UpdateAction.execute;
 import static org.apache.jena.update.UpdateFactory.create;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
-import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
@@ -181,8 +180,6 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
     static final String RDF_TYPE_URI = RDF_NAMESPACE + "type";
 
-    private static final List<String> RESTRICTED_PREDICATES = asList(HAS_MEMBER_RELATION.toString(), RDF_TYPE_URI);
-
     // A curried type accepting resource, translator, and "minimality", returning triples.
     protected static interface RdfGenerator extends Function<FedoraResource,
     Function<IdentifierConverter<Resource, FedoraResource>, Function<Boolean, Stream<Triple>>>> {}
@@ -294,7 +291,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
             isManagedNamespace.test(object.getNameSpace())) {
             return new ServerManagedTypeException(
                 "The " + predicateUri + " predicate may not take an object in the server managed namespaces (" +
-                object.isURI() + ").");
+                object.getNameSpace() + ").");
         }
         return null;
     });
@@ -316,7 +313,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
             isManagedPredicate.test(createProperty(object.getURI()))) {
             return new ServerManagedPropertyException(
                 "The " + HAS_MEMBER_RELATION + " predicate may not take the server managed type. (" +
-                CONTAINS + ").");
+                object.getURI() + ").");
         }
 
         return null;

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/observer/SimpleObserverIT.java
@@ -261,10 +261,10 @@ public class SimpleObserverIT extends AbstractIT {
 
         final Resource subject2 = subjects.reverse().convert(obj2);
 
+        obj1.addType("ldp:DirectContainer");
         obj1.updateProperties(subjects, "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n" +
                 "PREFIX pcdm: <http://pcdm.org/models#>\n" +
-                "INSERT { <> a ldp:DirectContainer ;\n" +
-                    "ldp:membershipResource <" + subject2 + "> ;\n" +
+                "INSERT { <> ldp:membershipResource <" + subject2 + "> ;\n" +
                     "ldp:hasMemberRelation pcdm:hasMember . } WHERE {}", obj1.getTriples(subjects, PROPERTIES));
 
         try {
@@ -309,11 +309,11 @@ public class SimpleObserverIT extends AbstractIT {
 
         final Resource subject2 = subjects.reverse().convert(obj2);
 
+        obj1.addType("ldp:IndirectContainer");
         obj1.updateProperties(subjects, "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n" +
                 "PREFIX pcdm: <http://pcdm.org/models#>\n" +
                 "PREFIX ore: <http://www.openarchives.org/ore/terms/>\n" +
-                "INSERT { <> a ldp:IndirectContainer ;\n" +
-                    "ldp:membershipResource <" + subject2 + "> ;\n" +
+                "INSERT { <> ldp:membershipResource <" + subject2 + "> ;\n" +
                     "ldp:hasMemberRelation pcdm:hasMember ;\n" +
                     "ldp:insertedContentRelation ore:proxyFor. } WHERE {}", obj1.getTriples(subjects, PROPERTIES));
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2899

# What does this Pull Request do?
Prevent PATCH update containing server managed predicates and triples.
Adds memento namespace to managed type and managed predicate check.

# How should this be tested?
- Run the tests to verify all passes
- Follow the instructions FCREPO-2899 description to replicate the problem and you should get a 409 on the third step.

# Interested parties
@fcrepo4/committers
