### PR TITLE
Remove references to obsolete JCR:Frozen resources

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -160,7 +160,7 @@ public interface FedoraResource {
      *
      * <p>Note: the type parameter should be in prefixed short form, so ldp:Container or ex:Image
      * are both acceptable types. This method does not assume any jcr to fedora prefix mappings are
-     * managed by the implementation, so hasType("jcr:frozenNode") is a valid use of this method.</p>
+     * managed by the implementation, so hasType("jcr:lastModified") is a valid use of this method.</p>
      *
      * @param type the given type
      * @return whether the object has the given type
@@ -178,7 +178,7 @@ public interface FedoraResource {
      *
      * <p>Note: the type parameter should be in prefixed short form, so ldp:Container or ex:Image
      * are both acceptable types. This method does not assume any jcr to fedora prefix mappings are
-     * managed by the implementation, so hasType("jcr:frozenNode") is a valid use of this method.</p>
+     * managed by the implementation, so hasType("jcr:lastModified") is a valid use of this method.</p>
      *
      * @param type the type to add
      */

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraJcrConstants.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraJcrConstants.java
@@ -34,17 +34,7 @@ public final class FedoraJcrConstants {
 
     public static final String JCR_CREATEDBY = "jcr:createdBy";
 
-    public static final String JCR_FROZEN_NODE = "jcr:frozenNode";
-
-    public static final String FROZEN_NODE = "nt:frozenNode";
-
-    public static final String FROZEN_MIXIN_TYPES = "jcr:frozenMixinTypes";
-
-    public static final String FROZEN_PRIMARY_TYPE = "jcr:frozenPrimaryType";
-
     public static final String ROOT = "mode:root";
-
-    public static final String VERSIONABLE = "mix:versionable";
 
     public static final String FIELD_DELIMITER = "\30^^\30";
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -49,14 +49,12 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RequiredRdfContext.MINIMAL;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
-import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FROZEN_MIXIN_TYPES;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATED;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_LASTMODIFIED;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.ROOT;
 import static org.fcrepo.kernel.modeshape.RdfJcrLexicon.jcrProperties;
 import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.nodeConverter;
 import static org.fcrepo.kernel.modeshape.rdf.JcrRdfTools.getRDFNamespaceForJcrNamespace;
-import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.isFrozen;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.property2values;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getContainingNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
@@ -764,9 +762,6 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         try {
             if (type.equals(FEDORA_REPOSITORY_ROOT)) {
                 return node.isNodeType(ROOT);
-            } else if (isFrozen.test(node) && hasProperty(FROZEN_MIXIN_TYPES)) {
-                return property2values.apply(getProperty(FROZEN_MIXIN_TYPES)).map(uncheck(Value::getString))
-                    .anyMatch(type::equals);
             }
             return node.isNodeType(type);
         } catch (final PathNotFoundException e) {

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/functions/AnyTypesPredicate.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/functions/AnyTypesPredicate.java
@@ -19,16 +19,10 @@ package org.fcrepo.kernel.modeshape.services.functions;
 
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
-import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FROZEN_MIXIN_TYPES;
-import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.isFrozen;
-import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.property2values;
-import static org.fcrepo.kernel.modeshape.utils.UncheckedFunction.uncheck;
 import static org.fcrepo.kernel.modeshape.utils.UncheckedPredicate.uncheck;
 
 import java.util.Collection;
 import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
 
 import org.fcrepo.kernel.modeshape.utils.UncheckedPredicate;
 
@@ -51,14 +45,8 @@ public class AnyTypesPredicate implements UncheckedPredicate<Node> {
     }
 
     @Override
-    public boolean testThrows(final Node input) throws RepositoryException {
+    public boolean testThrows(final Node input) {
         requireNonNull(input, "null node has no types!");
-        if (isFrozen.test(input) && input.hasProperty(FROZEN_MIXIN_TYPES)) {
-            if (property2values.apply(input.getProperty(FROZEN_MIXIN_TYPES)).map(uncheck(Value::getString))
-                    .anyMatch(nodeTypes::contains)) {
-                return true;
-            }
-        }
         return nodeTypes.stream().anyMatch(uncheck(input::isNodeType));
     }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/functions/JcrPropertyFunctions.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/functions/JcrPropertyFunctions.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.kernel.modeshape.services.functions;
 
-import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.Value;
 
@@ -29,7 +28,6 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Stream.of;
 import static javax.jcr.PropertyType.BINARY;
-import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FROZEN_NODE;
 import static org.modeshape.jcr.api.JcrConstants.JCR_DATA;
 import static org.fcrepo.kernel.modeshape.utils.UncheckedPredicate.uncheck;
 
@@ -54,11 +52,5 @@ public final class JcrPropertyFunctions {
      */
     public static final Predicate<Property> isBinaryContentProperty = uncheck(p -> p.getType() == BINARY &&
             p.getName().equals(JCR_DATA));
-
-    /**
-     * Predicate for determining whether this {@link javax.jcr.Node} is a frozen node
-     * (a part of the system version history).
-     */
-    public static final Predicate<Node> isFrozen = uncheck(n -> n.isNodeType(FROZEN_NODE));
 
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
@@ -53,12 +53,8 @@ import static javax.jcr.PropertyType.WEAKREFERENCE;
 import static com.google.common.collect.ImmutableSet.of;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
-import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FROZEN_MIXIN_TYPES;
-import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FROZEN_PRIMARY_TYPE;
-import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FROZEN_NODE;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATED;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATEDBY;
-import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_FROZEN_NODE;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_LASTMODIFIED;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_LASTMODIFIEDBY;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.ROOT;
@@ -86,7 +82,6 @@ public abstract class FedoraTypesUtils implements FedoraTypes {
     private static final Set<String> privateProperties = of(
             "jcr:mime",
             "jcr:mimeType",
-            "jcr:frozenUuid",
             "jcr:uuid",
             JCR_CONTENT,
             JCR_PRIMARY_TYPE,
@@ -95,8 +90,6 @@ public abstract class FedoraTypesUtils implements FedoraTypes {
             JCR_CREATED,
             JCR_CREATEDBY,
             JCR_MIXIN_TYPES,
-            FROZEN_MIXIN_TYPES,
-            FROZEN_PRIMARY_TYPE,
             MEMENTO_DATETIME);
 
     private static final Set<String> validJcrProperties = of(
@@ -123,12 +116,6 @@ public abstract class FedoraTypesUtils implements FedoraTypes {
      * binary.
      */
     public static final Predicate<Node> isFedoraBinary = new AnyTypesPredicate(FEDORA_BINARY);
-
-    /**
-     * Predicate for determining whether this {@link FedoraResource} has a frozen node
-     */
-    public static Predicate<FedoraResource> isFrozenNode = f -> f.hasType(FROZEN_NODE) ||
-            f.getPath().contains(JCR_FROZEN_NODE);
 
     /**
      * Predicate for determining whether this {@link Node} is a Fedora Skolem node.
@@ -171,12 +158,6 @@ public abstract class FedoraTypesUtils implements FedoraTypes {
      */
     private static final Predicate<Property> isProtectedAndShouldBeHidden = uncheck(p -> {
         if (!p.getDefinition().isProtected()) {
-            return false;
-        } else if (p.getParent().isNodeType(FROZEN_NODE)) {
-            // everything on a frozen node is protected
-            // but we wish to display it anyway and there's
-            // another mechanism in place to make clear that
-            // things cannot be edited.
             return false;
         } else if (isPublicJcrProperty.test(p.getName())) {
             return false;

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -1071,8 +1071,8 @@ public class FedoraResourceImplIT extends AbstractIT {
         final String pid = getRandomPid();
         final Container object = containerService.findOrCreate(session, "/" + pid);
         session.commit();
-        final FedoraResourceImpl frozenResource = new FedoraResourceImpl(getJcrNode(object));
-        assertFalse(frozenResource.hashCode() == 0);
+        final FedoraResourceImpl resource = new FedoraResourceImpl(getJcrNode(object));
+        assertFalse(resource.hashCode() == 0);
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/JcrRdfToolsTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/JcrRdfToolsTest.java
@@ -30,7 +30,6 @@ import static javax.jcr.PropertyType.URI;
 import static javax.jcr.PropertyType.WEAKREFERENCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FIELD_DELIMITER;
-import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FROZEN_NODE;
 import static org.fcrepo.kernel.modeshape.rdf.JcrRdfTools.getJcrNamespaceForRDFNamespace;
 import static org.fcrepo.kernel.modeshape.rdf.JcrRdfTools.getRDFNamespaceForJcrNamespace;
 import static org.junit.Assert.assertEquals;
@@ -149,7 +148,6 @@ public class JcrRdfToolsTest implements FedoraTypes {
         when(mockProperty.getValue()).thenReturn(mockValue);
         when(mockProperty.getType()).thenReturn(STRING);
         when(mockProperty.getParent()).thenReturn(mockNode);
-        when(mockNode.isNodeType(FROZEN_NODE)).thenReturn(false);
         when(mockProperty.getDefinition()).thenReturn(mockPropertyDefinition);
         when(mockPropertyDefinition.isProtected()).thenReturn(false);
         when(mockValue.getString()).thenReturn("abc");
@@ -514,9 +512,6 @@ public class JcrRdfToolsTest implements FedoraTypes {
 
     @Mock
     private Version mockVersion;
-
-    @Mock
-    private Node mockFrozenNode;
 
     @Mock
     private VersionManager mockVersionManager;


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2971

# What does this Pull Request do?
Removes references to obsolete JCR:Frozen resources.

# How should this be tested?
No functionality is added or removed. This update should have no effect on the Fedora application.

# Interested parties
@fcrepo4/committers
