### PR TITLE
FCREPO-2935-7 - LDP Container default properties

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -792,7 +792,7 @@ public class FedoraLdp extends ContentExposingResource {
             result = binaryService.findOrCreate(session.getFedoraSession(), path);
             timeMapService.findOrCreate(session.getFedoraSession(), path + "/" + FEDORA_DESCRIPTION);
         } else {
-            result = containerService.findOrCreate(session.getFedoraSession(), path);
+            result = containerService.findOrCreate(session.getFedoraSession(), path, interactionModel);
         }
 
         timeMapService.findOrCreate(session.getFedoraSession(), path);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -859,7 +859,7 @@ public class FedoraLdpTest {
         when(mockContainer.isNew()).thenReturn(true);
 
         when(mockNodeService.exists(mockFedoraSession, "/some/path")).thenReturn(false);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/some/path")).thenReturn(mockContainer);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/some/path", null)).thenReturn(mockContainer);
 
         final Response actual = testObj.createOrReplaceObjectRdf(null, null, null, null, null, null);
 
@@ -881,7 +881,7 @@ public class FedoraLdpTest {
         when(mockContainer.isNew()).thenReturn(true);
 
         when(mockNodeService.exists(mockFedoraSession, "/some/path")).thenReturn(false);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/some/path")).thenReturn(mockContainer);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/some/path", null)).thenReturn(mockContainer);
 
         final Response actual = testObj.createOrReplaceObjectRdf(NTRIPLES_TYPE,
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);
@@ -915,7 +915,7 @@ public class FedoraLdpTest {
         when(mockObject.isNew()).thenReturn(false);
 
         when(mockNodeService.exists(mockFedoraSession, "/some/path")).thenReturn(true);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/some/path")).thenReturn(mockObject);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/some/path", null)).thenReturn(mockObject);
 
         final Response actual = testObj.createOrReplaceObjectRdf(NTRIPLES_TYPE,
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);
@@ -933,7 +933,7 @@ public class FedoraLdpTest {
         when(mockObject.isNew()).thenReturn(false);
 
         when(mockNodeService.exists(mockFedoraSession, "/some/path")).thenReturn(true);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/some/path")).thenReturn(mockObject);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/some/path", null)).thenReturn(mockObject);
 
         testObj.createOrReplaceObjectRdf(NTRIPLES_TYPE,
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);
@@ -989,7 +989,8 @@ public class FedoraLdpTest {
     public void testCreateNewObject() throws MalformedRdfException, InvalidChecksumException,
             UnsupportedAlgorithmException {
         setResource(Container.class);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/b", null))
+                .thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, null, "b", null, null, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
     }
@@ -998,7 +999,7 @@ public class FedoraLdpTest {
     public void testCreateNewObjectWithVersionedResource() throws MalformedRdfException, InvalidChecksumException,
             UnsupportedAlgorithmException {
         setResource(Container.class);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/b", null)).thenReturn(mockContainer);
         final String versionedResourceLink = "<" + VERSIONED_RESOURCE.getURI() + ">;rel=\"type\"";
         final Response actual = testObj.createObject(null, null, "b", null, singletonList(versionedResourceLink), null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
@@ -1008,7 +1009,7 @@ public class FedoraLdpTest {
     public void testCreateNewObjectWithSparql() throws MalformedRdfException,
            InvalidChecksumException, UnsupportedAlgorithmException {
         setResource(Container.class);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/b", null)).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null,
                 MediaType.valueOf(contentTypeSPARQLUpdate), "b", toInputStream("x", UTF_8), null, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
@@ -1019,7 +1020,7 @@ public class FedoraLdpTest {
     public void testCreateNewObjectWithRdf() throws MalformedRdfException,
            InvalidChecksumException, UnsupportedAlgorithmException {
         setResource(Container.class);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/b")).thenReturn(mockContainer);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/b", null)).thenReturn(mockContainer);
         final Response actual = testObj.createObject(null, NTRIPLES_TYPE, "b",
                 toInputStream("_:a <info:b> _:c .", UTF_8), null, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
@@ -1178,7 +1179,7 @@ public class FedoraLdpTest {
     public void testLDPRNotImplementedInvalidLink() throws MalformedRdfException, InvalidChecksumException,
             UnsupportedAlgorithmException {
         setResource(Container.class);
-        when(mockContainerService.findOrCreate(mockFedoraSession, "/x")).thenReturn(mockContainer);
+        when(mockContainerService.findOrCreate(mockFedoraSession, "/x", null)).thenReturn(mockContainer);
         testObj.createObject(null, null, "x", null, singletonList("<http://foo;rel=\"type\""), null);
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
@@ -26,6 +26,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INSERTED_CONTENT_RELATION;
+import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.PROXY_FOR;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
@@ -47,7 +48,7 @@ import org.junit.Test;
 /**
  * @author bbpennel
  */
-public class ContainerTypeIT extends AbstractResourceIT {
+public class LDPContainerIT extends AbstractResourceIT {
 
     private final String PCDM_HAS_MEMBER = "http://pcdm.org/models#hasMember";
 
@@ -73,8 +74,12 @@ public class ContainerTypeIT extends AbstractResourceIT {
 
         final Resource resc = model.getResource(subjectURI);
         assertTrue("Must have container type", resc.hasProperty(RDF.type, INDIRECT_CONTAINER));
+
         assertTrue("Default ldp:membershipResource must be set",
                 resc.hasProperty(MEMBERSHIP_RESOURCE, resc));
+
+        assertTrue("Default ldp:hasMemberRelation must be set",
+                resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
     }
 
     @Test
@@ -96,6 +101,11 @@ public class ContainerTypeIT extends AbstractResourceIT {
                 resc.hasProperty(MEMBERSHIP_RESOURCE, createResource(parentURI)));
         assertFalse("Default ldp:membershipResource must not be present",
                 resc.hasProperty(MEMBERSHIP_RESOURCE, resc));
+
+        assertTrue("Provided ldp:hasMemberRelation must be set",
+                resc.hasProperty(HAS_MEMBER_RELATION, PCDM_HAS_MEMBER_PROP));
+        assertFalse("Default ldp:hasMemberRelation must not be present",
+                resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
     }
 
     @Test
@@ -131,6 +141,8 @@ public class ContainerTypeIT extends AbstractResourceIT {
 
         assertFalse("Provided ldp:hasMemberRelation must be removed",
                 resc.hasProperty(HAS_MEMBER_RELATION, createResource(parentURI)));
+        assertTrue("Default ldp:hasMemberRelation must be set",
+                resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
 
         assertFalse("Provided ldp:insertedContentRelation must be removed",
                 resc.hasProperty(INSERTED_CONTENT_RELATION, PROXY_FOR));
@@ -160,8 +172,11 @@ public class ContainerTypeIT extends AbstractResourceIT {
 
         final Resource resc = model.getResource(subjectURI);
         assertTrue("Must have container type", resc.hasProperty(RDF.type, DIRECT_CONTAINER));
+
         assertTrue("Default ldp:membershipResource must be set",
                 resc.hasProperty(MEMBERSHIP_RESOURCE, resc));
+        assertTrue("Default ldp:hasMemberRelation must be set",
+                resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
     }
 
     @Test
@@ -178,10 +193,16 @@ public class ContainerTypeIT extends AbstractResourceIT {
         final Model model = getModel(directId);
         final Resource resc = model.getResource(directURI);
         assertTrue("Must have container type", resc.hasProperty(RDF.type, DIRECT_CONTAINER));
+
         assertTrue("Provided ldp:membershipResource must be present",
                 resc.hasProperty(MEMBERSHIP_RESOURCE, createResource(parentURI)));
         assertFalse("Default ldp:membershipResource must not be present",
                 resc.hasProperty(MEMBERSHIP_RESOURCE, resc));
+
+        assertTrue("Provided ldp:hasMemberRelation must be set",
+                resc.hasProperty(HAS_MEMBER_RELATION, PCDM_HAS_MEMBER_PROP));
+        assertFalse("Default ldp:hasMemberRelation must not be present",
+                resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
     }
 
     @Test
@@ -216,6 +237,8 @@ public class ContainerTypeIT extends AbstractResourceIT {
 
         assertFalse("Provided ldp:hasMemberRelation must be removed",
                 resc.hasProperty(HAS_MEMBER_RELATION, createResource(parentURI)));
+        assertTrue("Default ldp:hasMemberRelation must be set",
+                resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
     }
 
     private void createDirectContainer(final String directId, final String membershipURI) throws Exception {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
@@ -28,6 +28,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.INSERTED_CONTENT_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMBER_SUBJECT;
 import static org.fcrepo.kernel.api.RdfLexicon.PROXY_FOR;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
@@ -80,6 +81,9 @@ public class LDPContainerIT extends AbstractResourceIT {
 
         assertTrue("Default ldp:hasMemberRelation must be set",
                 resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
+
+        assertTrue("Default ldp:insertedContentRelation must be set",
+                resc.hasProperty(INSERTED_CONTENT_RELATION, MEMBER_SUBJECT));
     }
 
     @Test
@@ -106,6 +110,11 @@ public class LDPContainerIT extends AbstractResourceIT {
                 resc.hasProperty(HAS_MEMBER_RELATION, PCDM_HAS_MEMBER_PROP));
         assertFalse("Default ldp:hasMemberRelation must not be present",
                 resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
+
+        assertTrue("Provided ldp:insertedContentRelation must be set",
+                resc.hasProperty(INSERTED_CONTENT_RELATION, PROXY_FOR));
+        assertFalse("Default ldp:insertedContentRelation must not be present",
+                resc.hasProperty(INSERTED_CONTENT_RELATION, MEMBER_SUBJECT));
     }
 
     @Test
@@ -146,6 +155,8 @@ public class LDPContainerIT extends AbstractResourceIT {
 
         assertFalse("Provided ldp:insertedContentRelation must be removed",
                 resc.hasProperty(INSERTED_CONTENT_RELATION, PROXY_FOR));
+        assertTrue("Default ldp:insertedContentRelation must be present",
+                resc.hasProperty(INSERTED_CONTENT_RELATION, MEMBER_SUBJECT));
     }
 
     private void createIndirectContainer(final String indirectId, final String membershipURI) throws Exception {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -141,6 +141,8 @@ public final class RdfLexicon {
             createProperty(LDP_NAMESPACE + "membershipResource");
     public static final Property HAS_MEMBER_RELATION =
             createProperty(LDP_NAMESPACE + "hasMemberRelation");
+    public static final Property INSERTED_CONTENT_RELATION =
+            createProperty(LDP_NAMESPACE + "insertedContentRelation");
     public static final Property CONTAINS =
         createProperty(LDP_NAMESPACE + "contains");
     public static final Property LDP_MEMBER =

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ContainerService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ContainerService.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.api.services;
 
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.models.Container;
 
 /**
@@ -27,4 +28,13 @@ import org.fcrepo.kernel.api.models.Container;
  */
 public interface ContainerService extends Service<Container> {
 
+    /**
+     * Find or create a container node using the provided interaction model.
+     *
+     * @param session the session
+     * @param path the path
+     * @param interactionModel interaction model for the container node
+     * @return Container object for the given path.
+     */
+    public Container findOrCreate(final FedoraSession session, final String path, final String interactionModel);
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -37,10 +37,12 @@ import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.INSERTED_CONTENT_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMBER_SUBJECT;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedNamespace;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
@@ -859,19 +861,20 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
     private void ensureInteractionModelDefaults(final String uri, final Model model) {
         final Resource resc = model.getResource(uri);
-        if (resc.hasProperty(RDF.type, INDIRECT_CONTAINER)) {
+        final boolean isIndirect = resc.hasProperty(RDF.type, INDIRECT_CONTAINER);
+        final boolean isDirect = !isIndirect && resc.hasProperty(RDF.type, DIRECT_CONTAINER);
+
+        if (isIndirect || isDirect) {
             if (!resc.hasProperty(MEMBERSHIP_RESOURCE)) {
                 resc.addProperty(MEMBERSHIP_RESOURCE, resc);
             }
             if (!resc.hasProperty(HAS_MEMBER_RELATION)) {
                 resc.addProperty(HAS_MEMBER_RELATION, LDP_MEMBER);
             }
-        } else if (resc.hasProperty(RDF.type, DIRECT_CONTAINER)) {
-            if (!resc.hasProperty(MEMBERSHIP_RESOURCE)) {
-                resc.addProperty(MEMBERSHIP_RESOURCE, resc);
-            }
-            if (!resc.hasProperty(HAS_MEMBER_RELATION)) {
-                resc.addProperty(HAS_MEMBER_RELATION, LDP_MEMBER);
+        }
+        if (isIndirect) {
+            if (!resc.hasProperty(INSERTED_CONTENT_RELATION)) {
+                resc.addProperty(INSERTED_CONTENT_RELATION, MEMBER_SUBJECT);
             }
         }
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -989,6 +989,9 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
     public void replaceProperties(final IdentifierConverter<Resource, FedoraResource> idTranslator,
         final Model inputModel, final RdfStream originalTriples) throws MalformedRdfException {
 
+        final Resource selfResource = idTranslator.reverse().convert(this);
+        ensureInteractionModelDefaults(selfResource.toString(), inputModel);
+
         // remove any statements that update "relaxed" server-managed triples so they can be updated separately
         final List<Statement> filteredStatements = new ArrayList<>();
         final StmtIterator it = inputModel.listStatements();
@@ -1012,7 +1015,7 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
 
 
         try (final RdfStream replacementStream =
-                new DefaultRdfStream(idTranslator.reverse().convert(this).asNode())) {
+                new DefaultRdfStream(selfResource.asNode())) {
 
             final GraphDifferencer differencer =
                 new GraphDifferencer(inputModel, filteredTriples);

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -72,6 +72,7 @@ import static org.fcrepo.kernel.modeshape.utils.NamespaceTools.getNamespaceRegis
 import static org.fcrepo.kernel.modeshape.utils.StreamUtils.iteratorToStream;
 import static org.fcrepo.kernel.modeshape.utils.UncheckedFunction.uncheck;
 import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
+import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -862,9 +863,15 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
             if (!resc.hasProperty(MEMBERSHIP_RESOURCE)) {
                 resc.addProperty(MEMBERSHIP_RESOURCE, resc);
             }
+            if (!resc.hasProperty(HAS_MEMBER_RELATION)) {
+                resc.addProperty(HAS_MEMBER_RELATION, LDP_MEMBER);
+            }
         } else if (resc.hasProperty(RDF.type, DIRECT_CONTAINER)) {
             if (!resc.hasProperty(MEMBERSHIP_RESOURCE)) {
                 resc.addProperty(MEMBERSHIP_RESOURCE, resc);
+            }
+            if (!resc.hasProperty(HAS_MEMBER_RELATION)) {
+                resc.addProperty(HAS_MEMBER_RELATION, LDP_MEMBER);
             }
         }
     }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImpl.java
@@ -21,8 +21,10 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_DIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.FedoraTypes.LDP_HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_MEMBER_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.modeshape.ContainerImpl.hasMixin;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getContainingNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.touch;
@@ -74,9 +76,11 @@ public class ContainerServiceImpl extends AbstractService implements ContainerSe
                 if (LDP_INDIRECT_CONTAINER.equals(interactionModel)) {
                     node.addMixin(LDP_INDIRECT_CONTAINER);
                     node.setProperty(LDP_MEMBER_RESOURCE, node);
+                    node.setProperty(LDP_HAS_MEMBER_RELATION, LDP_MEMBER.getURI());
                 } else if (LDP_DIRECT_CONTAINER.equals(interactionModel)) {
                     node.addMixin(LDP_DIRECT_CONTAINER);
                     node.setProperty(LDP_MEMBER_RESOURCE, node);
+                    node.setProperty(LDP_HAS_MEMBER_RELATION, LDP_MEMBER.getURI());
                 } else {
                     node.addMixin(LDP_BASIC_CONTAINER);
                 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImpl.java
@@ -23,8 +23,10 @@ import static org.fcrepo.kernel.api.FedoraTypes.LDP_BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_INDIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.FedoraTypes.LDP_INSERTED_CONTENT_RELATION;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_MEMBER_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMBER_SUBJECT;
 import static org.fcrepo.kernel.modeshape.ContainerImpl.hasMixin;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getContainingNode;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.touch;
@@ -77,6 +79,7 @@ public class ContainerServiceImpl extends AbstractService implements ContainerSe
                     node.addMixin(LDP_INDIRECT_CONTAINER);
                     node.setProperty(LDP_MEMBER_RESOURCE, node);
                     node.setProperty(LDP_HAS_MEMBER_RELATION, LDP_MEMBER.getURI());
+                    node.setProperty(LDP_INSERTED_CONTENT_RELATION, MEMBER_SUBJECT.getURI());
                 } else if (LDP_DIRECT_CONTAINER.equals(interactionModel)) {
                     node.addMixin(LDP_DIRECT_CONTAINER);
                     node.setProperty(LDP_MEMBER_RESOURCE, node);


### PR DESCRIPTION
**JIRA Tickets**:
https://jira.duraspace.org/browse/FCREPO-2935
https://jira.duraspace.org/browse/FCREPO-2936
https://jira.duraspace.org/browse/FCREPO-2937

# What does this Pull Request do?
Populates default values for Indirect and DirectContainers based on the specification's suggestions.
* ldp:membershipResource defaults to the direct or indirect container itself
* ldp:hasMemberRelation defaults to ldp:member
* ldp:insertedContentRelation defaults to ldp:MemberSubject for IndirectContainers

# What's new?
* ContainerServiceImpl modified to accept an interaction model, and populates the mixin and default properties for that model as appropriate
* Default Indirect/DirectContainer properties repopulated when removed via PUT or PATCH.
* Added integration tests for population of ldp containers.

# How should this be tested?

Create indirect/direct containers via curl.
Run new integration tests.
Run compatibility test suite.


# Additional Notes:
This PR assumes that ldp:membershipResource should default to the newly created direct/indirect resource itself. This is still being discussed here https://github.com/fcrepo/fcrepo-specification/issues/407 . At present, with this PR CTS tests 3.1.3-C and 3.1.2-C will still fail, but the other tests related to this feature should now be passing (I have 5 remaining failures, previously there were 10).

Also, I considered putting the default values into https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java#L495 but decided doing so since it would have required another retrieval of all the objects properties. This method may be close to being retireable as well.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
