### PR TITLE
"View Versions" link in HTMLUI no longer returns 404 if no versions have been created

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -222,7 +222,7 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
                     // node will not exist while the end point is visible to the user.
                     return null;
                 } else {
-                    throw new RuntimeException(e);
+                    throw e;
                 }
             }
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.annotation.PostConstruct;
+import javax.jcr.PathNotFoundException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -213,7 +214,17 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
         final Map<String, String> values = new HashMap<>();
         uriTemplate.match(subjectUri, values);
         if (values.containsKey("path")) {
-            return translator().convert(translator().toDomain(values.get("path")));
+            try {
+                return translator().convert(translator().toDomain(values.get("path")));
+            } catch (final RuntimeException e) {
+                if (e.getCause() instanceof PathNotFoundException) {
+                    //there is at least one case (ie Time Map endpoints - aka /fcr:versions) where the underlying jcr
+                    // node will not exist while the end point is visible to the user.
+                    return null;
+                } else {
+                    throw new RuntimeException(e);
+                }
+            }
         }
         return null;
     }

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -94,7 +94,7 @@ WHERE { }
       <form id="action_create_version" name="action_create_version" method="POST">
         <h3>Versions</h3>
         <button id="create-version-button" type="submit" class="btn btn-primary">Create Version</button>
-        <h4><a href="$topic/fcr:versions">View Versions</a></h4>
+        <h4><a id="view_versions" href="$topic/fcr:versions">View Versions</a></h4>
         <hr />
       </form>
     #end

--- a/fcrepo-http-api/src/main/resources/views/fcr-versions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/fcr-versions.vsl
@@ -18,12 +18,17 @@
     </div>
     <div id="historic-versions">
         <h2>Historic Versions</h2>
-        <ul>
-        #foreach($subject in $helpers.getVersions($rdf, $topic))
-            #set($label = $helpers.getVersionLabel($rdf, $subject))
-            <li><a href="$subject.getURI()" class="version_link">$esc.html($label)</a></li>
+        #set( $versions = $helpers.getVersions($rdf, $topic) )
+        #if($versions.hasNext())
+            <ul>
+            #foreach($subject in $versions)
+                #set($label = $helpers.getVersionLabel($rdf, $subject))
+                <li><a href="$subject.getURI()" class="version_link">$esc.html($label)</a></li>
+            #end
+            </ul>
+        #else
+            <p>No versions have been created for this resource.</p>
         #end
-        </ul>
   </div>
 </body>
 </html>

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 
+import com.gargoylesoftware.htmlunit.html.DomElement;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.client.CredentialsProvider;
@@ -238,6 +239,20 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
         assertEquals("Didn't get a 410!", 410, page2.getWebResponse()
                 .getStatusCode());
 
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(throwExceptionOnFailingStatusCode);
+    }
+
+    @Test
+    public void testVersionsListWorksWhenNoVersionsPresent() throws IOException {
+        final boolean throwExceptionOnFailingStatusCode = webClient.getOptions().isThrowExceptionOnFailingStatusCode();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(true);
+
+        final String pid = createNewObject();
+        final HtmlPage page = webClient.getPage(serverAddress + pid);
+        final DomElement viewVersions = page.getElementById("view_versions");
+        final Page versionsPage = viewVersions.click();
+        assertEquals("Didn't get a 200!", 200, versionsPage.getWebResponse()
+                                                    .getStatusCode());
         webClient.getOptions().setThrowExceptionOnFailingStatusCode(throwExceptionOnFailingStatusCode);
     }
 


### PR DESCRIPTION
**"View Versions" link in HTMLUI no longer returns 404 if no version is created yet for a resource.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2934

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Ensures that UI renders the versions list page even when there are no versions.  Previously the link would return 404 if there were no versions created.   Also includes an HTML UI integration test to verify this fix.

# How should this be tested?
1. fire up HTML UI 
2. create a resource.
3. click on "View Versions" link.  
4. Verify that  a non 404 response is returned.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
