### PR TITLE
FCREPO-2930 - FedoraLdpIT test fails on single digit days of month

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2912,8 +2912,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
                         getDateFromModel(model, nodeUri, createProperty(REPOSITORY_NAMESPACE + "lastModified"));
                 assertTrue(createdDateTriples.isPresent());
                 assertTrue(lastmodDateTriples.isPresent());
-                assertEquals(lastmodString, headerFormat.format(createdDateTriples.get()));
-                assertEquals(lastmodString, headerFormat.format(lastmodDateTriples.get()));
+                // Reformatting lastModified header to ensure consistent formatting between it and fedora timestamps
+                final Instant lastMod = headerFormat.parse(lastmodString, Instant::from);
+                final String formattedLastModifiedHeader = headerFormat.format(lastMod);
+                assertEquals(formattedLastModifiedHeader, headerFormat.format(createdDateTriples.get()));
+                assertEquals(formattedLastModifiedHeader, headerFormat.format(lastmodDateTriples.get()));
             }
         }
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2930

# What does this Pull Request do?
Fixes 
```
FedoraLdpIT.testCreatedAndModifiedDates:2915 expected:<Thu, [0]1 Nov 2018 17:25:26 ...> but was:<Thu, []1 Nov 2018 17:25:26 ...>
```
This only occurs on single digit days of the month

# Interested parties
@awoods 
