### PR TITLE
Correctly persist NonRDFSource description triples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 sudo: true
 
+dist: trusty
 jdk:
   - openjdk8
   - oraclejdk8

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/RdfAdder.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/RdfAdder.java
@@ -88,8 +88,8 @@ public class RdfAdder extends PersistingRdfStreamConsumer {
     protected void operateOnProperty(final Statement t, final FedoraResource resource) throws RepositoryException {
         LOGGER.debug("Adding property from triple: {} to resource: {}.", t, resource
                 .getPath());
-
-        jcrRdfTools().addProperty(resource, t.getPredicate(), t.getObject(),
-                getNamespaces(getJcrNode(resource).getSession()));
+        final FedoraResource description = resource.getDescription();
+        jcrRdfTools().addProperty(description, t.getPredicate(), t.getObject(),
+                getNamespaces(getJcrNode(description).getSession()));
     }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/RdfRemover.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/utils/iterators/RdfRemover.java
@@ -69,8 +69,9 @@ public class RdfRemover extends PersistingRdfStreamConsumer {
         throws RepositoryException {
         LOGGER.debug("Trying to remove property from triple: {} on resource: {}.", t, resource
                 .getPath());
-        jcrRdfTools().removeProperty(resource, t.getPredicate(), t.getObject(),
-                getNamespaces(getJcrNode(resource).getSession()));
+        final FedoraResource description = resource.getDescription();
+        jcrRdfTools().removeProperty(description, t.getPredicate(), t.getObject(),
+                getNamespaces(getJcrNode(description).getSession()));
     }
 
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3015

I got the idea for this fix from https://github.com/fcrepo4/fcrepo4/pull/1491

# What does this Pull Request do?
Tries to add/remove the triples for binaries on the description (was using the actual binary).

# How should this be tested?

See steps in associated ticket.

Create a binary, update the triples on the `/fcr:metadata` endpoint. 

Basically you can add triples but can't seemingly delete them. In practice I found when GET then PUT altered triples they were entirely ignored.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers @dannylamb
