### PR TITLE
GET on memento now succeeds even if the Accept-Datetime heaader is pr…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -257,7 +257,7 @@ public class FedoraLdp extends ContentExposingResource {
         checkMementoPath();
 
         final String datetimeHeader = headers.getHeaderString(ACCEPT_DATETIME);
-        if (!isBlank(datetimeHeader)) {
+        if (!isBlank(datetimeHeader) && resource().isOriginalResource()) {
             return getMemento(datetimeHeader, resource());
         }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -618,6 +618,20 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testGetOnMementoWithAcceptDatetimePresent() throws Exception {
+        createVersionedContainer(id);
+        final String mementoDateTime =
+            MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
+        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
+        // Status 200: GET request on existing memento
+        final HttpGet getMemento = new HttpGet(mementoUri);
+        getMemento.addHeader(ACCEPT_DATETIME, mementoDateTime);
+        assertEquals("Expected memento could not be retrieved when Accept-Datetime header is present: " + mementoUri,
+                     OK.getStatusCode(),
+                     getStatus(getMemento));
+    }
+
+    @Test
     public void testOptionsOnMemento() throws Exception {
 
         createVersionedContainer(id);


### PR DESCRIPTION
**GET on memento now succeeds even if the Accept-Datetime heaader is present.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2932

# What does this Pull Request do?
This PR resolves an problem that was identified by the Memento Validator tool where a GET request to a memento fails if the Accept-Datetime header is present in the request.  The memento spec allows this condition since it allows user agents to be a in a "date time negotiation mode" which is a typical use case. 

# What's new?
The Accept-Datetime header is now ignored when retrieving a memento.  An integration test verifies the fix.


# How should this be tested?
```
# create a memenot
curl -i http://localhost:8080/rest -X POST -H "Slug: test-memento" -u fedoraAdmin:fedoraAdmin
curl -i http://localhost:8080/rest/test-memento/fcr:versions  -X POST -u fedoraAdmin:fedoraAdmin

# get the newly created memento without the header to verify that the memento is returned with a 200.
curl -i http://localhost:8080/rest/test-memento/fcr:versions/<new memento> -X GET -u fedoraAdmin:fedoraAdmin
#perform the same request, but this time with an Accept-Datetime header and verify 
# that it returns the memento with a 200
curl -i http://localhost:8080/rest/test-memento/fcr:versions/<new memento> -X GET -u fedoraAdmin:fedoraAdmin -H "Accept-Datetime: Mon, 05 Nov 2018 00:00:00 GMT"
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
