### PR TITLE
Created FixityService interface.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -30,6 +30,7 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
@@ -41,6 +42,7 @@ import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+import org.fcrepo.kernel.api.services.FixityService;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
 
@@ -58,6 +60,8 @@ public class FedoraFixity extends ContentExposingResource {
 
     @PathParam("path") protected String externalPath;
 
+
+    @Inject private FixityService fixityService;
 
     /**
      * Default JAX-RS entry point
@@ -99,9 +103,12 @@ public class FedoraFixity extends ContentExposingResource {
 
         LOGGER.info("Get fixity for '{}'", externalPath);
         return new RdfNamespacedStream(
-                new DefaultRdfStream(asNode(resource()),
-                    ((Binary)resource()).getFixity(translator())),
-                namespaceRegistry.getNamespaces());
+            new DefaultRdfStream(
+                asNode(resource()),
+                fixityService.getFixity((Binary)resource())
+            ),
+            namespaceRegistry.getNamespaces()
+        );
     }
 
     @Override

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -130,6 +130,7 @@ import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+import org.fcrepo.kernel.api.services.FixityService;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
@@ -152,6 +153,8 @@ public class FedoraLdp extends ContentExposingResource {
     private static final String DIGEST = "Digest";
 
     @PathParam("path") protected String externalPath;
+
+    @Inject private FixityService fixityService;
 
     @Inject private FedoraHttpConfiguration httpConfiguration;
 
@@ -870,7 +873,7 @@ public class FedoraLdp extends ContentExposingResource {
                     "Unsupported digest algorithm provided in 'Want-Digest' header: " + wantDigest);
         }
 
-        final Collection<URI> checksumResults = binary.checkFixity(idTranslator, preferredDigests);
+        final Collection<URI> checksumResults = fixityService.checkFixity(binary, preferredDigests);
         return checksumResults.stream().map(uri -> uri.toString().replaceFirst("urn:", "")
                 .replaceFirst(":", "=").replaceFirst("sha1=", "sha=")).collect(Collectors.joining(","));
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Binary.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Binary.java
@@ -17,11 +17,7 @@
  */
 package org.fcrepo.kernel.api.models;
 
-import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
-import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
-import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 
 import java.io.InputStream;
@@ -132,32 +128,4 @@ public interface Binary extends FedoraResource {
      * @return original file name for the binary content, or the object's id.
      */
     String getFilename();
-
-    /**
-     * Get the fixity of this datastream compared to metadata stored in the repository
-     * @param idTranslator the id translator
-     * @return the fixity of this datastream compared to metadata stored in the repository
-     */
-    RdfStream getFixity(IdentifierConverter<Resource, FedoraResource> idTranslator);
-
-    /**
-     * Get the fixity of this datastream in a given repository's binary store.
-     * @param idTranslator the id translator
-     * @param contentDigest the checksum to compare against
-     * @param size the expected size of the binary
-     * @return the fixity of the datastream
-     */
-    RdfStream getFixity(IdentifierConverter<Resource, FedoraResource> idTranslator,
-                        URI contentDigest, long size);
-
-
-    /**
-     * Digest this datastream with the digest algorithms provided
-     * @param idTranslator the id translator
-     * @param algorithms the digest algorithms to be used
-     * @return the checksums of this datastream
-     * @throws org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException if unsupported digest algorithm occurred
-     */
-    Collection<URI> checkFixity(IdentifierConverter<Resource, FedoraResource> idTranslator,
-            Collection<String> algorithms) throws UnsupportedAlgorithmException;
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/FixityService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/FixityService.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
+import org.fcrepo.kernel.api.models.Binary;
+
+import java.net.URI;
+import java.util.Collection;
+
+public interface FixityService {
+
+  /**
+   * Get the fixity of this binary compared to metadata stored in the repository
+   * @param binary the binary resource to get fixity for
+   * @return the fixity of this binary compared to metadata stored in the repository
+   */
+  RdfStream getFixity(Binary binary);
+
+  /**
+   * Get the fixity of this binary in a given repository's binary store.
+   * @param binary the binary resource to compare
+   * @param contentDigest the checksum to compare against
+   * @param size the expected size of the binary
+   * @return the fixity of the binary
+   */
+  RdfStream getFixity(Binary binary, URI contentDigest, long size);
+
+
+  /**
+   * Digest this binary with the digest algorithms provided
+   * @param binary the binary resource to digest
+   * @param algorithms the digest algorithms to be used
+   * @return the checksums of this binary
+   * @throws org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException if unsupported digest algorithm occurred
+   */
+  Collection<URI> checkFixity(Binary binary, Collection<String> algorithms) throws UnsupportedAlgorithmException;
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3065

# What does this Pull Request do?

Moved fixity methods from the Binary interface to a new FixityService interface.

# What's new?

Extracted the getFixity() and checkFixity() methods from the Binary interface and placed them in a new FixityService interface. Modified their signatures to take a Binary as their first argument, instead of an idTranslator.

# How should this be tested?

A standard `mvn clean install`.

# Additional Notes:

None.

# Interested parties

@bbpennel, @fcrepo4/committers
