### PR TITLE
Address javadoc warnings in fcrepo-kernel-api

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/AutoReloadingConfiguration.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/AutoReloadingConfiguration.java
@@ -50,6 +50,9 @@ public abstract class AutoReloadingConfiguration {
 
     /**
      * Initialize the configuration and set up monitoring
+     *
+     * @throws IOException thrown if the configuration cannot be loaded.
+     *
      */
     public void init() throws IOException {
         if (isEmpty(configPath)) {


### PR DESCRIPTION
- include add '@throws IOException' comment for init() method

Resolves: https://jira.duraspace.org/browse/FCREPO-3028

**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *
https://jira.duraspace.org/browse/FCREPO-3028

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Fixes the Javadoc warning

# What's new?
Include add '@throws IOException' comment for init() method

# How should this be tested?
By rebuilding and verifying warning disappears.

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable) - remove @throws IOException' comment from init() method
* Test that the Pull Request does what is intended. - re-build 'fcrepo-kernel-api' and verify warning disappears


# Additional Notes:
Not applicable

Example:
* Does this change require documentation to be updated?  NO
* Does this change add any new dependencies? NO
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? NO
* Could this change impact execution of existing code? NO

# Interested parties
Tag  @fcrepo4/committers
