### PR TITLE
Update LICENSE with 2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
    END OF TERMS AND CONDITIONS
 
 -----------------------------------------------------------------------
-   Copyright 2013-2016 DuraSpace
+   Copyright 2013-2019 DuraSpace
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This update simply increments the DuraSpace copyright date to 2019.