### PR TITLE
Fcrepo-2923 - Allow modification of premis:hasSize property

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -32,6 +32,7 @@ import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
@@ -80,6 +81,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.apache.jena.rdf.model.Model;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -98,7 +100,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public abstract class AbstractResourceIT {
 
     protected static Logger logger;
-    private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
+
+    protected static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
 
     @Before
     public void setLogger() {
@@ -383,6 +386,14 @@ public abstract class AbstractResourceIT {
      */
     protected CloseableDataset getDataset(final HttpUriRequest req) throws IOException {
         return getDataset(client, req);
+    }
+
+    protected Model getModel(final String pid) throws Exception {
+        final Model model = createDefaultModel();
+        try (final CloseableHttpResponse response = execute(new HttpGet(serverAddress + pid))) {
+            model.read(response.getEntity().getContent(), serverAddress + pid, "TURTLE");
+        }
+        return model;
     }
 
     protected CloseableHttpResponse createObject() {

--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/ServerManagedTriplesIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/ServerManagedTriplesIT.java
@@ -30,6 +30,7 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.Response.Status.CREATED;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.RdfLexicon.WRITABLE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_NAMESPACE;
@@ -194,7 +195,7 @@ public class ServerManagedTriplesIT extends AbstractResourceIT {
     @Test
     public void testNonRdfSourceServerGeneratedTriples() throws Exception {
         final String pid = getRandomUniqueId();
-        final String describedPid = pid + "/fcr:metadata";
+        final String describedPid = pid + "/" + FCR_METADATA;
         final String location = serverAddress + pid;
 
         final String filename = "some-file.txt";

--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/ServerManagedTriplesIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/ServerManagedTriplesIT.java
@@ -21,20 +21,39 @@ import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.PREMIS_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static java.util.Arrays.asList;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.CREATED;
 import static org.fcrepo.kernel.api.RdfLexicon.WRITABLE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
+import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBED_BY;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+
 import java.util.List;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.integration.http.api.AbstractResourceIT;
 import org.junit.Test;
 
@@ -57,16 +76,6 @@ public class ServerManagedTriplesIT extends AbstractResourceIT {
             verifyRejectLiteral(predicate);
             verifyRejectUpdateLiteral(predicate);
         }
-    }
-
-    @Test
-    public void testLdpContains() throws Exception {
-        final String refPid = getRandomUniqueId();
-        final String refURI = serverAddress + refPid;
-        createObject(refPid);
-
-        verifyRejectUriRef(LDP_NAMESPACE + "contains", refURI);
-        verifyRejectUpdateUriRef(LDP_NAMESPACE + "contains", refURI);
     }
 
     @Test
@@ -152,6 +161,7 @@ public class ServerManagedTriplesIT extends AbstractResourceIT {
                 "INSERT { <> <" + predicate + "> \"value\" } WHERE { }";
 
         final String pid = getRandomUniqueId();
+        createObject(pid);
         try (final CloseableHttpResponse response = performUpdate(pid, updateString)) {
             assertEquals("Must reject update of server managed property <" + predicate + ">",
                     409, response.getStatusLine().getStatusCode());
@@ -167,6 +177,7 @@ public class ServerManagedTriplesIT extends AbstractResourceIT {
                 "INSERT { <> <" + predicate + "> <" + refURI + "> } WHERE { }";
 
         final String pid = getRandomUniqueId();
+        createObject(pid);
         try (final CloseableHttpResponse response = performUpdate(pid, updateString)) {
             assertEquals("Must reject update of server managed property <" + predicate + "> <" + refURI + ">",
                     409, response.getStatusLine().getStatusCode());
@@ -174,11 +185,101 @@ public class ServerManagedTriplesIT extends AbstractResourceIT {
     }
 
     private CloseableHttpResponse performUpdate(final String pid, final String updateString) throws Exception {
-        createObject(pid);
-
         final HttpPatch patchProp = patchObjMethod(pid);
         patchProp.setHeader(CONTENT_TYPE, "application/sparql-update");
         patchProp.setEntity(new StringEntity(updateString));
         return execute(patchProp);
+    }
+
+    @Test
+    public void testNonRdfSourceServerGeneratedTriples() throws Exception {
+        final String pid = getRandomUniqueId();
+        final String describedPid = pid + "/fcr:metadata";
+        final String location = serverAddress + pid;
+
+        final String filename = "some-file.txt";
+        final String content = "this is the content";
+        createBinary(pid, filename, TEXT_PLAIN, content);
+
+        final Model model = getModel(describedPid);
+
+        // verify properties initially generated
+        final Resource resc = model.getResource(location);
+        assertEquals(content.length(), resc.getProperty(HAS_SIZE).getLong());
+        assertEquals(serverAddress + describedPid, resc.getProperty(DESCRIBED_BY).getResource().getURI());
+        assertEquals("text/plain", resc.getProperty(HAS_MIME_TYPE).getString());
+        assertEquals(filename, resc.getProperty(HAS_ORIGINAL_NAME).getString());
+
+        // verify properties can be deleted
+        // iana:describedby cannot be totally removed since it is added in the response
+        verifyDeleteExistingProperty(describedPid, location, HAS_SIZE,
+                resc.getProperty(HAS_SIZE).getObject());
+        verifyDeleteExistingProperty(describedPid, location, HAS_MIME_TYPE,
+                resc.getProperty(HAS_MIME_TYPE).getObject());
+        verifyDeleteExistingProperty(describedPid, location, HAS_ORIGINAL_NAME,
+                resc.getProperty(HAS_ORIGINAL_NAME).getObject());
+
+        // verify property can be added
+        verifySetProperty(describedPid, location, DESCRIBED_BY, createResource("http://example.com"));
+        verifySetProperty(describedPid, location, HAS_SIZE, model.createTypedLiteral(99L));
+        verifySetProperty(describedPid, location, HAS_MIME_TYPE, model.createLiteral("text/special"));
+        verifySetProperty(describedPid, location, HAS_ORIGINAL_NAME, model.createLiteral("different.txt"));
+
+        // Verify deletion of added describedby
+        verifyDeleteExistingProperty(describedPid, location, DESCRIBED_BY,
+                createResource("http://example.com"));
+    }
+
+    private void createBinary(final String pid, final String filename, final String contentType, final String content)
+            throws Exception {
+        final HttpPost post = new HttpPost(serverAddress);
+        post.setEntity(new StringEntity(content));
+        post.setHeader("Slug", pid);
+        post.setHeader(CONTENT_TYPE, contentType);
+        post.setHeader(CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
+        post.setHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        try (final CloseableHttpResponse response = execute(post)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+    }
+
+    private void verifyDeleteExistingProperty(final String pid, final String subjectURI,
+            final Property property, final RDFNode object) throws Exception {
+        final String value = rdfNodeToString(object);
+        final String deleteString =
+                "DELETE { <> <" + property.getURI() + "> " + value + " } WHERE { }";
+
+        performUpdate(pid, deleteString).close();
+
+        final Model resultModel = getModel(pid);
+        final Resource resultResc = resultModel.getResource(subjectURI);
+        assertFalse("Must not contain deleted property " + property, resultResc.hasProperty(property, object));
+    }
+
+    private void verifySetProperty(final String pid, final String subjectURI, final Property property,
+            final RDFNode object) throws Exception {
+        final String value = rdfNodeToString(object);
+        final String updateString =
+                "INSERT { <> <" + property.getURI() + "> " + value + " } WHERE { }";
+
+        performUpdate(pid, updateString).close();
+
+        final Model model = getModel(pid);
+        final Resource resc = model.getResource(subjectURI);
+        assertTrue("Must contain updated property " + property, resc.hasProperty(property, object));
+    }
+
+    private String rdfNodeToString(final RDFNode object) {
+        String value;
+        if (object.isLiteral()) {
+            final Literal literal = object.asLiteral();
+            value = "\"" + literal.getValue().toString() + "\"";
+            if (!literal.getDatatype().equals(XSDDatatype.XSDstring)) {
+                value += "^^<" + literal.getDatatypeURI() + ">";
+            }
+        } else {
+            value = "<" + object.toString() + ">";
+        }
+        return value;
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -98,7 +98,7 @@ public final class RdfLexicon {
         createProperty(PREMIS_NAMESPACE + "hasFixity");
 
     private static final Set<Property> fixityProperties = of(
-            HAS_FIXITY_RESULT, HAS_MESSAGE_DIGEST, HAS_SIZE);
+            HAS_FIXITY_RESULT, HAS_MESSAGE_DIGEST);
 
     public static final Resource EVENT_OUTCOME_INFORMATION = createResource(PREMIS_NAMESPACE + "EventOutcomeDetail");
 

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/RdfLexiconTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/RdfLexiconTest.java
@@ -35,7 +35,7 @@ public class RdfLexiconTest {
 
     @Test
     public void repoPredicatesAreManaged() {
-        assertTrue(isManagedPredicate.test(createProperty(PREMIS_NAMESPACE + "hasSize")));
+        assertTrue(isManagedPredicate.test(createProperty(PREMIS_NAMESPACE + "hasMessageDigest")));
         assertTrue(isManagedPredicate.test(createProperty(REPOSITORY_NAMESPACE + "hasParent")));
     }
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2923

# What does this Pull Request do?
Allows clients to delete or set premis:hasSize property.

# What's new?
* Removed premis:hasSize from set of server managed triples
* Added integration test that verifies the expected behavior of the four server generated triples for binaries: premis:hasSize, ebucore:filename, ebucore:hasMimeType, iana:describedby
* Removes duplicate testLdpContains test (it is already being tested in testLdpNamespace)

# How should this be tested?
New integration test.

Create a binary, then issue a PATCH or PUT request to replace the premis:hasSize property. This can be done with a request similar to:

```
echo 'INSERT { <> <http://www.loc.gov/premis/rdf/v1#hasSize> "99"^^<http://www.w3.org/2001/XMLSchema#long> } WHERE { }' | curl -XPATCH -ufedoraAdmin:fedoraAdmin -H "Content-Type: application/sparql-update" --data-binary "@-" "http://localhost:8080/rest/test_bin"
 ```

Attempt to retrieve the description and perform head requests against the binary to see that the new size is being used. 

# Additional Notes:
While clients can set the premis:hasSize property, it must be of type "http://www.w3.org/2001/XMLSchema#long" and there can only be one property of this predicate at a time (adding a new one will replace the original). If the client replaces the binary, the property will be overwritten with the size of the new file. If no premis:hasSize is present, then 0 will be returned as the `Content-Length` header.

iana:describedby is added during requests to retrieve non-rdf resource descriptions, so it cannot be truly removed by clients. Clients can, however, add additional iana:describedby relations and delete those. This is not a new behavior in this PR.

This change is intended to align behaviors with the documentation here https://wiki.duraspace.org/display/FEDORA5x/What+are+the+Server+Managed+Triples

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
