### PR TITLE
Include user-provided rdf:types a Link headers

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -560,19 +560,15 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         // Add user-provided types as Link headers... when a description exists
-        if (resource.getDescription() != null) {
-            for (final URI typeURI : resource.getDescription().getTypes()) {
+        final FedoraResource resourceDescription = resource.getDescription();
+        if (resourceDescription != null) {
+            for (final URI typeURI : resourceDescription.getTypes()) {
 
                 // Get namespace of type
                 final String type = typeURI.toString();
-                final String namespace;
-                if (type.contains("#")) {
-                    namespace = type.substring(0, type.indexOf('#') + 1);
-                } else {
-                    namespace = type.substring(0, type.lastIndexOf('/') + 1);
-                }
+                final String namespace = createURI(type).getNameSpace();
 
-                // Omit server-managed types
+                // Omit server-managed types, as they are added elsewhere
                 if (!isManagedNamespace.test(namespace)) {
                     servletResponse.addHeader(LINK, buildLink(type, "type"));
                 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -558,6 +558,26 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 servletResponse.addHeader(LINK, buildLink(VERSIONING_TIMEMAP_TYPE, "type"));
             }
         }
+
+        // Add user-provided types as Link headers... when a description exists
+        if (resource.getDescription() != null) {
+            for (final URI typeURI : resource.getDescription().getTypes()) {
+
+                // Get namespace of type
+                final String type = typeURI.toString();
+                final String namespace;
+                if (type.contains("#")) {
+                    namespace = type.substring(0, type.indexOf('#') + 1);
+                } else {
+                    namespace = type.substring(0, type.lastIndexOf('/') + 1);
+                }
+
+                // Omit server-managed types
+                if (!isManagedNamespace.test(namespace)) {
+                    servletResponse.addHeader(LINK, buildLink(type, "type"));
+                }
+            }
+        }
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -53,6 +53,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -456,7 +457,12 @@ public abstract class AbstractResourceIT {
 
     protected CloseableHttpResponse setProperty(final String pid, final String propertyUri, final String value)
             throws IOException {
-        return setProperty(pid, null, propertyUri, value);
+        return setProperty(pid, null, propertyUri, "\"" + value + "\"");
+    }
+
+    protected CloseableHttpResponse setProperty(final String pid, final String propertyUri, final URI value)
+            throws IOException {
+        return setProperty(pid, null, propertyUri, "<" + value.toString() + ">");
     }
 
     private CloseableHttpResponse setProperty(final String id, final String txId, final String propertyUri,
@@ -464,7 +470,8 @@ public abstract class AbstractResourceIT {
         final HttpPatch postProp = new HttpPatch(serverAddress + (txId != null ? txId + "/" : "") + id);
         postProp.setHeader(CONTENT_TYPE, "application/sparql-update");
         final String updateString =
-                "INSERT { <" + serverAddress + id + "> <" + propertyUri + "> \"" + value + "\" } WHERE { }";
+                "INSERT { <" + serverAddress + id.replace("/" + FCR_METADATA, "") +
+                        "> <" + propertyUri + "> " + value + " } WHERE { }";
         postProp.setEntity(new StringEntity(updateString));
         final CloseableHttpResponse dcResp = execute(postProp);
         assertEquals(dcResp.getStatusLine().toString(), NO_CONTENT.getStatusCode(), getStatus(dcResp));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -754,7 +754,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testGetNonRDFSourceDescriptionWithUserTypes() throws IOException {
+    public void testGetNonRDFSourceAndDescriptionWithUserTypes() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "ds", "sample-content");
 
@@ -781,16 +781,20 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals(numInitialHeaders + 1, response.getAllHeaders().length);
 
             // Verify presence of user type
-            boolean found = false;
-            final Header[] headers = response.getHeaders("Link");
-            for (final Header header : headers) {
-                final Link link = Link.valueOf(header.getValue());
-                if (link.getUri().equals(userType)) {
-                    found = true;
-                }
-            }
+            checkForLinkHeader(response, userType.toString(), "type");
+        }
 
-            assertTrue("Header not found: " + userType, found);
+        // Verify presence of user type on NonRDFSource... if applicable
+        if (id.endsWith(FCR_METADATA)) {
+            // Strip the trailing /fcr:metadata
+            final HttpHead headBinary = new HttpHead(serverAddress + id.replace("/" + FCR_METADATA, ""));
+
+            try (final CloseableHttpResponse response = execute(headBinary)) {
+                assertEquals(headBinary.toString(), OK.getStatusCode(), response.getStatusLine().getStatusCode());
+
+                // Verify presence of user type
+                checkForLinkHeader(response, userType.toString(), "type");
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2968

# What does this Pull Request do?
Ensures that user-provided types on RDF and descriptions of nonRDF Sources are returned as `Link` headers in GET and HEAD requests.

# How should this be tested?
1. Create a resource (binary or container)
1. Add a type property
   ```
   INSERT {
    <> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://pcdm.org/models#File> .
   }
   WHERE {}
   ```
1. Ensure that the new type is contained as a `Link` header in GET and HEAD requests

# Interested parties
@fcrepo4/committers
