### PR TITLE
Fcrepo-2964/2966 - Prevent changing NonRdfSource type

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -62,8 +62,10 @@ import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.FedoraExternalContent.COPY;
+import static org.fcrepo.kernel.api.FedoraTypes.LDP_BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -495,11 +497,11 @@ public class FedoraLdp extends ContentExposingResource {
     private static void ensureInteractionType(final FedoraResource resource, final String interactionModel,
             final boolean defaultContent) {
         if (interactionModel != null) {
-            if (!interactionModel.equals("ldp:NonRDFSource") && !resource.hasType(interactionModel)) {
+            if (!resource.hasType(interactionModel)) {
                 resource.addType(interactionModel);
             }
         } else if (defaultContent) {
-            resource.addType("ldp:BasicContainer");
+            resource.addType(LDP_BASIC_CONTAINER);
         }
     }
 
@@ -873,7 +875,8 @@ public class FedoraLdp extends ContentExposingResource {
                 if ("type".equals(linq.getRel())) {
                     final Resource type = createResource(linq.getUri().toString());
                     if (type.equals(NON_RDF_SOURCE) || type.equals(BASIC_CONTAINER) ||
-                            type.equals(DIRECT_CONTAINER) || type.equals(INDIRECT_CONTAINER)) {
+                            type.equals(DIRECT_CONTAINER) || type.equals(INDIRECT_CONTAINER) ||
+                            type.equals(RDF_SOURCE)) {
                         return "ldp:" + type.getLocalName();
                     } else if (type.equals(VERSIONED_RESOURCE)) {
                         // skip if versioned resource link header

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -199,6 +199,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
     private static final String BASIC_CONTAINER_LINK_HEADER = "<" + BASIC_CONTAINER.getURI() + ">;rel=\"type\"";
     private static final String DIRECT_CONTAINER_LINK_HEADER = "<" + DIRECT_CONTAINER.getURI() + ">;rel=\"type\"";
     private static final String INDIRECT_CONTAINER_LINK_HEADER = "<" + INDIRECT_CONTAINER.getURI() + ">;rel=\"type\"";
+
+    private static final String RDF_SOURCE_LINK_HEADER = "<" + RDF_SOURCE.getURI() + ">;rel=\"type\"";
     private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
     private static final String VERSIONED_RESOURCE_LINK_HEADER = "<" + VERSIONED_RESOURCE.getURI() + ">; rel=\"type\"";
 
@@ -2317,6 +2319,26 @@ public class FedoraLdpIT extends AbstractResourceIT {
         put.setHeader(LINK, BASIC_CONTAINER_LINK_HEADER);
         assertEquals("Changed the NonRdfSource ixn to basic container",
                 CONFLICT.getStatusCode(), getStatus(put));
+    }
+
+    @Test
+    public void testPutChangeTypeNotAllowed() throws IOException {
+        final HttpPost postMethod = new HttpPost(serverAddress);
+        postMethod.setEntity(new StringEntity("TestString."));
+        postMethod.setHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        postMethod.addHeader(CONTENT_DISPOSITION, "attachment; filename=\"postCreate.txt\"");
+
+        final String location;
+        try (final CloseableHttpResponse response = execute(postMethod)) {
+            location = getLocation(response);
+        }
+
+        final HttpPut putMethod = new HttpPut(location);
+        putMethod.setEntity(new StringEntity("TestString2."));
+        putMethod.addHeader(CONTENT_DISPOSITION, "attachment; filename=\"putUpdate.txt\"");
+        putMethod.setHeader(LINK, RDF_SOURCE_LINK_HEADER);
+        assertEquals("Changed the NonRdfSource ixn to RdfSource",
+                CONFLICT.getStatusCode(), getStatus(putMethod));
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd
@@ -111,6 +111,8 @@
  */
 [fedora:Binary] > fedora:Resource mixin
 
+[ldp:NonRDFSource] > fedora:Resource mixin
+
 [fedora:Skolem] > mix:referenceable mixin
   - fedora:lastModified (DATE)
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2964
https://jira.duraspace.org/browse/FCREPO-2966

# What does this Pull Request do?
Returns a 409 when trying to change binaries to other interaction models.

# What's new?
* Adds ldp:NonRDFSource mixin and assigns it to new created binaries
* Adds integration test mirroring failing CTS test
* Recognizes RDFSource interaction model type in order to reject changing to it.

# How should this be tested?

Run failing CTS test
Also, the modifications from this gist should now return 409:
https://gist.github.com/bbpennel/4e4ca81d5a6cc406404bd79d2dca5691


# Additional Notes:
no

# Interested parties
@awoods @bseeger 
