### PR TITLE
Fcrepo-2969 - Adding types to binaries

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -48,7 +48,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -82,6 +85,8 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -394,6 +399,13 @@ public abstract class AbstractResourceIT {
             model.read(response.getEntity().getContent(), serverAddress + pid, "TURTLE");
         }
         return model;
+    }
+
+    protected static InputStream streamModel(final Model model, final RDFFormat format) throws IOException {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            RDFDataMgr.write(bos, model, format);
+            return new ByteArrayInputStream(bos.toByteArray());
+        }
     }
 
     protected CloseableHttpResponse createObject() {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -151,6 +151,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.FileEntity;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
@@ -161,12 +162,13 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.DC_11;
+import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.fcrepo.kernel.api.RdfLexicon;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -196,6 +198,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
     private static final Node rdfType = type.asNode();
 
     private static final Node DCTITLE = title.asNode();
+
+    private static final Resource PCDM_FILE_TYPE = createResource("http://pcdm.org/models#File");
 
     private static final String BASIC_CONTAINER_LINK_HEADER = "<" + BASIC_CONTAINER.getURI() + ">;rel=\"type\"";
     private static final String DIRECT_CONTAINER_LINK_HEADER = "<" + DIRECT_CONTAINER.getURI() + ">;rel=\"type\"";
@@ -4097,6 +4101,48 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPutUpdateBinaryWithType() throws Exception {
+        final String objid = getRandomUniqueId();
+        final String objURI = serverAddress + objid;
+        final String binURI = objURI + "/binary1";
+        final String descURI = objURI + "/binary1/fcr:metadata";
+
+        try (final CloseableHttpResponse response = execute(putDSMethod(objid, "binary1", "some test content"))) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        // Add type using PUT
+        final Model model1 = getModel(objid + "/binary1/fcr:metadata");
+        final Resource resc = model1.getResource(binURI);
+        resc.addProperty(RDF.type, PCDM_FILE_TYPE);
+
+        final HttpPut addMethod = new HttpPut(descURI);
+        addMethod.addHeader(CONTENT_TYPE, "text/turtle");
+        addMethod.setEntity(new InputStreamEntity(streamModel(model1, RDFFormat.TURTLE)));
+        try (final CloseableHttpResponse response = execute(addMethod)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+        }
+
+        final Model model2 = getModel(objid + "/binary1/fcr:metadata");
+        final Resource resc2 = model2.getResource(binURI);
+        assertTrue(resc2.hasProperty(RDF.type, PCDM_FILE_TYPE));
+
+        // Remove type using PUT
+        model2.remove(resc2, RDF.type, PCDM_FILE_TYPE);
+
+        final HttpPut removeMethod = new HttpPut(descURI);
+        removeMethod.addHeader(CONTENT_TYPE, "text/turtle");
+        removeMethod.setEntity(new InputStreamEntity(streamModel(model2, RDFFormat.TURTLE)));
+        try (final CloseableHttpResponse response = execute(removeMethod)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+        }
+
+        final Model model3 = getModel(objid + "/binary1/fcr:metadata");
+        final Resource resc3 = model3.getResource(binURI);
+        assertFalse(resc3.hasProperty(RDF.type, PCDM_FILE_TYPE));
+    }
+
+    @Test
     public void testPatchUpdateBinaryWithType() throws Exception {
         final String objid = getRandomUniqueId();
         final String objURI = serverAddress + objid;
@@ -4107,24 +4153,32 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
         }
 
-        final String rdfType = RdfLexicon.RDF_NAMESPACE + "type";
+        // Test adding an rdf:type
         final HttpPatch patchBinary = new HttpPatch(descURI);
         patchBinary.addHeader(CONTENT_TYPE, "application/sparql-update");
         patchBinary.setEntity(new StringEntity("INSERT { <" + binURI + "> " +
-                "<" + rdfType + "> <http://pcdm.org/models#File> } WHERE {}"));
+                "<" + RDF.type.getURI() + "> <" + PCDM_FILE_TYPE.getURI() + "> } WHERE {}"));
 
         try (final CloseableHttpResponse response = execute(patchBinary)) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
