### PR TITLE
Removes empty accordion panels in the version list view.

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/fcr-versions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/fcr-versions.vsl
@@ -18,21 +18,12 @@
     </div>
     <div id="historic-versions">
         <h2>Historic Versions</h2>
-        <div class="panel-group" id="accordion">
-            #foreach($subject in $helpers.getVersions($rdf, $topic))
-                <div class="panel panel-default" resource="$subject.getURI()">
-                    #set($label = $helpers.getVersionLabel($rdf, $subject))
-                    <div class="panel-heading collapsed" data-toggle="collapse" data-target="#$helpers.parameterize($subject.getURI())_triples" >
-                        <div class="ctitle panel-title"><a href="$subject.getURI()" class="version_link">$esc.html($label)</a></div>
-                    </div>
-                    <div class="panel-collapse collapse" id="$helpers.parameterize($subject.getURI())_triples">
-                        <div class="panel-body">
-                            #triples($subject)
-                        </div>
-                    </div>
-                </div>
-            #end
-        </div>
+        <ul>
+        #foreach($subject in $helpers.getVersions($rdf, $topic))
+            #set($label = $helpers.getVersionLabel($rdf, $subject))
+            <li><a href="$subject.getURI()" class="version_link">$esc.html($label)</a></li>
+        #end
+        </ul>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Resolves:

**Removes empty accordion panels in the version list view in the HTML UI.**
* * *

**JIRA Ticket**:  https://jira.duraspace.org/browse/FCREPO-2925


# How should this be tested?
create a resource
create a version of the resource
view the mementos
Observe the absence of an accordion panel for the newly created memento. New memento appears as a link in an unordered list.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
