### PR TITLE
Don't allow NonRdfSourceDescriptions to be deleted directly

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -128,6 +128,7 @@ import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraBinary;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
@@ -342,6 +343,12 @@ public class FedoraLdp extends ContentExposingResource {
                 throw new ClientErrorException("Depth header, if present, must be set to 'infinity' for containers",
                         SC_BAD_REQUEST);
             }
+        }
+        if (resource() instanceof NonRdfSourceDescription && resource().isOriginalResource()) {
+            LOGGER.debug("Trying to delete binary description directly.");
+            throw new ClientErrorException(
+                "NonRDFSource descriptions are removed when their associated NonRDFSource object is removed.",
+                METHOD_NOT_ALLOWED);
         }
 
         evaluateRequestPreconditions(request, servletResponse, resource(), session);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -132,6 +132,7 @@ import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.Variant;
@@ -1962,6 +1963,25 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createDatastream(id, "ds1", "foo");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteObjMethod(id + "/ds1")));
         assertDeleted(id + "/ds1");
+    }
+
+    @Test(expected = ClientErrorException.class)
+    public void testDeleteBinaryDescription() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id, NON_RDF_SOURCE_LINK_HEADER);
+
+        final HttpHead headBinary = headObjMethod(id);
+        try (final CloseableHttpResponse response = execute(headBinary)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+        }
+
+        final HttpHead headBinaryDesc = headObjMethod(id + "/" + FCR_METADATA);
+        try (final CloseableHttpResponse response = execute(headBinaryDesc)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+        }
+
+        final HttpDelete deleteBinaryDesc = deleteObjMethod(id + "/" + FCR_METADATA);
+        execute(deleteBinaryDesc);
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2996

# What does this Pull Request do?
Disallows deleting the internal description of a binary directly, instead you must delete the binary which removes the both.

# How should this be tested?

* Internal tests but also

Before PR.
1. Create a binary `curl -ufedoraAdmin:fedoraAdmin -H"Content-type: text/plain" -d"Some text" -XPUT http://localhost:8080/rest/binary`
1. Delete the description `curl -ufedoraAdmin:fedoraAdmin -XDELETE http://localhost:8080/rest/binary/fcr:metadata` -> `204 No Content`

After the PR
1. Do the same as above but deleting the description (`/fcr:metadata`) results in `405 Method Not Allowed`

# Additional Notes:

Example:
* Does this change require documentation to be updated?  no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers @peichman-umd 