-        final HttpGet getObjMethod = new HttpGet(descURI);
-        getObjMethod.addHeader(ACCEPT, "text/turtle");
-        final Model model = createDefaultModel();
-        try (final CloseableHttpResponse getResponse = execute(getObjMethod)) {
-            model.read(getResponse.getEntity().getContent(), binURI, "TURTLE");
+        final Model model = getModel(objid + "/binary1/fcr:metadata");
+        final Resource resc = model.getResource(binURI);
+        assertTrue(resc.hasProperty(RDF.type, PCDM_FILE_TYPE));
+
+        // Test removing an rdf:type
+        final HttpPatch patchBinary2 = new HttpPatch(descURI);
+        patchBinary2.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patchBinary2.setEntity(new StringEntity("DELETE { <" + binURI + "> " +
+                "<" + RDF.type.getURI() + "> <" + PCDM_FILE_TYPE.getURI() + "> } WHERE {}"));
+
+        try (final CloseableHttpResponse response = execute(patchBinary2)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
-        final Resource resc = model.getResource(binURI);
-        assertTrue(resc.hasProperty(createProperty(rdfType), createResource("http://pcdm.org/models#File")));
+        final Model model2 = getModel(objid + "/binary1/fcr:metadata");
+        final Resource resc2 = model2.getResource(binURI);
+        assertFalse(resc2.hasProperty(RDF.type, PCDM_FILE_TYPE));
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -166,6 +166,7 @@ import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.DC_11;
 import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
+import org.fcrepo.kernel.api.RdfLexicon;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -4093,5 +4094,37 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals("Must not be able to PATCH IndirectContainer updating Server Managed triples",
                          CONFLICT.getStatusCode(), getStatus(response));
         }
+    }
+
+    @Test
+    public void testPatchUpdateBinaryWithType() throws Exception {
+        final String objid = getRandomUniqueId();
+        final String objURI = serverAddress + objid;
+        final String binURI = objURI + "/binary1";
+        final String descURI = objURI + "/binary1/fcr:metadata";
+
+        try (final CloseableHttpResponse response = execute(putDSMethod(objid, "binary1", "some test content"))) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        final String rdfType = RdfLexicon.RDF_NAMESPACE + "type";
+        final HttpPatch patchBinary = new HttpPatch(descURI);
+        patchBinary.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patchBinary.setEntity(new StringEntity("INSERT { <" + binURI + "> " +
+                "<" + rdfType + "> <http://pcdm.org/models#File> } WHERE {}"));
+
+        try (final CloseableHttpResponse response = execute(patchBinary)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+        }
+
+        final HttpGet getObjMethod = new HttpGet(descURI);
+        getObjMethod.addHeader(ACCEPT, "text/turtle");
+        final Model model = createDefaultModel();
+        try (final CloseableHttpResponse getResponse = execute(getObjMethod)) {
+            model.read(getResponse.getEntity().getContent(), binURI, "TURTLE");
+        }
+
+        final Resource resc = model.getResource(binURI);
+        assertTrue(resc.hasProperty(createProperty(rdfType), createResource("http://pcdm.org/models#File")));
     }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/JcrPropertyStatementListener.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/JcrPropertyStatementListener.java
@@ -134,7 +134,7 @@ public class JcrPropertyStatementListener extends StatementListener {
             final RDFNode objectNode = s.getObject();
             if (property.equals(RDF.type) && objectNode.isResource()) {
                 final Resource mixinResource = objectNode.asResource();
-                jcrRdfTools.addMixin(resource, mixinResource, input.getModel().getNsPrefixMap());
+                jcrRdfTools.addMixin(description, mixinResource, input.getModel().getNsPrefixMap());
                 statements.put(input, Operation.ADD);
                 return;
             }
@@ -178,7 +178,7 @@ public class JcrPropertyStatementListener extends StatementListener {
 
             if (property.equals(RDF.type) && objectNode.isResource()) {
                 final Resource mixinResource = objectNode.asResource();
-                jcrRdfTools.removeMixin(resource, mixinResource, s.getModel().getNsPrefixMap());
+                jcrRdfTools.removeMixin(description, mixinResource, s.getModel().getNsPrefixMap());
                 statements.put(s, Operation.REMOVE);
                 return;
             }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/RdfAdder.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/RdfAdder.java
@@ -79,7 +79,8 @@ public class RdfAdder extends PersistingRdfStreamConsumer {
     @Override
     protected void operateOnMixin(final Resource mixinResource, final FedoraResource resource)
             throws RepositoryException {
-        jcrRdfTools().addMixin(resource, mixinResource, getNamespaces(getJcrNode(resource).getSession()));
+        final FedoraResource description = resource.getDescription();
+        jcrRdfTools().addMixin(description, mixinResource, getNamespaces(getJcrNode(description).getSession()));
     }
 
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/RdfRemover.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/RdfRemover.java
@@ -60,7 +60,8 @@ public class RdfRemover extends PersistingRdfStreamConsumer {
     protected void operateOnMixin(final Resource mixinResource,
         final FedoraResource resource) throws RepositoryException {
 
-        jcrRdfTools().removeMixin(resource, mixinResource, getNamespaces(getJcrNode(resource).getSession()));
+        final FedoraResource description = resource.getDescription();
+        jcrRdfTools().removeMixin(description, mixinResource, getNamespaces(getJcrNode(description).getSession()));
     }
 
     @Override


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2969

# What does this Pull Request do?

Adds rdf:types submitted via PUT and PATCH to binary descriptions

# What's new?
Also adds tests to verify behavior for PUT/PATCH and memento creation.

# How should this be tested?

See example on ticket

# Additional Notes:
rdf:types no longer being added to the binary node, only to the description node

# Interested parties
@awoods @dbernstein 
