### PR TITLE
Allow fcrepo5 to build and run on Windows

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -232,7 +232,7 @@ public class ExternalContentPathValidatorTest {
 
     @Test
     public void testCaseInsensitive() throws Exception {
-        final String goodPath = "FILE://" + dataDir.getAbsolutePath() + "/";
+        final String goodPath = "FILE://" + dataDir.toURI().getPath() + "/";
         final String extPath = dataUri + "/file.txt";
 
         addAllowedPath(goodPath);
@@ -251,25 +251,25 @@ public class ExternalContentPathValidatorTest {
         new File(threeFolder, "file").createNewFile();
         new File(manyFolder, "file").createNewFile();
 
-        addAllowedPath("file:" + oneFolder.getAbsolutePath() + "/");
-        addAllowedPath("file:/" + twoFolder.getAbsolutePath() + "/");
-        addAllowedPath("file://" + threeFolder.getAbsolutePath() + "/");
-        addAllowedPath("file:///" + manyFolder.getAbsolutePath() + "/");
+        addAllowedPath("file:" + oneFolder.toURI().getPath() + "/");
+        addAllowedPath("file:/" + twoFolder.toURI().getPath() + "/");
+        addAllowedPath("file://" + threeFolder.toURI().getPath() + "/");
+        addAllowedPath("file:///" + manyFolder.toURI().getPath() + "/");
 
-        validator.validate("file:" + oneFolder.getAbsolutePath() + "/file");
-        validator.validate("file:/" + oneFolder.getAbsolutePath() + "/file");
-        validator.validate("file://" + oneFolder.getAbsolutePath() + "/file");
+        validator.validate("file:" + oneFolder.toURI().getPath() + "/file");
+        validator.validate("file:/" + oneFolder.toURI().getPath() + "/file");
+        validator.validate("file://" + oneFolder.toURI().getPath() + "/file");
 
-        validator.validate("file:" + twoFolder.getAbsolutePath() + "/file");
-        validator.validate("file:/" + twoFolder.getAbsolutePath() + "/file");
-        validator.validate("file://" + twoFolder.getAbsolutePath() + "/file");
+        validator.validate("file:" + twoFolder.toURI().getPath() + "/file");
+        validator.validate("file:/" + twoFolder.toURI().getPath() + "/file");
+        validator.validate("file://" + twoFolder.toURI().getPath() + "/file");
 
-        validator.validate("file:" + threeFolder.getAbsolutePath() + "/file");
-        validator.validate("file:/" + threeFolder.getAbsolutePath() + "/file");
-        validator.validate("file://" + threeFolder.getAbsolutePath() + "/file");
+        validator.validate("file:" + threeFolder.toURI().getPath() + "/file");
+        validator.validate("file:/" + threeFolder.toURI().getPath() + "/file");
+        validator.validate("file://" + threeFolder.toURI().getPath() + "/file");
 
         try {
-            validator.validate("file:" + manyFolder.getAbsolutePath() + "file");
+            validator.validate("file:" + manyFolder.toURI().getPath() + "file");
             fail();
         } catch (final ExternalMessageBodyException e) {
             // expected

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -850,7 +850,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertEquals("Didn't get a OK response!", OK.getStatusCode(), getStatus(response));
             // verify headers in link format.
             verifyTimeMapHeaders(response, uri);
-            final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity()).split(",\n"));
+            final List<String> bodyList = Arrays.asList(EntityUtils.toString(response.getEntity())
+                    .split("," + System.lineSeparator()));
             //the links from the body are not
 
             final Link[] bodyLinks = bodyList.stream().map(String::trim).filter(t -> !t.isEmpty())

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/AutoReloadingConfiguration.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/AutoReloadingConfiguration.java
@@ -87,7 +87,14 @@ public abstract class AutoReloadingConfiguration {
             return;
         }
 
-        final Path path = Paths.get(configPath);
+        final Path path;
+        try {
+            path = Paths.get(configPath);
+        } catch (final Exception e) {
+            LOGGER.warn("Cannot monitor configuration {}, disabling monitoring; {}", configPath, e.getMessage());
+            return;
+        }
+
         if (!path.toFile().exists()) {
             LOGGER.debug("Configuration {} does not exist, disabling monitoring", configPath);
             return;

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/UrlBinaryTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/UrlBinaryTest.java
@@ -36,6 +36,7 @@ import static org.fcrepo.kernel.api.FedoraExternalContent.PROXY;
 import static org.fcrepo.kernel.modeshape.utils.TestHelpers.getContentNodeMock;
 import static org.fcrepo.kernel.modeshape.utils.TestHelpers.checksumString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -278,6 +279,10 @@ public class UrlBinaryTest {
 
     @Test(expected = ExternalContentAccessException.class)
     public void testDisappearingRemoteUri() throws Exception {
+
+        // wiremock connection reset fault dows not work on Windows
+        assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+
         final String remoteHost = "http://localhost:" + wireMockRule.port();
         final String remoteUri = "/resource1";
         stubFor(get(urlEqualTo(remoteUri))

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoaderTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/spring/DefaultPropertiesLoaderTest.java
@@ -132,7 +132,7 @@ public class DefaultPropertiesLoaderTest {
 
     @Test
     public void testValueSetForNoDefault() {
-        final String value = "/absolute/path";
+        final String value = new File("/absolute/path").getAbsolutePath();
         System.setProperty(NO_DEFAULT_PROP, value);
 
         loader.loadSystemProperties();


### PR DESCRIPTION
[FCREPO-2693](https://jira.duraspace.org/browse/FCREPO-2963)

# What does this Pull Request do?
* Fixes several tests that fail on Windows due to differences in file paths
* Conditionally disables one test due to the usage of a feature in `wiremock` that does not work on Windows
* Updates `AutoReloadingConfiguration` to be tolerant of exceptions thrown upon `Paths.get(string)`

# What's new?
The only change to runtime fcrepo code is in `AutoReloadingConfiguration`.  This PR changes its behavior such that if an exception is thrown when attempting to read a file path via `Paths.get(string)`, monitoring the file is simply disabled.  The previous behavior was a uncaught runtime exception that prevented the fcrepo webapp from loading.

# How should this be tested?

Just make sure tests still pass.

# Interested parties
@fcrepo4/committers
