### PR TITLE
FCREPO-2929 - Hash URIs in mementos

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -87,9 +87,9 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
     // The second group determines if the path is for a memento or timemap.
     // The third group allows for a memento identifier.
     // The fourth group for allows ACL.
-    // The fifth group allows for any hashed suffixes on the acls.
+    // The fifth group allows for any hashed suffixes.
     private final static Pattern FORWARD_COMPONENT_PATTERN = Pattern.compile(
-            ".*?(/" + FCR_METADATA + ")?(/" + FCR_VERSIONS + "(/\\d{14})?)?(/" + FCR_ACL + "(\\#\\w+)?)?$");
+            ".*?(/" + FCR_METADATA + ")?(/" + FCR_VERSIONS + "(/\\d{14})?)?(/" + FCR_ACL + ")?(\\#\\w+)?$");
 
     protected List<Converter<String, String>> translationChain;
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverterTest.java
@@ -335,6 +335,17 @@ public class HttpResourceConverterTest {
     }
 
     @Test
+    public void testDoForwardWithMementoWithHash() throws Exception {
+        final Resource resource = createResource(
+                "http://localhost:8080/some/container/fcr:versions/20180315180915#test");
+        when(session.getNode("/container/fedora:timemap/20180315180915/#/test")).thenReturn(node);
+
+        final FedoraResource converted = converter.convert(resource);
+        final Node resultNode = getJcrNode(converted);
+        assertEquals(node, resultNode);
+    }
+
+    @Test
     public void testDoForwardWithBinaryMemento() throws Exception {
         final Resource resource = createResource(
                 "http://localhost:8080/some/binary/fcr:versions/20180315180915");

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/SubjectMappingUtil.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/SubjectMappingUtil.java
@@ -57,9 +57,16 @@ public class SubjectMappingUtil {
      * @return triple with subject remapped to destinationNode or the original subject.
      */
     public static Triple mapSubject(final Triple t, final String resourceUri, final Node destinationNode) {
+        final Node tripleSubj = t.getSubject();
+        final String tripleSubjUri = tripleSubj.getURI();
         final Node subject;
-        if (t.getSubject().getURI().equals(resourceUri)) {
+        if (tripleSubjUri.equals(resourceUri)) {
             subject = destinationNode;
+        } else if (tripleSubjUri.startsWith(resourceUri)) {
+            // If the subject begins with the originating resource uri, such as a hash uri, then rebase
+            // the portions of the subject after the resource uri to the destination uri.
+            final String suffix = tripleSubjUri.substring(resourceUri.length());
+            subject = createURI(destinationNode.getURI() + suffix);
         } else {
             subject = t.getSubject();
         }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2929

# What does this Pull Request do?
Allows for the creation of mementos from RDF Sources that contain hash uris

# What's new?
* Allow for hashes in any uri when converting forward from HTTP URI to a resource.
* When creating a memento, allow for hash components of subject uris to be retained when converting from the original as the subject to the memento for storage.
* When retrieving a memento's RDF which contains a hash uri, convert the hash uri subject from the memento's URI as the subject to the original suffixed with the hash component as the subject.

# How should this be tested?
```
curl -XPUT -ufedoraAdmin:fedoraAdmin -"http://localhost:8080/rest/memento_hash_test"

echo 'INSERT { <#test> <http://example.com/label> "my hash resource title" } WHERE {} ' | curl -XPATCH -ufedoraAdmin:fedoraAdmin -H "Content-Type: application/sparql-update" --data-binary "@-" http://localhost:8080/rest/memento_hash_test

curl -XPOST -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/memento_hash_test/fcr:versions

curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/memento_hash_test/fcr:versions/20181101182710

# @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
# @prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
# @prefix ldp:  <http://www.w3.org/ns/ldp#> .
#
# <http://localhost:8080/rest/memento_hash_test>
#         rdf:type               fedora:Container ;
#         rdf:type               ldp:RDFSource ;
#         rdf:type               ldp:Container ;
#         rdf:type               fedora:Resource ;
#         rdf:type               ldp:BasicContainer ;
#         fedora:created         "2018-11-01T18:20:22.86Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
#         fedora:writable        true ;
#         fedora:lastModified    "2018-11-01T18:24:22.281Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
#         fedora:lastModifiedBy  "fedoraAdmin" ;
#         fedora:createdBy       "fedoraAdmin" .
#
# <http://localhost:8080/rest/memento_hash_test#test>
#         <http://example.com/label>  "my hash resource title" .
```

# Additional Notes:
Sadly this didn't magically resolve the issues with hash uris in binary descriptions.

# Interested parties
@awoods @dbernstein 
