### PR TITLE
Remove "4" from textual references to Fedora

### DIFF
--- a/fcrepo-auth-common/pom.xml
+++ b/fcrepo-auth-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-auth-common</artifactId>
   <name>Fedora Repository Authorization Commons Module</name>

--- a/fcrepo-auth-webac/pom.xml
+++ b/fcrepo-auth-webac/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-auth-webac</artifactId>
   <name>Fedora Repository WebAC Authorization Module</name>
@@ -47,19 +47,19 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-auth-common</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-kernel-api</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-kernel-modeshape</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -153,14 +153,14 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-configs</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.1.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-kernel-modeshape</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.1.0-SNAPSHOT</version>
       <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
@@ -168,7 +168,7 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-http-commons</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.1.0-SNAPSHOT</version>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
@@ -176,13 +176,13 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-http-api</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-http-api</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>5.1.0-SNAPSHOT</version>
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>

--- a/fcrepo-configs/pom.xml
+++ b/fcrepo-configs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-configs</artifactId>
   <name>Fedora Repository Configurations Module</name>

--- a/fcrepo-event-serialization/pom.xml
+++ b/fcrepo-event-serialization/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-event-serialization</artifactId>
   <name>Fedora Event Serialization</name>

--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-http-api</artifactId>

--- a/fcrepo-http-api/src/main/resources/views/common-header.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-header.vsl
@@ -8,7 +8,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="$uriInfo.baseUriBuilder.build()">Fedora 4</a>
+        <a class="navbar-brand" href="$uriInfo.baseUriBuilder.build()">Fedora</a>
     </div>
 
     <!-- Collect the nav links, forms, and other content for toggling -->

--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-http-commons</artifactId>
   <name>Fedora Repository HTTP Commons Module</name>

--- a/fcrepo-integration-ldp/pom.xml
+++ b/fcrepo-integration-ldp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>fcrepo-parent</artifactId>
     <groupId>org.fcrepo</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>../fcrepo-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/fcrepo-integration-rdf/pom.xml
+++ b/fcrepo-integration-rdf/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>fcrepo</artifactId>
         <groupId>org.fcrepo</groupId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>5.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fcrepo-jms/pom.xml
+++ b/fcrepo-jms/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-jms</artifactId>
   <name>Fedora Repository JMS Module</name>

--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <artifactId>fcrepo-kernel-api</artifactId>
   <name>Fedora Repository Kernel API</name>
-  <description>Fedora Repository Kernel API, containing types and constants for working with Fedora 4</description>
+  <description>Fedora Repository Kernel API, containing types and constants for working with Fedora</description>
 
   <packaging>bundle</packaging>
 

--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-kernel-api</artifactId>
   <name>Fedora Repository Kernel API</name>

--- a/fcrepo-kernel-modeshape/pom.xml
+++ b/fcrepo-kernel-modeshape/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-kernel-modeshape</artifactId>

--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.fcrepo</groupId>
   <artifactId>fcrepo-parent</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
   <name>Fedora Commons 4 :: Parent POM</name>
   <description>Parent POM for Fedora Commons Projects</description>
   <url>http://fedorarepository.org</url>

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-webapp</artifactId>

--- a/fcrepo-webapp/src/main/webapp/index.html
+++ b/fcrepo-webapp/src/main/webapp/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>Fedora Commons Repository 4.0</title>
+  <title>Fedora Commons Repository</title>
   <link rel="icon" type="image/png" href="static/images/fcrepo-favicon.png"/>
   <script src="static/js/jquery-1.12.4.min.js" ></script>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <relativePath>./fcrepo-parent</relativePath>
   </parent>
 
   <groupId>org.fcrepo</groupId>
   <artifactId>fcrepo</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.1.0-SNAPSHOT</version>
   <name>Fedora Commons 4</name>
   <description>Parent project for Fedora Commons Repository</description>
   <url>http://fedorarepository.org</url>

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -2,7 +2,7 @@ ${project.description}
 
 ## About
 
-This is the automatically generated documentation for Fedora 4.
+This is the automatically generated documentation for Fedora.
 
 You're probably looking for the [javadocs](apidocs/index.html).
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -14,7 +14,7 @@
   <body>
     <links>
       <item name="Fedora" href="http://fcrepo.org/" />
-      <item name="Fedora 4 on GitHub" href="http://github.com/fcrepo4/" />
+      <item name="Fedora on GitHub" href="http://github.com/fcrepo4/" />
       <item name="Developer Documentation" href="http://fcrepo4.github.com/fcrepo4/" />
     </links>
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2933

# What does this Pull Request do?
Removes the "4" from the HTML UI navbar and a few other places in code

# What's new?
Purely a change in nomenclature. References in text to "Fedora 4" are now just "Fedora" Should reduce confusion as to what Fedora people are running.

# How should this be tested?

Bring up HTML UI and confirm appearance in the navbar.

# Interested parties
@dbernstein @bbpennel