### PR TITLE
Resolves warning of missing Javadoc statement

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/HtmlTemplate.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/HtmlTemplate.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
 public @interface HtmlTemplate {
 
     /**
-     * The name of the HTML template to render for this method
+     * @return The name of the HTML template to render for this method
      */
     String value();
 }


### PR DESCRIPTION
**Resolves warning of missing Javadoc statement.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3027

# What does this Pull Request do?
Resolves a warning of a missing Javadoc statement in org.fcrepo.http.commons.responses.HtmlTemplate.java interface.

# What's new?
* Added a @return statement to the String value() method of the org.fcrepo.http.commons.responses.HtmlTemplate.java interface.

# How should this be tested?
Command: mvn clean install -pl fcrepo-http-commons does not produce warnings regarding missing @return statement.

# Additional Notes:
I have signed the agreement of a sprint participator and handed it in to my manager. It should reach you soon.

