### PR TITLE
Downgrades scm-provider-gitexe.plugin version from 1.11.1 back to 1.9…

### DIFF
--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -54,7 +54,7 @@
     <release.plugin.version>2.5.2</release.plugin.version>
     <remote-resources.plugin.version>1.5</remote-resources.plugin.version>
     <resources.plugin.version>3.1.0</resources.plugin.version>
-    <scm-provider-gitexe.plugin.version>1.11.1</scm-provider-gitexe.plugin.version>
+    <scm-provider-gitexe.plugin.version>1.9.4</scm-provider-gitexe.plugin.version>
     <site.plugin.version>3.7.1</site.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <surefire.plugin.version>2.22.1</surefire.plugin.version>


### PR DESCRIPTION
….4 due to release plugin failures.