### PR TITLE
Adds Support for X-If-State-Token on PUTs and PATCHs.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -858,7 +858,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             final String clientSuppliedStateToken = headers.getHeaderString("X-If-State-Token");
             if (clientSuppliedStateToken != null && !stateToken.equals(clientSuppliedStateToken)) {
                 throw new PreconditionException(format(
-                    "The client-supplied value ({0}) does not match the resource's current state token ({1}).",
+                    "The client-supplied value ({0}) does not match the current state token ({1}).",
                     clientSuppliedStateToken, stateToken), 412);
             }
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -18,6 +18,7 @@
 package org.fcrepo.http.api;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static java.text.MessageFormat.format;
 import static java.util.EnumSet.of;
 import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.empty;
@@ -95,7 +96,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Arrays;
@@ -124,6 +124,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.jena.atlas.RuntimeIOException;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -766,7 +768,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
         if (!etag.getValue().isEmpty()) {
             servletResponse.addHeader("ETag", etag.toString());
+        }
 
+        if (!resource.getStateToken().isEmpty()) {
             //State Tokens, while not used for caching per se,  nevertheless belong
             //here since we can conveniently reuse the value of the etag for
             //our state token
@@ -846,6 +850,17 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             final Object message = response.getEntity();
             throw new PreconditionException(message != null ? message.toString()
                     : "Request failed due to unspecified failed precondition.", response.getStatus());
+        }
+
+        final String method = request.getMethod();
+        if (method.equals(HttpPut.METHOD_NAME) || method.equals(HttpPatch.METHOD_NAME)) {
+            final String stateToken = resource.getStateToken();
+            final String clientSuppliedStateToken = headers.getHeaderString("X-If-State-Token");
+            if (clientSuppliedStateToken != null && !stateToken.equals(clientSuppliedStateToken)) {
+                throw new PreconditionException(format(
+                    "The client-supplied value ({0}) does not match the resource's current state token ({1}).",
+                    clientSuppliedStateToken, stateToken), 412);
+            }
         }
     }
 
