### PR TITLE
Add more complex travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,27 @@
 language: java
 sudo: true
+
 jdk:
+  - openjdk8
   - oraclejdk8
+  - openjdk11
+
+matrix:
+  allow_failures: 
+    - jdk: openjdk11
+  fast_finish: true
+
 before_install:  
  - "echo $JAVA_OPTS"
  - "export JAVA_OPTS=-Xmx512m"
 
-script:
+# Default installation command is 
+# mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+# this is what we test as our build phase so skip it here.
+install:
+ - true
+
+before_script:
  - sudo service mysql stop
  - sudo service postgresql stop
  - sudo service acpid stop
@@ -18,6 +33,8 @@ script:
  - sudo service resolvconf stop
  - sudo service sshguard stop
  - sudo service ssh stop
+
+script:
  - mvn -Dfcrepo.streaming.parallel=true install -B -V
 
 notifications:


### PR DESCRIPTION
**JIRA Ticket**: N/A

# What does this Pull Request do?
Expands the testing matrix to test Oracle JDK 8, OpenJDK 8 and OpenJDK 11. But OpenJDK 11 is for informational purposes and is an allowed failure.

# What's new?
Changes in `.travis.yml`

# How should this be tested?

Let travis run and pass.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
