### PR TITLE
Removed "4" from reference to Fedora in text, including UI navbar header

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/common-header.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-header.vsl
@@ -8,7 +8,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="$uriInfo.baseUriBuilder.build()">Fedora 4</a>
+        <a class="navbar-brand" href="$uriInfo.baseUriBuilder.build()">Fedora</a>
     </div>
 
     <!-- Collect the nav links, forms, and other content for toggling -->

--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <artifactId>fcrepo-kernel-api</artifactId>
   <name>Fedora Repository Kernel API</name>
-  <description>Fedora Repository Kernel API, containing types and constants for working with Fedora 4</description>
+  <description>Fedora Repository Kernel API, containing types and constants for working with Fedora</description>
 
   <packaging>bundle</packaging>
 

--- a/fcrepo-webapp/src/main/webapp/index.html
+++ b/fcrepo-webapp/src/main/webapp/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>Fedora Commons Repository 4.0</title>
+  <title>Fedora Commons Repository</title>
   <link rel="icon" type="image/png" href="static/images/fcrepo-favicon.png"/>
   <script src="static/js/jquery-1.12.4.min.js" ></script>
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -2,7 +2,7 @@ ${project.description}
 
 ## About
 
-This is the automatically generated documentation for Fedora 4.
+This is the automatically generated documentation for Fedora.
 
 You're probably looking for the [javadocs](apidocs/index.html).
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -14,7 +14,7 @@
   <body>
     <links>
       <item name="Fedora" href="http://fcrepo.org/" />
-      <item name="Fedora 4 on GitHub" href="http://github.com/fcrepo4/" />
+      <item name="Fedora on GitHub" href="http://github.com/fcrepo4/" />
       <item name="Developer Documentation" href="http://fcrepo4.github.com/fcrepo4/" />
     </links>
 


### PR DESCRIPTION
**JIRA Ticket:** https://jira.duraspace.org/browse/FCREPO-2933

# What does this Pull Request do?

Removes the "4" from the HTML UI navbar and a few other places in code

What's new?

Purely a change in nomenclature. References in text to "Fedora 4" are now just "Fedora" Should reduce confusion as to what Fedora people are running.

# How should this be tested?

Bring up HTML UI and confirm appearance in the navbar.

# Interested parties

@dbernstein @bbpennel
