### PR TITLE
Hide fedora:NonRdfSourceDescription type

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -109,6 +109,9 @@ public final class RdfLexicon {
     public static final Property WRITABLE =
             createProperty(REPOSITORY_NAMESPACE + "writable");
 
+    public static final String FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI = REPOSITORY_NAMESPACE +
+            "NonRdfSourceDescription";
+
     // Server managed properties
     public static final Property CREATED_DATE =
             createProperty(REPOSITORY_NAMESPACE + "created");

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/FedoraTypesUtils.java
@@ -52,6 +52,7 @@ import static javax.jcr.PropertyType.REFERENCE;
 import static javax.jcr.PropertyType.WEAKREFERENCE;
 import static com.google.common.collect.ImmutableSet.of;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATED;
 import static org.fcrepo.kernel.modeshape.FedoraJcrConstants.JCR_CREATEDBY;
@@ -176,7 +177,8 @@ public abstract class FedoraTypesUtils implements FedoraTypes {
     /**
      * Check whether a type is an internal type that should be suppressed from external output.
      */
-    public static final Predicate<URI> isInternalType = t -> t.toString().equals(MEMENTO_TYPE);
+    public static final Predicate<URI> isInternalType =
+        t -> t.toString().equals(MEMENTO_TYPE) || t.toString().equals(FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI);
 
     /**
      * A functional predicate to check whether a property is a JCR property that should be exposed.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2997

# What does this Pull Request do?

Hides the `fedora:NonRdfSourceDescription` type so it does not appear in the binary description RDF.

# How should this be tested?

Before the PR
1. Create a binary
1. Get the `binary/fcr:metadata` and see a `rdf:type` of `fedora:NonRdfSourceDescription`

After the PR
1. Create a binary
1. Get the `binary/fcr:metadata` and see **no** `rdf:type` of `fedora:NonRdfSourceDescription`


# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers @peichman-umd 
