### PR TITLE
Removed findOrCreateAcl() method from FedoraResource.

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -128,12 +128,6 @@ public interface FedoraResource {
     FedoraResource getAcl();
 
     /**
-     * Create the ACL for this resource if it doesn't exist
-     * @return the container for ACL of this resource
-     */
-    FedoraResource findOrCreateAcl();
-
-    /**
      * Get the child of this resource at the given path
      *
      * @param relPath the given path

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/WebacAclService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/WebacAclService.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.services;
+
+import org.fcrepo.kernel.api.models.WebacAcl;
+
+/**
+ * Service for creating and retrieving {@link WebacAcl}
+ *
+ * @author peichman
+ * @since 6.0.0
+ */
+public interface WebacAclService extends Service<WebacAcl> {
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -126,12 +126,6 @@ public class FedoraResourceImpl implements FedoraResource {
     }
 
     @Override
-    public FedoraResource findOrCreateAcl() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
     public FedoraResource getChild(final String relPath) {
         // TODO Auto-generated method stub
         return null;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3064

# What does this Pull Request do?

Removed findOrCreateAcl() method from FedoraResource.

# What's new?
Added a `WebacAclService` class that will handle the creation of ACLs. This service is the new home of the `findOrCreateAcl()` method, under the name `findOrCreate()`.

# How should this be tested?

Standard `mvn clean install` build.

# Additional Notes:

None

# Interested parties
@bbpennel , @fcrepo4/committers
