### PR TITLE
Adds DeleteResourceService interface as a replacement for FedoraResou…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -45,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import javax.inject.Inject;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
@@ -76,6 +77,7 @@ import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
 
@@ -99,6 +101,9 @@ public class FedoraAcl extends ContentExposingResource {
     @Context protected UriInfo uriInfo;
 
     @PathParam("path") protected String externalPath;
+
+    @Inject
+    private DeleteResourceService deleteResourceService;
 
     /**
      * Default JAX-RS entry point
@@ -294,7 +299,7 @@ public class FedoraAcl extends ContentExposingResource {
         try {
             final FedoraResource aclResource = resource().getAcl();
             if (aclResource != null) {
-                aclResource.delete();
+                deleteResourceService.perform(getTransaction(), aclResource);
             }
             session.commit();
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -24,6 +24,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
 import org.fcrepo.http.commons.session.HttpSession;
+import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.SessionMissingException;
 import org.fcrepo.kernel.api.exception.TombstoneException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
@@ -149,6 +150,10 @@ abstract public class FedoraBaseResource extends AbstractResource {
             throw new SessionMissingException("Invalid session");
         }
         return session;
+    }
+
+    protected Transaction getTransaction() {
+        return session().getTransaction();
     }
 
     protected String getUserPrincipal() {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -131,6 +131,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.FixityService;
+import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
@@ -157,6 +158,9 @@ public class FedoraLdp extends ContentExposingResource {
     @Inject private FixityService fixityService;
 
     @Inject private FedoraHttpConfiguration httpConfiguration;
+
+    @Inject
+    private DeleteResourceService deleteResourceService;
 
     /**
      * Default JAX-RS entry point
@@ -361,7 +365,7 @@ public class FedoraLdp extends ContentExposingResource {
         final AcquiredLock lock = lockManager.lockForDelete(resource().getPath());
 
         try {
-            resource().delete();
+            deleteResourceService.perform(getTransaction(), resource());
             session.commit();
             return noContent().build();
         } finally {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
@@ -19,9 +19,11 @@ package org.fcrepo.http.api;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
 
+import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -43,6 +45,9 @@ public class FedoraTombstones extends FedoraBaseResource {
 
     @PathParam("path") protected String externalPath;
 
+    @Inject
+    private DeleteResourceService deleteResourceService;
+
     /**
      * Default JAX-RS entry point
      */
@@ -59,7 +64,6 @@ public class FedoraTombstones extends FedoraBaseResource {
         this.externalPath = externalPath;
     }
 
-
     /**
      * Delete a tombstone resource (freeing the original resource to be reused)
      * @return the free resource
@@ -67,7 +71,7 @@ public class FedoraTombstones extends FedoraBaseResource {
     @DELETE
     public Response delete() {
         LOGGER.info("Delete tombstone: {}", resource());
-        resource().delete();
+        deleteResourceService.perform(getTransaction(), resource());
         session.commit();
         return noContent().build();
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -130,6 +130,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
+import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.kernel.api.services.TimeMapService;
@@ -238,6 +239,9 @@ public class FedoraLdpTest {
     @Mock
     private UpdatePropertiesService updatePropertiesService;
 
+    @Mock
+    private DeleteResourceService deleteResourceService;
+
     private static final Logger log = getLogger(FedoraLdpTest.class);
 
 
@@ -267,6 +271,7 @@ public class FedoraLdpTest {
         setField(testObj, "prefer", prefer);
         setField(testObj, "extContentHandlerFactory", extContentHandlerFactory);
         setField(testObj, "namespaceRegistry", rdfNamespaceRegistry);
+        setField(testObj, "deleteResourceService", deleteResourceService);
 
         when(rdfNamespaceRegistry.getNamespaces()).thenReturn(new HashMap<>());
 
@@ -884,7 +889,7 @@ public class FedoraLdpTest {
         when(mockRequest.getMethod()).thenReturn("PATCH");
         final Response actual = testObj.deleteObject();
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
-        verify(fedoraResource).delete();
+        verify(deleteResourceService).perform(mockTransaction, fedoraResource);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraTombstonesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraTombstonesTest.java
@@ -18,7 +18,9 @@
 package org.fcrepo.http.api;
 
 import org.fcrepo.http.commons.session.HttpSession;
+import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.models.Tombstone;
+import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,25 +52,32 @@ public class FedoraTombstonesTest {
     private HttpSession mockSession;
 
     @Mock
+    private Transaction mockTransaction;
+
+    @Mock
     private SecurityContext mockSecurityContext;
 
+    @Mock
+    private DeleteResourceService deleteResourceService;
 
     @Before
     public void setUp() {
         testObj = spy(new FedoraTombstones(path));
         setField(testObj, "session", mockSession);
         setField(testObj, "securityContext", mockSecurityContext);
+        setField(testObj, "deleteResourceService", deleteResourceService);
+
+
     }
 
     @Test
     public void testDelete() {
         final Tombstone mockResource = mock(Tombstone.class);
-
         doReturn(mockResource).when(testObj).resource();
-
+        doReturn(mockTransaction).when(mockSession).getTransaction();
         final Response actual = testObj.delete();
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
-        verify(mockResource).delete();
+        verify(deleteResourceService).perform(mockTransaction, mockResource);
         verify(mockSession).commit();
     }
 }

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -54,7 +54,9 @@ import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.kernel.api.services.UpdatePropertiesService;
 
@@ -101,6 +103,9 @@ abstract class AbstractJmsIT implements MessageListener {
 
     @Inject
     private ReplacePropertiesService replacePropertiesService;
+
+    @Inject
+    private DeleteResourceService deleteResourceService;
 
     @Inject
     private ActiveMQConnectionFactory connectionFactory;
@@ -155,7 +160,10 @@ abstract class AbstractJmsIT implements MessageListener {
             tx.commit();
             awaitMessageOrFail(testFile, RESOURCE_MODIFICATION.getType(), REPOSITORY_NAMESPACE + "Binary");
 
-            // binaryService.find(tx, testFile).delete();
+            final FedoraResource binaryResource = null;
+            //TODO update previous line to support new binary resource location
+            // approach that will replace binaryService.find(session, testFile)
+            deleteResourceService.perform(tx, binaryResource);
             tx.commit();
             awaitMessageOrFail(testFile, RESOURCE_DELETION.getType(), null);
         } finally {
@@ -216,7 +224,10 @@ abstract class AbstractJmsIT implements MessageListener {
         try {
             // final Container resource = containerService.findOrCreate(tx, testRemoved);
             tx.commit();
-            // resource.delete();
+            //TODO connect the next line with the new resource creation mechanism
+            // that will replace containerService.findOrCreate(session, testRemoved);
+            final Container resource = null;
+            deleteResourceService.perform(tx, resource);
             tx.commit();
             awaitMessageOrFail(testRemoved, RESOURCE_DELETION.getType(), null);
         } finally {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -135,11 +135,6 @@ public interface FedoraResource {
     boolean hasProperty(String relPath);
 
     /**
-     * Delete this resource, and any inbound references to it
-     */
-    void delete();
-
-    /**
      * Get the date this resource was created
      * @return created date
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/DeleteResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/DeleteResourceService.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.models.FedoraResource;
+
+/**
+ * A service interface for deleting Fedora resources.
+ * @author dbernstein
+ * @since 6.0.0
+ */
+public interface DeleteResourceService {
+  /**
+   * Delete the specified resource
+   *
+   * @param tx the transaction associated with the operation
+   * @param resource the Fedora resource to delete
+   */
+  void perform(final Transaction tx, final FedoraResource resource);
+}


### PR DESCRIPTION
…rce.delete().



**Refactors delete() method out of FedoraResource and into a service interface.**
* * *

**JIRA Ticket**: Resolves: https://jira.duraspace.org/browse/FCREPO-3062

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)


# How should this be tested?
No tests.  No functional change.  Just replaces one interface method with another.
# Interested parties
@fcrepo4/committers
