### PR TITLE
Allow versioning of resources with blank nodes

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -46,6 +46,7 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_LINK_FORMA
 import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_FIXITY;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
@@ -91,6 +92,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.Link;
+
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
@@ -245,6 +248,38 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                     results.contains(ANY, mementoSubject, RDF.type.asNode(), MEMENTO_TYPE_NODE));
 
             assertMementoEqualsOriginal(mementoUri);
+        }
+    }
+
+    @Test
+    public void testCreateVersionFromResourceWithBlankNode() throws Exception {
+        final HttpPost createMethod = postObjMethod();
+        createMethod.addHeader("Slug", id);
+        createMethod.addHeader(CONTENT_TYPE, TURTLE);
+        createMethod.setEntity(new StringEntity("<> <http://purl.org/dc/terms/subject> " +
+                "[ a <info:test#Something> ]"));
+
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+        }
+
+        final String mementoUri = createMemento(subjectUri, null, null, null);
+        assertMementoUri(mementoUri, subjectUri);
+
+        try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
+            final DatasetGraph results = dataset.asDatasetGraph();
+
+            // Expect triple with Blank Node as Object
+            final Iterator<Quad> quads =
+                    results.find(ANY, createURI(subjectUri), createURI("http://purl.org/dc/terms/subject"), ANY);
+
+            final List<Quad> quadList = ImmutableList.copyOf(quads);
+            assertEquals("Should only be one element: " + quadList.size(), 1, quadList.size());
+
+            final Quad quad = quadList.get(0);
+            // The quad:Object is the subject of the Blank Node triple we are expecting
+            assertTrue("Should have found blank node triple",
+                    results.contains(ANY, quad.getObject(), RDF.type.asNode(), createURI("info:test#Something")));
         }
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -89,7 +89,7 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
     // The fourth group for allows ACL.
     // The fifth group allows for any hashed suffixes.
     private final static Pattern FORWARD_COMPONENT_PATTERN = Pattern.compile(
-            ".*?(/" + FCR_METADATA + ")?(/" + FCR_VERSIONS + "(/\\d{14})?)?(/" + FCR_ACL + ")?(\\#\\w+)?$");
+            ".*?(/" + FCR_METADATA + ")?(/" + FCR_VERSIONS + "(/\\d{14})?)?(/" + FCR_ACL + ")?(\\#\\S+)?$");
 
     protected List<Converter<String, String>> translationChain;
 


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2970

# What does this Pull Request do?
Change HttpResourceConverter hash regex to match on non-whitespace (\S) instead of word characters (\w)

# How should this be tested?
See ticket description

# Interested parties
@whikloj / @bbpennel / @dbernstein 
