### PR TITLE
Remove dead and redundant code from fcrepo-http-api

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -71,7 +71,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
-import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
@@ -202,8 +201,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     static final Property WEBAC_ACCESS_TO_PROPERTY = createProperty(WEBAC_ACCESS_TO);
 
-    static final Node RDF_TYPE_URI = createURI(RDF_NAMESPACE + "type");
-
     @Context protected Request request;
     @Context protected HttpServletResponse servletResponse;
     @Context protected ServletContext context;
@@ -294,7 +291,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             varyValues.add(ACCEPT_DATETIME);
         }
 
-        varyValues.stream().forEach(x -> servletResponse.addHeader("Vary", x));
+        varyValues.forEach(x -> servletResponse.addHeader("Vary", x));
     }
 
 
@@ -451,11 +448,11 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
         }
 
-    protected RdfStream getTriples(final FedoraResource resource, final Set<? extends TripleCategory> x) {
+    private RdfStream getTriples(final FedoraResource resource, final Set<? extends TripleCategory> x) {
         return resource.getTriples(translator(), x);
     }
 
-    protected RdfStream getTriples(final FedoraResource resource, final TripleCategory x) {
+    private RdfStream getTriples(final FedoraResource resource, final TripleCategory x) {
         return resource.getTriples(translator(), x);
     }
 
@@ -478,7 +475,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     /**
      * Add the standard Accept-Post header, for reuse.
      */
-    protected void addAcceptPostHeader() {
+    private void addAcceptPostHeader() {
         final String rdfTypes = TURTLE + "," + N3 + "," + N3_ALT2 + "," + RDF_XML + "," + NTRIPLES + "," + JSON_LD;
         servletResponse.addHeader("Accept-Post", rdfTypes);
     }
@@ -486,11 +483,11 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     /**
      * Add the standard Accept-External-Content-Handling header, for reuse.
      */
-    protected void addAcceptExternalHeader() {
+    private void addAcceptExternalHeader() {
         servletResponse.addHeader(ACCEPT_EXTERNAL_CONTENT, COPY + "," + REDIRECT + "," + PROXY);
     }
 
-    protected void addMementoHeaders(final FedoraResource resource) {
+    private void addMementoHeaders(final FedoraResource resource) {
         if (resource.isMemento()) {
             final Instant mementoInstant = resource.getMementoDatetime();
             if (mementoInstant != null) {
@@ -514,7 +511,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
     }
 
-    protected void addAclHeader(final FedoraResource resource) {
+    private void addAclHeader(final FedoraResource resource) {
         if (!(resource instanceof FedoraWebacAcl) && !resource.isMemento()) {
             final String resourceUri = getUri(resource.getDescribedResource()).toString();
             final String aclLocation =  resourceUri + (resourceUri.endsWith("/") ? "" : "/") + FCR_ACL;
@@ -522,11 +519,11 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
     }
 
-    protected void addResourceLinkHeaders(final FedoraResource resource) {
+    private void addResourceLinkHeaders(final FedoraResource resource) {
         addResourceLinkHeaders(resource, false);
     }
 
-    protected void addResourceLinkHeaders(final FedoraResource resource, final boolean includeAnchor) {
+    private void addResourceLinkHeaders(final FedoraResource resource, final boolean includeAnchor) {
         if (resource instanceof NonRdfSourceDescription) {
             // Link to the original described resource
             final FedoraResource described = resource.getOriginalResource().getDescribedResource();
@@ -632,7 +629,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         return rawLinks.stream()
-                .flatMap(x -> Arrays.asList(x.split(",")).stream())
+                .flatMap(x -> Arrays.stream(x.split(",")))
                 .collect(Collectors.toList());
     }
 
@@ -830,7 +827,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * Returns an acceptable plain text media type if possible, or null if not.
      * @return an acceptable plain-text media type, or null
      */
-    protected MediaType acceptabePlainTextMediaType() {
+    private MediaType acceptabePlainTextMediaType() {
         final List<MediaType> acceptable = headers.getAcceptableMediaTypes();
         if (acceptable == null || acceptable.size() == 0) {
             return TEXT_PLAIN_TYPE;
@@ -974,7 +971,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      *   and a server-managed property as the object.
      *
      * @param inputModel to be checked
-     * @throws ServerManagedPropertyException
+     * @throws ServerManagedPropertyException on error
      */
     private void ensureValidMemberRelation(final Model inputModel) {
         // check that ldp:hasMemberRelation value is not server managed predicate.
@@ -1039,7 +1036,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * Returns a Statement with the resource containing the acl to be the accessTo target for the given auth subject.
      * 
      * @param authSubject - acl authorization subject uri string
-     * @return
+     * @return acl statement
      */
     private Statement createDefaultAccessToStatement(final String authSubject) {
         final String currentResourcePath = authSubject.substring(0, authSubject.indexOf("/" + FCR_ACL));
@@ -1117,7 +1114,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      */
     protected static void hasRestrictedPath(final String externalPath) {
         final String[] pathSegments = externalPath.split("/");
-        if (Arrays.asList(pathSegments).stream().anyMatch(p -> p.startsWith("fedora:"))) {
+        if (Arrays.stream(pathSegments).anyMatch(p -> p.startsWith("fedora:"))) {
             throw new ServerManagedTypeException("Path cannot contain a fedora: prefixed segment.");
         }
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -54,8 +54,8 @@ public class ExternalContentHandler {
 
     private static final Logger LOGGER = getLogger(FedoraLdp.class);
 
-    public final static String HANDLING = "handling";
-    public final static String EXT_CONTENT_TYPE = "type";
+    private final static String HANDLING = "handling";
+    private final static String EXT_CONTENT_TYPE = "type";
 
     private final Link link;
     private final String handling;
@@ -114,7 +114,7 @@ public class ExternalContentHandler {
      * @return boolean value representing whether or not the content handling is "copy"
      */
     public boolean isCopy() {
-        return handling != null ? handling.equals(COPY) : false;
+        return handling != null && handling.equals(COPY);
     }
 
     /**
@@ -122,7 +122,7 @@ public class ExternalContentHandler {
      * @return boolean value representing whether or not the content handling is "redirect"
      */
     public boolean isRedirect() {
-        return handling != null ? handling.equals(REDIRECT) : false;
+        return handling != null && handling.equals(REDIRECT);
     }
 
     /**
@@ -130,15 +130,14 @@ public class ExternalContentHandler {
      * @return boolean value representing whether or not the content handling is "proxy"
      */
     public boolean isProxy() {
-        return handling != null ? handling.equals(PROXY) : false;
+        return handling != null && handling.equals(PROXY);
     }
 
     /**
      * Fetch the external content
      * @return InputStream containing the external content
-     * @throws IOException
      */
-    public InputStream fetchExternalContent() throws IOException {
+    public InputStream fetchExternalContent() {
 
         final URI uri = link.getUri();
         final String scheme = uri.getScheme();
@@ -159,11 +158,10 @@ public class ExternalContentHandler {
 
     /**
      * Validate that an external content link header is appropriately formatted
-     * @param link
+     * @param link to be validated
      * @return Link object if the header is formatted correctly, else null
-     * @throws ExternalMessageBodyException
+     * @throws ExternalMessageBodyException on error
      */
-
     private Link parseLinkHeader(final String link) throws ExternalMessageBodyException {
         final Link realLink = Link.valueOf(link);
 
@@ -182,7 +180,7 @@ public class ExternalContentHandler {
 
     /**
      * Find the content type for a remote resource
-     * @param url
+     * @param url of remote resource
      * @return the content type reported by remote system or "application/octet-stream" if not supplied
      */
     private MediaType findContentType(final String url) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -140,7 +140,7 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
                                 line, configPath);
                         return false;
                     }
-                    if (schemeMatches && "file".equals(schemeMatcher.group(1))) {
+                    if ("file".equals(schemeMatcher.group(1))) {
                         // If a file uri ends with / it must be a directory, otherwise it must be a file.
                         final File allowing = new File(URI.create(line).getPath());
                         if ((line.endsWith("/") && !allowing.isDirectory())

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -46,7 +46,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import javax.jcr.ItemNotFoundException;
-import javax.jcr.nodetype.ConstraintViolationException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
@@ -75,7 +74,6 @@ import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
-import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.slf4j.Logger;
@@ -94,7 +92,7 @@ public class FedoraAcl extends ContentExposingResource {
 
     public static final String ROOT_AUTHORIZATION_PROPERTY = "fcrepo.auth.webac.authorization";
 
-    public static final String ROOT_AUTHORIZATION_LOCATION = "/root-authorization.ttl";
+    private static final String ROOT_AUTHORIZATION_LOCATION = "/root-authorization.ttl";
 
     @Context protected Request request;
     @Context protected HttpServletResponse servletResponse;
@@ -114,12 +112,10 @@ public class FedoraAcl extends ContentExposingResource {
      * @param requestContentType The content type of the resource body
      * @param requestBodyStream  The request body as stream
      * @return the response for a request to create a Fedora WebAc acl
-     * @throws ConstraintViolationException in case this action would violate a constraint on repository structure
      */
     @PUT
     public Response createFedoraWebacAcl(@HeaderParam(CONTENT_TYPE) final MediaType requestContentType,
-                                         final InputStream requestBodyStream)
-        throws ConstraintViolationException {
+                                         final InputStream requestBodyStream) {
 
         if (resource().isAcl() || resource().isMemento()) {
             throw new BadRequestException("ACL resource creation is not allowed for resource " + resource().getPath());
@@ -241,14 +237,13 @@ public class FedoraAcl extends ContentExposingResource {
      * @param rangeValue the range value
      * @return a binary or the triples for the specified node
      * @throws IOException if IO exception occurred
-     * @throws UnsupportedAlgorithmException  if unsupported digest algorithm occurred
      */
     @GET
     @Produces({ TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
                 N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
                 TURTLE_X, TEXT_HTML_WITH_CHARSET })
     public Response getResource(@HeaderParam("Range") final String rangeValue)
-            throws IOException, UnsupportedAlgorithmException, ItemNotFoundException {
+            throws IOException, ItemNotFoundException {
 
         LOGGER.info("GET resource '{}'", externalPath);
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -141,7 +141,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
         return "";
     }
 
-    protected HttpSession session() {
+    private HttpSession session() {
         if (session == null) {
             throw new SessionMissingException("Invalid session");
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTransactions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTransactions.java
@@ -50,7 +50,7 @@ public class FedoraTransactions extends FedoraBaseResource {
     private static final Logger LOGGER = getLogger(FedoraTransactions.class);
 
     @Inject
-    protected BatchService batchService;
+    private BatchService batchService;
 
     /**
      * Create a new transaction resource and add it to the registry

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -47,6 +47,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -229,7 +230,7 @@ public class FedoraVersioning extends ContentExposingResource {
             final Instant mementoInstant,
             final InputStream requestBodyStream,
             final ExternalContentHandler extContent,
-            final String digest) throws InvalidChecksumException, UnsupportedAlgorithmException, IOException {
+            final String digest) throws InvalidChecksumException, UnsupportedAlgorithmException {
 
         final Collection<String> checksums = parseDigestHeader(digest);
         final Collection<URI> checksumURIs = checksums == null ? new HashSet<>() : checksums.stream().map(
@@ -290,7 +291,7 @@ public class FedoraVersioning extends ContentExposingResource {
             });
             // Based on the dates of the above mementos, add the range to the below link.
             final Instant[] Mementos = Arrays.stream(children).map(FedoraResource::getMementoDatetime)
-                .sorted((a, b) -> a.compareTo(b))
+                .sorted(Comparator.naturalOrder())
                 .toArray(Instant[]::new);
             final Builder linkBuilder =
                 Link.fromUri(parentUri + "/" + FCR_VERSIONS).rel("self").type(APPLICATION_LINK_FORMAT);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/PathLockManager.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/PathLockManager.java
@@ -37,12 +37,12 @@ public interface PathLockManager {
      * anyone else receiving one of these such locks from a LockManager
      * should not retain a reference to the used lock after releasing it.
      */
-    public interface AcquiredLock {
+    interface AcquiredLock {
 
         /**
          * Releases the lock, after which it's useless.
          */
-        public void release();
+        void release();
     }
 
     /**
@@ -54,7 +54,7 @@ public interface PathLockManager {
      * @param path the path to a resource to be viewed
      * @return an acquired Lock on the relevant resources
      */
-    public AcquiredLock lockForRead(String path);
+    AcquiredLock lockForRead(String path);
 
     /**
      * Locks the necessary resources affected in order to safely write to a resource
@@ -69,7 +69,7 @@ public interface PathLockManager {
      * @param nodeService the repository NodeService implementation
      * @return an acquired Lock on the relevant resources
      */
-    public AcquiredLock lockForWrite(String path, FedoraSession session, NodeService nodeService);
+    AcquiredLock lockForWrite(String path, FedoraSession session, NodeService nodeService);
 
     /**
      * Locks the necessary resources affected in order to safely delete a resource
@@ -82,6 +82,6 @@ public interface PathLockManager {
      *        all descendant resources)
      * @return an acquired Lock on the relevant resources
      */
-    public AcquiredLock lockForDelete(String path);
+    AcquiredLock lockForDelete(String path);
 
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryBackup.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryBackup.java
@@ -54,13 +54,13 @@ public class FedoraRepositoryBackup extends AbstractResource {
     private static final Logger LOGGER = getLogger(FedoraRepositoryBackup.class);
 
     @Inject
-    protected HttpSession session;
+    private HttpSession session;
 
     /**
      * The fcrepo repository service
      */
     @Inject
-    protected RepositoryService repositoryService;
+    private RepositoryService repositoryService;
 
     /**
      * This method runs a repository backup.

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryRestore.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryRestore.java
@@ -53,13 +53,13 @@ public class FedoraRepositoryRestore extends AbstractResource {
     private static final Logger LOGGER = getLogger(FedoraRepositoryRestore.class);
 
     @Inject
-    protected HttpSession session;
+    private HttpSession session;
 
     /**
      * The fcrepo repository service
      */
     @Inject
-    protected RepositoryService repositoryService;
+    private RepositoryService repositoryService;
 
     /**
      * This method runs a repository restore.

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/DefaultPathLockManagerTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/DefaultPathLockManagerTest.java
@@ -46,7 +46,7 @@ public class DefaultPathLockManagerTest {
      * Tests are written such that we'll only wait this long if there's something
      * broken in the code and the test would fail.
      */
-    public static final int WAIT = 1000;
+    private static final int WAIT = 1000;
 
     @Mock
     private FedoraSession session;
@@ -171,7 +171,7 @@ public class DefaultPathLockManagerTest {
      * An interface whose single method acquires an AcquiredLock.
      */
     private interface Locker {
-        public AcquiredLock acquireLock();
+        AcquiredLock acquireLock();
     }
 
     /**
@@ -181,7 +181,7 @@ public class DefaultPathLockManagerTest {
 
         private boolean interrupted;
 
-        private Locker l;
+        private final Locker l;
 
         public Actor(final Locker l) {
             this.l = l;
@@ -220,7 +220,7 @@ public class DefaultPathLockManagerTest {
          * Determines if the thread has/can complete (ie, is not blocked).
          * The current implementation joins this thread (with a timeout)
          * and verifies that it is no longer alive.
-         * @return
+         * @return true if thread can complete
          */
         private boolean canComplete() {
             try {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
@@ -52,7 +52,7 @@ public class ExternalContentHandlerFactoryTest {
     }
 
     @Test
-    public void testValidLinkHeader() throws Exception {
+    public void testValidLinkHeader() {
         final ExternalContentHandler handler = factory.createFromLinks(
                 makeLinks("http://test.com"));
 
@@ -62,14 +62,14 @@ public class ExternalContentHandlerFactoryTest {
     }
 
     @Test(expected = ExternalMessageBodyException.class)
-    public void testValidationFailure() throws Exception {
+    public void testValidationFailure() {
         doThrow(new ExternalMessageBodyException("")).when(validator).validate(anyString());
 
         factory.createFromLinks(makeLinks("http://test.com"));
     }
 
     @Test(expected = ExternalMessageBodyException.class)
-    public void testMultipleExtLinkHeaders() throws Exception {
+    public void testMultipleExtLinkHeaders() {
         final List<String> links = makeLinks("http://test.com", "http://test2.com");
 
         factory.createFromLinks(links);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -316,7 +316,7 @@ public class ExternalContentPathValidatorTest {
         // Check that the new allowed path was detected
         boolean pass = false;
         // Polling to see if change occurred for 20 seconds
-        final long endTimes = System.nanoTime() + 20000000000l;
+        final long endTimes = System.nanoTime() + 20000000000L;
         while (System.nanoTime() < endTimes) {
             Thread.sleep(50);
             try {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -22,6 +22,7 @@ import static java.net.URI.create;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Stream.of;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
 import static javax.ws.rs.core.HttpHeaders.LINK;
@@ -78,7 +79,6 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -160,7 +160,7 @@ public class FedoraLdpTest {
     private final String binaryDescriptionPath = binaryPath + "/fedora:description";
     private FedoraLdp testObj;
 
-    private final List<String> nonRDFSourceLink = Arrays.asList(
+    private final List<String> nonRDFSourceLink = singletonList(
             Link.fromUri(NON_RDF_SOURCE.toString()).rel("type").build().toString());
 
     @Mock
@@ -293,7 +293,7 @@ public class FedoraLdpTest {
     private FedoraResource setResource(final Class<? extends FedoraResource> klass) {
         final FedoraResource mockResource = mock(klass);
         if (mockResource instanceof FedoraBinary) {
-            when(((FedoraBinary) mockResource).getContentSize()).thenReturn(1l);
+            when(((FedoraBinary) mockResource).getContentSize()).thenReturn(1L);
         }
 
         final Answer<RdfStream> answer = invocationOnMock -> new DefaultRdfStream(
@@ -472,7 +472,7 @@ public class FedoraLdpTest {
     }
 
     @Test
-    public void testOption() throws Exception {
+    public void testOption() {
         setResource(FedoraResource.class);
         final Response actual = testObj.options();
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -481,7 +481,7 @@ public class FedoraLdpTest {
     }
 
     @Test
-    public void testOptionWithLDPRS() throws Exception {
+    public void testOptionWithLDPRS() {
         setResource(Container.class);
         final Response actual = testObj.options();
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -491,7 +491,7 @@ public class FedoraLdpTest {
     }
 
     @Test
-    public void testOptionWithBinary() throws Exception {
+    public void testOptionWithBinary() {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
@@ -504,7 +504,7 @@ public class FedoraLdpTest {
     }
 
     @Test
-    public void testOptionWithBinaryDescription() throws Exception {
+    public void testOptionWithBinaryDescription() {
         final NonRdfSourceDescription mockResource
                 = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
@@ -592,7 +592,7 @@ public class FedoraLdpTest {
             final Model model = entity.stream.collect(toModel());
             final List<String> rdfNodes = model.listObjects().mapWith(RDFNode::toString).toList();
             assertTrue("Expected RDF contexts missing", rdfNodes.stream()
-                    .filter(x -> x.contains("PROPERTIES") && x.contains("MINIMAL")).findFirst().isPresent());
+                    .anyMatch(x -> x.contains("PROPERTIES") && x.contains("MINIMAL")));
             assertFalse("Included non-minimal contexts", rdfNodes.contains("LDP_MEMBERSHIP"));
             assertFalse("Included non-minimal contexts", rdfNodes.contains("LDP_CONTAINMENT"));
         }
@@ -603,10 +603,9 @@ public class FedoraLdpTest {
      * Emulates an 'If-None-Match' precondition failing for a GET request.  There should not be any entity body set
      * on the response.
      *
-     * @throws Exception if something exceptional happens
      */
     @Test
-    public void testGetWhenIfNoneMatchPreconditionFails() throws Exception {
+    public void testGetWhenIfNoneMatchPreconditionFails() {
         setResource(FedoraResource.class);
 
         // Set up the expectations for the ResponseBuilder
@@ -643,10 +642,9 @@ public class FedoraLdpTest {
      * Emulates an 'If-Modified-Since' precondition failing for a GET request.  There should not be any entity body set
      * on the response.
      *
-     * @throws Exception if something exceptional happens
      */
     @Test
-    public void testGetWhenIfModifiedSincePreconditionFails() throws Exception {
+    public void testGetWhenIfModifiedSincePreconditionFails() {
         setResource(FedoraResource.class);
 
         // Set up the expectations for the ResponseBuilder
@@ -713,7 +711,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testGetWithObjectIncludeReferences()
-            throws ParseException, IOException, UnsupportedAlgorithmException {
+            throws IOException, UnsupportedAlgorithmException {
         setResource(Container.class);
         setField(testObj, "prefer", new MultiPrefer("return=representation; include=\"" + INBOUND_REFERENCES + "\""));
         final Response actual = testObj.getResource(null);
@@ -783,7 +781,7 @@ public class FedoraLdpTest {
                 .toString()
                 .replaceAll("<.*>", "< >");
 
-        testObj.createObject(null, null, null, null, Arrays.asList(badExternal), null);
+        testObj.createObject(null, null, null, null, singletonList(badExternal), null);
     }
 
     @Test(expected = ExternalMessageBodyException.class)
@@ -793,7 +791,7 @@ public class FedoraLdpTest {
 
          final String badExternal = Link.fromUri("http://test.com")
             .rel(EXTERNAL_CONTENT.toString()).param("handling", "boogie").type("text/plain").build().toString();
-        testObj.createObject(null, null, null, null, Arrays.asList(badExternal), null);
+        testObj.createObject(null, null, null, null, singletonList(badExternal), null);
     }
 
     @Test
@@ -841,7 +839,7 @@ public class FedoraLdpTest {
     }
 
     @Test
-    public void testDelete() throws Exception {
+    public void testDelete() {
         final FedoraResource fedoraResource = setResource(FedoraResource.class);
         final Response actual = testObj.deleteObject();
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
@@ -866,7 +864,7 @@ public class FedoraLdpTest {
     @Test(expected = CannotCreateResourceException.class)
     public void testPutNewObjectLdpr() throws Exception {
         testObj.createOrReplaceObjectRdf(null, null, null, null,
-                asList("<http://www.w3.org/ns/ldp#Resource>; rel=\"type\""), null);
+                singletonList("<http://www.w3.org/ns/ldp#Resource>; rel=\"type\""), null);
     }
 
     @Test
@@ -984,7 +982,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObject() throws MalformedRdfException, InvalidChecksumException,
-           IOException, UnsupportedAlgorithmException {
+            UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, null, "b", null, null, null);
@@ -993,17 +991,17 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObjectWithVersionedResource() throws MalformedRdfException, InvalidChecksumException,
-           IOException, UnsupportedAlgorithmException {
+            UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final String versionedResourceLink = "<" + VERSIONED_RESOURCE.getURI() + ">;rel=\"type\"";
-        final Response actual = testObj.createObject(null, null, "b", null, Arrays.asList(versionedResourceLink), null);
+        final Response actual = testObj.createObject(null, null, "b", null, singletonList(versionedResourceLink), null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
     }
 
     @Test
     public void testCreateNewObjectWithSparql() throws MalformedRdfException,
-           InvalidChecksumException, UnsupportedAlgorithmException, IOException {
+           InvalidChecksumException, UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null,
@@ -1014,7 +1012,7 @@ public class FedoraLdpTest {
 
     @Test
     public void testCreateNewObjectWithRdf() throws MalformedRdfException,
-           InvalidChecksumException, IOException, UnsupportedAlgorithmException {
+           InvalidChecksumException, UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, NTRIPLES_TYPE, "b",
@@ -1155,7 +1153,7 @@ public class FedoraLdpTest {
     }
 
     @Test(expected = ClientErrorException.class)
-    public void testPostToBinary() throws MalformedRdfException, InvalidChecksumException, IOException,
+    public void testPostToBinary() throws MalformedRdfException, InvalidChecksumException,
             UnsupportedAlgorithmException {
         final FedoraBinary mockObject = (FedoraBinary)setResource(FedoraBinary.class);
         doReturn(mockObject).when(testObj).resource();
@@ -1164,18 +1162,19 @@ public class FedoraLdpTest {
 
     @Test(expected = CannotCreateResourceException.class)
     public void testLDPRNotImplemented() throws MalformedRdfException, InvalidChecksumException,
-            IOException, UnsupportedAlgorithmException {
+            UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/x")).thenReturn(mockContainer);
-        testObj.createObject(null, null, "x", null, asList("<http://www.w3.org/ns/ldp#Resource>; rel=\"type\""), null);
+        testObj.createObject(null, null, "x", null,
+                singletonList("<http://www.w3.org/ns/ldp#Resource>; rel=\"type\""), null);
     }
 
     @Test(expected = ClientErrorException.class)
     public void testLDPRNotImplementedInvalidLink() throws MalformedRdfException, InvalidChecksumException,
-            IOException, UnsupportedAlgorithmException {
+            UnsupportedAlgorithmException {
         setResource(Container.class);
         when(mockContainerService.findOrCreate(mockFedoraSession, "/x")).thenReturn(mockContainer);
-        testObj.createObject(null, null, "x", null, asList("<http://foo;rel=\"type\""), null);
+        testObj.createObject(null, null, "x", null, singletonList("<http://foo;rel=\"type\""), null);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -62,8 +62,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyListOf;
-import static org.mockito.ArgumentMatchers.anySetOf;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -307,7 +307,7 @@ public class FedoraLdpTest {
         when(mockResource.getEtagValue()).thenReturn("");
         when(mockResource.getDescription()).thenReturn(mockResource);
         when(mockResource.getDescribedResource()).thenReturn(mockResource);
-        when(mockResource.getTriples(eq(idTranslator), anySetOf(TripleCategory.class))).thenAnswer(answer);
+        when(mockResource.getTriples(eq(idTranslator), anySet())).thenAnswer(answer);
         when(mockResource.getTriples(eq(idTranslator), any(TripleCategory.class))).thenAnswer(answer);
 
         return mockResource;
@@ -770,7 +770,7 @@ public class FedoraLdpTest {
 
     @Test(expected = ExternalMessageBodyException.class)
     public void testGetWithExternalMessageMissingURLBinary() throws Exception {
-        when(extContentHandlerFactory.createFromLinks(anyListOf(String.class)))
+        when(extContentHandlerFactory.createFromLinks(anyList()))
                 .thenThrow(new ExternalMessageBodyException(""));
 
         final String badExternal = Link.fromUri("http://test.com")
@@ -786,7 +786,7 @@ public class FedoraLdpTest {
 
     @Test(expected = ExternalMessageBodyException.class)
     public void testPostWithExternalMessageBadHandling() throws Exception {
-        when(extContentHandlerFactory.createFromLinks(anyListOf(String.class)))
+        when(extContentHandlerFactory.createFromLinks(anyList()))
                 .thenThrow(new ExternalMessageBodyException(""));
 
          final String badExternal = Link.fromUri("http://test.com")

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
@@ -34,7 +34,6 @@ import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.jcr.Value;
 import javax.jcr.ValueFactory;
 import javax.jcr.Workspace;
 import javax.jcr.nodetype.NodeType;
@@ -64,9 +63,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.sparql.util.Context;
 
 
 /**
@@ -102,19 +98,10 @@ public class FedoraNodesTest {
     private Request mockRequest;
 
     @Mock
-    private FedoraResource mockResource;
-
-    @Mock
     Session mockSession;
 
     @Mock
     private FedoraResource mockContainer;
-
-    @Mock
-    private Model mockModel;
-
-    @Mock
-    private Context mockContext;
 
     @Mock
     private HttpServletResponse mockResponse;
@@ -125,15 +112,9 @@ public class FedoraNodesTest {
     private UriInfo mockUriInfo;
 
     @Mock
-    private Value mockValue;
-
-    @Mock
-    private ValueFactory mockValueFactory;
-
-    @Mock
     private SecurityContext mockSecurityContext;
 
-    private String path = "/some/path";
+    private final String path = "/some/path";
 
     @Before
     public void setUp() throws Exception {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraTombstonesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraTombstonesTest.java
@@ -42,10 +42,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 @RunWith(MockitoJUnitRunner.class)
 public class FedoraTombstonesTest {
 
-    @Mock
-    private Tombstone mockResource;
-
-    private String path = "/test/object";
+    private final String path = "/test/object";
 
     private FedoraTombstones testObj;
 
@@ -64,7 +61,7 @@ public class FedoraTombstonesTest {
     }
 
     @Test
-    public void testDelete() throws Exception {
+    public void testDelete() {
         final Tombstone mockResource = mock(Tombstone.class);
 
         doReturn(mockResource).when(testObj).resource();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProviderTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProviderTest.java
@@ -50,7 +50,6 @@ import javax.jcr.Workspace;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
@@ -170,7 +169,7 @@ public class StreamingBaseHtmlProviderTest {
                 mockTemplate));
         testProvider.writeTo(testData, RdfNamespacedStream.class, mock(Type.class),
                 new Annotation[]{}, MediaType.valueOf("text/html"),
-                (MultivaluedMap) new MultivaluedHashMap<>(), outStream);
+                new MultivaluedHashMap<>(), outStream);
         final byte[] results = outStream.toByteArray();
         assertTrue("Got no output from serialization!", results.length > 0);
 
@@ -199,7 +198,7 @@ public class StreamingBaseHtmlProviderTest {
         testProvider.writeTo(testData, RdfNamespacedStream.class, mock(Type.class),
                 new Annotation[]{mockAnnotation}, MediaType
                         .valueOf("text/html"),
-                (MultivaluedMap) new MultivaluedHashMap<>(), outStream);
+                new MultivaluedHashMap<>(), outStream);
         final byte[] results = outStream.toByteArray();
         assertTrue("Got no output from serialization!", results.length > 0);
 
@@ -226,7 +225,7 @@ public class StreamingBaseHtmlProviderTest {
         testProvider.writeTo(testData2, RdfNamespacedStream.class, mock(Type.class),
                 new Annotation[] {}, MediaType
                         .valueOf("text/html"),
-                (MultivaluedMap) new MultivaluedHashMap<>(), outStream);
+                new MultivaluedHashMap<>(), outStream);
         final byte[] results = outStream.toByteArray();
         assertTrue("Got no output from serialization!", results.length > 0);
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProviderTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProviderTest.java
@@ -150,7 +150,6 @@ public class StreamingBaseHtmlProviderTest {
 
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void testWriteTo() throws WebApplicationException,
             IllegalArgumentException, IOException {
@@ -175,7 +174,6 @@ public class StreamingBaseHtmlProviderTest {
 
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void testWriteToWithAnnotation() throws WebApplicationException,
             IllegalArgumentException, IOException {
@@ -204,7 +202,6 @@ public class StreamingBaseHtmlProviderTest {
 
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void testWriteToWithParentTemplate() throws WebApplicationException,
             IllegalArgumentException, IOException {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/url/HttpApiResourcesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/url/HttpApiResourcesTest.java
@@ -33,7 +33,6 @@ import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -87,16 +86,6 @@ public class HttpApiResourcesTest {
             testObj.createModelForResource(mockResource, uriInfo, mockSubjects);
 
         assertTrue(model.contains(graphSubject, HAS_TRANSACTION_SERVICE));
-    }
-
-    @Test
-    @Ignore("Until implemented with Memento")
-    public void shouldDecorateNodesWithLinksToVersions() {
-    }
-
-    @Test
-    @Ignore ("Until implemented with Memento")
-    public void shouldNotDecorateNodesWithLinksToVersionsUnlessVersionable() {
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -105,15 +105,15 @@ public abstract class AbstractResourceIT {
         logger = getLogger(this.getClass());
     }
 
-    protected static final int SERVER_PORT = parseInt(System.getProperty("fcrepo.dynamic.test.port", "8080"));
+    private static final int SERVER_PORT = parseInt(System.getProperty("fcrepo.dynamic.test.port", "8080"));
 
-    protected static final String HOSTNAME = "localhost";
+    private static final String HOSTNAME = "localhost";
 
-    protected static final String PROTOCOL = "http";
+    private static final String PROTOCOL = "http";
 
     protected static final String serverAddress = PROTOCOL + "://" + HOSTNAME + ":" + SERVER_PORT + "/";
 
-    protected static CloseableHttpClient client = createClient();
+    protected static final CloseableHttpClient client = createClient();
 
     protected static CloseableHttpClient createClient() {
         return createClient(false);
@@ -154,13 +154,6 @@ public abstract class AbstractResourceIT {
 
     protected static HttpPatch patchObjMethod(final String id) {
         return new HttpPatch(serverAddress + id);
-    }
-
-    protected static HttpPost postObjMethod(final String id, final String query) {
-        if (query.equals("")) {
-            return new HttpPost(serverAddress + id);
-        }
-        return new HttpPost(serverAddress + id + "?" + query);
     }
 
     protected static HttpPut putDSMethod(final String pid, final String ds, final String content)
@@ -350,7 +343,7 @@ public abstract class AbstractResourceIT {
      * @return the graph retrieved
      * @throws IOException in case of IOException
      */
-    protected CloseableDataset getDataset(final CloseableHttpClient client, final HttpUriRequest req)
+    private CloseableDataset getDataset(final CloseableHttpClient client, final HttpUriRequest req)
             throws IOException {
         if (!req.containsHeader(ACCEPT)) {
             req.addHeader(ACCEPT, "application/n-triples");
@@ -443,8 +436,8 @@ public abstract class AbstractResourceIT {
         return setProperty(pid, null, propertyUri, value);
     }
 
-    protected CloseableHttpResponse setProperty(final String id, final String txId, final String propertyUri,
-            final String value) throws IOException {
+    private CloseableHttpResponse setProperty(final String id, final String txId, final String propertyUri,
+                                              final String value) throws IOException {
         final HttpPatch postProp = new HttpPatch(serverAddress + (txId != null ? txId + "/" : "") + id);
         postProp.setHeader(CONTENT_TYPE, "application/sparql-update");
         final String updateString =
@@ -491,15 +484,6 @@ public abstract class AbstractResourceIT {
      * @return string containing new id
      */
     protected static String getRandomUniqueId() {
-        return randomUUID().toString();
-    }
-
-    /**
-     * Gets a random (but valid) property name for use in testing.
-     *
-     * @return string containing random property name
-     */
-    protected static String getRandomPropertyName() {
         return randomUUID().toString();
     }
 
@@ -572,19 +556,6 @@ public abstract class AbstractResourceIT {
     }
 
     /**
-     * Test a response for N instances of a specific LINK header
-     *
-     * @param response the HTTP response
-     * @param uri the URI expected in the LINK header
-     * @param rel the rel argument to check for
-     * @param count how many LINK headers should exist
-     */
-    protected static void checkForNLinkHeaders(final HttpResponse response, final String uri, final String rel,
-        final int count) {
-        assertEquals(count, countLinkHeader(response, uri, rel));
-    }
-
-    /**
      * Utility for counting LINK headers
      *
      * @param response the HTTP response
@@ -594,7 +565,7 @@ public abstract class AbstractResourceIT {
      */
     private static int countLinkHeader(final HttpResponse response, final String uri, final String rel) {
         final Link linkA = Link.valueOf("<" + uri + ">; rel=" + rel);
-        return (int) Arrays.asList(response.getHeaders(LINK)).stream().filter(x -> {
+        return (int) Arrays.stream(response.getHeaders(LINK)).filter(x -> {
             final Link linkB = Link.valueOf(x.getValue());
             return linkB.equals(linkA);
         }).count();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/DirtyContextBeforeAndAfterClassTestExecutionListener.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/DirtyContextBeforeAndAfterClassTestExecutionListener.java
@@ -37,12 +37,12 @@ public class DirtyContextBeforeAndAfterClassTestExecutionListener
     }
 
     @Override
-    public void beforeTestClass(final TestContext testContext) throws Exception {
+    public void beforeTestClass(final TestContext testContext) {
         testContext.markApplicationContextDirty(HierarchyMode.EXHAUSTIVE);
     }
 
     @Override
-    public void afterTestClass(final TestContext testContext) throws Exception {
+    public void afterTestClass(final TestContext testContext) {
         testContext.markApplicationContextDirty(HierarchyMode.EXHAUSTIVE);
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -101,7 +101,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testExternalDatastreamProxyWithWantDigestForLocalFile() throws IOException, ParseException {
+    public void testExternalDatastreamProxyWithWantDigestForLocalFile() throws IOException {
 
         final File externalFile = createExternalLocalFile(TEST_BINARY_CONTENT);
 
@@ -126,7 +126,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testExternalDatastreamCopyWithWantDigestForLocalFile() throws IOException, ParseException {
+    public void testExternalDatastreamCopyWithWantDigestForLocalFile() throws IOException {
 
         final File externalFile = createExternalLocalFile(TEST_BINARY_CONTENT);
 
@@ -151,7 +151,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testExternalDatastreamProxyWithWantDigest() throws IOException, ParseException {
+    public void testExternalDatastreamProxyWithWantDigest() throws IOException {
 
         final String dsId = getRandomUniqueId();
         createDatastream(dsId, "x", TEST_BINARY_CONTENT);
@@ -177,7 +177,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testExternalDatastreamCopyWithWantDigest() throws IOException, ParseException {
+    public void testExternalDatastreamCopyWithWantDigest() throws IOException {
 
         final String dsId = getRandomUniqueId();
         createDatastream(dsId, "x", TEST_BINARY_CONTENT);
@@ -203,7 +203,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testExternalDatastreamProxyWithWantDigestMultipleForLocalFile() throws IOException, ParseException {
+    public void testExternalDatastreamProxyWithWantDigestMultipleForLocalFile() throws IOException {
 
         final File externalFile = createExternalLocalFile(TEST_BINARY_CONTENT);
 
@@ -224,9 +224,9 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
+                    digesterHeaderValue.contains(TEST_SHA_DIGEST_HEADER_VALUE));
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
+                    digesterHeaderValue.contains(TEST_MD5_DIGEST_HEADER_VALUE));
         }
 
         // GET request with Want-Digest
@@ -239,9 +239,9 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
+                    digesterHeaderValue.contains(TEST_SHA_DIGEST_HEADER_VALUE));
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
+                    digesterHeaderValue.contains(TEST_MD5_DIGEST_HEADER_VALUE));
         }
     }
 
@@ -330,16 +330,16 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf(sha1) >= 0);
+                    digesterHeaderValue.contains(sha1));
             if (md5 != null) {
                 assertTrue("MD5 fixity checksum doesn't match",
-                        digesterHeaderValue.indexOf(md5) >= 0);
+                        digesterHeaderValue.contains(md5));
             }
         }
     }
 
     @Test
-    public void testRedirectWithWantDigest() throws IOException, ParseException {
+    public void testRedirectWithWantDigest() throws IOException {
 
         final String dsId = getRandomUniqueId();
         createDatastream(dsId, "x", TEST_BINARY_CONTENT);
@@ -656,7 +656,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
             final HttpGet get = new HttpGet(getLocation(response));
             try (final CloseableHttpClient noFollowClient =
                     HttpClientBuilder.create().disableRedirectHandling().build();
-                    final CloseableHttpResponse getResponse = noFollowClient.execute(get);) {
+                    final CloseableHttpResponse getResponse = noFollowClient.execute(get)) {
                 assertEquals(TEMPORARY_REDIRECT.getStatusCode(), getStatus(getResponse));
             }
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -204,7 +204,7 @@ public class FedoraAclIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testGetNonExistentAcl() throws Exception {
+    public void testGetNonExistentAcl() {
         createObjectAndClose(id);
         final HttpGet getNotFound = new HttpGet(subjectUri + "/" + FCR_ACL);
         assertEquals(NOT_FOUND.getStatusCode(), getStatus(getNotFound));
@@ -241,14 +241,14 @@ public class FedoraAclIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testDeleteDefaultRootAcl() throws Exception {
+    public void testDeleteDefaultRootAcl() {
         final String rootAclUri = serverAddress + FCR_ACL;
         assertEquals("DELETE should fail for default generated root ACL.",
                 CONFLICT.getStatusCode(), getStatus(new HttpDelete(rootAclUri)));
     }
 
     @Test
-    public void testPatchDefaultRootAcl() throws Exception {
+    public void testPatchDefaultRootAcl() {
         final String rootAclUri = serverAddress + FCR_ACL;
         assertEquals("PATCH should fail for default generated root ACL.",
                 CONFLICT.getStatusCode(), getStatus(new HttpPatch(rootAclUri)));
@@ -485,7 +485,7 @@ public class FedoraAclIT extends AbstractResourceIT {
 
         try (final CloseableHttpResponse response = execute(put)) {
             assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
-            assertEquals(ex.toString(), response.getFirstHeader(LINK).getValue().toString());
+            assertEquals(ex.toString(), response.getFirstHeader(LINK).getValue());
         }
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraCrudConcurrentIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraCrudConcurrentIT.java
@@ -58,8 +58,8 @@ public class FedoraCrudConcurrentIT extends AbstractResourceIT {
 
         final int[] numThreadsToTest = {2, 4, 8, 16, 32};
         logger.info("# Start CRUD concurrent performance testing...");
-        for (int i = 0; i < numThreadsToTest.length; i++) {
-            startCrudConcurrentPerformanceTest(numThreadsToTest[i]);
+        for (int aNumThreadsToTest : numThreadsToTest) {
+            startCrudConcurrentPerformanceTest(aNumThreadsToTest);
         }
     }
 
@@ -67,8 +67,8 @@ public class FedoraCrudConcurrentIT extends AbstractResourceIT {
      * Test CRUD concurrent access performance:
      * create/update/delete object, create/update/delete content file
      *
-     * @param numThreads
-     * @throws Exception
+     * @param numThreads to run
+     * @throws Exception on error
      */
     private void startCrudConcurrentPerformanceTest(final int numThreads) throws Exception {
         String pid = null;
@@ -243,10 +243,9 @@ public class FedoraCrudConcurrentIT extends AbstractResourceIT {
     }
 
     private static void startThreads(final List<HttpRunner> tasks) throws InterruptedException {
-        final int taskSize = tasks.size();
-        for (int i = 0; i < taskSize; i++) {
+        for (HttpRunner task : tasks) {
 
-            final Thread thread = new Thread(tasks.get(i));
+            final Thread thread = new Thread(task);
             thread.run();
             thread.join();
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -217,10 +217,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final Logger LOGGER = getLogger(FedoraLdpIT.class);
 
-    private static DateTimeFormatter headerFormat =
+    private static final DateTimeFormatter headerFormat =
       DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(of("GMT"));
 
-    private static DateTimeFormatter tripleFormat =
+    private static final DateTimeFormatter tripleFormat =
       DateTimeFormatter.ISO_INSTANT.withZone(of("GMT"));
 
     @Test
@@ -398,7 +398,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testHeadDatastreamWithWantDigest() throws IOException, ParseException {
+    public void testHeadDatastreamWithWantDigest() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", TEST_BINARY_CONTENT);
 
@@ -415,7 +415,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testHeadDatastreamWithWantDigestMultiple() throws IOException, ParseException {
+    public void testHeadDatastreamWithWantDigestMultiple() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", TEST_BINARY_CONTENT);
 
@@ -428,14 +428,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
+                    digesterHeaderValue.contains(TEST_SHA_DIGEST_HEADER_VALUE));
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
+                    digesterHeaderValue.contains(TEST_MD5_DIGEST_HEADER_VALUE));
         }
     }
 
     @Test
-    public void testHeadDatastreamWithWantDigestSha256() throws IOException, ParseException {
+    public void testHeadDatastreamWithWantDigestSha256() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", TEST_BINARY_CONTENT);
 
@@ -448,7 +448,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-256 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_SHA256_DIGEST_HEADER_VALUE) >= 0);
+                    digesterHeaderValue.contains(TEST_SHA256_DIGEST_HEADER_VALUE));
         }
     }
 
@@ -709,13 +709,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
             final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
             assertTrue("SHA-1 Fixity Checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_SHA_DIGEST_HEADER_VALUE) >= 0);
+                    digesterHeaderValue.contains(TEST_SHA_DIGEST_HEADER_VALUE));
             assertTrue("MD5 fixity checksum doesn't match",
-                    digesterHeaderValue.indexOf(TEST_MD5_DIGEST_HEADER_VALUE) >= 0);
-            assertTrue("SHA-256 fixity checksum doesn't match",
-                digesterHeaderValue
-                            .indexOf(
-                                    "sha-256=fb871ff8cce8fea83dfaeab41784305a1461e008dc02a371ed26d856c766c903") >= 0);
+                    digesterHeaderValue.contains(TEST_MD5_DIGEST_HEADER_VALUE));
+            assertTrue("SHA-256 fixity checksum doesn't match",digesterHeaderValue.contains(
+                    "sha-256=fb871ff8cce8fea83dfaeab41784305a1461e008dc02a371ed26d856c766c903"));
         }
     }
 
@@ -1085,7 +1083,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         checkForLinkHeader(response, subjectURI, "timegate");
         checkForLinkHeader(response, subjectURI + "/" + FCR_VERSIONS, "timemap");
         checkForLinkHeader(response, subjectURI + "/" + FCR_ACL, "acl");
-        assertEquals(1, Arrays.asList(response.getHeaders("Vary")).stream().filter(x -> x.getValue().contains(
+        assertEquals(1, Arrays.stream(response.getHeaders("Vary")).filter(x -> x.getValue().contains(
                 "Accept-Datetime")).count());
     }
 
@@ -1433,7 +1431,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String etag1;
         try (final CloseableHttpResponse response = execute(get)) {
             etag1 = response.getFirstHeader("ETag").getValue();
-            final String resp = IOUtils.toString(response.getEntity().getContent(), UTF_8);
+            IOUtils.toString(response.getEntity().getContent(), UTF_8);
         }
 
         assertEquals("Child resource not deleted!", NO_CONTENT.getStatusCode(),
@@ -1442,7 +1440,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String etag2;
         try (final CloseableHttpResponse response = execute(get)) {
             etag2 = response.getFirstHeader("ETag").getValue();
-            final String resp = IOUtils.toString(response.getEntity().getContent(), UTF_8);
+            IOUtils.toString(response.getEntity().getContent(), UTF_8);
         }
 
         assertNotEquals("ETag didn't change!", etag1, etag2);
@@ -1875,10 +1873,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testGetLongRange() throws IOException, ParseException {
+    public void testGetLongRange() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
-        final StringBuffer buf = new StringBuffer();
+        final StringBuilder buf = new StringBuilder();
         while ( buf.length() < 9000 ) {
             buf.append("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         }
@@ -2627,7 +2625,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 subjectURI + "> <" + REPOSITORY_NAMESPACE + "uuid> \"value-doesn't-matter\" } WHERE {}\n"));
         try (final CloseableHttpResponse response = execute(patchObjMethod)) {
             assertEquals(CONFLICT.getStatusCode(), getStatus(response));
-            assertEquals(ex.toString(), response.getFirstHeader(LINK).getValue().toString());
+            assertEquals(ex.toString(), response.getFirstHeader(LINK).getValue());
         }
     }
 
@@ -2897,7 +2895,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testCreatedAndModifiedDates() throws IOException, ParseException {
+    public void testCreatedAndModifiedDates() throws IOException {
         final String location = getLocation(postObjMethod());
         final HttpGet getObjMethod = new HttpGet(location);
         try (final CloseableHttpResponse response = execute(getObjMethod)) {
@@ -3036,7 +3034,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         // Ensure container has been updated with relationship... indirectly
         try (final CloseableHttpResponse getResponse1 = execute(new HttpGet(container));
-                final CloseableDataset dataset = getDataset(getResponse1);) {
+                final CloseableDataset dataset = getDataset(getResponse1)) {
             final DatasetGraph graph = dataset.asDatasetGraph();
             assertFalse("Expected NOT to have resource: " + graph, graph.contains(ANY,
                     createURI(container), createURI("info:some/relation"), createURI(resource)));
@@ -3282,7 +3280,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     private static Optional<Instant> getDateFromModel(final Model model, final Resource subj, final Property pred)
-            throws NoSuchElementException, ParseException {
+            throws NoSuchElementException {
         final StmtIterator stmts = model.listStatements(subj, pred, (String) null);
         return Optional.ofNullable(
            stmts.hasNext() ? Instant.from(tripleFormat.parse(stmts.nextStatement().getString())) : null);
@@ -3467,7 +3465,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testCreationResponseDefault() throws Exception {
+    public void testCreationResponseDefault() {
         testCreationResponse(null, null, CREATED, "text/plain");
         testCreationResponse(null, "application/ld+json", NOT_ACCEPTABLE, "text/html");
     }
@@ -3582,7 +3580,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         try (final CloseableDataset dataset = getDataset(getObjMethod(parent))) {
             final DatasetGraph graphStore = dataset.asDatasetGraph();
-            final List<String> childPaths = new ArrayList<String>();
+            final List<String> childPaths = new ArrayList<>();
             final Iterator<Quad> children = graphStore.find(ANY, ANY, CONTAINS.asNode(), ANY);
             assertTrue("Four children should have been created (none found).", children.hasNext());
             childPaths.add(children.next().getObject().getURI());
@@ -3710,7 +3708,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableDataset dataset = getDataset(getObjMethod(path))) {
             final DatasetGraph graphStore = dataset.asDatasetGraph();
             final List<String> missingDcIdentifiers
-                    = new ArrayList<>(Arrays.asList(new String[] { "one", "two", "three", "four" }));
+                    = new ArrayList<>(Arrays.asList("one", "two", "three", "four"));
             final Iterator<Quad> dcIdentifierIt = graphStore.find(ANY, createURI(serverAddress + path),
                     createProperty("http://purl.org/dc/elements/1.1/identifier").asNode(), ANY);
             while (dcIdentifierIt.hasNext()) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -20,6 +20,7 @@ package org.fcrepo.integration.http.api;
 import static java.lang.Thread.sleep;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.ZoneId.of;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Arrays.asList;
 import static java.util.regex.Pattern.compile;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
@@ -119,6 +120,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -218,7 +220,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     private static final Logger LOGGER = getLogger(FedoraLdpIT.class);
 
     private static final DateTimeFormatter headerFormat =
-      DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(of("GMT"));
+            RFC_1123_DATE_TIME.withLocale(Locale.US).withZone(ZoneId.of("GMT"));
 
     private static final DateTimeFormatter tripleFormat =
       DateTimeFormatter.ISO_INSTANT.withZone(of("GMT"));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
@@ -48,7 +48,6 @@ import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashSet;
@@ -91,7 +90,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FedoraRelaxedLdpIT extends AbstractResourceIT {
 
-    private String providedUsername = "provided-username";
+    private final String providedUsername = "provided-username";
     private Calendar providedDate;
 
     public FedoraRelaxedLdpIT() {
@@ -127,7 +126,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testCreateResourceWithSpecificCreationInformationIsAllowed() throws IOException, ParseException {
+    public void testCreateResourceWithSpecificCreationInformationIsAllowed() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
         final String subjectURI;
         try (CloseableHttpResponse response = postResourceWithTTL(
@@ -144,7 +143,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testUpdateNonRdfResourceWithSpecificInformationIsAllowed() throws IOException, ParseException {
+    public void testUpdateNonRdfResourceWithSpecificInformationIsAllowed() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
 
         final String subjectURI;
@@ -230,7 +229,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testUpdateResourceWithSpecificModificationInformationIsAllowed() throws IOException, ParseException {
+    public void testUpdateResourceWithSpecificModificationInformationIsAllowed() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
 
         final String subjectURI;
@@ -385,9 +384,9 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     /**
      * Parses the provided triples and filters it to just include statements with the
      * specified predicates.
-     * @param triples
-     * @param predicates
-     * @return
+     * @param triples to filter
+     * @param predicates to filter on
+     * @return filtered triples
      */
     private String filterRdf(final String triples, final Property ... predicates) {
         try (CloseableDataset original = parseTriples(new ByteArrayInputStream(triples.getBytes()))) {
@@ -458,7 +457,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         return execute(httpPut);
     }
 
-    private ResultGraphWrapper triples(final String uri, final Dataset dataset) throws IOException {
+    private ResultGraphWrapper triples(final String uri, final Dataset dataset) {
         return new ResultGraphWrapper(uri, dataset.asDatasetGraph());
     }
 
@@ -468,11 +467,11 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
 
     private class ResultGraphWrapper {
 
-        private DatasetGraph graph;
-        private Node nodeUri;
-        private String statements;
+        private final DatasetGraph graph;
+        private final Node nodeUri;
+        private final String statements;
 
-        public ResultGraphWrapper(final String subjectURI, final DatasetGraph graph) throws IOException {
+        public ResultGraphWrapper(final String subjectURI, final DatasetGraph graph) {
             this.graph = graph;
             final Model model = createModelForGraph(graph.getDefaultGraph());
             nodeUri = createURI(subjectURI);

--- a/fcrepo-jms/src/test/java/org/fcrepo/jms/AbstractJMSPublisherTest.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/jms/AbstractJMSPublisherTest.java
@@ -26,8 +26,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-import java.io.IOException;
-
 import javax.jms.Connection;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -94,7 +92,7 @@ abstract class AbstractJMSPublisherTest {
     }
 
     @Test
-    public void testPublishJCREvent() throws IOException, JMSException {
+    public void testPublishJCREvent() throws JMSException {
         final Message mockMsg = mock(Message.class);
         final FedoraEvent mockEvent = mock(FedoraEvent.class);
         when(mockEventFactory.getMessage(eq(mockEvent), isNull())).thenReturn(mockMsg);

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraBinaryImplIT.java
@@ -415,7 +415,7 @@ public class FedoraBinaryImplIT extends AbstractIT {
 
     @Test
     public void testGetFixityWithWantDigest() throws InvalidChecksumException,
-            URISyntaxException, UnsupportedAlgorithmException {
+            UnsupportedAlgorithmException {
         final Collection<String> digestAlgs = singletonList("SHA");
         final String pid = "testFixityWithWantDigest-" + randomUUID();
         final FedoraSession session = repo.login();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/VersionServiceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/VersionServiceImplIT.java
@@ -22,7 +22,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
 import javax.inject.Inject;
-import javax.jcr.RepositoryException;
 
 import org.fcrepo.integration.kernel.modeshape.AbstractIT;
 import org.fcrepo.kernel.api.FedoraRepository;
@@ -90,7 +89,7 @@ public class VersionServiceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testCreateVersion() throws RepositoryException {
+    public void testCreateVersion() {
         final String pid = getRandomPid();
         final FedoraResource resource = containerService.findOrCreate(session, "/" + pid);
         session.commit();
@@ -138,7 +137,7 @@ public class VersionServiceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testRemoveVersion() throws RepositoryException {
+    public void testRemoveVersion() {
         final String pid = getRandomPid();
         final FedoraResource resource = containerService.findOrCreate(session, "/" + pid);
         session.commit();
@@ -155,7 +154,7 @@ public class VersionServiceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testCreateDescriptionVersion() throws Exception {
+    public void testCreateDescriptionVersion() {
         final String pid = getRandomPid();
         final FedoraResource resource = binaryService.findOrCreate(session, "/" + pid);
         session.commit();


### PR DESCRIPTION
- Tighten method and field qualifiers.

Resolves: https://jira.duraspace.org/browse/FCREPO-2909

# What does this Pull Request do?
Non-functional clean-up of fcrepo-http-api

# How should this be tested?
Successful build, deployment and one-click

# Interested parties
@fcrepo4/committers
