### PR TITLE
Generate timemap paths in platform-independent way (#1516)

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4474,4 +4474,12 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     }
 
+    @Test
+    public void testCreateWithTrailingSlash() throws IOException {
+        final String subjectURI = serverAddress + getRandomUniqueId() + "/";
+        final HttpPut putMethod = new HttpPut(subjectURI);
+        try (final CloseableHttpResponse response = execute(putMethod)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+    }
 }

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TimeMapServiceImpl.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/services/TimeMapServiceImpl.java
@@ -24,7 +24,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.LDPCV_TIME_MAP;
 import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.nio.file.Paths;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import org.fcrepo.kernel.api.FedoraSession;
@@ -95,7 +94,7 @@ public class TimeMapServiceImpl extends AbstractService implements TimeMapServic
         if (path.endsWith("/" + LDPCV_TIME_MAP)) {
             return path;
         } else {
-            return Paths.get(path, LDPCV_TIME_MAP).toString();
+            return path.replaceFirst("/*$", "") + "/" + LDPCV_TIME_MAP;
         }
     }
 


### PR DESCRIPTION
**Generate timemap paths in platform-independent way**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2986 

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
* Generate timemap paths in platform-independent way
* Special case for resources ending in slash
* Emulates the previous behavior where path termination with a slash is
irrelevant

# What's new?
This commit was included in the 5.0.2 release but did not get merged into master. Thus it is missing on 5.1.0-RC and is the likely cause of failures of the code to build on winows.

# How should this be tested?

To test, please build on windows and verify that it passes.

# Interested parties
@birkland 