### PR TITLE
Generate timemap paths in platform-independent way

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4237,4 +4237,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final Resource resc2 = model2.getResource(binURI);
         assertFalse(resc2.hasProperty(RDF.type, PCDM_FILE_TYPE));
     }
+
+    @Test
+    public void testCreateWithTrailingSlash() throws IOException {
+        final String subjectURI = serverAddress + getRandomUniqueId() + "/";
+        final HttpPut putMethod = new HttpPut(subjectURI);
+        try (final CloseableHttpResponse response = execute(putMethod)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+    }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TimeMapServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TimeMapServiceImpl.java
@@ -94,7 +94,7 @@ public class TimeMapServiceImpl extends AbstractService implements TimeMapServic
         if (path.endsWith("/" + LDPCV_TIME_MAP)) {
             return path;
         } else {
-            return path + "/" + LDPCV_TIME_MAP;
+            return path.replaceFirst("/*$", "") + "/" + LDPCV_TIME_MAP;
         }
     }
 

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TimeMapServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TimeMapServiceImpl.java
@@ -24,7 +24,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
 import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.nio.file.Paths;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import org.fcrepo.kernel.api.FedoraSession;
@@ -95,7 +94,7 @@ public class TimeMapServiceImpl extends AbstractService implements TimeMapServic
         if (path.endsWith("/" + LDPCV_TIME_MAP)) {
             return path;
         } else {
-            return Paths.get(path, LDPCV_TIME_MAP).toString();
+            return path + "/" + LDPCV_TIME_MAP;
         }
     }
 


### PR DESCRIPTION

https://jira.duraspace.org/browse/FCREPO-2986

# What does this Pull Request do?
Uses string concatenation instead of `Paths` to generate timemap paths.  `Paths` uses system-dependent filesystem semantics in its path logic, which resulted in exceptions when the path included a ":" character

# How should this be tested?
Build and run on Windows successfully.  Other platforms should continue to run successfully.

# Interested parties
@fcrepo4/committers
