### PR TITLE
Allow undefined prefixes in paths by encoding their colons

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4290,4 +4290,51 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final Resource resc2 = model2.getResource(binURI);
         assertFalse(resc2.hasProperty(RDF.type, PCDM_FILE_TYPE));
     }
+
+    /**
+     * Utility to assert a GET of id and id/fcr:versions
+     * 
+     * @param id the path
+     * @throws Exception
+     */
+    private void doGetIdAndVersions(final String id) throws Exception {
+        final HttpGet getMethod = getObjMethod(id);
+        try (final CloseableHttpResponse response = execute(getMethod)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+        }
+
+        final HttpGet getVersion = getObjMethod(id + "/" + FCR_VERSIONS);
+        try (final CloseableHttpResponse response = execute(getVersion)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testPutGetRdfSourceWithUndefinedPrefix() throws Exception {
+        final String id = "some_prefix:" + getRandomUniqueId();
+        final HttpPut putMethod = putObjMethod(id);
+        try (final CloseableHttpResponse response = execute(putMethod)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        doGetIdAndVersions(id);
+    }
+
+    @Test
+    public void testPutGetNonRdfSourceWithUndefinedPrefix() throws Exception {
+        final String id = "some_prefix:" + getRandomUniqueId();
+        final String dsid = "anotherPrefix:" + getRandomUniqueId();
+
+        try (final CloseableHttpResponse response = execute(putDSMethod(id, dsid, "some test content"))) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        // Check id/dsid
+        doGetIdAndVersions(id + "/" + dsid);
+
+        // Check id/dsid/fcr:metadata
+        doGetIdAndVersions(id + "/" + dsid + "/" + FCR_METADATA);
+
+    }
+
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/BinaryServiceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/BinaryServiceImplIT.java
@@ -170,4 +170,30 @@ public class BinaryServiceImplIT extends AbstractIT {
         session.expire();
     }
 
+    @Test
+    public void testCreateDatastreamNodeWithUndefinedPrefix() throws Exception {
+        FedoraSession session = repository.login();
+        final String id = getRandomPid();
+        final String pathUri = "/new_ns:" + id;
+        final String encodedPath = "new_ns%3A" + id;
+        final String encodedUri = "/" + encodedPath;
+
+        binaryService.findOrCreate(session, pathUri).setContent(
+            new ByteArrayInputStream("asdf".getBytes()),
+            "application/octet-stream",
+            null,
+            null,
+            null);
+
+        session.commit();
+        session.expire();
+
+        session = repository.login();
+        final Session jcrSession = getJcrSession(session);
+
+        assertTrue(jcrSession.getRootNode().hasNode(encodedPath));
+        assertEquals("asdf", jcrSession.getNode(encodedUri)
+            .getProperty(JCR_DATA).getString());
+        session.expire();
+    }
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/NodeServiceImplIT.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/integration/kernel/modeshape/services/NodeServiceImplIT.java
@@ -17,10 +17,11 @@
  */
 package org.fcrepo.integration.kernel.modeshape.services;
 
+import static org.junit.Assert.assertEquals;
+
 import org.fcrepo.integration.kernel.modeshape.AbstractIT;
 import org.fcrepo.kernel.api.FedoraRepository;
 import org.fcrepo.kernel.api.FedoraSession;
-import org.fcrepo.kernel.api.exception.FedoraInvalidNamespaceException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.services.NodeService;
 
@@ -42,12 +43,12 @@ public class NodeServiceImplIT extends AbstractIT {
     @Inject
     private NodeService nodeService;
 
-    @Test(expected = FedoraInvalidNamespaceException.class)
-    public void testExistsWithBadNamespace() {
+    @Test
+    public void testExistsWithNewNamespace() {
         final FedoraSession session = repository.login();
         final String path = "/bad_ns: " + getRandomPid();
 
-        nodeService.exists(session, path);
+        assertEquals(false, nodeService.exists(session, path));
     }
 
     @Test (expected = RepositoryRuntimeException.class)

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/AbstractServiceTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/AbstractServiceTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.modeshape.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import static org.fcrepo.kernel.modeshape.services.AbstractService.encodePath;
+import static org.fcrepo.kernel.modeshape.services.AbstractService.decodePath;
+import static org.fcrepo.kernel.modeshape.services.AbstractService.registeredPrefixes;
+
+import javax.jcr.NamespaceRegistry;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * AbstractService tests.
+ *
+ * @author whikloj
+ * @since 2019-04-09
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AbstractServiceTest {
+
+    @Mock
+    private Session mockSession;
+
+    @Mock
+    private FedoraSessionImpl mockFedoraSession;
+
+    @Mock
+    private Workspace mockWork;
+
+    @Mock
+    private NamespaceRegistry mockRegistry;
+
+    private final String[] prefixes = { "fedora", "fcr", "test" };
+
+    @Before
+    public void setUp() throws RepositoryException {
+        initMocks(this);
+        when(mockFedoraSession.getJcrSession()).thenReturn(mockSession);
+        when(mockSession.getWorkspace()).thenReturn(mockWork);
+        when(mockWork.getNamespaceRegistry()).thenReturn(mockRegistry);
+        when(mockRegistry.getPrefixes()).thenReturn(prefixes);
+        when(mockRegistry.getURI("fedora")).thenReturn("info/fedora#");
+        when(mockRegistry.getURI("fcr")).thenReturn("info/fcr#");
+        when(mockRegistry.getURI("test")).thenReturn("info/test#");
+        // Needed due to static nature and previous tests.
+        registeredPrefixes = null;
+    }
+
+    @Test
+    public void testEncodingPaths() throws Exception {
+        assertEquals("", encodePath("", mockFedoraSession));
+        assertEquals("/", encodePath("/", mockFedoraSession));
+        assertEquals("/ham/and/cheese/", encodePath("/ham/and/cheese/", mockFedoraSession));
+        assertEquals("/1234/5678/--9", encodePath("/1234/5678/--9", mockFedoraSession));
+        assertEquals("/1234/ham/new_ns%3Aspecial/bacon",
+            encodePath("/1234/ham/new_ns:special/bacon", mockFedoraSession));
+        assertEquals("/1234/ham/test:special/bacon", encodePath("/1234/ham/test:special/bacon", mockFedoraSession));
+        assertEquals("1234-5678", encodePath("1234-5678", mockFedoraSession));
+        assertEquals("very/large/container/fcr:acl", encodePath("very/large/container/fcr:acl", mockFedoraSession));
+        assertEquals("something/else/fcr:versions", encodePath("something/else/fcr:versions", mockFedoraSession));
+        assertEquals("what/is/the/1234/fedora:timemap",
+            encodePath("what/is/the/1234/fedora:timemap", mockFedoraSession));
+
+        assertEquals("block%3Aparty", encodePath("block:party", mockFedoraSession));
+        assertEquals("/block%3Aparty", encodePath("/block:party", mockFedoraSession));
+        assertEquals("block%3Aparty/", encodePath("block:party/", mockFedoraSession));
+        assertEquals("/block%3Aparty/", encodePath("/block:party/", mockFedoraSession));
+
+        assertEquals("big/block%3Aparty", encodePath("big/block:party", mockFedoraSession));
+        assertEquals("/big/block%3Aparty", encodePath("/big/block:party", mockFedoraSession));
+        assertEquals("big/block%3Aparty/", encodePath("big/block:party/", mockFedoraSession));
+        assertEquals("/big/block%3Aparty/", encodePath("/big/block:party/", mockFedoraSession));
+
+        assertEquals("what%3Aa/big/block%3Aparty", encodePath("what:a/big/block:party", mockFedoraSession));
+        assertEquals("/what%3Aa/big/block%3Aparty", encodePath("/what:a/big/block:party", mockFedoraSession));
+        assertEquals("what%3Aa/big/block%3Aparty/", encodePath("what:a/big/block:party/", mockFedoraSession));
+        assertEquals("/what%3Aa/big/block%3Aparty/", encodePath("/what:a/big/block:party/", mockFedoraSession));
+
+        assertEquals("what%3Aa/big/block%3Aparty/fcr:versions",
+            encodePath("what:a/big/block:party/fcr:versions", mockFedoraSession));
+        assertEquals("/what%3Aa/big/block%3Aparty/fcr:versions",
+            encodePath("/what:a/big/block:party/fcr:versions", mockFedoraSession));
+        assertEquals("what%3Aa/big/block%3Aparty/fcr:versions/",
+            encodePath("what:a/big/block:party/fcr:versions/", mockFedoraSession));
+        assertEquals("/what%3Aa/big/block%3Aparty/fcr:versions/",
+            encodePath("/what:a/big/block:party/fcr:versions/", mockFedoraSession));
+
+        assertEquals("/what/fedora:doing/to/the/fcr:jam/in/the%3Ahouse",
+            encodePath("/what/fedora:doing/to/the/fcr:jam/in/the:house", mockFedoraSession));
+
+    }
+
+    @Test
+    public void testDecodingPaths() throws Exception {
+        assertEquals("", decodePath("", mockFedoraSession));
+        assertEquals("/", decodePath("/", mockFedoraSession));
+        assertEquals("/ham/and/cheese/", decodePath("/ham/and/cheese/", mockFedoraSession));
+        assertEquals("/1234/5678/--9", decodePath("/1234/5678/--9", mockFedoraSession));
+        assertEquals("/1234/ham/new_ns:special/bacon",
+            decodePath("/1234/ham/new_ns%3Aspecial/bacon", mockFedoraSession));
+        assertEquals("/1234/ham/test:special/bacon", decodePath("/1234/ham/test:special/bacon", mockFedoraSession));
+        assertEquals("1234-5678", decodePath("1234-5678", mockFedoraSession));
+        assertEquals("very/large/container/fcr:acl", decodePath("very/large/container/fcr:acl", mockFedoraSession));
+        assertEquals("something/else/fcr:versions", decodePath("something/else/fcr:versions", mockFedoraSession));
+        assertEquals("what/is/the/1234/fedora:timemap",
+            decodePath("what/is/the/1234/fedora:timemap", mockFedoraSession));
+
+        assertEquals("block:party", decodePath("block%3Aparty", mockFedoraSession));
+        assertEquals("/block:party", decodePath("/block%3Aparty", mockFedoraSession));
+        assertEquals("block:party/", decodePath("block%3Aparty/", mockFedoraSession));
+        assertEquals("/block:party/", decodePath("/block%3Aparty/", mockFedoraSession));
+
+        assertEquals("big/block:party", decodePath("big/block%3Aparty", mockFedoraSession));
+        assertEquals("/big/block:party", decodePath("/big/block%3Aparty", mockFedoraSession));
+        assertEquals("big/block:party/", decodePath("big/block%3Aparty/", mockFedoraSession));
+        assertEquals("/big/block:party/", decodePath("/big/block%3Aparty/", mockFedoraSession));
+
+        assertEquals("what:a/big/block:party", decodePath("what%3Aa/big/block%3Aparty", mockFedoraSession));
+        assertEquals("/what:a/big/block:party", decodePath("/what%3Aa/big/block%3Aparty", mockFedoraSession));
+        assertEquals("what:a/big/block:party/", decodePath("what%3Aa/big/block%3Aparty/", mockFedoraSession));
+        assertEquals("/what:a/big/block:party/", decodePath("/what%3Aa/big/block%3Aparty/", mockFedoraSession));
+
+        assertEquals("what:a/big/block:party/fcr:versions",
+            decodePath("what%3Aa/big/block%3Aparty/fcr:versions", mockFedoraSession));
+        assertEquals("/what:a/big/block:party/fcr:versions",
+            decodePath("/what%3Aa/big/block%3Aparty/fcr:versions", mockFedoraSession));
+        assertEquals("what:a/big/block:party/fcr:versions/",
+            decodePath("what%3Aa/big/block%3Aparty/fcr:versions/", mockFedoraSession));
+        assertEquals("/what:a/big/block:party/fcr:versions/",
+            decodePath("/what%3Aa/big/block%3Aparty/fcr:versions/", mockFedoraSession));
+
+        assertEquals("/what/fedora:doing/to/the/fcr:jam/in/the:house",
+            decodePath("/what/fedora:doing/to/the/fcr:jam/in/the%3Ahouse", mockFedoraSession));
+
+    }
+}

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/BinaryServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/BinaryServiceImplTest.java
@@ -28,9 +28,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import javax.jcr.NamespaceRegistry;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Workspace;
 
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_CONTAINER;
@@ -68,6 +70,14 @@ public class BinaryServiceImplTest {
     @Mock
     private Node mockRoot;
 
+    @Mock
+    private NamespaceRegistry mockRegistry;
+
+    @Mock
+    private Workspace mockWorkspace;
+
+    private final String[] prefixes = { "fedora", "fcr", "test" };
+
     @Before
     public void setUp() throws RepositoryException {
         testObj = new BinaryServiceImpl();
@@ -78,6 +88,13 @@ public class BinaryServiceImplTest {
         when(mockDsNode.canAddMixin(anyString())).thenReturn(true);
         when(mockDescNode.canAddMixin(anyString())).thenReturn(true);
         when(mockRoot.isNew()).thenReturn(false);
+
+        when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
+        when(mockWorkspace.getNamespaceRegistry()).thenReturn(mockRegistry);
+        when(mockRegistry.getPrefixes()).thenReturn(prefixes);
+        when(mockRegistry.getURI("fedora")).thenReturn("info/fedora#");
+        when(mockRegistry.getURI("fcr")).thenReturn("info/fcr#");
+        when(mockRegistry.getURI("test")).thenReturn("info/test#");
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/BinaryServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/BinaryServiceImplTest.java
@@ -37,6 +37,7 @@ import javax.jcr.Workspace;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_NON_RDF_SOURCE_DESCRIPTION;
+import static org.fcrepo.kernel.modeshape.services.AbstractService.registeredPrefixes;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -95,6 +96,8 @@ public class BinaryServiceImplTest {
         when(mockRegistry.getURI("fedora")).thenReturn("info/fedora#");
         when(mockRegistry.getURI("fcr")).thenReturn("info/fcr#");
         when(mockRegistry.getURI("test")).thenReturn("info/test#");
+        // Needed due to static nature and previous tests.
+        registeredPrefixes = null;
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImplTest.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.modeshape.services;
 
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -35,6 +36,7 @@ import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.exception.TombstoneException;
 import org.fcrepo.kernel.api.services.ContainerService;
 import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -142,5 +144,18 @@ public class ContainerServiceImplTest implements FedoraTypes {
 
     }
 
+    @Test
+    public void testIdentiferWithColon() throws Exception {
+        when(mockNode.getParent()).thenReturn(mockRoot);
+        when(mockRoot.isNew()).thenReturn(false);
+        when(mockRoot.getNode("/with%3Acolon")).thenReturn(mockNode);
+        when(mockNode.isNew()).thenReturn(true);
+        when(mockNode.getDepth()).thenReturn(1);
+
+        when(mockRoot.getNode("with%3Acolon")).thenReturn(mockNode);
+        when(mockJcrTools.findOrCreateNode(mockSession, "/with%3Acolon", NT_FOLDER, NT_FOLDER)).thenReturn(mockNode);
+        final Container actual = testObj.findOrCreate(testSession, "/with:colon");
+        assertEquals(mockNode, getJcrNode(actual));
+    }
 
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/ContainerServiceImplTest.java
@@ -19,12 +19,15 @@ package org.fcrepo.kernel.modeshape.services;
 
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
 
+import static org.fcrepo.kernel.modeshape.services.AbstractService.registeredPrefixes;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -80,6 +83,8 @@ public class ContainerServiceImplTest implements FedoraTypes {
         when(mockRoot.getNode(testPath.substring(1))).thenReturn(mockNode);
         when(mockNode.getParent()).thenReturn(mockRoot);
         when(mockRoot.isNew()).thenReturn(false);
+        // Needed due to static nature and previous tests.
+        registeredPrefixes = new HashSet<>(Arrays.asList("a_valid_namespace"));
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/NodeServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/NodeServiceImplTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.modeshape.services;
 
+import static org.fcrepo.kernel.modeshape.services.AbstractService.registeredPrefixes;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -100,7 +101,8 @@ public class NodeServiceImplTest {
         when(mockWorkspace.getNamespaceRegistry()).thenReturn(mockNameReg);
         when(mockNameReg.getPrefixes()).thenReturn(mockPrefixes);
         when(mockNameReg.getURI(MOCK_PREFIX)).thenReturn(MOCK_URI);
-
+        // Needed due to static nature and previous tests.
+        registeredPrefixes = null;
     }
 
     @Test

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/NodeServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/NodeServiceImplTest.java
@@ -31,7 +31,6 @@ import javax.jcr.Workspace;
 import javax.jcr.nodetype.NodeTypeIterator;
 
 import org.fcrepo.kernel.api.FedoraSession;
-import org.fcrepo.kernel.api.exception.FedoraInvalidNamespaceException;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 
@@ -132,10 +131,10 @@ public class NodeServiceImplTest {
         assertEquals(false, testObj.exists(testSession, "/foo/bar"));
     }
 
-    @Test(expected = FedoraInvalidNamespaceException.class)
-    public void testInvalidPath() throws RepositoryException {
+    @Test
+    public void testUndefinedNs() throws RepositoryException {
         final String badPath = "/foo/bad_ns:bar";
-        when(mockNameReg.getURI("bad_ns")).thenThrow(new FedoraInvalidNamespaceException("Invalid namespace (bad_ns)"));
-        testObj.exists(testSession, badPath);
+        when(mockSession.nodeExists("/foo/bad_ns%3Abar")).thenReturn(true);
+        assertEquals(true, testObj.exists(testSession, badPath));
     }
 }

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/RepositoryServiceImplTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/services/RepositoryServiceImplTest.java
@@ -174,6 +174,8 @@ public class RepositoryServiceImplTest implements FedoraTypes {
             expectedNS
                     .put(MOCKPREFIX, mockNamespaceRegistry.getURI(MOCKPREFIX));
 
+            AbstractService.registeredPrefixes = null;
+
         } catch (final RepositoryException e) {
             e.printStackTrace();
             fail(e.getMessage());


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2991

# What does this Pull Request do?
Previously prefixes in slugs and paths that were not registered in the Modeshape registry would fail, now they are URL encoded.

ie. `newNS:12345` becomes `newNS%3A12345`

Namespaces already in Modeshape (and `fcr`) are exempt from this encoding.
ie. All of [these](https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-kernel-modeshape/src/main/resources/fedora-node-types.cnd#L4-L45)

# What's new?
Everywhere we validate, save or retrieve a path we attempt to encode or decode it. 

# How should this be tested?

Prior to PR doing
```
curl -i -XPUT -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/abc:123
```
Would return a 400 error with `Prefix abc has not been registered`

With this PR it will succeed.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers @bbpennel @birkland 
