### PR TITLE
Move update and replace properties into services.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -165,6 +165,8 @@ import org.fcrepo.kernel.api.models.FedoraWebacAcl;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
+import org.fcrepo.kernel.api.services.ReplacePropertiesService;
+import org.fcrepo.kernel.api.services.UpdatePropertiesService;
 import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
@@ -233,6 +235,12 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     @Inject
     protected RdfNamespaceRegistry namespaceRegistry;
+
+    @Inject
+    protected ReplacePropertiesService replacePropertiesService;
+
+    @Inject
+    protected UpdatePropertiesService updatePropertiesService;
 
     private static final Predicate<Triple> IS_MANAGED_TYPE = t -> t.getPredicate().equals(type.asNode()) &&
             isManagedNamespace.test(t.getObject().getNameSpace());
@@ -975,7 +983,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
         ensureValidACLAuthorization(resource, inputModel);
 
-        resource.replaceProperties(translator(), inputModel, resourceTriples);
+        replacePropertiesService.replaceProperties(resource, inputModel, resourceTriples);
     }
 
     /**
@@ -1090,7 +1098,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected void patchResourcewithSparql(final FedoraResource resource,
             final String requestBody,
             final RdfStream resourceTriples) {
-        resource.updateProperties(translator(), requestBody, resourceTriples);
+        updatePropertiesService.updateProperties(resource, requestBody, resourceTriples);
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -133,7 +133,9 @@ import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
 import org.fcrepo.kernel.api.services.BinaryService;
 import org.fcrepo.kernel.api.services.ContainerService;
 import org.fcrepo.kernel.api.services.NodeService;
+import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.kernel.api.services.TimeMapService;
+import org.fcrepo.kernel.api.services.UpdatePropertiesService;
 import org.glassfish.jersey.internal.PropertiesDelegate;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.junit.Before;
@@ -229,6 +231,12 @@ public class FedoraLdpTest {
 
     @Mock
     private ExternalContentHandlerFactory extContentHandlerFactory;
+
+    @Mock
+    private ReplacePropertiesService replacePropertiesService;
+
+    @Mock
+    private UpdatePropertiesService updatePropertiesService;
 
     private static final Logger log = getLogger(FedoraLdpTest.class);
 
@@ -917,7 +925,7 @@ public class FedoraLdpTest {
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);
 
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
-        verify(mockContainer).replaceProperties(eq(idTranslator), any(Model.class), any(RdfStream.class));
+        verify(replacePropertiesService).replaceProperties(eq(mockContainer), any(Model.class), any(RdfStream.class));
     }
 
     @Test
@@ -953,7 +961,7 @@ public class FedoraLdpTest {
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);
 
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
-        verify(mockObject).replaceProperties(eq(idTranslator), any(Model.class), any(RdfStream.class));
+        verify(replacePropertiesService).replaceProperties(eq(mockObject), any(Model.class), any(RdfStream.class));
     }
 
     @Test(expected = ClientErrorException.class)
@@ -1046,7 +1054,7 @@ public class FedoraLdpTest {
         final Response actual = testObj.createObject(null,
                 MediaType.valueOf(contentTypeSPARQLUpdate), "b", toInputStream("x", UTF_8), null, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
-        verify(mockContainer).updateProperties(eq(idTranslator), eq("x"), any(RdfStream.class));
+        verify(updatePropertiesService).updateProperties(eq(mockContainer), eq("x"), any(RdfStream.class));
     }
 
     @Test
@@ -1057,7 +1065,7 @@ public class FedoraLdpTest {
         final Response actual = testObj.createObject(null, NTRIPLES_TYPE, "b",
                 toInputStream("_:a <info:b> _:c .", UTF_8), null, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
-        verify(mockContainer).replaceProperties(eq(idTranslator), any(Model.class), any(RdfStream.class));
+        verify(replacePropertiesService).replaceProperties(eq(mockContainer), any(Model.class), any(RdfStream.class));
     }
 
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -28,11 +28,7 @@ import org.apache.jena.rdf.model.Resource;
 
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.TripleCategory;
-import org.fcrepo.kernel.api.exception.AccessDeniedException;
-import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
-
-import org.apache.jena.rdf.model.Model;
 
 /**
  * @author ajs6f
@@ -185,20 +181,6 @@ public interface FedoraResource {
     void addType(final String type);
 
     /**
-     * Update the provided properties with a SPARQL Update query. The updated
-     * properties may be serialized to the persistence layer.
-     *
-     * @param idTranslator the property of idTranslator
-     * @param sparqlUpdateStatement sparql update statement
-     * @param originalTriples original triples
-     * @throws MalformedRdfException if malformed rdf exception occurred
-     * @throws AccessDeniedException if access denied in updating properties
-     */
-    void updateProperties(final IdentifierConverter<Resource, FedoraResource> idTranslator,
-                          final String sparqlUpdateStatement,
-                          final RdfStream originalTriples) throws MalformedRdfException, AccessDeniedException;
-
-    /**
      * Return the RDF properties of this object using the provided context
      * @param idTranslator the property of idTranslator
      * @param context the context
@@ -222,19 +204,6 @@ public interface FedoraResource {
      * @return if resource created in this session
      */
     Boolean isNew();
-
-    /**
-     * Replace the properties of this object with the properties from the given
-     * model
-     *
-     * @param idTranslator the given property of idTranslator
-     * @param inputModel the input model
-     * @param originalTriples the original triples
-     * @throws MalformedRdfException if malformed rdf exception occurred
-     */
-    void replaceProperties(final IdentifierConverter<Resource, FedoraResource> idTranslator,
-                                final Model inputModel,
-                                final RdfStream originalTriples) throws MalformedRdfException;
 
     /**
      * Construct an ETag value for the resource.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplacePropertiesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplacePropertiesService.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import org.apache.jena.rdf.model.Model;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.models.FedoraResource;
+
+/**
+ * @author peichman
+ * @since 6.0.0
+ */
+public interface ReplacePropertiesService {
+  /**
+   * Replace the properties of this object with the properties from the given
+   * model
+   *
+   * @param fedoraResource the Fedora resource to update
+   * @param inputModel the input model
+   * @param originalTriples the original triples
+   * @throws MalformedRdfException if malformed rdf exception occurred
+   */
+  void replaceProperties(final FedoraResource fedoraResource,
+                         final Model inputModel,
+                         final RdfStream originalTriples) throws MalformedRdfException;
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdatePropertiesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdatePropertiesService.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.AccessDeniedException;
+import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.models.FedoraResource;
+
+/**
+ * @author peichman
+ * @since 6.0.0
+ */
+public interface UpdatePropertiesService {
+  /**
+   * Update the provided properties with a SPARQL Update query. The updated
+   * properties may be serialized to the persistence layer.
+   *
+   * @param fedoraResource the Fedora resource to update
+   * @param sparqlUpdateStatement sparql update statement
+   * @param originalTriples original triples
+   * @throws MalformedRdfException if malformed rdf exception occurred
+   * @throws AccessDeniedException if access denied in updating properties
+   */
+  void updateProperties(final FedoraResource fedoraResource,
+                        final String sparqlUpdateStatement,
+                        final RdfStream originalTriples) throws MalformedRdfException, AccessDeniedException;
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3057

# What does this Pull Request do?
Creates two new service interfaces for updating and replacing properties.

# What's new?
Moves the methods `updateProperties` and `replaceProperties` out of the `FedoraResource` interface and into their own separate service interfaces.

# How should this be tested?

* Just a standard `mvn clean install` should do.

# Additional Notes:
None.

# Interested parties
@dbernstein, @fcrepo4/committers
