### PR TITLE
Add new identifier translator

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -95,7 +95,7 @@ public class HttpIdentifierConverter extends Converter<String, String> {
 
             return FEDORA_ID_PREFIX + fedoraId.replaceFirst("\\/", "");
         }
-        return path;
+        return "";
 
     }
 
@@ -109,7 +109,7 @@ public class HttpIdentifierConverter extends Converter<String, String> {
             // Need to pass as Array or second arg is ignored. Second arg is DON'T encode slashes
             return uriBuilder().build(values, false).toString();
         }
-        return null;
+        return "";
     }
 
     /**

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.api.rdf;
+
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import javax.ws.rs.core.UriBuilder;
+
+import com.google.common.base.Converter;
+import org.glassfish.jersey.uri.UriTemplate;
+import org.slf4j.Logger;
+
+/**
+ * Convert between HTTP URIs (LDP paths) and internal Fedora ID using a
+ * JAX-RS UriBuilder to mediate the URI translation.
+ *
+ * @author whikloj
+ * @since 2019-09-26
+ */
+public class HttpIdentifierConverter extends Converter<String, String> {
+
+    private static final Logger LOGGER = getLogger(HttpIdentifierConverter.class);
+
+    private final UriBuilder uriBuilder;
+
+    protected Converter<String, String> forward = identity();
+    protected Converter<String, String> reverse = identity();
+
+    private final UriTemplate uriTemplate;
+
+    private static final String FEDORA_ID_PREFIX = "info:fedora/";
+
+    /**
+     * Split uri on delim and return the first part.
+     */
+    private static BiFunction<String, String, String> removeDelim =
+        (uri, delim) -> {
+            final String newUri;
+            if (uri.indexOf(delim) >= 0) {
+                newUri = uri.split(delim)[0];
+            } else {
+                newUri = uri;
+            }
+            return newUri;
+        };
+
+    /**
+     * Create a new identifier converter within the given session with the given URI template
+     * @param uriBuilder the uri builder
+     */
+    public HttpIdentifierConverter(final UriBuilder uriBuilder) {
+
+        this.uriBuilder = uriBuilder;
+        this.uriTemplate = new UriTemplate(uriBuilder.toTemplate());
+    }
+
+    private UriBuilder uriBuilder() {
+        return UriBuilder.fromUri(uriBuilder.toTemplate());
+    }
+
+    @Override
+    protected String doForward(final String httpUri) {
+        LOGGER.debug(String.format("Translating http URI %s to Fedora ID", httpUri));
+
+        final String path = getPath(httpUri);
+        if (path != null) {
+
+            // Take the URL and remove any hash uris, or fcr: endpoints.
+            final String fedoraId = Arrays.asList(path).stream().map(p -> removeDelim.apply(p, "#"))
+                .map(p -> removeDelim.apply(p, "/" + FCR_METADATA))
+                .map(p -> removeDelim.apply(p, "/" + FCR_ACL))
+                .map(p -> removeDelim.apply(p, "/" + FCR_VERSIONS)).findFirst().orElse("");
+
+            return FEDORA_ID_PREFIX + fedoraId.replaceFirst("\\/", "");
+        }
+        return path;
+
+    }
+
+    @Override
+    protected String doBackward(final String fedoraId) {
+        LOGGER.debug(String.format("Translating Fedora ID %s to Http URI", fedoraId));
+        if (fedoraId.startsWith(FEDORA_ID_PREFIX)) {
+            // If it starts with our prefix, strip the prefix and use it as the path
+            // part of the URI.
+            final String[] values = { fedoraId.substring(FEDORA_ID_PREFIX.length()) };
+            // Need to pass as Array or second arg is ignored. Second arg is DON'T encode slashes
+            return uriBuilder().build(values, false).toString();
+        }
+        return null;
+    }
+
+    /**
+     * Split the path off the URI.
+     *
+     * @param httpUri the incoming URI.
+     * @return the path of the URI.
+     */
+    private String getPath(final String httpUri) {
+        final Map<String, String> values = new HashMap<>();
+
+        if (uriTemplate.match(httpUri, values) && values.containsKey("path")) {
+            return "/" + values.get("path");
+        } else if (isRootWithoutTrailingSlash(httpUri)) {
+            return "/";
+        }
+        return null;
+    }
+
+    /**
+     * Test if the URI is the root but missing the trailing slash
+     *
+     * @param httpUri the incoming URI.
+     * @return whether or not it is the root minus trailing slash
+     */
+    private boolean isRootWithoutTrailingSlash(final String httpUri) {
+        final Map<String, String> values = new HashMap<>();
+
+        return uriTemplate.match(httpUri + "/", values) && values.containsKey("path") &&
+            values.get("path").isEmpty();
+    }
+
+}

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
@@ -22,7 +22,6 @@ import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;
 
