### PR TITLE
FCREPO-3095 - Implement OCFL Object Session

### DIFF
--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentSessionClosedException.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentSessionClosedException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.api.exceptions;
+
+
+/**
+ * Exception indicating that a persistence session is closed.
+ *
+ * @author bbpennel
+ */
+public class PersistentSessionClosedException extends PersistentStorageException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor with message
+     *
+     * @param msg message
+     */
+    public PersistentSessionClosedException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructor with message and cause
+     *
+     * @param msg message
+     * @param e cause
+     */
+    public PersistentSessionClosedException(final String msg, final Throwable e) {
+        super(msg, e);
+    }
+}

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentStorageException.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentStorageException.java
@@ -39,4 +39,13 @@ public class PersistentStorageException extends Exception {
         super(msg);
     }
 
+    /**
+     * Constructor
+     *
+     * @param msg message
+     * @param e cause
+     */
+    public PersistentStorageException(final String msg, final Throwable e) {
+        super(msg, e);
+    }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -48,6 +48,13 @@ public interface OCFLObjectSession {
     void delete(String subpath) throws PersistentStorageException;
 
     /**
+     * Delete the object specified by this session
+     *
+     * @throws PersistentStorageException if unable to delete the object
+     */
+    void deleteObject() throws PersistentStorageException;
+
+    /**
      * Read the state of the file at the specified subpath within the ocfl object as it exists within the current
      * session.
      *
@@ -79,7 +86,8 @@ public interface OCFLObjectSession {
      *
      * @param commitOption option indicating where changes should be committed.
      * @return identifier of the version committed
+     * @throws PersistentStorageException if unable to commit
      */
-    String commit(CommitOption commitOption);
+    String commit(CommitOption commitOption) throws PersistentStorageException;
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -20,6 +20,9 @@ package org.fcrepo.persistence.ocfl.api;
 
 import java.io.InputStream;
 
+import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+
 /**
  * A session for building and tracking the state of an OCFL object within a persistence session.
  *
@@ -32,15 +35,17 @@ public interface OCFLObjectSession {
      *
      * @param subpath path of the resource to write, relative to the OCFL object
      * @param stream stream of content to write
+     * @throws PersistentStorageException thrown if unable to persist content
      */
-    void write(String subpath, InputStream stream);
+    void write(String subpath, InputStream stream) throws PersistentStorageException;
 
     /**
      * Delete a file from this ocfl object.
      *
      * @param subpath path of the file relative to a version of an ocfl object
+     * @throws PersistentStorageException if unable to delete file
      */
-    void delete(String subpath);
+    void delete(String subpath) throws PersistentStorageException;
 
     /**
      * Read the state of the file at the specified subpath within the ocfl object as it exists within the current
@@ -48,8 +53,9 @@ public interface OCFLObjectSession {
      *
      * @param subpath path of the file relative to a version of an ocfl object
      * @return contents of the file as an InputStream.
+     * @throws PersistentItemNotFoundException if the file or object is not found
      */
-    InputStream read(String subpath);
+    InputStream read(String subpath) throws PersistentItemNotFoundException;
 
     /**
      * Read the state of the file at subpath from the specified version of the OCFL object.
@@ -57,8 +63,9 @@ public interface OCFLObjectSession {
      * @param subpath path relative to the object
      * @param version identifier of the version
      * @return the contents of the file from the specified version
+     * @throws PersistentItemNotFoundException if the file or object is not found
      */
-    InputStream read(String subpath, String version);
+    InputStream read(String subpath, String version) throws PersistentItemNotFoundException;
 
     /**
      * Verify that the change set in this session can be committed. A PersistentStorageException is thrown if there
@@ -71,7 +78,8 @@ public interface OCFLObjectSession {
      * Creates the OCFL object if it did not previous exist.
      *
      * @param commitOption option indicating where changes should be committed.
+     * @return identifier of the version committed
      */
-    void commit(CommitOption commitOption);
+    String commit(CommitOption commitOption);
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -90,4 +90,11 @@ public interface OCFLObjectSession {
      */
     String commit(CommitOption commitOption) throws PersistentStorageException;
 
+    /**
+     * Close this session without committing changes.
+     *
+     * @throws PersistentStorageException if unable to close the session.
+     */
+    void close() throws PersistentStorageException;
+
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -20,7 +20,6 @@ package org.fcrepo.persistence.ocfl.api;
 
 import java.io.InputStream;
 
-import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 /**
@@ -60,9 +59,9 @@ public interface OCFLObjectSession {
      *
      * @param subpath path of the file relative to a version of an ocfl object
      * @return contents of the file as an InputStream.
-     * @throws PersistentItemNotFoundException if the file or object is not found
+     * @throws PersistentStorageException if unable to read the file
      */
-    InputStream read(String subpath) throws PersistentItemNotFoundException;
+    InputStream read(String subpath) throws PersistentStorageException;
 
     /**
      * Read the state of the file at subpath from the specified version of the OCFL object.
@@ -70,9 +69,9 @@ public interface OCFLObjectSession {
      * @param subpath path relative to the object
      * @param version identifier of the version
      * @return the contents of the file from the specified version
-     * @throws PersistentItemNotFoundException if the file or object is not found
+     * @throws PersistentStorageException if unable to read the file
      */
-    InputStream read(String subpath, String version) throws PersistentItemNotFoundException;
+    InputStream read(String subpath, String version) throws PersistentStorageException;
 
     /**
      * Verify that the change set in this session can be committed. A PersistentStorageException is thrown if there

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -17,20 +17,32 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import static edu.wisc.library.ocfl.api.OcflOption.OVERWRITE;
+import static edu.wisc.library.ocfl.api.OcflOption.MOVE_SOURCE;
 import static org.fcrepo.persistence.ocfl.api.CommitOption.NEW_VERSION;
-import static org.fcrepo.persistence.ocfl.api.CommitOption.MUTABLE_HEAD;
+import static java.lang.String.format;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
+import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.CommitOption;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import edu.wisc.library.ocfl.api.OcflObjectUpdater;
+import edu.wisc.library.ocfl.api.exception.NotFoundException;
+import edu.wisc.library.ocfl.api.model.CommitInfo;
 
 /**
  * Default implementation of an OCFL object session, which stages changes to the
@@ -61,25 +73,27 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
         this.objectIdentifier = objectIdentifier;
         this.stagingPath = stagingPath;
         this.ocflRepository = ocflRepository;
-    }
-
-    private Set<String> getDeletePaths() {
-        if (deletePaths == null) {
-            // TODO check to see if a delete log exists, in case resuming after reboot
-            deletePaths = new HashSet<>();
-        }
-        return deletePaths;
+        this.deletePaths = new HashSet<>();
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void write(final String subpath, final InputStream stream) {
-        // TODO write contents to the subpath within the staging path
-
+    public void write(final String subpath, final InputStream stream) throws PersistentStorageException {
         // Determine the staging path for the incoming content
-        resolveStagedPath(subpath);
+        final var stagedPath = resolveStagedPath(subpath);
+        final var parentPath = stagedPath.getParent();
+
+        try {
+            // Fill in any missing parent directories
+            Files.createDirectories(parentPath);
+            // write contents to subpath within the staging path
+            Files.copy(stream, stagedPath, StandardCopyOption.REPLACE_EXISTING);
+            stream.close();
+        } catch (final IOException e) {
+            throw new PersistentStorageException("Unable to persist content to " + stagedPath, e);
+        }
     }
 
     /**
@@ -89,51 +103,87 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
      * deletion will be recorded for replay at commit time.
      */
     @Override
-    public void delete(final String subpath) {
-        if (newInSession(subpath)) {
-            // TODO delete the file from the staging path
-        } else {
-            getDeletePaths().add(subpath);
+    public void delete(final String subpath) throws PersistentStorageException {
+        final var stagedPath = resolveStagedPath(subpath);
+        final var hasStagedChanges = hasStagedChanges(stagedPath);
+
+        if (hasStagedChanges) {
+            // delete the file from the staging path
+            try {
+                Files.delete(stagedPath);
+            } catch (final IOException e) {
+                throw new PersistentStorageException("Unable to delete " + stagedPath, e);
+            }
+        }
+
+        // for file that existed before this session, queue up its deletion for commit time
+        if (!newInSession(subpath)) {
+            deletePaths.add(subpath);
+        } else if (!hasStagedChanges) {
+            // Doesn't exist in staging or head version, so file doesn't exist
+            throw new PersistentItemNotFoundException(format("Could not find %s within object %s",
+                    subpath, objectIdentifier));
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     private boolean newInSession(final String subpath) {
-        // TODO determine if this subpath exists in the OCFL object
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public InputStream read(final String subpath) {
-        if (hasStagedChanges(subpath)) {
-            // TODO read the staged version of the file
-        } else {
-            // TODO read the head version of the file from the ocfl object
+        // If the object isn't created yet, then there is no history for the subpath
+        if (!ocflRepository.containsObject(objectIdentifier)) {
+            return true;
         }
-        return null;
-    }
-
-    private boolean hasStagedChanges(final String subpath) {
-        return false;
+        // determine if this subpath exists in the OCFL object
+        return !ocflRepository.getObject(ObjectVersionId.head(objectIdentifier))
+                .containsFile(subpath);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public InputStream read(final String subpath, final String version) {
-        final AtomicReference<InputStream> contentRef = new AtomicReference<>();
+    public InputStream read(final String subpath) throws PersistentItemNotFoundException {
+        final var stagedPath = resolveStagedPath(subpath);
 
-        ocflRepository.readObject(ObjectVersionId.version(objectIdentifier, version), reader -> {
-            contentRef.set(reader.getFile(subpath));
-        });
+        if (hasStagedChanges(stagedPath)) {
+            // prioritize read of the staged version of the file
+            try {
+                return new FileInputStream(stagedPath.toFile());
+            } catch (final FileNotFoundException e) {
+                throw new PersistentItemNotFoundException(format("Could not find %s within object %s",
+                        subpath, objectIdentifier));
+            }
+        } else {
+            // Fall back to the head version
+            return readVersion(subpath, ObjectVersionId.head(objectIdentifier));
+        }
+    }
 
-        return contentRef.get();
+    private boolean hasStagedChanges(final Path path) {
+        return path.toFile().exists();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InputStream read(final String subpath, final String version) throws PersistentItemNotFoundException {
+        return readVersion(subpath, ObjectVersionId.version(objectIdentifier, version));
+    }
+
+    private InputStream readVersion(final String subpath, final ObjectVersionId version) throws PersistentItemNotFoundException {
+        try {
+            // read the head version of the file from the ocfl object
+            final var file = ocflRepository.getObject(version)
+                    .getFile(subpath);
+            if (file == null) {
+                throw new PersistentItemNotFoundException(format("Could not find %s within object %s version %s",
+                        subpath, objectIdentifier, version.getVersionId()));
+            }
+            return file.getStream();
+        } catch (final NotFoundException e) {
+            throw new PersistentItemNotFoundException(format(
+                    "Unable to read %s from object %s version %s, object was not found.",
+                    subpath, objectIdentifier, version.getVersionId()));
+        }
     }
 
     /**
@@ -141,30 +191,78 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
      */
     @Override
     public void prepare() {
-        // TODO check for conflicts
+        // TODO check for conflicts and lock the object
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void commit(final CommitOption commitOption) {
+    public String commit(final CommitOption commitOption) {
+        if (commitOption == null) {
+            throw new IllegalArgumentException("Invalid commit option provided: " + commitOption);
+        }
         // Determine if a new object needs to be created
         if (isNewObject()) {
-            // TODO create new object from the staged content
+            return commitNewObject(commitOption);
         } else {
-            if (NEW_VERSION.equals(commitOption)) {
-                // TODO perform commit to new version
-            } else if (MUTABLE_HEAD.equals(commitOption)) {
-                // TODO perform commit to head version
+            return commitUpdates(commitOption);
+        }
+    }
+
+    private String commitNewObject(final CommitOption commitOption) {
+        final var commitInfo = new CommitInfo().setMessage("initial commit");
+
+        if (NEW_VERSION.equals(commitOption)) {
+            // perform commit to new version
+            return ocflRepository.putObject(ObjectVersionId.head(objectIdentifier),
+                    stagingPath,
+                    commitInfo,
+                    MOVE_SOURCE)
+                    .getVersionId()
+                    .toString();
+        } else {
+            // perform commit to head version
+            return ocflRepository.stageChanges(ObjectVersionId.head(objectIdentifier), commitInfo, updater -> {
+                updater.addPath(stagingPath, "", MOVE_SOURCE);
+            }).getVersionId().toString();
+        }
+    }
+
+    private String commitUpdates(final CommitOption commitOption) {
+        // Updater which pushes all updated files and then performs queued deletes
+        final Consumer<OcflObjectUpdater> commitChangeUpdater = updater -> {
+            updater.addPath(stagingPath, "", MOVE_SOURCE, OVERWRITE);
+            deletePaths.forEach(updater::removeFile);
+        };
+
+        if (NEW_VERSION.equals(commitOption)) {
+            // check if a mutable head exists for this object
+            if (ocflRepository.hasStagedChanges(objectIdentifier)) {
+                // Persist the current changes to the mutable head, and then commit the head as a version
+                ocflRepository.stageChanges(ObjectVersionId.head(objectIdentifier),
+                        new CommitInfo(),
+                        commitChangeUpdater);
+                return ocflRepository.commitStagedChanges(objectIdentifier, new CommitInfo())
+                        .getVersionId().toString();
             } else {
-                throw new IllegalArgumentException("Invalid commit option provided: " + commitOption);
+                // Commit directly to a new version
+                return ocflRepository.updateObject(ObjectVersionId.head(objectIdentifier),
+                        new CommitInfo(),
+                        commitChangeUpdater)
+                        .getVersionId().toString();
             }
+        } else {
+            // perform commit to mutable head version
+            return ocflRepository.stageChanges(ObjectVersionId.head(objectIdentifier),
+                    new CommitInfo(),
+                    commitChangeUpdater)
+                    .getVersionId().toString();
         }
     }
 
     private boolean isNewObject() {
-        return false;
+        return !ocflRepository.containsObject(objectIdentifier);
     }
 
     private Path resolveStagedPath(final String subpath) {

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.fcrepo.persistence.ocfl.api.CommitOption.NEW_VERSION;
+import static org.fcrepo.persistence.ocfl.api.CommitOption.MUTABLE_HEAD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static edu.wisc.library.ocfl.api.OcflOption.MOVE_SOURCE;
+import static java.lang.String.format;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.commons.io.IOUtils;
+import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import edu.wisc.library.ocfl.api.OcflObjectVersion;
+import edu.wisc.library.ocfl.api.model.CommitInfo;
+import edu.wisc.library.ocfl.api.model.ObjectVersionId;
+import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
+import edu.wisc.library.ocfl.core.mapping.ObjectIdPathMapperBuilder;
+import edu.wisc.library.ocfl.core.storage.FileSystemOcflStorage;
+
+/**
+ * @author bbpennel
+ *
+ */
+public class DefaultOCFLObjectSessionTest {
+
+    private final static String OBJ_ID = "obj1";
+
+    private final static String FILE1_SUBPATH = "test_file1.txt";
+
+    private final static String FILE2_SUBPATH = "test_file2.txt";
+
+    private final static String FILE_CONTENT1 = "Some content";
+
+    private final static String FILE_CONTENT2 = "Content, 6.0";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private Path stagingPath;
+
+    private DefaultOCFLObjectSession session;
+
+    private MutableOcflRepository ocflRepository;
+
+    @Before
+    public void setup() throws Exception {
+        tempFolder.create();
+
+        stagingPath = tempFolder.newFolder("obj1-staging").toPath();
+        final var repoDir = tempFolder.newFolder("ocfl-repo").toPath();
+        final var workDir = tempFolder.newFolder("ocfl-work").toPath();
+
+        ocflRepository = new OcflRepositoryBuilder().buildMutable(
+                new FileSystemOcflStorage(repoDir,
+                        new ObjectIdPathMapperBuilder().buildFlatMapper()),
+                workDir);
+
+        session = makeNewSession();
+    }
+
+    private DefaultOCFLObjectSession makeNewSession() {
+        return new DefaultOCFLObjectSession(OBJ_ID, stagingPath, ocflRepository);
+    }
+
+    @Test
+    public void writeNewFile_ToNewVersion_NewObject() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream());
+        final String versionId = session.commit(NEW_VERSION);
+
+        assertEquals("v1", versionId);
+        assertNoMutableHead(OBJ_ID);
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT1);
+    }
+
+    @Test
+    public void writeNewFile_ToMHead_NewObject() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream());
+        session.commit(MUTABLE_HEAD);
+
+        assertMutableHeadPopulated(OBJ_ID);
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void commitWithoutOption() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream());
+        session.commit(null);
+    }
+
+    @Test
+    public void overwriteStagedFile_NewVersion_NewObject() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        // Change the same file again
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+        final String versionId = session.commit(NEW_VERSION);
+
+        assertEquals("v1", versionId);
+        assertNoMutableHead(OBJ_ID);
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT2);
+    }
+
+    @Test
+    public void replaceFile_NewVersion_ExistingObject() throws Exception {
+        final var preStagingPath = tempFolder.newFolder("prestage").toPath();
+        Files.writeString(preStagingPath.resolve(FILE1_SUBPATH), FILE_CONTENT1);
+        ocflRepository.putObject(ObjectVersionId.head(OBJ_ID), preStagingPath, new CommitInfo());
+
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+        final String versionId = session.commit(NEW_VERSION);
+
+        assertEquals("v2", versionId);
+        assertNoMutableHead(OBJ_ID);
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT2);
+        assertFileInVersion(OBJ_ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
+    }
+
+    @Test
+    public void replaceFile_MHead_ExistingObject() throws Exception {
+        final var preStagingPath = tempFolder.newFolder("prestage").toPath();
+        Files.writeString(preStagingPath.resolve(FILE1_SUBPATH), FILE_CONTENT1);
+        ocflRepository.stageChanges(ObjectVersionId.head(OBJ_ID), new CommitInfo(), updater -> {
+            updater.addPath(preStagingPath, "", MOVE_SOURCE);
+        });
+
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+        final String versionId = session.commit(MUTABLE_HEAD);
+
+        assertEquals("Multiple commits to head should stay on version", "v2", versionId);
+        assertMutableHeadPopulated(OBJ_ID);
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT2);
+    }
+
+    @Test
+    public void writeToMHeadThenNewVersion() throws Exception {
+        // Write first file to mutable head
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(MUTABLE_HEAD);
+
+        assertMutableHeadPopulated(OBJ_ID);
+
+        stagingPath = tempFolder.newFolder("obj1-staging").toPath();
+        session = new DefaultOCFLObjectSession(OBJ_ID, stagingPath, ocflRepository);
+
+        // Commit changes to new version in second commit
+        session.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
+        final String versionId = session.commit(NEW_VERSION);
+
+        assertEquals("v2", versionId);
+        assertNoMutableHead(OBJ_ID);
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT1);
+        assertFileInHeadVersion(OBJ_ID, FILE2_SUBPATH, FILE_CONTENT2);
+        // Initial version is empty since created with mutable head
+        assertFileNotInVersion(OBJ_ID, "v1", FILE1_SUBPATH);
+        assertFileNotInVersion(OBJ_ID, "v1", FILE2_SUBPATH);
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void read_ObjectNotExist() throws Exception {
+        session.read(FILE1_SUBPATH);
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void read_FileNotExist() throws Exception {
+        Files.writeString(stagingPath.resolve(FILE1_SUBPATH), FILE_CONTENT1);
+        ocflRepository.putObject(ObjectVersionId.head(OBJ_ID), stagingPath, new CommitInfo());
+
+        session.read(FILE2_SUBPATH);
+    }
+
+    @Test
+    public void read_FromStaged_NewObject() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+
+        assertStreamMatches(FILE_CONTENT1, session.read(FILE1_SUBPATH));
+    }
+
+    @Test
+    public void read_FromMHead() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(MUTABLE_HEAD);
+
+        assertStreamMatches(FILE_CONTENT1, session.read(FILE1_SUBPATH));
+    }
+
+    @Test
+    public void read_FromVersion() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        assertStreamMatches(FILE_CONTENT1, session.read(FILE1_SUBPATH));
+    }
+
+    @Test
+    public void read_FromStagedAndVersion() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+
+        assertStreamMatches(FILE_CONTENT2, session2.read(FILE1_SUBPATH));
+        assertStreamMatches(FILE_CONTENT1, session2.read(FILE1_SUBPATH, "v1"));
+    }
+
+    @Test
+    public void read_FromStagedAndMHead() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(MUTABLE_HEAD);
+
+        final var session2 = makeNewSession();
+        session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+
+        assertStreamMatches(FILE_CONTENT2, session2.read(FILE1_SUBPATH));
+        // initial version when creating with mutable head is version 2
+        assertStreamMatches(FILE_CONTENT1, session2.read(FILE1_SUBPATH, "v2"));
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void read_FromVersion_NotExist() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        // Try a path that doesn't exist
+        session.read(FILE2_SUBPATH, "v1");
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void read_FromVersion_ObjectNotExist() throws Exception {
+        // No object created
+        session.read(FILE2_SUBPATH, "v1");
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void read_FromNonExistentVersion() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        // version that hasn't been created yet
+        session.read(FILE2_SUBPATH, "v99");
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void delete_FileNotExist() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        // Try a path that doesn't exist
+        session2.delete(FILE2_SUBPATH);
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void delete_ObjectNotExist() throws Exception {
+        // Object not created or populated yet
+        session.delete(FILE1_SUBPATH);
+    }
+
+    @Test
+    public void delete_FromStaged_InitialVersion() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+
+        assertEquals(1, stagingPath.toFile().listFiles().length);
+
+        session.delete(FILE1_SUBPATH);
+
+        assertEquals(0, stagingPath.toFile().listFiles().length);
+    }
+
+    @Test
+    public void delete_FromStaged_VersionsExist() throws Exception {
+
+    }
+
+    @Test
+    public void delete_FromMHead() throws Exception {
+
+    }
+
+    @Test
+    public void delete_FromVersion() throws Exception {
+
+    }
+
+    @Test
+    public void delete_FromStagedAndVersion() throws Exception {
+
+    }
+
+    @Test
+    public void delete_FromStagedAndMHead() throws Exception {
+
+    }
+
+    private InputStream fileStream() {
+        return fileStream(FILE_CONTENT1);
+    }
+
+    private InputStream fileStream(final String content) {
+        return new ByteArrayInputStream(content.getBytes());
+    }
+
+    private void assertFileInHeadVersion(final String objId, final String subpath, final String content) {
+        final OcflObjectVersion objVersion = ocflRepository.getObject(ObjectVersionId.head(objId));
+        assertFileContents(subpath, objVersion, content);
+    }
+
+    private void assertFileInVersion(final String objId, final String versionId, final String subpath,
+            final String content) {
+        final OcflObjectVersion objVersion = ocflRepository.getObject(ObjectVersionId.version(objId, versionId));
+        assertFileContents(subpath, objVersion, content);
+    }
+
+    private void assertFileNotInVersion(final String objId, final String versionId, final String subpath) {
+        final OcflObjectVersion objVersion = ocflRepository.getObject(ObjectVersionId.version(objId, versionId));
+        assertFalse(String.format("File %s must not be in %s version %s", subpath, objId, versionId),
+                objVersion.containsFile(subpath));
+    }
+
+    private void assertFileContents(final String subpath, final OcflObjectVersion objVersion, final String content) {
+        assertStreamMatches(content, objVersion.getFile(subpath).getStream());
+    }
+
+    private void assertStreamMatches(final String expectedContent, final InputStream contentStream) {
+        try {
+            assertEquals(expectedContent, IOUtils.toString(contentStream, "UTF-8"));
+        } catch (final IOException e) {
+            fail(format("Failed to read stream due to %s", e.getMessage()));
+        }
+    }
+
+    private void assertMutableHeadPopulated(final String objId) {
+        assertTrue("Mutable head must be populated for " + objId, ocflRepository.hasStagedChanges(objId));
+    }
+
+    private void assertNoMutableHead(final String objId) {
+        assertFalse("No mutable head should be present for " + objId, ocflRepository.hasStagedChanges(objId));
+    }
+
+    // read file
+    //   does not exist
+    //   does exist
+    //   is in staged changes
+    //   is in both
+    // from past version
+    // from invalid version
+
+    // write file that doesn't exist
+    // write file that is already staged
+    // write file in sub dir
+
+    // multiple writes
+
+    // delete (are these meaningful before a commit?)
+    //   file that is staged
+    //   file that is not staged
+    //   file that is staged and already exists
+    //   doesn't exist
+
+    // commit
+    //   a new object to new version
+    //   a new object to head
+    //   commit to existing object new v
+    //   commit to existing obj head
+    //   commit to new version with existing head
+    //   no commit option new obj
+    //   no commit option existing
+
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +43,9 @@ import org.junit.rules.TemporaryFolder;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.api.OcflObjectVersion;
 import edu.wisc.library.ocfl.api.model.CommitInfo;
+import edu.wisc.library.ocfl.api.model.ObjectDetails;
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
+import edu.wisc.library.ocfl.api.model.VersionId;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
 import edu.wisc.library.ocfl.core.mapping.ObjectIdPathMapperBuilder;
 import edu.wisc.library.ocfl.core.storage.FileSystemOcflStorage;
@@ -76,7 +79,6 @@ public class DefaultOCFLObjectSessionTest {
     public void setup() throws Exception {
         tempFolder.create();
 
-        stagingPath = tempFolder.newFolder("obj1-staging").toPath();
         final var repoDir = tempFolder.newFolder("ocfl-repo").toPath();
         final var workDir = tempFolder.newFolder("ocfl-work").toPath();
 
@@ -88,13 +90,16 @@ public class DefaultOCFLObjectSessionTest {
         session = makeNewSession();
     }
 
-    private DefaultOCFLObjectSession makeNewSession() {
+    private DefaultOCFLObjectSession makeNewSession() throws Exception {
+        if (stagingPath == null || !stagingPath.toFile().exists()) {
+            stagingPath = tempFolder.newFolder("obj1-staging").toPath();
+        }
         return new DefaultOCFLObjectSession(OBJ_ID, stagingPath, ocflRepository);
     }
 
     @Test
     public void writeNewFile_ToNewVersion_NewObject() throws Exception {
-        session.write(FILE1_SUBPATH, fileStream());
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         final String versionId = session.commit(NEW_VERSION);
 
         assertEquals("v1", versionId);
@@ -104,21 +109,15 @@ public class DefaultOCFLObjectSessionTest {
 
     @Test
     public void writeNewFile_ToMHead_NewObject() throws Exception {
-        session.write(FILE1_SUBPATH, fileStream());
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         session.commit(MUTABLE_HEAD);
 
         assertMutableHeadPopulated(OBJ_ID);
         assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void commitWithoutOption() throws Exception {
-        session.write(FILE1_SUBPATH, fileStream());
-        session.commit(null);
-    }
-
     @Test
-    public void overwriteStagedFile_NewVersion_NewObject() throws Exception {
+    public void write_OverwriteStagedFile_NewVersion_NewObject() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         // Change the same file again
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
@@ -130,7 +129,7 @@ public class DefaultOCFLObjectSessionTest {
     }
 
     @Test
-    public void replaceFile_NewVersion_ExistingObject() throws Exception {
+    public void write_ReplaceFile_NewVersion_ExistingObject() throws Exception {
         final var preStagingPath = tempFolder.newFolder("prestage").toPath();
         Files.writeString(preStagingPath.resolve(FILE1_SUBPATH), FILE_CONTENT1);
         ocflRepository.putObject(ObjectVersionId.head(OBJ_ID), preStagingPath, new CommitInfo());
@@ -145,7 +144,7 @@ public class DefaultOCFLObjectSessionTest {
     }
 
     @Test
-    public void replaceFile_MHead_ExistingObject() throws Exception {
+    public void write_ReplaceFileInMHead_ExistingObject() throws Exception {
         final var preStagingPath = tempFolder.newFolder("prestage").toPath();
         Files.writeString(preStagingPath.resolve(FILE1_SUBPATH), FILE_CONTENT1);
         ocflRepository.stageChanges(ObjectVersionId.head(OBJ_ID), new CommitInfo(), updater -> {
@@ -269,6 +268,17 @@ public class DefaultOCFLObjectSessionTest {
         session.read(FILE2_SUBPATH, "v99");
     }
 
+    // Verify that subpaths with parent directories are created and readable
+    @Test
+    public void nestedPath_NewVersion_NewObject() throws Exception {
+        final String nestedSubpath = "path/to/the/file.txt";
+        session.write(nestedSubpath, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        assertStreamMatches(FILE_CONTENT1, session2.read(nestedSubpath));
+    }
+
     @Test(expected = PersistentItemNotFoundException.class)
     public void delete_FileNotExist() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
@@ -297,36 +307,242 @@ public class DefaultOCFLObjectSessionTest {
     }
 
     @Test
-    public void delete_FromStaged_VersionsExist() throws Exception {
+    public void delete_FromStaged_OtherFilesVersioned() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
 
+        final var session2 = makeNewSession();
+        session2.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
+
+        // Try a path that doesn't exist
+        session2.delete(FILE2_SUBPATH);
+        session2.commit(NEW_VERSION);
+
+        assertFileNotInHeadVersion(OBJ_ID, FILE2_SUBPATH);
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT1);
     }
 
     @Test
     public void delete_FromMHead() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(MUTABLE_HEAD);
 
+        final var session2 = makeNewSession();
+        session2.delete(FILE1_SUBPATH);
+        session2.commit(MUTABLE_HEAD);
+
+        assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
     }
 
     @Test
     public void delete_FromVersion() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
 
+        final var session2 = makeNewSession();
+        session2.delete(FILE1_SUBPATH);
+        session2.commit(NEW_VERSION);
+
+        assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
+        assertFileInVersion(OBJ_ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
     }
 
     @Test
     public void delete_FromStagedAndVersion() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
 
+        final var session2 = makeNewSession();
+        session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+        session2.delete(FILE1_SUBPATH);
+        session2.commit(NEW_VERSION);
+
+        assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
+        assertFileInVersion(OBJ_ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
     }
 
     @Test
     public void delete_FromStagedAndMHead() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(MUTABLE_HEAD);
 
+        final var session2 = makeNewSession();
+        session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+        session2.delete(FILE1_SUBPATH);
+        session2.commit(MUTABLE_HEAD);
+
+        assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
+        assertFileNotInVersion(OBJ_ID, "v1", FILE1_SUBPATH);
     }
 
-    private InputStream fileStream() {
-        return fileStream(FILE_CONTENT1);
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void delete_FromDeletedObject() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        // Try to delete a file from an object that was just deleted
+        session2.deleteObject();
+        session2.delete(FILE1_SUBPATH);
+        session2.commit(NEW_VERSION);
+
+        assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
+        assertFileNotInVersion(OBJ_ID, "v1", FILE1_SUBPATH);
     }
 
-    private InputStream fileStream(final String content) {
+    @Test
+    public void delete_FileAddedAfterObjectDeleted() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        // Try to delete a file from an object that was just deleted
+        session2.deleteObject();
+        // Adding 2 files so that staging won't be empty when committing
+        session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+        session2.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
+        session2.delete(FILE1_SUBPATH);
+        session2.commit(NEW_VERSION);
+
+        assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
+        assertFileInHeadVersion(OBJ_ID, FILE2_SUBPATH, FILE_CONTENT2);
+
+        assertOnlyFirstVersionExists();
+    }
+
+    @Test
+    public void deleteObject_ObjectExists() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        session2.deleteObject();
+        session2.commit(NEW_VERSION);
+
+        assertFalse("Deleted object must not exist",
+                ocflRepository.containsObject(OBJ_ID));
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void deleteObject_NotExists() throws Exception {
+        session.deleteObject();
+    }
+
+    @Test
+    public void deleteObject_StagedChanges_ObjectNotCreated() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.deleteObject();
+        session.commit(NEW_VERSION);
+
+        assertFalse("Deleted object must not exist",
+                ocflRepository.containsObject(OBJ_ID));
+    }
+
+    @Test
+    public void deleteObject_CreateAndRecreateSameSession() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.deleteObject();
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+        session.commit(NEW_VERSION);
+
+        // State of object should reflect post-delete object state
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT2);
+    }
+
+    @Test
+    public void deleteObject_Recreate() throws Exception {
+        // Create object
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        // Delete object
+        final var session2 = makeNewSession();
+        session2.deleteObject();
+        session2.commit(NEW_VERSION);
+
+        // Recreate object
+        final var session3 = makeNewSession();
+        session3.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
+        session3.commit(NEW_VERSION);
+
+        assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT2);
+
+        assertOnlyFirstVersionExists();
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void read_FromDeletedObject() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        session2.deleteObject();
+        session2.read(FILE1_SUBPATH);
+    }
+
+    @Test(expected = PersistentItemNotFoundException.class)
+    public void readVersion_FromDeletedObject() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        session2.deleteObject();
+        session2.read(FILE1_SUBPATH, "v1");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void commit_WithoutOption() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(null);
+    }
+
+    @Test(expected = PersistentStorageException.class)
+    public void commit_NewObject_NoContents() throws Exception {
+        session.commit(NEW_VERSION);
+    }
+
+    @Test
+    public void commit_NewVersion_NoChanges() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+
+        final var session2 = makeNewSession();
+        session2.commit(NEW_VERSION);
+
+        final ObjectDetails objDetails = ocflRepository.describeObject(OBJ_ID);
+        final var versionMap = objDetails.getVersionMap();
+        assertEquals("Two versions should exist", 2, versionMap.size());
+
+        assertFileInVersion(OBJ_ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
+        assertFileInVersion(OBJ_ID, "v2", FILE1_SUBPATH, FILE_CONTENT1);
+    }
+
+    @Test
+    public void commit_MHead_NoChanges() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(MUTABLE_HEAD);
+
+        final var session2 = makeNewSession();
+        session2.commit(MUTABLE_HEAD);
+
+        final ObjectDetails objDetails = ocflRepository.describeObject(OBJ_ID);
+        final var versionMap = objDetails.getVersionMap();
+        assertEquals("Only the mutable head and initial version exist", 2, versionMap.size());
+
+        assertFileInVersion(OBJ_ID, "v2", FILE1_SUBPATH, FILE_CONTENT1);
+        assertFileNotInVersion(OBJ_ID, "v1", FILE1_SUBPATH);
+    }
+
+    private static InputStream fileStream(final String content) {
         return new ByteArrayInputStream(content.getBytes());
+    }
+
+    private void assertOnlyFirstVersionExists() {
+        final ObjectDetails objDetails = ocflRepository.describeObject(OBJ_ID);
+        final var versionMap = objDetails.getVersionMap();
+        assertEquals("Only a single version should remain", 1, versionMap.size());
+        assertTrue("First version must be present",
+                versionMap.containsKey(VersionId.fromString("v1")));
     }
 
     private void assertFileInHeadVersion(final String objId, final String subpath, final String content) {
@@ -338,6 +554,12 @@ public class DefaultOCFLObjectSessionTest {
             final String content) {
         final OcflObjectVersion objVersion = ocflRepository.getObject(ObjectVersionId.version(objId, versionId));
         assertFileContents(subpath, objVersion, content);
+    }
+
+    private void assertFileNotInHeadVersion(final String objId, final String subpath) {
+        final OcflObjectVersion objVersion = ocflRepository.getObject(ObjectVersionId.head(objId));
+        assertFalse(String.format("File %s must not be in %s head version", subpath, objId),
+                objVersion.containsFile(subpath));
     }
 
     private void assertFileNotInVersion(final String objId, final String versionId, final String subpath) {
@@ -365,34 +587,4 @@ public class DefaultOCFLObjectSessionTest {
     private void assertNoMutableHead(final String objId) {
         assertFalse("No mutable head should be present for " + objId, ocflRepository.hasStagedChanges(objId));
     }
-
-    // read file
-    //   does not exist
-    //   does exist
-    //   is in staged changes
-    //   is in both
-    // from past version
-    // from invalid version
-
-    // write file that doesn't exist
-    // write file that is already staged
-    // write file in sub dir
-
-    // multiple writes
-
-    // delete (are these meaningful before a commit?)
-    //   file that is staged
-    //   file that is not staged
-    //   file that is staged and already exists
-    //   doesn't exist
-
-    // commit
-    //   a new object to new version
-    //   a new object to head
-    //   commit to existing object new v
-    //   commit to existing obj head
-    //   commit to new version with existing head
-    //   no commit option new obj
-    //   no commit option existing
-
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3095

# What does this Pull Request do?
Implements the core functionality involved in committing changes to an OCFL object.

# What's new?
* Implements all methods exception `prepare`
* Add unit tests for object session
* Adds additional methods to the object session interface: deleteObject, close
* Adds throws expectations

# How should this be tested?

There is a unit test for now.

# Additional Notes:
This PR does not address locking beyond synchronization to prevent simultaneous modifications to the same object session.

Also, if an object is deleted in a session, it will cause the OCFL object to be deleted at commit time. The same session can also create a new OCFL object with the same identifier.

# Interested parties
@dbernstein, @pwinckles, @fcrepo4/committers