@@ -1012,7 +1027,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                     // Throw exception if object is a server-managed property
                     if (isManagedPredicate.test(createProperty(uri))) {
                             throw new ServerManagedPropertyException(
-                                    MessageFormat.format(
+                                    format(
                                             "{0} cannot take a server managed property " +
                                                     "as an object: property value = {1}.",
                                             HAS_MEMBER_RELATION, uri));
@@ -1046,7 +1061,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 if (graph.contains(subject, WEBAC_ACCESS_TO_URI, Node.ANY) &&
                         graph.contains(subject, WEBAC_ACCESS_TO_CLASS_URI, Node.ANY)) {
                     throw new ACLAuthorizationConstraintViolationException(
-                        MessageFormat.format(
+                        format(
                                 "Using both accessTo and accessToClass within " +
                                         "a single Authorization is not allowed: {0}.",
                                 subject.toString().substring(subject.toString().lastIndexOf("#"))));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -263,22 +263,26 @@ public class FedoraLdpTest {
         when(mockHttpConfiguration.putRequiresIfMatch()).thenReturn(false);
 
         when(mockContainer.getEtagValue()).thenReturn("");
+        when(mockContainer.getStateToken()).thenReturn("");
         when(mockContainer.getPath()).thenReturn(path);
         when(mockContainer.getDescription()).thenReturn(mockContainer);
         when(mockContainer.getDescribedResource()).thenReturn(mockContainer);
 
         when(mockNonRdfSourceDescription.getEtagValue()).thenReturn("");
+        when(mockNonRdfSourceDescription.getStateToken()).thenReturn("");
         when(mockNonRdfSourceDescription.getPath()).thenReturn(binaryDescriptionPath);
         when(mockNonRdfSourceDescription.getDescribedResource()).thenReturn(mockBinary);
         when(mockNonRdfSourceDescription.getOriginalResource()).thenReturn(mockNonRdfSourceDescription);
 
         when(mockBinary.getEtagValue()).thenReturn("");
+        when(mockBinary.getStateToken()).thenReturn("");
         when(mockBinary.getPath()).thenReturn(binaryPath);
         when(mockBinary.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockBinary.getDescribedResource()).thenReturn(mockBinary);
         when(mockBinary.getOriginalResource()).thenReturn(mockBinary);
 
         when(mockHeaders.getHeaderString("user-agent")).thenReturn("Test UserAgent");
+        when(mockHeaders.getHeaderString("X-If-State-Token")).thenReturn(null);
 
         when(mockLockManager.lockForRead(any())).thenReturn(mockLock);
         when(mockLockManager.lockForWrite(any(), any(), any())).thenReturn(mockLock);
@@ -310,6 +314,7 @@ public class FedoraLdpTest {
         doReturn(mockResource).when(testObj).resource();
         when(mockResource.getPath()).thenReturn(path);
         when(mockResource.getEtagValue()).thenReturn("");
+        when(mockResource.getStateToken()).thenReturn("");
         when(mockResource.getDescription()).thenReturn(mockResource);
         when(mockResource.getDescribedResource()).thenReturn(mockResource);
         when(mockResource.getTriples(eq(idTranslator), anySet())).thenAnswer(answer);
@@ -321,6 +326,7 @@ public class FedoraLdpTest {
     @Test
     public void testHead() throws Exception {
         setResource(FedoraResource.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should have a Link header", mockResponse.containsHeader(LINK));
@@ -334,6 +340,7 @@ public class FedoraLdpTest {
     @Test
     public void testHeadWithObject() throws Exception {
         setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should advertise Accept-Post flavors", mockResponse.containsHeader("Accept-Post"));
@@ -344,6 +351,7 @@ public class FedoraLdpTest {
     @Test
     public void testHeadWithDefaultContainer() throws Exception {
         setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPBasicContainer();
@@ -357,6 +365,7 @@ public class FedoraLdpTest {
     @Test
     public void testHeadWithBasicContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         when(resource.hasType(LDP_BASIC_CONTAINER)).thenReturn(true);
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -366,6 +375,7 @@ public class FedoraLdpTest {
     @Test
     public void testHeadWithDirectContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         when(resource.hasType(LDP_DIRECT_CONTAINER)).thenReturn(true);
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -380,6 +390,7 @@ public class FedoraLdpTest {
     @Test
     public void testHeadWithIndirectContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         when(resource.hasType(LDP_INDIRECT_CONTAINER)).thenReturn(true);
         final Response actual = testObj.head();
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -394,6 +405,7 @@ public class FedoraLdpTest {
     @Test
     public void testHeadWithBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockResource.getMimeType()).thenReturn("image/jpeg");
@@ -434,6 +446,7 @@ public class FedoraLdpTest {
     @Test
     public void testHeadWithExternalBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         final String url = "http://example.com/some/url";
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getMimeType()).thenReturn("text/plain");
@@ -454,6 +467,7 @@ public class FedoraLdpTest {
     public void testHeadWithBinaryDescription() throws Exception {
         final NonRdfSourceDescription mockResource
                 = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);
+        when(mockRequest.getMethod()).thenReturn("HEAD");
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Response actual = testObj.head();
@@ -526,6 +540,7 @@ public class FedoraLdpTest {
     @Test
     public void testGet() throws Exception {
         setResource(FedoraResource.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should have a Link header", mockResponse.containsHeader(LINK));
@@ -544,6 +559,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithObject() throws Exception {
         setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should advertise Accept-Post flavors", mockResponse.containsHeader("Accept-Post"));
@@ -561,6 +577,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithBasicContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         when(resource.hasType(LDP_BASIC_CONTAINER)).thenReturn(true);
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -570,6 +587,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithDirectContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         when(resource.hasType(LDP_DIRECT_CONTAINER)).thenReturn(true);
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -579,6 +597,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithIndirectContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         when(resource.hasType(LDP_INDIRECT_CONTAINER)).thenReturn(true);
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -587,8 +606,8 @@ public class FedoraLdpTest {
 
     @Test
     public void testGetWithObjectPreferMinimal() throws Exception {
-
         setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer", new MultiPrefer("return=minimal"));
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -685,6 +704,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithObjectOmitContainment() throws Exception {
         setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer",
                 new MultiPrefer("return=representation; omit=\"" + LDP_NAMESPACE + "PreferContainment\""));
         final Response actual = testObj.getResource( null);
@@ -701,6 +721,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithObjectOmitMembership() throws Exception {
         setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer",
                 new MultiPrefer("return=representation; omit=\"" + LDP_NAMESPACE + "PreferMembership\""));
         final Response actual = testObj.getResource(null);
@@ -718,6 +739,7 @@ public class FedoraLdpTest {
     public void testGetWithObjectIncludeReferences()
             throws IOException, UnsupportedAlgorithmException {
         setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer", new MultiPrefer("return=representation; include=\"" + INBOUND_REFERENCES + "\""));
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
@@ -735,6 +757,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getMimeType()).thenReturn("text/plain");
         when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
@@ -756,6 +779,7 @@ public class FedoraLdpTest {
     @Test
     public void testGetWithExternalMessageBinary() throws Exception {
         final FedoraBinary mockResource = (FedoraBinary)setResource(FedoraBinary.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         final String url = "http://example.com/some/url";
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getMimeType()).thenReturn("text/plain");
@@ -806,6 +830,7 @@ public class FedoraLdpTest {
 
         final NonRdfSourceDescription mockResource
                 = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);
+        when(mockRequest.getMethod()).thenReturn("GET");
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockBinary.getTriples(eq(idTranslator), any(TripleCategory.class)))
@@ -846,6 +871,7 @@ public class FedoraLdpTest {
     @Test
     public void testDelete() {
         final FedoraResource fedoraResource = setResource(FedoraResource.class);
+        when(mockRequest.getMethod()).thenReturn("PATCH");
         final Response actual = testObj.deleteObject();
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
         verify(fedoraResource).delete();
@@ -855,6 +881,7 @@ public class FedoraLdpTest {
     public void testPutNewObject() throws Exception {
         setField(testObj, "externalPath", "some/path");
         final FedoraBinary mockObject = (FedoraBinary)setResource(FedoraBinary.class);
+        when(mockRequest.getMethod()).thenReturn("PUT");
         doReturn(mockObject).when(testObj).resource();
         when(mockContainer.isNew()).thenReturn(true);
 
@@ -877,6 +904,7 @@ public class FedoraLdpTest {
 
         setField(testObj, "externalPath", "some/path");
         final FedoraBinary mockObject = (FedoraBinary)setResource(FedoraBinary.class);
+        when(mockRequest.getMethod()).thenReturn("PUT");
         doReturn(mockObject).when(testObj).resource();
         when(mockContainer.isNew()).thenReturn(true);
 
@@ -894,6 +922,7 @@ public class FedoraLdpTest {
     public void testPutNewBinary() throws Exception {
         setField(testObj, "externalPath", "some/path");
         final FedoraBinary mockObject = (FedoraBinary)setResource(FedoraBinary.class);
+        when(mockRequest.getMethod()).thenReturn("PUT");
         doReturn(mockObject).when(testObj).resource();
         when(mockBinary.isNew()).thenReturn(true);
 
@@ -911,6 +940,7 @@ public class FedoraLdpTest {
 
         setField(testObj, "externalPath", "some/path");
         final Container mockObject = (Container)setResource(Container.class);
+        when(mockRequest.getMethod()).thenReturn("PUT");
         doReturn(mockObject).when(testObj).resource();
         when(mockObject.isNew()).thenReturn(false);
 
@@ -944,7 +974,7 @@ public class FedoraLdpTest {
     public void testPatchObject() throws Exception {
 
         setResource(Container.class);
-
+        when(mockRequest.getMethod()).thenReturn("PATCH");
         testObj.updateSparql(toInputStream("xyz", UTF_8));
     }
 
@@ -954,6 +984,7 @@ public class FedoraLdpTest {
     public void testPatchBinaryDescription() throws MalformedRdfException, IOException {
 
         final NonRdfSourceDescription mockObject = (NonRdfSourceDescription)setResource(NonRdfSourceDescription.class);
+        when(mockRequest.getMethod()).thenReturn("PATCH");
         when(mockObject.getDescribedResource()).thenReturn(mockBinary);
 
         when(mockBinary.getTriples(eq(idTranslator), any(TripleCategory.class)))

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
@@ -203,6 +203,8 @@ public class FedoraNodesTest {
 
         when(mockSession.getValueFactory()).thenReturn(mockVF);
         when(mockNodes.exists(testSession, path)).thenReturn(true);
+        when(mockContainer.getStateToken()).thenReturn("");
+        when(mockRequest.getMethod()).thenReturn("MOVE");
 
         testObj.moveObject("http://localhost/fcrepo/bar");
         verify(mockNodes).moveObject(testSession, path, "/bar");
@@ -230,6 +232,8 @@ public class FedoraNodesTest {
         when(mockContainer.getEtagValue()).thenReturn("");
         doThrow(new RepositoryRuntimeException(new ItemExistsException()))
                 .when(mockNodes).moveObject(testSession, path, "/baz");
+        when(mockContainer.getStateToken()).thenReturn("");
+        when(mockRequest.getMethod()).thenReturn("MOVE");
 
         final Response response = testObj.moveObject("http://localhost/fcrepo/baz");
 
@@ -244,7 +248,8 @@ public class FedoraNodesTest {
             .thenReturn(mockContainer);
         when(mockNodes.exists(testSession, path)).thenReturn(true);
         when(mockContainer.getEtagValue()).thenReturn("");
-
+        when(mockContainer.getStateToken()).thenReturn("");
+        when(mockRequest.getMethod()).thenReturn("MOVE");
         testObj.moveObject("http://somewhere/else/baz");
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
@@ -18,7 +18,9 @@
 package org.fcrepo.integration.http.api;
 
 import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -27,15 +29,22 @@ import java.io.IOException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author dbernstein
  */
 public class StateTokensIT extends AbstractResourceIT {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(StateTokensIT.class);
+
     private static final String X_STATE_TOKEN_HEADER = "X-State-Token";
+    public static final String X_IF_STATE_TOKEN_HEADER = "X-If-State-Token";
 
     @Test
     public void testGetHasStateTokenRDFSource() throws IOException {
@@ -142,6 +151,118 @@ public class StateTokensIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(new HttpHead(location))) {
             assertEquals(OK.getStatusCode(), getStatus(response));
             assertNotNull(X_STATE_TOKEN_HEADER, response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue());
+        }
+    }
+
+    @Test
+    public void testPutWithStateTokenOnNonRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        final String location = serverAddress + id + "/binary";
+        //create a binary
+        final HttpPut method = putDSMethod(id, "binary", "foo");
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        //get state token
+        final String stateToken;
+        try (final CloseableHttpResponse response = execute(new HttpHead(location))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            stateToken = response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue();
+        }
+
+        //perform put with valid X-If-State-Token
+        final HttpPut validPut = putDSMethod(id, "binary", "bar");
+        validPut.addHeader(X_IF_STATE_TOKEN_HEADER, stateToken);
+        try (final CloseableHttpResponse response = execute(validPut)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+        }
+
+        //perform put with an invalid X-If-State-Token
+        final HttpPut invalidPut = putDSMethod(id, "binary", "boo");
+        invalidPut.addHeader(X_IF_STATE_TOKEN_HEADER, "invalid_token");
+        try (final CloseableHttpResponse response = execute(invalidPut)) {
+            assertEquals(PRECONDITION_FAILED.getStatusCode(), getStatus(response));
+        }
+
+    }
+
+    @Test
+    public void testPatchWithStateTokenOnRDFSource() throws IOException {
+        final String id = getRandomUniqueId();
+        final String location = serverAddress + id;
+        //create a resource
+        final HttpPut method = putObjMethod(id);
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        //get state token
+        final String stateToken;
+        try (final CloseableHttpResponse response = execute(new HttpHead(location))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            stateToken = response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue();
+        }
+
+        LOGGER.debug("stateToken={}", stateToken);
+
+        //perform patch with an invalid X-If-State-Token
+        final HttpPatch invalidPatch = patchObjMethod(id);
+        invalidPatch.addHeader(X_IF_STATE_TOKEN_HEADER, "invalid_token");
+        invalidPatch.setHeader("Content-Type", "application/sparql-update");
+        invalidPatch.setEntity(new StringEntity("INSERT { <> a <http://example.org/test> } WHERE {}"));
+
+        try (final CloseableHttpResponse response = execute(invalidPatch)) {
+            assertEquals(PRECONDITION_FAILED.getStatusCode(), getStatus(response));
+        }
+
+
+        //perform patch with valid X-If-State-Token
+        final HttpPatch validPatch = patchObjMethod(id);
+        validPatch.addHeader(X_IF_STATE_TOKEN_HEADER, stateToken);
+        validPatch.setHeader("Content-Type", "application/sparql-update");
+        validPatch.setEntity(new StringEntity("INSERT { <> a <http://example.org/test> } WHERE {}"));
+        try (final CloseableHttpResponse response = execute(validPatch)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testPatchWithStateTokenOnAcl() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String aclPid = id + "/fcr:acl";
+        final String location = serverAddress + aclPid;
+        final HttpPut method = putObjMethod(aclPid, "text/turtle",
+                                            "<#auth>  a <http://www.w3.org/ns/auth/acl#Authorization> .");
+
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+
+        final String stateToken;
+        try (final CloseableHttpResponse response = execute(new HttpHead(location))) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            stateToken = response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue();
+        }
+
+        //perform patch with an invalid X-If-State-Token
+        final HttpPatch invalidPatch = patchObjMethod(aclPid);
+        invalidPatch.addHeader(X_IF_STATE_TOKEN_HEADER, "invalid_token");
+        invalidPatch.setHeader("Content-Type", "application/sparql-update");
+        invalidPatch.setEntity(new StringEntity("INSERT { <> a <http://example.org/test> } WHERE {}"));
+
+        try (final CloseableHttpResponse response = execute(invalidPatch)) {
+            assertEquals(PRECONDITION_FAILED.getStatusCode(), getStatus(response));
+        }
+
+        //perform patch with valid X-If-State-Token
+        final HttpPatch validPatch = patchObjMethod(aclPid);
+        validPatch.addHeader(X_IF_STATE_TOKEN_HEADER, stateToken);
+        validPatch.setHeader("Content-Type", "application/sparql-update");
+        validPatch.setEntity(new StringEntity("INSERT { <> a <http://example.org/test> } WHERE {}"));
+        try (final CloseableHttpResponse response = execute(validPatch)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
@@ -33,15 +33,11 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author dbernstein
  */
 public class StateTokensIT extends AbstractResourceIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(StateTokensIT.class);
 
     private static final String X_STATE_TOKEN_HEADER = "X-State-Token";
     public static final String X_IF_STATE_TOKEN_HEADER = "X-If-State-Token";
@@ -203,8 +199,6 @@ public class StateTokensIT extends AbstractResourceIT {
             assertEquals(OK.getStatusCode(), getStatus(response));
             stateToken = response.getFirstHeader(X_STATE_TOKEN_HEADER).getValue();
         }
-
-        LOGGER.debug("stateToken={}", stateToken);
 
         //perform patch with an invalid X-If-State-Token
         final HttpPatch invalidPatch = patchObjMethod(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 public class StateTokensIT extends AbstractResourceIT {
 
     private static final String X_STATE_TOKEN_HEADER = "X-State-Token";
-    public static final String X_IF_STATE_TOKEN_HEADER = "X-If-State-Token";
+    private static final String X_IF_STATE_TOKEN_HEADER = "X-If-State-Token";
 
     @Test
     public void testGetHasStateTokenRDFSource() throws IOException {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -244,6 +244,12 @@ public interface FedoraResource {
     String getEtagValue();
 
     /**
+     * Construct a State Token value for the resource.
+     *
+     * @return constructed etag value
+     */
+    String getStateToken();
+    /**
      * Check if a resource is an original resource
      * (ie versionable, as opposed to non-versionable resources
      * like mementos, timemaps, and acls).

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -239,14 +239,14 @@ public interface FedoraResource {
     /**
      * Construct an ETag value for the resource.
      *
-     * @return constructed etag value
+     * @return constructed state-token value
      */
     String getEtagValue();
 
     /**
      * Construct a State Token value for the resource.
      *
-     * @return constructed etag value
+     * @return constructed state-token value
      */
     String getStateToken();
     /**

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/FedoraResourceImpl.java
@@ -1162,6 +1162,13 @@ public class FedoraResourceImpl extends JcrTools implements FedoraTypes, FedoraR
         return "";
     }
 
+    /* (non-Javadoc)
+     * @see org.fcrepo.kernel.api.models.FedoraResource#getStateToken()
+     */
+    @Override
+    public String getStateToken() {
+        return getEtagValue();
+    }
 
     /**
      * Returns a function that converts the subject to the original URI and the object of a triple from an


### PR DESCRIPTION

**Adds Support for X-If-State-Token on PUTs and PATCHs..**
* * *

**JIRA Tickets**: 
https://jira.duraspace.org/browse/FCREPO-2993
https://jira.duraspace.org/browse/FCREPO-2994

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Ensures that PUTs and  PATCHs honor the X-If-State-Token header as defined by the Fedora specification.

# What's new?
I added a new method FedoraResource.getStateToken() in order to ensure that we distinguish between StateTokens and Etags.  Currently we are using weak etags.  However, that may change in Fedora 6.  Therefore we may want to handle the implementation differently in 6.

# How should this be tested?
Integration tests cover success and failure for both PUTs and PATCHs  for rdf, nonrdf and acl's.

Example:
* Does this change require documentation to be updated? Yes 
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? Unlikely.

# Interested parties
@fcrepo4/committers
