### PR TITLE
Requiring allowed list http domains end with slash

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -51,6 +51,7 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
 
     private static final Pattern SCHEME_PATTERN = Pattern.compile("^(http|https|file):/.*");
 
+    // Pattern to check that an http uri contains a / after the domain if a domain is present
     private static final Pattern HTTP_DOMAIN_PATTERN = Pattern.compile("^(http|https)://([^/]+/.*|$)");
 
     private static final Pattern RELATIVE_MOD_PATTERN = Pattern.compile(".*(^|/)\\.\\.($|/).*");

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -47,13 +47,15 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
 
     private static final Logger LOGGER = getLogger(ExternalContentPathValidator.class);
 
-    private final Set<String> ALLOWED_SCHEMES = new HashSet<>(Arrays.asList("file", "http", "https"));
+    private static final Set<String> ALLOWED_SCHEMES = new HashSet<>(Arrays.asList("file", "http", "https"));
 
-    private final Pattern SCHEME_PATTERN = Pattern.compile("^(http|https|file):/.*");
+    private static final Pattern SCHEME_PATTERN = Pattern.compile("^(http|https|file):/.*");
 
-    private final Pattern RELATIVE_MOD_PATTERN = Pattern.compile(".*(^|/)\\.\\.($|/).*");
+    private static final Pattern HTTP_DOMAIN_PATTERN = Pattern.compile("^(http|https)://([^/]+/.*|$)");
 
-    private final Pattern NORMALIZE_FILE_URI = Pattern.compile("^file:/{2,3}");
+    private static final Pattern RELATIVE_MOD_PATTERN = Pattern.compile(".*(^|/)\\.\\.($|/).*");
+
+    private static final Pattern NORMALIZE_FILE_URI = Pattern.compile("^file:/{2,3}");
 
     private List<String> allowedList;
 
@@ -132,26 +134,37 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
         LOGGER.info("Loading list of allowed external content locations from {}", configPath);
         try (final Stream<String> stream = Files.lines(Paths.get(configPath))) {
             allowedList = stream.map(line -> normalizePath(line.trim().toLowerCase()))
-                .filter(line -> {
-                    final Matcher schemeMatcher = SCHEME_PATTERN.matcher(line);
-                    final boolean schemeMatches = schemeMatcher.matches();
-                    if (!schemeMatches || RELATIVE_MOD_PATTERN.matcher(line).matches()) {
-                        LOGGER.error("Invalid path {} specified in external path configuration {}",
-                                line, configPath);
-                        return false;
-                    }
-                    if ("file".equals(schemeMatcher.group(1))) {
-                        // If a file uri ends with / it must be a directory, otherwise it must be a file.
-                        final File allowing = new File(URI.create(line).getPath());
-                        if ((line.endsWith("/") && !allowing.isDirectory())
-                                || (!line.endsWith("/") && !allowing.isFile())) {
-                            LOGGER.error("Invalid path {} in configuration {}, directories must end with a '/'",
-                                    line, configPath);
-                            return false;
-                        }
-                    }
-                    return true;
-                }).collect(Collectors.toList());
+                    .filter(line -> isAllowanceValid(line))
+                    .collect(Collectors.toList());
         }
+    }
+
+    private boolean isAllowanceValid(final String allowance) {
+        final Matcher schemeMatcher = SCHEME_PATTERN.matcher(allowance);
+        final boolean schemeMatches = schemeMatcher.matches();
+        if (!schemeMatches || RELATIVE_MOD_PATTERN.matcher(allowance).matches()) {
+            LOGGER.error("Invalid path {} specified in external path configuration {}",
+                    allowance, configPath);
+            return false;
+        }
+
+        final String protocol = schemeMatcher.group(1);
+        if ("file".equals(protocol)) {
+            // If a file uri ends with / it must be a directory, otherwise it must be a file.
+            final File allowing = new File(URI.create(allowance).getPath());
+            if ((allowance.endsWith("/") && !allowing.isDirectory()) || (!allowance.endsWith("/") && !allowing
+                    .isFile())) {
+                LOGGER.error("Invalid path {} in configuration {}, directories must end with a '/'",
+                        allowance, configPath);
+                return false;
+            }
+        } else if ("http".equals(protocol) || "https".equals(protocol)) {
+            if (!HTTP_DOMAIN_PATTERN.matcher(allowance).matches()) {
+                LOGGER.error("Invalid path {} in configuration {}, domain must end with a '/'",
+                        allowance, configPath);
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -167,6 +167,17 @@ public class ExternalContentPathValidatorTest {
     }
 
     @Test(expected = ExternalMessageBodyException.class)
+    public void testHttpUriMissingSlash() throws Exception {
+        // Slash after domain is required
+        final String goodPath = "http://good.example.com";
+        final String extPath = "http://good.example.com:8080/offlimits";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test(expected = ExternalMessageBodyException.class)
     public void testRelativeModifier() throws Exception {
         final String extPath = dataUri + "../sneaky.txt";
 


### PR DESCRIPTION
# What does this Pull Request do?
External content allow list entry for http uri with a domain but no slash after it will log an error and be ignored.

# How should this be tested?

```
echo "http://example.com" > /tmp/allowed.txt
mvn jetty:run -Dfcrepo.external.content.allowed=/tmp/allowed.txt

# ERROR 15:58:32.025 (ExternalContentPathValidator) Invalid path http://example.com in configuration /Users/bbpennel/git/fcrepo4/fcrepo-webapp/allowed.txt, domain must end with a '/'

curl -v -X PUT -H "Link: <http://example.com/>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/blocked_http -ufedoraAdmin:fedoraAdmin

# 400 Bad Request
# External content is disallowed by the server


rm /tmp/allowed.txt
echo "http://example.com/" > /tmp/allowed.txt

mvn jetty:run -Dfcrepo.external.content.allowed=/tmp/allowed.txt
# no error

curl -v -X PUT -H "Link: <http://example.com/>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/http_bin -ufedoraAdmin:fedoraAdmin

# 201 created

curl -v -X PUT -H "Link: <http://example.com:8080/>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" http://localhost:8080/rest/diff_port -ufedoraAdmin:fedoraAdmin

# 400 Bad Request
# Path did not match any allowed external content paths: http://example.com:8080/
```

# Interested parties
@bseeger @awoods 