@@ -50,11 +49,16 @@ public class HttpIdentifierConverterTest {
         converter = new HttpIdentifierConverter(uriBuilder);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testBlankUri() {
         final String testUri = "";
         final String fedoraId = converter.convert(testUri);
-        assertTrue(fedoraId.length() == 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBlankId() {
+        final String testId = "";
+        final String fedoraId = converter.reverse().convert(testId);
     }
 
     @Test
@@ -103,9 +107,9 @@ public class HttpIdentifierConverterTest {
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_METADATA;
         final String fedoraId = converter.convert(testUri);
-        assertEquals("info:fedora/" + baseUid, fedoraId);
+        assertEquals("info:fedora/" + baseUid + "/" + FCR_METADATA, fedoraId);
         final String httpUri = converter.reverse().convert(fedoraId);
-        assertEquals(baseUrl, httpUri);
+        assertEquals(testUri, httpUri);
     }
 
     @Test
@@ -124,7 +128,7 @@ public class HttpIdentifierConverterTest {
         final String memento = "20190926133245";
         final String baseUid = getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
-        final String testUri = baseUrl + "/" + FCR_VERSIONS + memento;
+        final String testUri = baseUrl + "/" + FCR_VERSIONS + "/" + memento;
         final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
         final String httpUri = converter.reverse().convert(fedoraId);
@@ -158,9 +162,9 @@ public class HttpIdentifierConverterTest {
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_METADATA;
         final String fedoraId = converter.convert(testUri);
-        assertEquals("info:fedora/" + baseUid, fedoraId);
+        assertEquals("info:fedora/" + baseUid + "/" + FCR_METADATA, fedoraId);
         final String httpUri = converter.reverse().convert(fedoraId);
-        assertEquals(baseUrl, httpUri);
+        assertEquals(testUri, httpUri);
     }
 
     @Test
@@ -179,7 +183,7 @@ public class HttpIdentifierConverterTest {
         final String memento = "20190926133245";
         final String baseUid = getUniqueId() + "/" + getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
-        final String testUri = baseUrl + "/" + FCR_VERSIONS + memento;
+        final String testUri = baseUrl + "/" + FCR_VERSIONS + "/" + memento;
         final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
         final String httpUri = converter.reverse().convert(fedoraId);
@@ -197,6 +201,10 @@ public class HttpIdentifierConverterTest {
         assertEquals(baseUrl, httpUri);
     }
 
+    /**
+     * Utility function to get a UUID.
+     * @return a UUID.
+     */
     private static String getUniqueId() {
         return UUID.randomUUID().toString();
     }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.api.rdf;
+
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.UUID;
+
+import javax.ws.rs.core.UriBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class HttpIdentifierConverterTest {
+
+    private HttpIdentifierConverter converter;
+
+    private static final String uriBase = "http://localhost:8080/some";
+
+    private static final String uriTemplate = uriBase + "/{path: .*}";
+
+    private UriBuilder uriBuilder;
+
+    @Before
+    public void setUp() {
+        uriBuilder = UriBuilder.fromUri(uriTemplate);
+        converter = new HttpIdentifierConverter(uriBuilder);
+    }
+
+    @Test
+    public void testBlankUri() {
+        final String testUri = "";
+        final String fedoraId = converter.doForward(testUri);
+        assertNull(fedoraId);
+    }
+
+    @Test
+    public void testRootUriWithTrailingSlash() {
+        final String testUri = uriBase + "/";
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/", fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(testUri, httpUri);
+    }
+
+    @Test
+    public void testRootUriWithoutTrailingSlash() {
+        final String testUri = uriBase;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/", fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        // We also return the trailing slash.
+        assertEquals(testUri + "/", httpUri);
+    }
+
+    @Test
+    public void testFirstLevel() {
+        final String baseUid = getUniqueId();
+        final String testUri = uriBase + "/" + baseUid;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(testUri, httpUri);
+    }
+
+    @Test
+    public void testFirstLevelWithAcl() {
+        final String baseUid = getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_ACL;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    @Test
+    public void testFirstLevelWithMetadata() {
+        final String baseUid = getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_METADATA;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    @Test
+    public void testFirstLevelWithVersions() {
+        final String baseUid = getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_VERSIONS;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    @Test
+    public void testFirstLevelWithMemento() {
+        final String memento = "20190926133245";
+        final String baseUid = getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_VERSIONS + memento;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    @Test
+    public void testSecondLevel() {
+        final String baseUid = getUniqueId() + "/" + getUniqueId();
+        final String testUri = uriBase + "/" + baseUid;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(testUri, httpUri);
+    }
+
+    @Test
+    public void testSecondLevelWithAcl() {
+        final String baseUid = getUniqueId() + "/" + getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_ACL;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    @Test
+    public void testSecondLevelWithMetadata() {
+        final String baseUid = getUniqueId() + "/" + getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_METADATA;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    @Test
+    public void testSecondLevelWithVersions() {
+        final String baseUid = getUniqueId() + "/" + getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_VERSIONS;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    @Test
+    public void testSecondLevelWithMemento() {
+        final String memento = "20190926133245";
+        final String baseUid = getUniqueId() + "/" + getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_VERSIONS + memento;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    @Test
+    public void testItemWithDoubleAcl() {
+        final String baseUid = getUniqueId();
+        final String baseUrl = uriBase + "/" + baseUid;
+        final String testUri = baseUrl + "/" + FCR_ACL + "/" + FCR_ACL;
+        final String fedoraId = converter.doForward(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.doBackward(fedoraId);
+        assertEquals(baseUrl, httpUri);
+    }
+
+    private static String getUniqueId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
@@ -22,7 +22,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;
 
@@ -53,25 +53,25 @@ public class HttpIdentifierConverterTest {
     @Test
     public void testBlankUri() {
         final String testUri = "";
-        final String fedoraId = converter.doForward(testUri);
-        assertNull(fedoraId);
+        final String fedoraId = converter.convert(testUri);
+        assertTrue(fedoraId.length() == 0);
     }
 
     @Test
     public void testRootUriWithTrailingSlash() {
         final String testUri = uriBase + "/";
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/", fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(testUri, httpUri);
     }
 
     @Test
     public void testRootUriWithoutTrailingSlash() {
         final String testUri = uriBase;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/", fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         // We also return the trailing slash.
         assertEquals(testUri + "/", httpUri);
     }
@@ -80,9 +80,9 @@ public class HttpIdentifierConverterTest {
     public void testFirstLevel() {
         final String baseUid = getUniqueId();
         final String testUri = uriBase + "/" + baseUid;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(testUri, httpUri);
     }
 
@@ -91,9 +91,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_ACL;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 
@@ -102,9 +102,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_METADATA;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 
@@ -113,9 +113,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_VERSIONS;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 
@@ -125,9 +125,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_VERSIONS + memento;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 
@@ -135,9 +135,9 @@ public class HttpIdentifierConverterTest {
     public void testSecondLevel() {
         final String baseUid = getUniqueId() + "/" + getUniqueId();
         final String testUri = uriBase + "/" + baseUid;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(testUri, httpUri);
     }
 
@@ -146,9 +146,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId() + "/" + getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_ACL;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 
@@ -157,9 +157,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId() + "/" + getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_METADATA;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 
@@ -168,9 +168,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId() + "/" + getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_VERSIONS;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 
@@ -180,9 +180,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId() + "/" + getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_VERSIONS + memento;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 
@@ -191,9 +191,9 @@ public class HttpIdentifierConverterTest {
         final String baseUid = getUniqueId();
         final String baseUrl = uriBase + "/" + baseUid;
         final String testUri = baseUrl + "/" + FCR_ACL + "/" + FCR_ACL;
-        final String fedoraId = converter.doForward(testUri);
+        final String fedoraId = converter.convert(testUri);
         assertEquals("info:fedora/" + baseUid, fedoraId);
-        final String httpUri = converter.doBackward(fedoraId);
+        final String httpUri = converter.reverse().convert(fedoraId);
         assertEquals(baseUrl, httpUri);
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3088

https://docs.google.com/document/d/1IvZK_VInC8HhtMVs98jJ3czInpwX4Ro8MWJd8hb3W40/edit

# What does this Pull Request do?
Adds a new Converter to translate a URI to an internal Fedora ID.

In the most basic sense `doForward()` takes the URI, grabs the path without the base context. Then strips off any with `fcr:*` or `#something` and prepends `info:fedora/`

`doReverse` removes the `info:fedora/` prefix and makes what is left as the path of the URI template.

Due to the removal of `fcr:*`, etc this is not necessarily an strictly invertable conversion. 

For example:
`http://localhost:8080/fcrepo/rest/my_thing` -> `info:fedora/my_thing`
and
`info:fedora/my_thing` -> `http://localhost:8080/fcrepo/rest/my_thing`

But
`http://localhost:8080/fcrepo/rest/my_thing/fcr:acl` -> `info:fedora/my_thing`
and
`info:fedora/my_thing` -> `http://localhost:8080/fcrepo/rest/my_thing`

# How should this be tested?

Not a functioning repository, but there are unit tests.

# Additional Notes:

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
