### PR TITLE
Adds HttpRdfService to help translate uris to fedora ids in the rdf.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -978,8 +978,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                                              final MediaType contentType,
                                              final RdfStream resourceTriples) throws MalformedRdfException {
 
-        final Model inputModel = httpRdfService.bodyToInternalModel(resource, requestBodyStream, contentType,
-                                                                    httpIdentifierConverter);
+        final Model inputModel = httpRdfService.bodyToInternalModel(resource.getId(), requestBodyStream, contentType);
+
 
         ensureValidMemberRelation(inputModel);
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -80,18 +80,19 @@ public class HttpRdfService {
         while (stmtIterator.hasNext()) {
             final Statement stmt = stmtIterator.nextStatement();
             final String originalSubj = stmt.getSubject().getURI();
-            final String subj = idTranslator.convert(originalSubj);
+            final String subj = idTranslator.inExternalDomain(originalSubj) ?
+                idTranslator.toInternalId(originalSubj) : originalSubj;
 
             RDFNode obj = stmt.getObject();
             if (stmt.getObject().isResource()) {
                 final String objString = stmt.getObject().asResource().getURI();
-                obj = model.getResource(idTranslator.convert(objString));
+                obj = model.getResource(idTranslator.inExternalDomain(objString) ?
+                    idTranslator.toInternalId(objString) : objString);
             }
 
             if (!subj.equals(originalSubj) || !obj.equals(stmt.getObject())) {
                 insertStatements.add(new StatementImpl(model.getResource(subj),
-                        stmt.getPredicate(),
-                        obj));
+                    stmt.getPredicate(), obj));
 
                 stmtIterator.remove();
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.http.api.services;
+
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
+import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import java.io.InputStream;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.MediaType;
+import org.apache.jena.atlas.RuntimeIOException;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RiotException;
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.slf4j.Logger;
+
+/**
+ * A service that will translate the resourceURI to fedora ID in the Rdf InputStream
+ *
+ * @author bseeger
+ * @author bbpennel
+ * @since 2019-11-07
+ */
+
+public class HttpRdfService {
+
+    private static final Logger LOGGER = getLogger(HttpRdfService.class);
+
+    /**
+     * Parse the request body to a Model, with the URI to Fedora ID translations done.
+     *
+     * @param resource the fedora resource
+     * @param stream the input stream containing the RDF
+     * @param contentType the media type of the RDF
+     * @param idTranslator the uri to fedora resource ID translator
+     * @return RdfStream containing triples from request body, with fedora IDs in them
+     * @throws MalformedRdfException in case rdf json cannot be parsed
+     * @throws BadRequestException in the case where the RDF syntax is bad
+     */
+    public Model bodyToInternalModel(final FedoraResource resource, final InputStream stream,
+                                     final MediaType contentType, final HttpIdentifierConverter idTranslator)
+                                     throws RepositoryRuntimeException, BadRequestException {
+
+        final Model model = parseBodyAsModel(stream, contentType, resource);
+
+        final StmtIterator stmtIterator = model.listStatements();
+        while (stmtIterator.hasNext()) {
+            final Statement stmt = stmtIterator.next();
+
+            String subj = stmt.getSubject().getURI().toString();
+            subj = subj.replace(subj, idTranslator.convert(subj));
+            String obj = stmt.getObject().asLiteral().toString();
+            if (stmt.getObject().isURIResource()) {
+                obj = stmt.getObject().asLiteral().toString().replace(obj, idTranslator.convert(obj));
+            }
+
+            model.getResource(subj).addProperty(stmt.getPredicate(), obj);
+            stmtIterator.remove();
+        }
+
+        LOGGER.debug("Model: {}", model);
+        return model;
+    }
+
+     /**
+     * Parse the request body to a RdfStream, with the URI to Fedora ID translations done.
+     *
+     * @param resource the fedora resource
+     * @param stream the input stream containing the RDF
+     * @param contentType the media type of the RDF
+     * @param idTranslator the uri to fedora resource ID translator
+     * @return RdfStream containing triples from request body, with fedora IDs in them
+     * @throws MalformedRdfException in case rdf json cannot be parsed
+     * @throws BadRequestException in the case where the RDF syntax is bad
+     */
+    public RdfStream bodyToInternalStream(final FedoraResource resource, final InputStream stream,
+                                          final MediaType contentType, final HttpIdentifierConverter idTranslator)
+                                          throws RepositoryRuntimeException, BadRequestException {
+        final Model model = bodyToInternalModel(resource, stream, contentType, idTranslator);
+
+        return fromModel(model.getResource(resource.getId()).asNode(), model);
+    }
+
+    /**
+     * Parse the request body as a Model.
+     *
+     * @param requestBodyStream rdf request body
+     * @param contentType content type of body
+     * @param resource the fedora resource
+     * @return Model containing triples from request body
+     * @throws MalformedRdfException in case rdf json cannot be parsed
+     * @throws BadRequestException in the case where the RDF syntax is bad
+     */
+    public static Model parseBodyAsModel(final InputStream requestBodyStream,
+                                         final MediaType contentType,
+                                         final FedoraResource resource) throws BadRequestException,
+                                         RepositoryRuntimeException {
+        final Lang format = contentTypeToLang(contentType.toString());
+
+        final Model inputModel;
+        try {
+            inputModel = createDefaultModel();
+            inputModel.read(requestBodyStream, resource.getId(), format.getName().toUpperCase());
+            return inputModel;
+        } catch (final RiotException e) {
+            throw new BadRequestException("RDF was not parsable: " + e.getMessage(), e);
+
+        } catch (final RuntimeIOException e) {
+            if (e.getCause() instanceof JsonParseException) {
+                throw new MalformedRdfException(e.getCause());
+            }
+            throw new RepositoryRuntimeException(e);
+        }
+    }
+
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
@@ -18,21 +18,32 @@
 package org.fcrepo.http.api.services;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.when;
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
+import static org.slf4j.LoggerFactory.getLogger;
 
-import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
-import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.RdfStream;
 import javax.ws.rs.core.MediaType;
+//import javax.ws.rs.BadRequestException;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.graph.Triple;
+//import org.junit.Ignore;
+import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.junit.Ignore;
 import org.junit.Test;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.runner.RunWith;
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.RdfStream;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import org.slf4j.Logger;
 
 /**
  * Unit tests for HttpRdfService
@@ -43,6 +54,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class HttpRdfServiceTest {
 
 
+    private static final Logger log = getLogger(HttpRdfService.class);
+
     @Mock
     HttpIdentifierConverter idTranslator;
 
@@ -52,41 +65,82 @@ public class HttpRdfServiceTest {
     @InjectMocks
     private HttpRdfService httpRdfService;
 
-    private final String resourceUri = "www.example.com/fedora/rest/resource1";
-    private final String systemId = "info:fedora/resource1";
-    private final String rdfString = "@prefix dc: <http://purl.org/dc/elements/1.1/> . \n" +
-                "<www.example.com/resource1>\n" +
-                "dc:title 'fancy title'\n";
+    private final String fedoraUri = "http://www.example.com/fedora/rest/resource1";
+    private final String fedoraId = "info:fedora/resource1";
+    private final String externalUri = "http://www.otherdomain.org/resource5";
+    private final String rdfString = String.format("@prefix dc: <http://purl.org/dc/elements/1.1/> . " +
+                "@prefix dcterms: <http://purl.org/dc/terms/> ." +
+                "<%s>  dc:title 'fancy title' ;" +
+                "  dcterms:isPartOf <%s>, <%s> . ", fedoraUri, externalUri, fedoraUri);
+
+
     private final MediaType contentType = new MediaType("text", "turtle");
     private final InputStream requestBodyStream = new ByteArrayInputStream(rdfString.getBytes());
+
+    private final String badRdfString = String.format("@prefix dc: <http://purl.org/dc/elements/1.1/> . \n" +
+            "@prefix dcterms: <http://purl.org/dc/terms/> .\n" +
+            "<%s> dc:title ; 'fancy title' . \n" +
+            " dcterms:isPartOf <%s>; \n" +
+            " dcterms:isPartOf <%s>.\n", fedoraUri, externalUri, fedoraUri);
+    private final InputStream badRequestStream = new ByteArrayInputStream(rdfString.getBytes());
+
+    @Test (expected = MalformedRdfException.class)
+    @Ignore
+    public void testGetModelWithBadRdf() throws Exception {
+        when(idTranslator.convert(fedoraUri)).thenReturn(fedoraId);
+        when(resource.getId()).thenReturn(fedoraId);
+
+        final Model model = httpRdfService.bodyToInternalModel(fedoraUri, badRequestStream,
+            contentType);
+    }
 
     @Test
     @Ignore
     public void testGetModelFromInputStream() {
-        when(idTranslator.convert(resourceUri)).thenReturn("info:fedora/resource1");
-        when(resource.getId()).thenReturn("info:fedora/resource1");
+        when(idTranslator.convert(fedoraUri)).thenReturn(fedoraId);
+        when(resource.getId()).thenReturn(fedoraId);
 
-        final Model model = httpRdfService.bodyToInternalModel(resource, requestBodyStream,
-            contentType, idTranslator);
+
+        final Model model = httpRdfService.bodyToInternalModel(fedoraUri, requestBodyStream,
+            contentType);
 
         assertTrue(model.listStatements().toList().size() > 0);
 
-        // TODO - look at triples and ensure that the URI has been changed to an internal Fedora ID
+        verifyTriples(model);
     }
 
     @Test
     @Ignore
     public void testGetRdfStreamFromInputStream() {
-        when(idTranslator.convert(resourceUri)).thenReturn("info:fedora/resource1");
+        when(idTranslator.convert(fedoraUri)).thenReturn("info:fedora/resource1");
 
-        final RdfStream stream = httpRdfService.bodyToInternalStream(resource, requestBodyStream,
-            contentType, idTranslator);
+        final RdfStream stream = httpRdfService.bodyToInternalStream(fedoraUri, requestBodyStream,
+            contentType);
 
         assertTrue(stream.toString().length() > 0);
-
-        // TODO - look at triples and ensure that the URI has been changed to an internal Fedora ID
+        verifyTriples(stream);
     }
 
+    private void verifyTriples(final Model model)  {
+        verifyTriples(fromModel(model.getResource(fedoraId).asNode(),model));
+    }
 
+    private void verifyTriples(final RdfStream rdfStream) {
 
+        final Integer numOutsideDomain = Integer.valueOf(0);
+
+        final List<Triple> triples = rdfStream.map(triple -> {
+            log.info("\nTriple: s: '{}' p: '{}' o: '{}'\n", triple.getSubject().getURI(),
+                triple.getPredicate().getURI(),
+                triple.getObject().isURI() ? triple.getObject().getURI() : "notta");
+            assertFalse(triple.getSubject().getURI().equals(fedoraUri));
+            assertFalse(triple.getObject().isURI() && triple.getObject().toString().equals(fedoraUri));
+            return triple;
+        })
+        .filter(triple -> triple.getObject().isURI() && triple.getObject().getURI().equals(externalUri))
+        .collect(Collectors.toList());
+
+        log.info("external URI triples: {}", triples.size());
+        assertTrue(triples.size() == 1);
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api.services;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.RdfStream;
+import javax.ws.rs.core.MediaType;
+import org.apache.jena.rdf.model.Model;
+import org.junit.Ignore;
+import org.junit.Test;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for HttpRdfService
+ * @author bseeger
+ * @since 2019-11-08
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class HttpRdfServiceTest {
+
+
+    @Mock
+    HttpIdentifierConverter idTranslator;
+
+    @Mock
+    FedoraResource resource;
+
+    @InjectMocks
+    private HttpRdfService httpRdfService;
+
+    private final String resourceUri = "www.example.com/fedora/rest/resource1";
+    private final String systemId = "info:fedora/resource1";
+    private final String rdfString = "@prefix dc: <http://purl.org/dc/elements/1.1/> . \n" +
+                "<www.example.com/resource1>\n" +
+                "dc:title 'fancy title'\n";
+    private final MediaType contentType = new MediaType("text", "turtle");
+    private final InputStream requestBodyStream = new ByteArrayInputStream(rdfString.getBytes());
+
+    @Test
+    @Ignore
+    public void testGetModelFromInputStream() {
+        when(idTranslator.convert(resourceUri)).thenReturn("info:fedora/resource1");
+        when(resource.getId()).thenReturn("info:fedora/resource1");
+
+        final Model model = httpRdfService.bodyToInternalModel(resource, requestBodyStream,
+            contentType, idTranslator);
+
+        assertTrue(model.listStatements().toList().size() > 0);
+
+        // TODO - look at triples and ensure that the URI has been changed to an internal Fedora ID
+    }
+
+    @Test
+    @Ignore
+    public void testGetRdfStreamFromInputStream() {
+        when(idTranslator.convert(resourceUri)).thenReturn("info:fedora/resource1");
+
+        final RdfStream stream = httpRdfService.bodyToInternalStream(resource, requestBodyStream,
+            contentType, idTranslator);
+
+        assertTrue(stream.toString().length() > 0);
+
+        // TODO - look at triples and ensure that the URI has been changed to an internal Fedora ID
+    }
+
+
+
+}


### PR DESCRIPTION
HttpRdfService will translate from resource URI to internal resource ID

This is part of https://jira.duraspace.org/browse/FCREPO-3060 and is used by any of the code that needs the URIs to be translated into internal fedora IDs. 

**JIRA Ticket**: part of https://jira.duraspace.org/browse/FCREPO-3060


# What does this Pull Request do?
Adds a service at the HTTP Layer that will look at the InputStream rdf and return it as a Model or RdfStream, having translated the URIs into internal fedora ids in the data. 


# Interested parties
@whikloj @bbpennel 