### PR TITLE
Don't allow ldp:membershipResource if you don't have acl:Write

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/CachedHttpRequest.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/CachedHttpRequest.java
@@ -37,7 +37,7 @@ import org.apache.commons.io.IOUtils;
  * 
  * @author mohideen
  */
-public class CachedSparqlRequest extends HttpServletRequestWrapper {
+public class CachedHttpRequest extends HttpServletRequestWrapper {
 
     private byte[] cachedContent;
 
@@ -47,7 +47,7 @@ public class CachedSparqlRequest extends HttpServletRequestWrapper {
      * Create a new CachedSparqlRequest for the given servlet request.
      * @param request the original servlet request
      */
-    public CachedSparqlRequest(final ServletRequest request) {
+    public CachedHttpRequest(final ServletRequest request) {
         super((HttpServletRequest) request);
     }
 

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -138,9 +138,10 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
         }
 
         // for non-admins, we must check the ACL for the requested resource
+        @SuppressWarnings("unchecked")
         Set<URI> targetURIs = (Set<URI>) request.getAttribute(URIS_TO_AUTHORIZE);
         if (targetURIs == null) {
-            targetURIs = new HashSet<URI>();
+            targetURIs = new HashSet<>();
         }
         final Map<URI, Map<String, Collection<String>>> rolesForURI =
                 new HashMap<URI, Map<String, Collection<String>>>();
@@ -154,7 +155,7 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
             rolesForURI.put(uri, getRolesForPath(path));
         }
 
-        for (Object o : principals.asList()) {
+        for (final Object o : principals.asList()) {
             log.debug("User has principal with name: {}", ((Principal) o).getName());
         }
         final Principal userPrincipal = principals.oneByType(BasicUserPrincipal.class);
@@ -210,7 +211,7 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
                 final Collection<String> modesForUser = roles.get(agentName);
                 if (modesForUser != null) {
                     // add WebACPermission instance for each mode in the Authorization
-                    for (String mode : modesForUser) {
+                    for (final String mode : modesForUser) {
                         final WebACPermission perm = new WebACPermission(URI.create(mode), uri);
                         authzInfo.addObjectPermission(perm);
                         log.debug("Added permission {}", perm);
@@ -243,7 +244,7 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
         try {
             resource = translator().convert(translator().toDomain(path));
             log.debug("Got FedoraResource for {}", path);
-        } catch (RepositoryRuntimeException e) {
+        } catch (final RepositoryRuntimeException e) {
             if (e.getCause() instanceof PathNotFoundException) {
                 log.debug("Path {} does not exist", path);
                 // go up the path looking for a node that exists

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -60,6 +60,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.jena.atlas.RuntimeIOException;
 import org.apache.jena.query.QueryParseException;
 import org.apache.jena.rdf.model.Model;
@@ -137,7 +138,14 @@ public class WebACFilter implements Filter {
         // this method intentionally left empty
     }
 
+    /**
+     * Add URIs to collect permissions information for.
+     *
+     * @param httpRequest the request.
+     * @param uri the uri to check.
+     */
     public void addURIToAuthorize(final HttpServletRequest httpRequest, final URI uri) {
+        @SuppressWarnings("unchecked")
         Set<URI> targetURIs = (Set<URI>) httpRequest.getAttribute(URIS_TO_AUTHORIZE);
         if (targetURIs == null) {
             targetURIs = new HashSet<URI>();
@@ -430,7 +438,7 @@ public class WebACFilter implements Filter {
 
     /**
      * Is the request on or to create an indirect or direct container.
-     * 
+     *
      * @param request The current request
      * @return whether we are acting on/creating an indirect/direct container.
      */
@@ -458,7 +466,7 @@ public class WebACFilter implements Filter {
             throws IOException {
         if (isIndirectOrDirect(request)) {
             final URI membershipResource = getHasMember(request.getRequestURL().toString(),
-                    request.getInputStream(),
+                    new CloseShieldInputStream(request.getInputStream()),
                     request.getContentType());
             if (membershipResource != null) {
                 log.debug("Found membership resource: {}", membershipResource);

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
@@ -27,11 +27,14 @@ import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_CONTROL;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_READ;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_WRITE;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 
 import javax.servlet.ServletException;
 
@@ -93,7 +96,7 @@ public class WebACFilterTest {
     private FedoraResource mockBinary;
 
     @InjectMocks
-    private WebACFilter webacFilter = new WebACFilter();
+    private final WebACFilter webacFilter = new WebACFilter();
 
     private static final WebACPermission readPermission = new WebACPermission(WEBAC_MODE_READ, testURI);
 
@@ -145,6 +148,9 @@ public class WebACFilterTest {
 
         when(mockNodeService.exists(mockFedoraSession, testPath)).thenReturn(true);
         when(mockNodeService.exists(mockFedoraSession, testChildPath)).thenReturn(false);
+
+        when(mockContainer.getTypes()).thenReturn(Arrays.asList(URI.create(BASIC_CONTAINER.toString())));
+        when(mockBinary.getTypes()).thenReturn(Arrays.asList(URI.create(NON_RDF_SOURCE.toString())));
     }
 
     private void setupContainerResource() {
@@ -626,6 +632,7 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadWritePost() throws ServletException, IOException {
         setupAuthUserReadWrite();
+        setupContainerResource();
         // POST => 200
         request.setMethod("POST");
         webacFilter.doFilter(request, response, filterChain);
@@ -635,6 +642,7 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadWritePut() throws ServletException, IOException {
         setupAuthUserReadWrite();
+        setupContainerResource();
         // PUT => 200
         request.setMethod("PUT");
         webacFilter.doFilter(request, response, filterChain);
@@ -644,6 +652,7 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadWritePatch() throws ServletException, IOException {
         setupAuthUserReadWrite();
+        setupContainerResource();
         // PATCH => 200
         request.setMethod("PATCH");
         webacFilter.doFilter(request, response, filterChain);
@@ -769,8 +778,6 @@ public class WebACFilterTest {
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
     }
-
-
 
     @After
     public void clearSubject() {

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
@@ -172,6 +172,9 @@ public class WebACFilterTest {
         of("RepositoryRoot", "Resource", "Container").forEach(x -> rootTypes.add(URI.create(REPOSITORY_NAMESPACE +
                 x)));
         when(mockRoot.getTypes()).thenReturn(rootTypes);
+
+        // Setup Container by default
+        setupContainerResource();
     }
 
     private void setupContainerResource() {
@@ -379,7 +382,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserNoPermsPost() throws ServletException, IOException {
         setupAuthUserNoPerms();
-        setupContainerResource();
         // POST => 403
         request.setMethod("POST");
         webacFilter.doFilter(request, response, filterChain);
@@ -443,7 +445,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadOnlyPost() throws ServletException, IOException {
         setupAuthUserReadOnly();
-        setupContainerResource();
         // POST => 403
         request.setMethod("POST");
         webacFilter.doFilter(request, response, filterChain);
@@ -542,7 +543,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserAppendPostContainer() throws IOException, ServletException {
         setupAuthUserAppendOnly();
-        setupContainerResource();
         // POST => 200
         request.setRequestURI(testPath);
         request.setMethod("POST");
@@ -574,7 +574,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadAppendPostContainer() throws IOException, ServletException {
         setupAuthUserReadAppend();
-        setupContainerResource();
         // POST => 200
         request.setRequestURI(testPath);
         request.setMethod("POST");
@@ -606,7 +605,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadAppendWritePostContainer() throws IOException, ServletException {
         setupAuthUserReadAppendWrite();
-        setupContainerResource();
         // POST => 200
         request.setRequestURI(testPath);
         request.setMethod("POST");
@@ -655,7 +653,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadWritePost() throws ServletException, IOException {
         setupAuthUserReadWrite();
-        setupContainerResource();
         // POST => 200
         request.setMethod("POST");
         webacFilter.doFilter(request, response, filterChain);
@@ -665,7 +662,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadWritePut() throws ServletException, IOException {
         setupAuthUserReadWrite();
-        setupContainerResource();
         // PUT => 200
         request.setMethod("PUT");
         request.setRequestURI(testPath);
@@ -676,7 +672,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserReadWritePatch() throws ServletException, IOException {
         setupAuthUserReadWrite();
-        setupContainerResource();
         // PATCH => 200
         request.setMethod("PATCH");
         webacFilter.doFilter(request, response, filterChain);
@@ -705,7 +700,6 @@ public class WebACFilterTest {
     @Test
     public void testAuthUserAppendPutNewChild() throws IOException, ServletException {
         setupAuthUserAppendOnly();
-        setupContainerResource();
         // PUT => 200
         request.setRequestURI(testChildPath);
         request.setPathInfo(testChildPath);

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -1371,6 +1371,9 @@ public class WebACRecipesIT extends AbstractResourceIT {
                 "   acl:default <" + writeableResource + "> .";
         ingestAclString(writeableUri, writeableAcl, "fedoraAdmin");
 
+        // Ensure we can still POST/PUT to writeable resource.
+        testCanWrite(writeableResource, username);
+
         // Try to create indirect container referencing readonly resource with POST.
         final HttpPost userPost = postObjMethod(writeableResource);
         setAuth(userPost, username);
@@ -1487,6 +1490,9 @@ public class WebACRecipesIT extends AbstractResourceIT {
         setAuth(deleteIndirect, username);
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(deleteIndirect));
 
+        // Ensure we can still write to the writeable resource.
+        testCanWrite(writeableResource, username);
+
     }
 
     @Test
@@ -1526,6 +1532,9 @@ public class WebACRecipesIT extends AbstractResourceIT {
                 "   acl:accessTo <" + writeableResource + "> ;\n" +
                 "   acl:default <" + writeableResource + "> .";
         ingestAclString(writeableUri, writeableAcl, "fedoraAdmin");
+
+        // Ensure we can write to the writeable resource.
+        testCanWrite(writeableResource, username);
 
         // Try to create indirect container referencing readonly resource with POST.
         final HttpPost userPost = postObjMethod(writeableResource);
@@ -1600,6 +1609,10 @@ public class WebACRecipesIT extends AbstractResourceIT {
         setAuth(patchIndirect3, username);
         patchIndirect3.setEntity(new StringEntity(patch_insert_relation, sparqlContentType));
         assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(patchIndirect3));
+
+        // Ensure we can still write to the writeable resource.
+        testCanWrite(writeableResource, username);
+
     }
 
     @Test
@@ -1639,6 +1652,9 @@ public class WebACRecipesIT extends AbstractResourceIT {
                 "   acl:accessTo <" + writeableResource + "> ;\n" +
                 "   acl:default <" + writeableResource + "> .";
         ingestAclString(writeableUri, writeableAcl, "fedoraAdmin");
+
+        // Ensure we can write to writeable resource.
+        testCanWrite(writeableResource, username);
 
         // Try to create direct container referencing readonly resource with POST.
         final HttpPost userPost = postObjMethod(writeableResource);
@@ -1748,6 +1764,10 @@ public class WebACRecipesIT extends AbstractResourceIT {
         final HttpDelete deleteIndirect = new HttpDelete(directUri);
         setAuth(deleteIndirect, username);
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(deleteIndirect));
+
+        // Ensure we can still write to the writeable resource.
+        testCanWrite(writeableResource, username);
+
     }
 
     @Test
@@ -1787,6 +1807,9 @@ public class WebACRecipesIT extends AbstractResourceIT {
                 "   acl:accessTo <" + writeableResource + "> ;\n" +
                 "   acl:default <" + writeableResource + "> .";
         ingestAclString(writeableUri, writeableAcl, "fedoraAdmin");
+
+        // Ensure we can write to the writeable resource.
+        testCanWrite(writeableResource, username);
 
         // Try to create direct container referencing readonly resource with POST.
         final HttpPost userPost = postObjMethod(writeableResource);
@@ -1859,6 +1882,9 @@ public class WebACRecipesIT extends AbstractResourceIT {
         setAuth(patchDirect3, username);
         patchDirect3.setEntity(new StringEntity(patch_insert_relation, sparqlContentType));
         assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(patchDirect3));
+
+        // Ensure we can write to the writeable resource.
+        testCanWrite(writeableResource, username);
     }
 
     /**
@@ -1878,5 +1904,24 @@ public class WebACRecipesIT extends AbstractResourceIT {
         putReq.setHeader("Content-type", "text/turtle");
         putReq.setEntity(new StringEntity(acl, turtleContentType));
         return execute(putReq);
+    }
+
+    /**
+     * Ensure that a writeable resource is still writeable
+     *
+     * @param writeableResource the URI of the writeable resource.
+     * @param username the user will write access.
+     */
+    private void testCanWrite(final String writeableResource, final String username) {
+        // Try to create a basic container inside the writeable resource with POST.
+        final HttpPost okPost = postObjMethod(writeableResource);
+        setAuth(okPost, username);
+        assertEquals(HttpStatus.SC_CREATED, getStatus(okPost));
+
+        // Try to create a basic container inside the writeable resource with PUT.
+        final String temp_resource = getRandomUniqueId();
+        final HttpPut okPut = putObjMethod(writeableResource + "/" + temp_resource);
+        setAuth(okPut, username);
+        assertEquals(HttpStatus.SC_CREATED, getStatus(okPut));
     }
 }

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -1443,6 +1443,44 @@ public class WebACRecipesIT extends AbstractResourceIT {
         setAuth(patchIndirect3, username);
         patchIndirect3.setEntity(new StringEntity(patch_insert_relation, sparqlContentType));
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(patchIndirect3));
+
+        // Patch the indirect to the readonly target as admin
+        final HttpPatch patchAsAdmin = new HttpPatch(indirectUri);
+        setAuth(patchAsAdmin, "fedoraAdmin");
+        patchAsAdmin.setEntity(new StringEntity(patch_text, sparqlContentType));
+        assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(patchAsAdmin));
+
+        // Try to POST a child as user
+        final HttpPost postChild = new HttpPost(indirectUri);
+        final String postTarget = "@prefix ldp: <http://www.w3.org/ns/ldp#> .\n" +
+                "@prefix test: <http://example.org/test#> .\n\n" +
+                "<> test:something <" + tempTarget + "> .";
+        final HttpEntity putPostChild = new StringEntity(postTarget, turtleContentType);
+        setAuth(postChild, username);
+        postChild.setEntity(putPostChild);
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(postChild));
+
+        // Try to PUT a child as user
+        final String id = getRandomUniqueId();
+        final HttpPut putChild = new HttpPut(indirectUri + "/" + id);
+        setAuth(putChild, username);
+        putChild.setEntity(putPostChild);
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(putChild));
+
+        // Put the child as Admin
+        setAuth(putChild, "fedoraAdmin");
+        assertEquals(HttpStatus.SC_CREATED, getStatus(putChild));
+
+        // Try to delete the child as user
+        final HttpDelete deleteChild = new HttpDelete(indirectUri + "/" + id);
+        setAuth(deleteChild, username);
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(deleteChild));
+
+        // Try to delete the indirect container
+        final HttpDelete deleteIndirect = new HttpDelete(indirectUri);
+        setAuth(deleteIndirect, username);
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(deleteIndirect));
+
     }
 
     @Test
@@ -1667,6 +1705,43 @@ public class WebACRecipesIT extends AbstractResourceIT {
         setAuth(patchDirect3, username);
         patchDirect3.setEntity(new StringEntity(patch_insert_relation, sparqlContentType));
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(patchDirect3));
+
+        // Patch the indirect to the readonly target as admin
+        final HttpPatch patchAsAdmin = new HttpPatch(directUri);
+        setAuth(patchAsAdmin, "fedoraAdmin");
+        patchAsAdmin.setEntity(new StringEntity(patch_text, sparqlContentType));
+        assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(patchAsAdmin));
+
+        // Try to POST a child as user
+        final HttpPost postChild = new HttpPost(directUri);
+        final String postTarget = "@prefix ldp: <http://www.w3.org/ns/ldp#> .\n" +
+                "@prefix test: <http://example.org/test#> .\n\n" +
+                "<> test:something <" + tempTarget + "> .";
+        final HttpEntity putPostChild = new StringEntity(postTarget, turtleContentType);
+        setAuth(postChild, username);
+        postChild.setEntity(putPostChild);
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(postChild));
+
+        // Try to PUT a child as user
+        final String id = getRandomUniqueId();
+        final HttpPut putChild = new HttpPut(directUri + "/" + id);
+        setAuth(putChild, username);
+        putChild.setEntity(putPostChild);
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(putChild));
+
+        // Put the child as Admin
+        setAuth(putChild, "fedoraAdmin");
+        assertEquals(HttpStatus.SC_CREATED, getStatus(putChild));
+
+        // Try to delete the child as user
+        final HttpDelete deleteChild = new HttpDelete(directUri + "/" + id);
+        setAuth(deleteChild, username);
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(deleteChild));
+
+        // Try to delete the indirect container
+        final HttpDelete deleteIndirect = new HttpDelete(directUri);
+        setAuth(deleteIndirect, username);
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(deleteIndirect));
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/converters/PropertyConverter.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/converters/PropertyConverter.java
@@ -18,7 +18,6 @@
 package org.fcrepo.kernel.modeshape.rdf.converters;
 
 import com.google.common.base.Converter;
-import com.google.common.collect.ImmutableBiMap;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 
@@ -32,7 +31,6 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
 import java.util.Map;
-
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.fcrepo.kernel.modeshape.rdf.JcrRdfTools.getJcrNamespaceForRDFNamespace;
 import static org.fcrepo.kernel.modeshape.rdf.JcrRdfTools.getRDFNamespaceForJcrNamespace;
@@ -144,12 +142,12 @@ public class PropertyConverter extends Converter<javax.jcr.Property, Property> {
             prefix = namespaceRegistry.getPrefix(namespace);
         } else {
             LOGGER.debug("Didn't discover namespace: {} in namespace registry.",namespace);
-            final ImmutableBiMap<String, String> nsMap =
-                    ImmutableBiMap.copyOf(namespaceMapping);
-            if (nsMap.containsValue(namespace)) {
+            if (namespaceMapping != null && namespaceMapping.containsValue(namespace)) {
                 LOGGER.debug("Discovered namespace: {} in namespace map: {}.", namespace,
-                        nsMap);
-                prefix = nsMap.inverse().get(namespace);
+                    namespaceMapping);
+                prefix = namespaceMapping.entrySet().stream()
+                    .filter(t -> t.getValue().equals(namespace))
+                    .map(Map.Entry::getKey).findFirst().orElse(null);
                 namespaceRegistry.registerNamespace(prefix, namespace);
             } else {
                 prefix = namespaceRegistry.registerNamespace(namespace);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-1889

# What does this Pull Request do?
Currently you can create a direct or indirect container that would reference a resource you do **not** have `acl:Write` access to with its `ldp:membershipResource` and create triples on that resource.
This now checks for the creation or updating of Direct and Indirect containers to ensure you have `acl:Write` permissions is there is a `ldp:membershipResource` in the request.

# What's new?

@peichman-umd altered the WebACAuthorizingRealm to allow the addition of more than one URI to collect permissions on, this enables us to check both the target of the current request and the referenced URI 

# How should this be tested?

1. Create a container (readonly) and give a user read only access to it.
1. Create a container (users) and give the same user read/write access to it.
1. Try to create an indirect and/or direct container in the _users_ container with a `ldp:membershipResource` of the _readonly_ container. Before PR - works, after PR - 403 forbidden
1. Try to create an indirect and/or direct container in the _users_ container with a `ldp:membershipResource` of another user accessible resource. This should work.
1. Then try to PATCH the indirect/direct container to point the `ldp:membershipResource` to the _readonly_. Before PR - works, after PR - 403 forbidden

There are a lot of integration tests to.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
