### PR TITLE
Fcrepo 2975 - Create timemap when resource created

### DIFF
--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
@@ -25,7 +25,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.RdfLexicon.PROV_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.CONTAINER_WEBAC_ACL;
-import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_TIME_MAP;
+import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -57,6 +57,7 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSE
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_PAIRTREE;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_DESCRIPTION;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODEL_RESOURCES;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
@@ -789,10 +790,12 @@ public class FedoraLdp extends ContentExposingResource {
         if ("ldp:NonRDFSource".equals(interactionModel) || contentExternal ||
                 (contentPresent && interactionModel == null && !isRDF(simpleContentType))) {
             result = binaryService.findOrCreate(session.getFedoraSession(), path);
+            timeMapService.findOrCreate(session.getFedoraSession(), path + "/" + FEDORA_DESCRIPTION);
         } else {
             result = containerService.findOrCreate(session.getFedoraSession(), path);
         }
 
+        timeMapService.findOrCreate(session.getFedoraSession(), path);
 
         final String resInteractionModel = getInteractionModel(result);
         if (StringUtils.isNoneBlank(interactionModel) && StringUtils.isNoneBlank(resInteractionModel)

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -133,6 +133,7 @@ import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.ContainerService;
 import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.api.services.TimeMapService;
 import org.glassfish.jersey.internal.PropertiesDelegate;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.junit.Before;
@@ -195,6 +196,9 @@ public class FedoraLdpTest {
     private BinaryService mockBinaryService;
 
     @Mock
+    private TimeMapService mockTimeMapService;
+
+    @Mock
     private FedoraHttpConfiguration mockHttpConfiguration;
 
     @Mock
@@ -244,6 +248,7 @@ public class FedoraLdpTest {
         setField(testObj, "nodeService", mockNodeService);
         setField(testObj, "containerService", mockContainerService);
         setField(testObj, "binaryService", mockBinaryService);
+        setField(testObj, "timeMapService", mockTimeMapService);
         setField(testObj, "httpConfiguration", mockHttpConfiguration);
         setField(testObj, "session", mockSession);
         setField(testObj, "securityContext", mockSecurityContext);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTransactionsIT.java
@@ -348,18 +348,21 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
         }
     }
 
+    /**
+     * Test for issue https://jira.duraspace.org/browse/FCREPO-2975
+     */
     @Test
-    public void testBinaryHeadAndDeleteInTransaction() throws Exception {
+    public void testHeadAndDeleteInTransaction() throws Exception {
         final String id = getRandomUniqueId();
+        createObject(id);
 
-        // Create the child resource
-        try (final CloseableHttpResponse response = execute(putDSMethod(id, "child", "some test content"))) {
-            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        try (final CloseableHttpResponse resp = execute(new HttpHead(serverAddress + "/" + id))) {
+            assertEquals(OK.getStatusCode(), resp.getStatusLine().getStatusCode());
         }
 
         final String txLocation = createTransaction();
 
-        // Make a head request against the binary within the transaction
+        // Make a head request against the object within the transaction
         final String childTxPath = txLocation + "/" + id;
         try (final CloseableHttpResponse resp = execute(new HttpHead(childTxPath))) {
             assertEquals(OK.getStatusCode(), resp.getStatusLine().getStatusCode());

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
@@ -30,6 +30,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.api.services.TimeMapService;
 import org.fcrepo.kernel.api.services.ContainerService;
 import org.fcrepo.kernel.api.services.VersionService;
 import org.fcrepo.kernel.api.services.functions.ConfigurableHierarchicalSupplier;
@@ -79,6 +80,12 @@ public class AbstractResource {
      */
     @Inject
     protected VersionService versionService;
+
+    /**
+     * The timemap service
+     */
+    @Inject
+    protected TimeMapService timeMapService;
 
     /**
      * A resource that can mint new Fedora PIDs.

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -23,7 +23,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.replaceOnce;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.CONTAINER_WEBAC_ACL;
-import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_TIME_MAP;
+import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -241,6 +241,11 @@ public final class RdfLexicon {
      */
     public static final String FEDORA_DESCRIPTION = "fedora:description";
 
+    /**
+     * Fedora defined node path for a timemap
+     */
+    public static final String LDPCV_TIME_MAP = "fedora:timemap";
+
     // VERSIONING
     /**
      * Memento TimeMap type.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/TimeMapService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/TimeMapService.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import org.fcrepo.kernel.api.models.FedoraTimeMap;
+
+/**
+ * Service for creating and retrieving {@link org.fcrepo.kernel.api.models.FedoraTimeMap}
+ *
+ * @author bbpennel
+ */
+public interface TimeMapService extends Service<FedoraTimeMap> {
+
+}

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/AbstractFedoraBinary.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/AbstractFedoraBinary.java
@@ -21,6 +21,7 @@ import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_DESCRIPTION;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FIELD_DELIMITER;
 import static org.fcrepo.kernel.modeshape.services.functions.JcrPropertyFunctions.property2values;
+import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
 
 import static org.slf4j.LoggerFactory.getLogger;
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/NonRdfSourceDescriptionImpl.java
@@ -21,6 +21,7 @@ import static org.fcrepo.kernel.api.utils.SubjectMappingUtil.mapSubject;
 import static java.util.stream.Stream.empty;
 import static org.fcrepo.kernel.api.RequiredRdfContext.MINIMAL;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.isNonRdfSourceDescription;
+import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.jcr.Node;

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TimeMapServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TimeMapServiceImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.modeshape.services;
+
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_RESOURCE;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_TIME_MAP;
+import static org.fcrepo.kernel.api.FedoraTypes.MEMENTO_ORIGINAL;
+import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
+import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.nio.file.Paths;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import org.fcrepo.kernel.api.FedoraSession;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.ResourceTypeException;
+import org.fcrepo.kernel.api.models.FedoraTimeMap;
+import org.fcrepo.kernel.api.services.TimeMapService;
+import org.fcrepo.kernel.modeshape.FedoraTimeMapImpl;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * Service for creating and retrieving {@link org.fcrepo.kernel.api.models.FedoraTimeMap} without using the JCR API.
+ *
+ * @author bbpennel
+ */
+@Component
+public class TimeMapServiceImpl extends AbstractService implements TimeMapService {
+
+    private static final Logger LOGGER = getLogger(TimeMapServiceImpl.class);
+
+    @Override
+    public FedoraTimeMap find(final FedoraSession session, final String path) {
+        final String ldpcvPath = getLdpcvPath(path);
+
+        return cast(findNode(session, ldpcvPath));
+    }
+
+    @Override
+    public FedoraTimeMap findOrCreate(final FedoraSession session, final String path) {
+        try {
+            // Add fedora:timemap to path if not present
+            final String ldpcvPath = getLdpcvPath(path);
+
+            final Node node = findOrCreateNode(session, ldpcvPath, NT_FOLDER);
+
+            if (node.isNew()) {
+                LOGGER.debug("Created TimeMap LDPCv {}", node.getPath());
+
+                // add mixin type fedora:Resource
+                if (node.canAddMixin(FEDORA_RESOURCE)) {
+                    node.addMixin(FEDORA_RESOURCE);
+                }
+
+                // add mixin type fedora:TimeMap
+                if (node.canAddMixin(FEDORA_TIME_MAP)) {
+                    node.addMixin(FEDORA_TIME_MAP);
+                }
+
+                // Set reference from timegate/map to original resource
+                node.setProperty(MEMENTO_ORIGINAL, node.getParent());
+            }
+
+            return new FedoraTimeMapImpl(node);
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean exists(final FedoraSession session, final String path) {
+        final String ldpcvPath = getLdpcvPath(path);
+        return super.exists(session, ldpcvPath);
+    }
+
+    private static final String getLdpcvPath(final String path) {
+        if (path.endsWith("/" + LDPCV_TIME_MAP)) {
+            return path;
+        } else {
+            return Paths.get(path, LDPCV_TIME_MAP).toString();
+        }
+    }
+
+    private FedoraTimeMap cast(final Node node) {
+        assertIsType(node);
+        return new FedoraTimeMapImpl(node);
+    }
+
+    private static void assertIsType(final Node node) {
+        if (!FedoraTimeMapImpl.hasMixin(node)) {
+            throw new ResourceTypeException(node + " can not be used as a timemap");
+        }
+    }
+}

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/VersionServiceImpl.java
@@ -33,7 +33,7 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_CONTAINMENT;
 import static org.fcrepo.kernel.api.RequiredRdfContext.LDP_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
 import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
-import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_TIME_MAP;
+import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
 import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.fcrepo.kernel.modeshape.rdf.impl.RequiredPropertiesUtil.assertRequiredContainerTriples;
 import static org.fcrepo.kernel.modeshape.rdf.impl.RequiredPropertiesUtil.assertRequiredDescriptionTriples;

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraResourceImplIT.java
@@ -66,6 +66,7 @@ import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.ContainerService;
 import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.api.services.TimeMapService;
 import org.fcrepo.kernel.api.services.VersionService;
 import org.fcrepo.kernel.modeshape.FedoraResourceImpl;
 import org.fcrepo.kernel.modeshape.rdf.impl.DefaultIdentifierTranslator;
@@ -107,7 +108,7 @@ import static org.fcrepo.kernel.api.RequiredRdfContext.SERVER_MANAGED;
 import static org.fcrepo.kernel.api.RequiredRdfContext.VERSIONS;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.FIELD_DELIMITER;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.ROOT;
-import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.LDPCV_TIME_MAP;
+import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
 import static org.fcrepo.kernel.modeshape.FedoraResourceImpl.CONTAINER_WEBAC_ACL;
 import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.fcrepo.kernel.modeshape.RdfJcrLexicon.HAS_MIXIN_TYPE;
@@ -156,6 +157,9 @@ public class FedoraResourceImplIT extends AbstractIT {
 
     @Inject
     private BinaryService binaryService;
+
+    @Inject
+    private TimeMapService timeMapService;
 
     @Inject
     private VersionService versionService;
@@ -1116,13 +1120,14 @@ public class FedoraResourceImplIT extends AbstractIT {
     }
 
     @Test
-    public void testFindOrCreateTimeMapLDPCv() throws RepositoryException {
+    public void testFindTimeMapLDPCv() throws RepositoryException {
         final String pid = getRandomPid();
         final Session jcrSession = getJcrSession(session);
         final FedoraResource resource = containerService.findOrCreate(session, "/" + pid);
+        timeMapService.findOrCreate(session, "/" + pid);
         session.commit();
 
-        // Create TimeMap (LDPCv)
+        // Find TimeMap (LDPCv)
         final FedoraResource ldpcvResource = resource.getTimeMap();
 
         assertNotNull(ldpcvResource);
@@ -1188,7 +1193,9 @@ public class FedoraResourceImplIT extends AbstractIT {
 
     @Test
     public void testGetMementoByDatetimeEmpty() {
-        final FedoraResource object1 = containerService.findOrCreate(session, "/" + getRandomPid());
+        final String pid = getRandomPid();
+        final FedoraResource object1 = containerService.findOrCreate(session, "/" + pid);
+        timeMapService.findOrCreate(session, "/" + pid);
 
         final DateTimeFormatter FMT = new DateTimeFormatterBuilder()
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraTimeMapImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/FedoraTimeMapImplIT.java
@@ -33,6 +33,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.FedoraTimeMap;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.ContainerService;
+import org.fcrepo.kernel.api.services.TimeMapService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -57,6 +58,9 @@ public class FedoraTimeMapImplIT extends AbstractIT {
     @Inject
     private BinaryService binaryService;
 
+    @Inject
+    private TimeMapService timeMapService;
+
     private FedoraSession session;
 
     @Rule
@@ -76,6 +80,7 @@ public class FedoraTimeMapImplIT extends AbstractIT {
     public void testGetOriginalResource() {
         final String pid = getRandomPid();
         final Container object = containerService.findOrCreate(session, "/" + pid);
+        timeMapService.findOrCreate(session, "/" + pid);
         session.commit();
 
         final FedoraTimeMap timeMap = (FedoraTimeMap) object.getTimeMap();
@@ -93,9 +98,10 @@ public class FedoraTimeMapImplIT extends AbstractIT {
         try (InputStream contentStream = new ByteArrayInputStream("content".getBytes())) {
             object.setContent(contentStream, "text/plain", null, null, null);
         }
+        timeMapService.findOrCreate(session, "/" + pid);
+        session.commit();
 
         final FedoraTimeMap timeMap = (FedoraTimeMap) object.getTimeMap();
-        session.commit();
 
         final FedoraResource originalResource = timeMap.getOriginalResource();
         assertTrue(originalResource instanceof FedoraBinary);
@@ -110,6 +116,7 @@ public class FedoraTimeMapImplIT extends AbstractIT {
         try (InputStream contentStream = new ByteArrayInputStream("content".getBytes())) {
             binary.setContent(contentStream, "text/plain", null, null, null);
         }
+        timeMapService.findOrCreate(session, "/" + pid);
         session.commit();
 
         final FedoraResource description = binary.getDescribedResource();

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/TimeMapServiceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/TimeMapServiceImplIT.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.kernel.modeshape.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_DESCRIPTION;
+
+import javax.inject.Inject;
+
+import org.fcrepo.integration.kernel.modeshape.AbstractIT;
+import org.fcrepo.kernel.api.FedoraRepository;
+import org.fcrepo.kernel.api.FedoraSession;
+import org.fcrepo.kernel.api.models.Container;
+import org.fcrepo.kernel.api.models.FedoraBinary;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.FedoraTimeMap;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
+import org.fcrepo.kernel.api.services.BinaryService;
+import org.fcrepo.kernel.api.services.ContainerService;
+import org.fcrepo.kernel.api.services.TimeMapService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author bbpennel
+ */
+@ContextConfiguration({ "/spring-test/fcrepo-config.xml" })
+public class TimeMapServiceImplIT extends AbstractIT {
+
+    @Inject
+    private FedoraRepository repo;
+
+    @Inject
+    private ContainerService containerService;
+
+    @Inject
+    private TimeMapService timeMapService;
+
+    @Inject
+    private BinaryService binaryService;
+
+    private FedoraSession session;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        session = repo.login();
+    }
+
+    @After
+    public void tearDown() {
+        session.expire();
+    }
+
+    @Test
+    public void testCreateTimeMap() {
+        final String path = "/" + getRandomPid();
+        final Container object = containerService.findOrCreate(session, path);
+        final FedoraTimeMap timeMap = timeMapService.findOrCreate(session, path);
+        session.commit();
+
+        verifyTimeMap(object, timeMap, Container.class);
+    }
+
+    @Test
+    public void testCreateTimeMapFromFullPath() {
+        final String path = "/" + getRandomPid();
+        final Container object = containerService.findOrCreate(session, path);
+        final String timeMapPath = path + "/" + LDPCV_TIME_MAP;
+        final FedoraTimeMap timeMap = timeMapService.findOrCreate(session, timeMapPath);
+        session.commit();
+
+        verifyTimeMap(object, timeMap, Container.class);
+    }
+
+    @Test
+    public void testFindTimeMap() {
+        final String path = "/" + getRandomPid();
+        final Container object = containerService.findOrCreate(session, path);
+        timeMapService.findOrCreate(session, path);
+        session.commit();
+
+        final FedoraTimeMap timeMap = timeMapService.find(session, path);
+
+        verifyTimeMap(object, timeMap, Container.class);
+    }
+
+    @Test
+    public void testTimeMapExists() {
+        final String path = "/" + getRandomPid();
+        containerService.findOrCreate(session, path);
+        session.commit();
+
+        assertFalse(timeMapService.exists(session, path));
+
+        timeMapService.findOrCreate(session, path);
+        session.commit();
+
+        assertTrue(timeMapService.exists(session, path));
+    }
+
+    @Test
+    public void testFindOrCreateForBinary() throws Exception {
+        final String path = "/" + getRandomPid();
+        final FedoraBinary object = binaryService.findOrCreate(session, path);
+        try (InputStream contentStream = new ByteArrayInputStream("content".getBytes())) {
+            object.setContent(contentStream, "text/plain", null, null, null);
+        }
+
+        final FedoraTimeMap binaryTimeMap = timeMapService.findOrCreate(session, path);
+        verifyTimeMap(object, binaryTimeMap, FedoraBinary.class);
+
+        final FedoraTimeMap descTimeMap = timeMapService.findOrCreate(session, path + "/" + FEDORA_DESCRIPTION);
+        verifyTimeMap(object.getDescription(), descTimeMap, NonRdfSourceDescription.class);
+    }
+
+    private void verifyTimeMap(final FedoraResource resource, final FedoraTimeMap timeMap,
+            final Class<?> resClass) {
+        final FedoraResource originalResource = timeMap.getOriginalResource();
+        assertTrue(resClass.isInstance(originalResource));
+        assertEquals("Original resource must reference original container",
+                resource.getPath(), originalResource.getPath());
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2975

# What does this Pull Request do?
Resolves an NPE when committing transactions containing HEAD and DELETE requests to the same resource by creating timemaps at the same time that the original resource was created.

# What's new?
 Creating timemap at the same time that a resource is created. 
 * Implemented TimeMapService for the creation of timemaps
 * Changed FedoraResourceImpl.getTimeMap() to never create timemaps
 * Allow for responses for versioning disabled resources to not return a timemap uri
 * Moved constant for fedora:timemap node to constants class for consistency and since it did not primarily belong to FedoraResourceImpl anymore.
 * Added and updated tests

# How should this be tested?

See example in ticket as well as new integration tests. 

# Additional Notes:
This changes the approach in fcrepo5 regarding when timemaps are created from lazy-creation to explicit creation at object creation time.

# Interested parties
@awoods @dbernstein 