### PR TITLE
Adds a minimal implementation of the OCFLPersistentStorageSession to …

### DIFF
--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -66,5 +66,14 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+
+    <!-- This dependency is for compile-time: it keeps this module independent
+         of any given choice of JAX-RS implementation. It must be _after_ the test
+         gear. Otherwise it will get loaded during test phase, but because this is
+         just an API, the tests will not be able to execute. -->
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/FedoraToOCFLObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/FedoraToOCFLObjectIndex.java
@@ -26,14 +26,12 @@ import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
 public interface FedoraToOCFLObjectIndex {
 
     /**
-     * Retrieve the mapping of OCFL Object Id to parent Fedora resource identifier.
-     * We say "parent" identifier because it refers to the Archival Group identifier for
-     * the fedora resource associated with this mapping in the case that the resource was
-     * part of an Archival Group.  In the case of binary descriptive metadata, this identifer
-     * will correspond to "root" of the resource.
+     * Retrieve identification information for the OCFL object which either contains, or is identified by,
+     * the provided fedora resource id. In other words the method will find the closest resource that is persisted
+     * as an OCFL object and returns its identifiers.
      *
-     * So if you pass fedora identifier that is not part of an archival group such as
-     * "my/fedora/binary/fcr:metadata"  the parent returned in the mapping will be "my/fedora/binary".
+     * If you pass fedora identifier that is not part of an archival group such as
+     * "my/fedora/binary/fcr:metadata"  the parent fedora resource returned in the mapping will be "my/fedora/binary".
      *
      * Contrast this  with an Archival Group example:  if you pass in "my/archival-group/binary/fcr:metadata" the
      * parent returned in the mapping would be "my/archival-group".

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/FedoraToOCFLObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/FedoraToOCFLObjectIndex.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl;
+
+import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
+
+/**
+ * @author dbernstein
+ * @since 6.0.0
+ */
+public interface FedoraToOCFLObjectIndex {
+
+    /**
+     * Retrieve the mapping of OCFL Object Id to parent Fedora resource identifier.
+     * We say "parent" identifier because it refers to the Archival Group identifier for
+     * the fedora resource associated with this mapping in the case that the resource was
+     * part of an Archival Group.  In the case of binary descriptive metadata, this identifer
+     * will correspond to "root" of the resource.
+     *
+     * So if you pass fedora identifier that is not part of an archival group such as
+     * "my/fedora/binary/fcr:metadata"  the parent returned in the mapping will be "my/fedora/binary".
+     *
+     * Contrast this  with an Archival Group example:  if you pass in "my/archival-group/binary/fcr:metadata" the
+     * parent returned in the mapping would be "my/archival-group".
+     *
+     * @param fedoraResourceIdentifier the fedora resource identifier
+     * @return the mapping
+     */
+    FedoraOCFLMapping getMapping(final String fedoraResourceIdentifier);
+}
+

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManager.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl;
 
+import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,6 +36,9 @@ public class OCFLPersistentSessionManager implements PersistentStorageSessionMan
     private OCFLPersistentStorageSession readOnlySession;
 
     private Map<String,OCFLPersistentStorageSession> sessionMap;
+
+    @Inject
+    private FedoraToOCFLObjectIndex fedoraOcflIndex;
 
     /**
      * Default constructor
@@ -56,7 +60,7 @@ public class OCFLPersistentSessionManager implements PersistentStorageSessionMan
             return session;
         }
 
-        final OCFLPersistentStorageSession newSession = new OCFLPersistentStorageSession(sessionId);
+        final OCFLPersistentStorageSession newSession = new OCFLPersistentStorageSession(sessionId, fedoraOcflIndex);
 
         sessionMap.put(sessionId, newSession);
 
@@ -66,7 +70,7 @@ public class OCFLPersistentSessionManager implements PersistentStorageSessionMan
     @Override
     public PersistentStorageSession getReadOnlySession() {
         if(this.readOnlySession == null) {
-            this.readOnlySession = new OCFLPersistentStorageSession();
+            this.readOnlySession = new OCFLPersistentStorageSession(fedoraOcflIndex);
         }
 
         return this.readOnlySession;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
@@ -17,14 +17,28 @@
  */
 package org.fcrepo.persistence.ocfl;
 
+import static java.lang.String.format;
+
+import java.io.File;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.fcrepo.persistence.ocfl.api.Persister;
+import org.fcrepo.persistence.ocfl.impl.CreateRDFSourcePersister;
+import org.fcrepo.persistence.ocfl.impl.DefaultOCFLObjectSession;
+import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
 
 /**
  * OCFL Persistent Storage class.
@@ -39,20 +53,34 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
      */
     private final String sessionId;
 
+    private final FedoraToOCFLObjectIndex fedoraOcflIndex;
+
+    private final Map<String,OCFLObjectSession> sessionMap;
+
+    private final File stagingPathRoot = new File(System.getProperty("java.io.tmpdir"), "ocfl-staging");
+
+    private final static List<Persister> PERSISTER_LIST = new LinkedList<>();
+    static {
+        PERSISTER_LIST.add( new CreateRDFSourcePersister());
+        //TODO add new persisters here as they are implemented.
+    }
     /**
      * Constructor
      *
      * @param sessionId session id.
      */
-    protected OCFLPersistentStorageSession(final String sessionId) {
+    protected OCFLPersistentStorageSession(final String sessionId, final FedoraToOCFLObjectIndex fedoraOcflIndex) {
         this.sessionId = sessionId;
+        this.fedoraOcflIndex = fedoraOcflIndex;
+        this.sessionMap = new HashMap<>();
+        stagingPathRoot.mkdirs();
     }
 
     /**
      * Constructor
      */
-    protected OCFLPersistentStorageSession() {
-        this.sessionId = null;
+    protected OCFLPersistentStorageSession(final FedoraToOCFLObjectIndex fedoraOcflIndex) {
+       this(null, fedoraOcflIndex);
     }
 
     @Override
@@ -63,7 +91,37 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
     @Override
     public void persist(final ResourceOperation operation) throws PersistentStorageException {
         actionNeedsWrite();
-        // Perform the persistence operation
+
+        //resolve the mapping between the fedora resource identifier and the associated OCFL object.
+        final FedoraOCFLMapping mapping = fedoraOcflIndex.getMapping(operation.getResourceId());
+
+        //get the session.
+        final OCFLObjectSession objSession = findOrCreateSession(mapping.getOcflObjectId());
+
+        //resolve the persister based on the operation
+        final Persister persister = PERSISTER_LIST.stream().filter(p->p.handle(operation)).findFirst().orElse(null);
+
+        if(persister == null) {
+            throw new UnsupportedOperationException(format("The %s is not yet supported", operation.getClass()));
+        }
+
+
+
+        //perform the operation
+        persister.persist(objSession, operation, mapping);
+    }
+
+    private OCFLObjectSession findOrCreateSession(final String ocflId) {
+        final OCFLObjectSession sessionObj =  this.sessionMap.get(ocflId);
+        if(sessionObj != null) {
+            return sessionObj;
+        }
+
+        final File stagingDirectory = new File(stagingPathRoot, sessionId);
+        stagingDirectory.mkdir();
+        final OCFLObjectSession newSession = new DefaultOCFLObjectSession(ocflId, stagingDirectory.toPath(),null);
+        sessionMap.put(ocflId, newSession);
+        return newSession;
     }
 
     @Override

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
@@ -55,15 +55,18 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
 
     private final FedoraToOCFLObjectIndex fedoraOcflIndex;
 
-    private final Map<String,OCFLObjectSession> sessionMap;
+    private final Map<String, OCFLObjectSession> sessionMap;
 
+    //TODO make the stagingPathRoot configurable.
     private final File stagingPathRoot = new File(System.getProperty("java.io.tmpdir"), "ocfl-staging");
 
     private final static List<Persister> PERSISTER_LIST = new LinkedList<>();
+
     static {
-        PERSISTER_LIST.add( new CreateRDFSourcePersister());
+        PERSISTER_LIST.add(new CreateRDFSourcePersister());
         //TODO add new persisters here as they are implemented.
     }
+
     /**
      * Constructor
      *
@@ -78,9 +81,10 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
 
     /**
      * Constructor
+     * @param fedoraOcflIndex  the index
      */
     protected OCFLPersistentStorageSession(final FedoraToOCFLObjectIndex fedoraOcflIndex) {
-       this(null, fedoraOcflIndex);
+        this(null, fedoraOcflIndex);
     }
 
     @Override
@@ -99,12 +103,11 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
         final OCFLObjectSession objSession = findOrCreateSession(mapping.getOcflObjectId());
 
         //resolve the persister based on the operation
-        final Persister persister = PERSISTER_LIST.stream().filter(p->p.handle(operation)).findFirst().orElse(null);
+        final Persister persister = PERSISTER_LIST.stream().filter(p -> p.handle(operation)).findFirst().orElse(null);
 
-        if(persister == null) {
+        if (persister == null) {
             throw new UnsupportedOperationException(format("The %s is not yet supported", operation.getClass()));
         }
-
 
 
         //perform the operation
@@ -112,14 +115,14 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
     }
 
     private OCFLObjectSession findOrCreateSession(final String ocflId) {
-        final OCFLObjectSession sessionObj =  this.sessionMap.get(ocflId);
-        if(sessionObj != null) {
+        final OCFLObjectSession sessionObj = this.sessionMap.get(ocflId);
+        if (sessionObj != null) {
             return sessionObj;
         }
 
         final File stagingDirectory = new File(stagingPathRoot, sessionId);
         stagingDirectory.mkdir();
-        final OCFLObjectSession newSession = new DefaultOCFLObjectSession(ocflId, stagingDirectory.toPath(),null);
+        final OCFLObjectSession newSession = new DefaultOCFLObjectSession(ocflId, stagingDirectory.toPath(), null);
         sessionMap.put(ocflId, newSession);
         return newSession;
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/Persister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/Persister.java
@@ -30,7 +30,7 @@ public interface Persister<T extends ResourceOperation> {
 
     /**
      * The method returns true if the operation can be persisted by this persister.
-     * @param operation
+     * @param operation the operation to persist
      * @return true or false
      */
     boolean handle(ResourceOperation operation);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/Persister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/Persister.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.api;
+
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
+
+/**
+ * @param <T> The operation to be persisted.
+ *
+ * @author dbernstein
+ * @since 6.0.0
+ */
+public interface Persister<T extends ResourceOperation> {
+
+    /**
+     * The method returns true if the operation can be persisted by this persister.
+     * @param operation
+     * @return true or false
+     */
+    boolean handle(ResourceOperation operation);
+
+    /**
+     * The persistence handling for the given operation using the provided session and mapping.
+     * @param session The OCFL object session associated with the fedora resource
+     * @param operation The operation and associated data need to perform the operation.
+     * @param mapping The mapping information needed to perform the persistence operation
+     */
+    void persist(final OCFLObjectSession session, final T operation, final FedoraOCFLMapping mapping);
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/Persister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/Persister.java
@@ -37,7 +37,7 @@ public interface Persister<T extends ResourceOperation> {
 
     /**
      * The persistence handling for the given operation using the provided session and mapping.
-     * @param session The OCFL object session associated with the fedora resource
+     * @param session The session associated with the OCFL object
      * @param operation The operation and associated data need to perform the operation.
      * @param mapping The mapping information needed to perform the persistence operation
      */

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -33,23 +33,21 @@ import org.fcrepo.persistence.ocfl.api.Persister;
 public abstract class AbstractPersister<T extends ResourceOperation> implements Persister<T> {
 
     private ResourceOperationType resourceOperationType;
-    private Class clazz;
 
-    protected AbstractPersister(final ResourceOperationType resourceOperationType) {
+    AbstractPersister(final ResourceOperationType resourceOperationType) {
         this.resourceOperationType = resourceOperationType;
     }
 
     @Override
     public boolean handle(final ResourceOperation operation) {
         //get the class of T
-        final Class clazz = ((Class<T>) ((ParameterizedType) getClass()
-                .getGenericSuperclass()).getActualTypeArguments()[0]);
+        final var clazz = ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
 
         //retrieve the interfaces of the operation class
-        final Class[] interfaces = operation.getClass().getInterfaces();
+        final var interfaces = operation.getClass().getInterfaces();
 
         //ensure that at least one of them match.
-        for (Class i : interfaces) {
+        for (var i : interfaces) {
             if (clazz.equals(i)) {
                 //return true if the operation types match.
                 return this.resourceOperationType.equals(operation.getType());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import java.lang.reflect.ParameterizedType;
+
+
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.operations.ResourceOperationType;
+import org.fcrepo.persistence.ocfl.api.Persister;
+
+/**
+ * A base abstract persister class
+ *
+ * @author dbernstein
+ * @since 6.0.0
+ */
+public abstract class AbstractPersister<T extends ResourceOperation> implements Persister<T> {
+
+    private ResourceOperationType resourceOperationType;
+    private Class clazz;
+
+    protected AbstractPersister(final ResourceOperationType resourceOperationType) {
+        this.resourceOperationType = resourceOperationType;
+    }
+
+    @Override
+    public boolean handle(final ResourceOperation operation) {
+        //get the class of T
+        final Class clazz = ((Class<T>) ((ParameterizedType) getClass()
+                .getGenericSuperclass()).getActualTypeArguments()[0]);
+
+        //retrieve the interfaces of the operation class
+        final Class[] interfaces = operation.getClass().getInterfaces();
+
+        //ensure that at least one of them match.
+        for (Class i : interfaces) {
+            if (clazz.equals(i)) {
+                //return true if the operation types match.
+                return this.resourceOperationType.equals(operation.getType());
+            }
+        }
+        return false;
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
+
+/**
+ * This class implements the persistence of a new RDFSource
+ *
+ * @author dbernstein
+ * @since 6.0.0
+ */
+public class CreateRDFSourcePersister extends AbstractPersister<NonRdfSourceOperation> {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(CreateRDFSourcePersister.class);
+
+    /**
+     * Constructor
+     */
+    public CreateRDFSourcePersister() {
+        super(CREATE);
+    }
+
+    @Override
+    public void persist(final OCFLObjectSession session, final NonRdfSourceOperation operation,
+                        final FedoraOCFLMapping mapping) {
+        LOGGER.warn("Persisting of " + operation.getClass() + " not implemented yet!");
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
@@ -32,7 +32,7 @@ import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
  */
 public class CreateRDFSourcePersister extends AbstractPersister<NonRdfSourceOperation> {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(CreateRDFSourcePersister.class);
+    private static final Logger log = LoggerFactory.getLogger(CreateRDFSourcePersister.class);
 
     /**
      * Constructor
@@ -44,6 +44,6 @@ public class CreateRDFSourcePersister extends AbstractPersister<NonRdfSourceOper
     @Override
     public void persist(final OCFLObjectSession session, final NonRdfSourceOperation operation,
                         final FedoraOCFLMapping mapping) {
-        LOGGER.warn("Persisting of {} not implemented yet!", operation.getClass());
+        log.warn("Persisting of {} not implemented yet!", operation.getClass());
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
@@ -44,6 +44,6 @@ public class CreateRDFSourcePersister extends AbstractPersister<NonRdfSourceOper
     @Override
     public void persist(final OCFLObjectSession session, final NonRdfSourceOperation operation,
                         final FedoraOCFLMapping mapping) {
-        LOGGER.warn("Persisting of " + operation.getClass() + " not implemented yet!");
+        LOGGER.warn("Persisting of {} not implemented yet!", operation.getClass());
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.fcrepo.persistence.ocfl.api.CommitOption;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 
+import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
-import edu.wisc.library.ocfl.api.model.ObjectId;
 
 /**
  * Default implementation of an OCFL object session, which stages changes to the
@@ -129,7 +129,7 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
     public InputStream read(final String subpath, final String version) {
         final AtomicReference<InputStream> contentRef = new AtomicReference<>();
 
-        ocflRepository.readObject(ObjectId.version(objectIdentifier, version), reader -> {
+        ocflRepository.readObject(ObjectVersionId.version(objectIdentifier, version), reader -> {
             contentRef.set(reader.getFile(subpath));
         });
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
@@ -42,7 +42,6 @@ public class FedoraOCFLMapping {
      * the fedora resource associated with this mapping in the case that the resource was
      * part of an Archival Group.  In the case of binary descriptive metadata, this identifer
      * will correspond to "root" or "parent" of the resource.
-     * @see {@link org.fcrepo.persistence.ocfl.FedoraToOCFLObjectIndex}
      * @return the fedora resource identifier
      */
     public String getParentFedoraResourceId() {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+/**
+ * A data structure that linking parent fedora resource identifiers to its corresponding OCFL Object Id.
+ *
+ * @author dbernstein
+ */
+public class FedoraOCFLMapping {
+    private String parentFedoraResourceId;
+    private String ocflObjectId;
+
+    /**
+     * Default constructor
+     * @param parentFedoraResourceId The parent fedora resource identifier
+     * @param ocflObjectId The OCFL Object identitifer
+     */
+    public FedoraOCFLMapping(final String parentFedoraResourceId, final String ocflObjectId){
+        this.parentFedoraResourceId = parentFedoraResourceId;
+        this.ocflObjectId = ocflObjectId;
+    }
+
+    /**
+     * Retrieve the parent fedora resource identifier associated with the OCFL Object Id.
+     * It is a "parent" identifier because it refers to the Archival Group identifier for
+     * the fedora resource associated with this mapping in the case that the resource was
+     * part of an Archival Group.  In the case of binary descriptive metadata, this identifer
+     * will correspond to "root" or "parent" of the resource.
+     * @see {@link org.fcrepo.persistence.ocfl.FedoraToOCFLObjectIndex}
+     * @return the fedora resource identifier
+     */
+    public String getParentFedoraResourceId() {
+        return parentFedoraResourceId;
+    }
+
+    /**
+     * Retrieve the OCFL object identifier associated with the Fedora resource
+     * @return the ocfl object identifier
+     */
+    public String getOcflObjectId() {
+        return ocflObjectId;
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
@@ -18,7 +18,7 @@
 package org.fcrepo.persistence.ocfl.impl;
 
 /**
- * A data structure that linking parent fedora resource identifiers to its corresponding OCFL Object Id.
+ * A mapping that links the parent fedora resource to its corresponding OCFL object.
  *
  * @author dbernstein
  */
@@ -37,11 +37,7 @@ public class FedoraOCFLMapping {
     }
 
     /**
-     * Retrieve the parent fedora resource identifier associated with the OCFL Object Id.
-     * It is a "parent" identifier because it refers to the Archival Group identifier for
-     * the fedora resource associated with this mapping in the case that the resource was
-     * part of an Archival Group.  In the case of binary descriptive metadata, this identifer
-     * will correspond to "root" or "parent" of the resource.
+     * The id for the fedora resource which represents this ocfl object
      * @return the fedora resource identifier
      */
     public String getParentFedoraResourceId() {

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManagerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManagerTest.java
@@ -17,23 +17,32 @@
  */
 package org.fcrepo.persistence.ocfl;
 
-import static java.util.UUID.randomUUID;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
-import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
-
+import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.Silent.class)
+import static java.util.UUID.randomUUID;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link org.fcrepo.persistence.ocfl.OCFLPersistentSessionManager}
+ *
+ * @author dbernstein
+ */
+@RunWith(MockitoJUnitRunner.class)
 public class OCFLPersistentSessionManagerTest {
 
-    private PersistentStorageSessionManager sessionFactory;
+    @InjectMocks
+    private OCFLPersistentSessionManager sessionFactory;
 
     private PersistentStorageSession readWriteSession;
 
@@ -49,16 +58,25 @@ public class OCFLPersistentSessionManagerTest {
     @Mock
     private ResourceOperation mockOperation;
 
+    @Mock
+    private FedoraToOCFLObjectIndex index;
+
+    @Mock
+    private FedoraOCFLMapping mapping;
+
     @Before
     public void setUp() {
-        this.sessionFactory = new OCFLPersistentSessionManager();
         readWriteSession = this.sessionFactory.getSession(testSessionId);
         readOnlySession = this.sessionFactory.getReadOnlySession();
     }
 
-    @Test
+    @Test(expected = UnsupportedOperationException.class)
     public void testNormalSession() throws Exception {
-
+        final String resourceId = "resource1";
+        final String ocflObjectId = "ocflObjectId";
+        when(mockOperation.getResourceId()).thenReturn(resourceId);
+        when(index.getMapping(eq(resourceId))).thenReturn(mapping);
+        when(mapping.getOcflObjectId()).thenReturn(ocflObjectId);
         readWriteSession.persist(mockOperation);
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractPersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractPersisterTest.java
@@ -1,0 +1,43 @@
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author dbernstein
+ * @since 6.0.0
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractPersisterTest {
+
+    @Mock
+    private NonRdfSourceOperation nonRdfSourceOperation;
+
+
+    @Test
+    public void testHandle() {
+        class MyPersister extends AbstractPersister<NonRdfSourceOperation> {
+           MyPersister(){
+               super(CREATE);
+           }
+
+            @Override
+            public void persist(final OCFLObjectSession session,
+                                final NonRdfSourceOperation operation,
+                                final FedoraOCFLMapping mapping) {}
+        }
+
+        when(nonRdfSourceOperation.getType()).thenReturn(CREATE);
+        final MyPersister mp = new MyPersister();
+        assertTrue(mp.handle(nonRdfSourceOperation));
+    }
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractPersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractPersisterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.fcrepo.persistence.ocfl.impl;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;


### PR DESCRIPTION
…pave

way for implementating the various persist operations it will need to support.

Resolves:  https://jira.duraspace.org/browse/FCREPO-3081


* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
It fleshes out the OCFLPersistentStorageSession.persist() method by providing a framework for plugging in persist handlers for the various operations we intend to support.

# What's new?
Developers now need only implement the org.fcrepo.persistence.ocfl.Persister  interface and add it to the OCFLPersistentStorageSession.PERSISTER_LIST in order to support a new kind of ResourceOperation.  See CreateRDFSourcePersister as an example (which is currently only minimally implemented).

# How should this be tested?
Unit tests where it made sense.  Integration tests will cover functionality once we're able to turn them back on.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
