### PR TITLE
Adds Support for X-State-Token in GET and HEAD requests.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -765,7 +765,13 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         if (!etag.getValue().isEmpty()) {
-            servletResponse.addHeader("ETag", etag.toString());
+            final String etagStrVal = etag.toString();
+            servletResponse.addHeader("ETag", etagStrVal);
+
+            //State Tokens, while not used for caching per se,  nevertheless belong
+            //here since we can conveniently reuse the value of the etag for
+            //our state token
+            servletResponse.addHeader("X-State-Token", etagStrVal);
         }
 
         if (date != null) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -765,13 +765,12 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         if (!etag.getValue().isEmpty()) {
-            final String etagStrVal = etag.toString();
-            servletResponse.addHeader("ETag", etagStrVal);
+            servletResponse.addHeader("ETag", etag.toString());
 
             //State Tokens, while not used for caching per se,  nevertheless belong
             //here since we can conveniently reuse the value of the etag for
             //our state token
-            servletResponse.addHeader("X-State-Token", etagStrVal);
+            servletResponse.addHeader("X-State-Token", etag.getValue());
         }
 
         if (date != null) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPut;
+import org.junit.Test;
+
+/**
+ * @author dbernstein
+ */
+public class StateTokensIT extends AbstractResourceIT {
+
+    public static final String X_STATE_TOKEN_HEADER = "X-State-Token";
+
+    @Test
+    public void testGetHasStateTokenRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        try (final CloseableHttpResponse response = execute(new HttpGet(serverAddress + id))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+
+    @Test
+    public void testHeadHasStateTokenRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        try (final CloseableHttpResponse response = execute(new HttpHead(serverAddress + id))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+
+    @Test
+    public void testAclGetHasStateTokenRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String aclPid = id + "/fcr:acl";
+
+        final HttpPut method = putObjMethod(aclPid, "text/turtle",
+                                            "<#auth>  a <http://www.w3.org/ns/auth/acl#Authorization> .");
+
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        try (final CloseableHttpResponse response = execute(new HttpGet(serverAddress + aclPid))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+
+    @Test
+    public void testAclHeadHasStateTokenRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String aclPid = id + "/fcr:acl";
+
+        final HttpPut method = putObjMethod(aclPid, "text/turtle",
+                                            "<#auth>  a <http://www.w3.org/ns/auth/acl#Authorization> .");
+
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        try (final CloseableHttpResponse response = execute(new HttpHead(serverAddress + aclPid))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+
+    @Test
+    public void testLdpcvGetHasStateTokenRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        try (final CloseableHttpResponse response = execute(new HttpGet(serverAddress + id + "/fcr:versions"))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+
+    @Test
+    public void testLdpcvHeadHasStateTokenRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        try (final CloseableHttpResponse response = execute(new HttpHead(serverAddress + id + "/fcr:versions"))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+
+    @Test
+    public void testGetHasStateTokenNonRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        final String location = serverAddress + id + "/binary";
+        final HttpPut method = putDSMethod(id, "binary", "foo");
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        try (final CloseableHttpResponse response = execute(new HttpGet(location))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+
+    @Test
+    public void testHeadHasStateTokenNonRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        final String location = serverAddress + id + "/binary";
+        final HttpPut method = putDSMethod(id, "binary", "foo");
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        try (final CloseableHttpResponse response = execute(new HttpHead(location))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
@@ -35,7 +35,7 @@ import org.junit.Test;
  */
 public class StateTokensIT extends AbstractResourceIT {
 
-    public static final String X_STATE_TOKEN_HEADER = "X-State-Token";
+    private static final String X_STATE_TOKEN_HEADER = "X-State-Token";
 
     @Test
     public void testGetHasStateTokenRDFSource() throws IOException {


### PR DESCRIPTION
**Adds Support for X-State-Token in GET and HEAD requests.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2976

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR adds the X-State-Token header into the http responses for LDP-RS and LDP-NS objects including ACLs and LDPCVs.

# What's new?
The change is very simple:  the value of the Etag for a resource is being plugged into the X-State-Token header on GET and HEAD requests.

# How should this be tested?
Integration tests cover the functionality.  For manual tests, perform GETs and HEADs above mentioned classes of resources and you should see the  X-State-Token header in the responses.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? Yes
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
