### PR TITLE
Include caching headers in transaction requests.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -757,11 +757,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                                                  final FedoraResource resource,
                                                  final Transaction transaction) {
 
-        if (!transaction.isShortLived()) {
-            // Do not add caching headers if in a transaction
-            return;
-        }
-
         final EntityTag etag;
         final Instant date;
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
@@ -453,6 +453,7 @@ public class TransactionsIT extends AbstractResourceIT {
         try (final CloseableHttpResponse resp = execute(new HttpGet(txLocation + "/" + id))) {
             assertTrue("Expected a Last-Modified header", resp.getHeaders("Last-Modified").length > 0);
             assertTrue("Expected an ETag header", resp.getHeaders("ETag").length > 0);
+            assertTrue("Expected an X-State-Token header", resp.getHeaders("X-State-Token").length > 0);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3092

# What does this Pull Request do?

Include caching headers in transaction requests.

# What's new?

Removed the code that skipped adding cache-related headers (ETag, Last-Modified) if a request was part of a transaction.

# How should this be tested?

Just building it, since the tests for Transactions are currently disabled.

# Additional Notes:

This adds a test to the TransactionsIT, but that test is not currently being run because the transactions implementation is incomplete.

# Interested parties

@dbernstein , @fcrepo4/committers
