### PR TITLE
Implement OCFLPersistentStorageSession.getTriples()

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -25,11 +25,13 @@ import java.util.stream.Stream;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 /**
  * Implementation of a Fedora resource, containing functionality common to the more concrete resource implementations.
@@ -173,6 +175,8 @@ public class FedoraResourceImpl implements FedoraResource {
             return getSession().getTriples(id, getMementoDatetime());
         } catch (final PersistentItemNotFoundException e) {
             throw new ItemNotFoundException("Unable to retrieve triples for " + getId(), e);
+        } catch (PersistentStorageException e) {
+            throw new RepositoryRuntimeException(e);
         }
     }
 
@@ -182,6 +186,8 @@ public class FedoraResourceImpl implements FedoraResource {
             return getSession().getManagedProperties(id, getMementoDatetime());
         } catch (final PersistentItemNotFoundException e) {
             throw new ItemNotFoundException("Unable to retrieve managed properties for " + getId(), e);
+        } catch (PersistentStorageException e) {
+            throw new RepositoryRuntimeException(e);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -38,6 +38,7 @@ import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 
 /**
@@ -143,6 +144,8 @@ public class ResourceFactoryImpl implements ResourceFactory {
             throw new RepositoryRuntimeException("Unable to construct object", e);
         } catch (final PersistentItemNotFoundException e) {
             throw new PathNotFoundException(e);
+        } catch (PersistentStorageException e) {
+            throw new RepositoryRuntimeException(e);
         }
     }
 

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/CommitOption.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/CommitOption.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.api;
+
+/**
+ * Options for defining the behavior when performing a commit to the persistent storage layer.
+ *
+ * @author bbpennel
+ */
+public enum CommitOption {
+    /* Commit unversioned content */
+    UNVERSIONED,
+    /* Commit a new version */
+    NEW_VERSION
+}

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
@@ -23,8 +23,6 @@ import java.time.Instant;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
-import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
-import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 /**
@@ -58,8 +56,7 @@ public interface PersistentStorageSession {
      * @param version instant identifying the version of the resource to read from.
      *      If null, then the head version is used.
      * @return header information
-     * @throws PersistentItemNotFoundException If the identifier doesn't exist.
-     * @throws PersistentSessionClosedException If the session is closed.
+     * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
     public ResourceHeaders getHeaders(final String identifier, final Instant version)
             throws PersistentStorageException;
@@ -71,10 +68,10 @@ public interface PersistentStorageSession {
      * @param version instant identifying the version of the resource to read from. If null, then the head version is
      *        used.
      * @return the triples as an RdfStream.
-     * @throws PersistentItemNotFoundException If the identifier doesn't exist.
+     * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
     public RdfStream getTriples(final String identifier, final Instant version)
-            throws PersistentItemNotFoundException, PersistentStorageException;
+            throws PersistentStorageException;
 
     /**
      * Get the server managed properties for this provided resource.
@@ -83,12 +80,10 @@ public interface PersistentStorageSession {
      * @param version instant identifying the version of the resource to read from. If null, then the head version is
      *        used.
      * @return the server managed properties as an RdfStream.
-     * @throws PersistentItemNotFoundException If the identifier doesn't exist.
-     * @throws PersistentSessionClosedException If the session is closed.
-     * @throws PersistentStorageException Other issues.
+     * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
     public RdfStream getManagedProperties(final String identifier, final Instant version)
-            throws PersistentItemNotFoundException, PersistentSessionClosedException, PersistentStorageException;
+            throws PersistentStorageException;
 
     /**
      * Get the persisted binary content for the provided resource.
@@ -97,10 +92,10 @@ public interface PersistentStorageSession {
      * @param version instant identifying the version of the resource to read from. If null, then the head version is
      *        used.
      * @return the binary content.
-     * @throws PersistentItemNotFoundException If the identifier doesn't exist.
+     * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
     public InputStream getBinaryContent(final String identifier, final Instant version)
-            throws PersistentItemNotFoundException;
+            throws PersistentStorageException;
 
     /**
      * Commits any changes in the current sesssion to persistent storage.

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
@@ -24,6 +24,7 @@ import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 /**
@@ -58,9 +59,10 @@ public interface PersistentStorageSession {
      *      If null, then the head version is used.
      * @return header information
      * @throws PersistentItemNotFoundException If the identifier doesn't exist.
+     * @throws PersistentSessionClosedException If the session is closed.
      */
     public ResourceHeaders getHeaders(final String identifier, final Instant version)
-            throws PersistentItemNotFoundException;
+            throws PersistentStorageException;
 
     /**
      * Get the client managed triples for the provided resource.
@@ -72,7 +74,7 @@ public interface PersistentStorageSession {
      * @throws PersistentItemNotFoundException If the identifier doesn't exist.
      */
     public RdfStream getTriples(final String identifier, final Instant version)
-            throws PersistentItemNotFoundException;
+            throws PersistentItemNotFoundException, PersistentStorageException;
 
     /**
      * Get the server managed properties for this provided resource.
@@ -82,9 +84,11 @@ public interface PersistentStorageSession {
      *        used.
      * @return the server managed properties as an RdfStream.
      * @throws PersistentItemNotFoundException If the identifier doesn't exist.
+     * @throws PersistentSessionClosedException If the session is closed.
+     * @throws PersistentStorageException Other issues.
      */
     public RdfStream getManagedProperties(final String identifier, final Instant version)
-            throws PersistentItemNotFoundException;
+            throws PersistentItemNotFoundException, PersistentSessionClosedException, PersistentStorageException;
 
     /**
      * Get the persisted binary content for the provided resource.
@@ -100,10 +104,10 @@ public interface PersistentStorageSession {
 
     /**
      * Commits any changes in the current sesssion to persistent storage.
-     *
+     * @param option The commit option indicating the
      * @throws PersistentStorageException Error during commit.
      */
-    public void commit() throws PersistentStorageException;
+    public void commit(final CommitOption option) throws PersistentStorageException;
 
     /**
      * Rolls back any changes in the current session.

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
@@ -99,10 +99,9 @@ public interface PersistentStorageSession {
 
     /**
      * Commits any changes in the current sesssion to persistent storage.
-     * @param option The commit option indicating the
      * @throws PersistentStorageException Error during commit.
      */
-    public void commit(final CommitOption option) throws PersistentStorageException;
+    public void commit() throws PersistentStorageException;
 
     /**
      * Rolls back any changes in the current session.

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManager.java
@@ -17,12 +17,13 @@
  */
 package org.fcrepo.persistence.ocfl;
 
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
+
 import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.fcrepo.persistence.api.PersistentStorageSession;
-import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 
 /**
  * OCFL implementation of PersistentStorageSessionManager
@@ -36,6 +37,9 @@ public class OCFLPersistentSessionManager implements PersistentStorageSessionMan
     private OCFLPersistentStorageSession readOnlySession;
 
     private Map<String,OCFLPersistentStorageSession> sessionMap;
+
+    @Inject
+    private OCFLObjectSessionFactory objectSessionFactory;
 
     @Inject
     private FedoraToOCFLObjectIndex fedoraOcflIndex;
@@ -60,7 +64,9 @@ public class OCFLPersistentSessionManager implements PersistentStorageSessionMan
             return session;
         }
 
-        final OCFLPersistentStorageSession newSession = new OCFLPersistentStorageSession(sessionId, fedoraOcflIndex);
+        final OCFLPersistentStorageSession newSession = new OCFLPersistentStorageSession(sessionId,
+                                                                                         fedoraOcflIndex,
+                                                                                         objectSessionFactory);
 
         sessionMap.put(sessionId, newSession);
 
@@ -70,7 +76,7 @@ public class OCFLPersistentSessionManager implements PersistentStorageSessionMan
     @Override
     public PersistentStorageSession getReadOnlySession() {
         if(this.readOnlySession == null) {
-            this.readOnlySession = new OCFLPersistentStorageSession(fedoraOcflIndex);
+            this.readOnlySession = new OCFLPersistentStorageSession(fedoraOcflIndex, objectSessionFactory);
         }
 
         return this.readOnlySession;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManager.java
@@ -34,9 +34,9 @@ import java.util.Map;
  */
 public class OCFLPersistentSessionManager implements PersistentStorageSessionManager {
 
-    private OCFLPersistentStorageSession readOnlySession;
+    private PersistentStorageSession readOnlySession;
 
-    private Map<String,OCFLPersistentStorageSession> sessionMap;
+    private Map<String, PersistentStorageSession> sessionMap;
 
     @Inject
     private OCFLObjectSessionFactory objectSessionFactory;
@@ -54,32 +54,28 @@ public class OCFLPersistentSessionManager implements PersistentStorageSessionMan
     @Override
     public PersistentStorageSession getSession(final String sessionId) {
 
-        if(sessionId == null) {
+        if (sessionId == null) {
             throw new IllegalArgumentException("session id must be non-null");
         }
 
-        final OCFLPersistentStorageSession session = sessionMap.get(sessionId);
+        final PersistentStorageSession session = sessionMap.get(sessionId);
 
-        if(session != null) {
+        if (session != null) {
             return session;
         }
 
-        final OCFLPersistentStorageSession newSession = new OCFLPersistentStorageSession(sessionId,
-                                                                                         fedoraOcflIndex,
-                                                                                         objectSessionFactory);
-
+        final PersistentStorageSession newSession = new OCFLPersistentStorageSession(sessionId,
+                fedoraOcflIndex,
+                objectSessionFactory);
         sessionMap.put(sessionId, newSession);
-
         return newSession;
     }
 
     @Override
     public PersistentStorageSession getReadOnlySession() {
-        if(this.readOnlySession == null) {
+        if (this.readOnlySession == null) {
             this.readOnlySession = new OCFLPersistentStorageSession(fedoraOcflIndex, objectSessionFactory);
         }
-
         return this.readOnlySession;
     }
-
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
@@ -230,7 +230,7 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
     }
 
     @Override
-    public synchronized void commit(final CommitOption option) throws PersistentStorageException {
+    public synchronized void commit() throws PersistentStorageException {
         ensureCommitNotStarted();
         if (isReadOnly()) {
             // No changes to commit.
@@ -265,6 +265,7 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
 
             //perform commit
             for (OCFLObjectSession objectSession : sessions) {
+                final CommitOption option = objectSession.getDefaultCommitOption();
                 objectSession.commit(option);
                 sessionsToRollback.add(new CommittedSession(objectSession, option));
             }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
@@ -319,6 +319,8 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
                 if (cs.option == NEW_VERSION) {
                     //TODO rollback to previous OCFL version
                     //add any failure messages here.
+                    rollbackFailures.add(format("rollback of previously committed versions is not yet supported",
+                            cs.session));
                 } else {
                     rollbackFailures.add(format("%s was already committed to the unversioned head", cs.session));
                 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageUtils.java
@@ -77,7 +77,9 @@ public class OCFLPersistentStorageUtils {
      * @return The resolved subpath
      */
     public static String relativizeSubpath(final String ancestorResourceId, final String resourceId) {
-        if (resourceId.startsWith(ancestorResourceId)) {
+        if (resourceId.equals(ancestorResourceId)) {
+            return resourceId;
+        } else if (resourceId.startsWith(ancestorResourceId)) {
             return resourceId.substring(ancestorResourceId.length() + 1);
         }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -31,6 +31,13 @@ import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 public interface OCFLObjectSession {
 
     /**
+     * The default commit option configured for the OCFL Object represented by this session.
+     * If no default commit option has been defined for the specific OCFL Object, the
+     * value returned will be the system defined global default commit option.
+     * @return The default commit option
+     */
+    CommitOption getDefaultCommitOption();
+    /**
      * Write the provided content to specified subpath.
      *
      * @param subpath path of the resource to write, relative to the OCFL object

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -20,6 +20,7 @@ package org.fcrepo.persistence.ocfl.api;
 
 import java.io.InputStream;
 
+import org.fcrepo.persistence.api.CommitOption;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 /**
@@ -67,7 +68,7 @@ public interface OCFLObjectSession {
      * Read the state of the file at subpath from the specified version of the OCFL object.
      *
      * @param subpath path relative to the object
-     * @param version identifier of the version
+     * @param version identifier of the version. If null, the head state of the file will be returned.
      * @return the contents of the file from the specified version
      * @throws PersistentStorageException if unable to read the file
      */

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSessionFactory.java
@@ -17,13 +17,18 @@
  */
 package org.fcrepo.persistence.ocfl.api;
 
-
 /**
- * Options for defining the behavior when performing a commit to an OCFL object
- *
- * @author bbpennel
+ * A factory interface for creating {@link org.fcrepo.persistence.ocfl.api.OCFLObjectSession}.
+ * @author dbernstein
+ * @since 6.0.0
  */
-public enum CommitOption {
-    MUTABLE_HEAD,
-    NEW_VERSION
+public interface OCFLObjectSessionFactory {
+
+    /**
+     * Create new session.
+     * @param ocflId The OCFL Object identifier
+     * @param persistentStorageSessionId The id of the persistent storage session associated with this session.
+     * @return The newly created session.
+     */
+    OCFLObjectSession create(final String ocflId, final String persistentStorageSessionId);
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -19,8 +19,10 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import static edu.wisc.library.ocfl.api.OcflOption.OVERWRITE;
 import static edu.wisc.library.ocfl.api.OcflOption.MOVE_SOURCE;
+import static java.lang.System.getProperty;
 import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
 import static java.lang.String.format;
+import static org.fcrepo.persistence.api.CommitOption.UNVERSIONED;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -72,6 +74,10 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
 
     private MutableOcflRepository ocflRepository;
 
+
+    private static CommitOption globalDefaultCommitOption =
+            Boolean.valueOf(getProperty("fcrepo.autoversioning.enabled", "false")) ? NEW_VERSION : UNVERSIONED;
+
     /**
      * Instantiate an OCFL object session
      *
@@ -87,6 +93,21 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
         this.deletePaths = new HashSet<>();
         this.objectDeleted = false;
         this.sessionClosed = false;
+    }
+
+    /**
+     * Set the system-wide default {@link org.fcrepo.persistence.api.CommitOption}.
+     * This method overrides system runtime settings, but not OCFL Object level
+     * settings.
+     * @param commitOption The commit option to be set.
+     */
+    public static void setGlobaDefaultCommitOption(final CommitOption commitOption) {
+        globalDefaultCommitOption = commitOption;
+    }
+
+    @Override
+    public CommitOption getDefaultCommitOption() {
+        return globalDefaultCommitOption;
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -19,7 +19,7 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import static edu.wisc.library.ocfl.api.OcflOption.OVERWRITE;
 import static edu.wisc.library.ocfl.api.OcflOption.MOVE_SOURCE;
-import static org.fcrepo.persistence.ocfl.api.CommitOption.NEW_VERSION;
+import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
 import static java.lang.String.format;
 
 import java.io.FileInputStream;
@@ -37,7 +37,7 @@ import org.apache.commons.io.FileUtils;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
-import org.fcrepo.persistence.ocfl.api.CommitOption;
+import org.fcrepo.persistence.api.CommitOption;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
+import edu.wisc.library.ocfl.core.mapping.ObjectIdPathMapperBuilder;
+import edu.wisc.library.ocfl.core.storage.FileSystemOcflStorage;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
+
+import java.io.File;
+
+import static java.lang.System.getProperty;
+
+/**
+ * A default implemenntation of the {@link org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory} interface.
+ *
+ * @author dbernstein
+ * @since 6.0.0
+ */
+public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory {
+
+    private static final File DEFAULT_STAGING_DIR = new File(getProperty("fcrepo.ocfl.staging.dir",
+            getProperty("java.io.tmpdir") + File.separator + "fcrepo-ocfl-staging"));
+    private static final File DEFAULT_OCFL_STORAGE_ROOT_DIR = new File(getProperty("fcrepo.ocfl.storage.root.dir",
+            getProperty("java.io.tmpdir") + File.separator + "fcrepo-ocfl"));
+    private static final File DEFAULT_OCFL_WORK_DIR = new File(getProperty("fcrepo.ocfl.work.dir",
+            getProperty("java.io.tmpdir") + File.separator + "fcrepo-ocfl-work"));
+
+    private File ocflStagingRoot;
+
+    private MutableOcflRepository ocflRepository;
+
+    /**
+     * Default Constructor.  You can set the ocfl staging, storage root, and work directories by setting the following
+     * system properties: fcrepo.ocfl.staging.dir, fcrepo.ocfl.storage.root.dir, and  fcrepo.ocfl.work.dir.  If these
+     * are not set, default directories will be created in java.io.tmpdir.
+     */
+    public DefaultOCFLObjectSessionFactory() {
+        this(DEFAULT_STAGING_DIR, DEFAULT_OCFL_STORAGE_ROOT_DIR, DEFAULT_OCFL_WORK_DIR);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param ocflStagingDir     The OCFL staging directory
+     * @param ocflStorageRootDir The OCFL storage root directory
+     * @param ocflWorkDir        The OCFL work directory
+     */
+    public DefaultOCFLObjectSessionFactory(final File ocflStagingDir, final File ocflStorageRootDir,
+                                           final File ocflWorkDir) {
+        ocflStagingDir.mkdirs();
+        ocflStorageRootDir.mkdirs();
+        ocflWorkDir.mkdirs();
+
+        this.ocflStagingRoot = ocflStagingRoot;
+        this.ocflRepository = new OcflRepositoryBuilder().buildMutable(
+                new FileSystemOcflStorage(ocflStorageRootDir.toPath(),
+                        new ObjectIdPathMapperBuilder().buildFlatMapper()),
+                ocflWorkDir.toPath());
+
+    }
+
+    @Override
+    public OCFLObjectSession create(final String ocflId, final String persistentStorageSessionId) {
+        final File stagingDirectory = new File(this.ocflStagingRoot, persistentStorageSessionId);
+        stagingDirectory.mkdirs();
+        return new DefaultOCFLObjectSession(ocflId, stagingDirectory.toPath(), this.ocflRepository);
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -72,7 +72,7 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
         this.ocflStagingRoot = ocflStagingRoot;
         this.ocflRepository = new OcflRepositoryBuilder().buildMutable(
                 new FileSystemOcflStorage(ocflStorageRootDir.toPath(),
-                        new ObjectIdPathMapperBuilder().buildFlatMapper()),
+                        new ObjectIdPathMapperBuilder().buildDefaultPairTreeMapper()),
                 ocflWorkDir.toPath());
 
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -25,8 +25,10 @@ import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 
 import java.io.File;
+import java.nio.file.Paths;
 
 import static java.lang.System.getProperty;
+import static org.apache.commons.lang3.SystemUtils.JAVA_IO_TMPDIR;
 
 /**
  * A default implemenntation of the {@link org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory} interface.
@@ -36,16 +38,23 @@ import static java.lang.System.getProperty;
  */
 public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory {
 
-    private static final File DEFAULT_STAGING_DIR = new File(getProperty("fcrepo.ocfl.staging.dir",
-            getProperty("java.io.tmpdir") + File.separator + "fcrepo-ocfl-staging"));
-    private static final File DEFAULT_OCFL_STORAGE_ROOT_DIR = new File(getProperty("fcrepo.ocfl.storage.root.dir",
-            getProperty("java.io.tmpdir") + File.separator + "fcrepo-ocfl"));
-    private static final File DEFAULT_OCFL_WORK_DIR = new File(getProperty("fcrepo.ocfl.work.dir",
-            getProperty("java.io.tmpdir") + File.separator + "fcrepo-ocfl-work"));
+    private static final File STAGING_DIR = resolveDir("fcrepo.ocfl.staging.dir", "fcrepo-ocfl-staging");
+    private static final File OCFL_STORAGE_ROOT_DIR = resolveDir("fcrepo.ocfl.storage.root.dir", "fcrepo-ocfl");
+    private static final File OCFL_WORK_DIR = resolveDir("fcrepo.ocfl.work.dir", "fcrepo-ocfl-work");
 
-    private File ocflStagingRoot;
+    private File ocflStagingDir;
 
     private MutableOcflRepository ocflRepository;
+
+    private static final File resolveDir(final String systemPropertyKey, final String defaultDirectoryName) {
+        final String path = getProperty(systemPropertyKey);
+        if (path != null) {
+            return new File(path);
+        } else {
+            //return default
+            return Paths.get(getProperty(JAVA_IO_TMPDIR), defaultDirectoryName).toFile();
+        }
+    }
 
     /**
      * Default Constructor.  You can set the ocfl staging, storage root, and work directories by setting the following
@@ -53,7 +62,7 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
      * are not set, default directories will be created in java.io.tmpdir.
      */
     public DefaultOCFLObjectSessionFactory() {
-        this(DEFAULT_STAGING_DIR, DEFAULT_OCFL_STORAGE_ROOT_DIR, DEFAULT_OCFL_WORK_DIR);
+        this(STAGING_DIR, OCFL_STORAGE_ROOT_DIR, OCFL_WORK_DIR);
     }
 
     /**
@@ -69,7 +78,7 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
         ocflStorageRootDir.mkdirs();
         ocflWorkDir.mkdirs();
 
-        this.ocflStagingRoot = ocflStagingRoot;
+        this.ocflStagingDir = ocflStagingDir;
         this.ocflRepository = new OcflRepositoryBuilder().buildMutable(
                 new FileSystemOcflStorage(ocflStorageRootDir.toPath(),
                         new ObjectIdPathMapperBuilder().buildDefaultPairTreeMapper()),
@@ -79,7 +88,7 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
 
     @Override
     public OCFLObjectSession create(final String ocflId, final String persistentStorageSessionId) {
-        final File stagingDirectory = new File(this.ocflStagingRoot, persistentStorageSessionId);
+        final File stagingDirectory = new File(this.ocflStagingDir, persistentStorageSessionId);
         stagingDirectory.mkdirs();
         return new DefaultOCFLObjectSession(ocflId, stagingDirectory.toPath(), this.ocflRepository);
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/NonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/NonRdfSourcePersister.java
@@ -19,13 +19,12 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
-import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.INTERNAL_FEDORA_DIRECTORY;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.getInternalFedoraDirectory;
 import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.relativizeSubpath;
 import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.writeRDF;
 
 import static java.util.Arrays.asList;
 
-import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -67,6 +66,6 @@ public class NonRdfSourcePersister extends AbstractPersister {
         session.write(subpath, nonRdfSourceOperation.getContentStream());
 
         //write server props
-        writeRDF(session, operation.getServerManagedProperties(), INTERNAL_FEDORA_DIRECTORY + File.separator + subpath);
+        writeRDF(session, operation.getServerManagedProperties(), getInternalFedoraDirectory() + subpath);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersister.java
@@ -19,13 +19,12 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
-import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.INTERNAL_FEDORA_DIRECTORY;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.getInternalFedoraDirectory;
 import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.relativizeSubpath;
 import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.writeRDF;
 
 import static java.util.Arrays.asList;
 
-import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -66,7 +65,6 @@ public class RDFSourcePersister extends AbstractPersister {
         writeRDF(session, ((RdfSourceOperation) operation).getTriples(), subpath);
 
         //write server props
-        writeRDF(session, operation.getServerManagedProperties(), INTERNAL_FEDORA_DIRECTORY + File.separator + subpath);
+        writeRDF(session, operation.getServerManagedProperties(), getInternalFedoraDirectory() + subpath);
     }
-
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersister.java
@@ -21,6 +21,7 @@ import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
 import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.getInternalFedoraDirectory;
 import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.relativizeSubpath;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.resolveOCFLSubpath;
 import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.writeRDF;
 
 import static java.util.Arrays.asList;
@@ -58,13 +59,14 @@ public class RDFSourcePersister extends AbstractPersister {
     @Override
     public void persist(final OCFLObjectSession session, final ResourceOperation operation,
                         final FedoraOCFLMapping mapping) throws PersistentStorageException {
+        final RdfSourceOperation rdfSourceOp = (RdfSourceOperation)operation;
         log.debug("persisting RDFSource ({}) to {}", operation.getResourceId(), mapping.getOcflObjectId());
         final String subpath = relativizeSubpath(mapping.getParentFedoraResourceId(), operation.getResourceId());
-
+        final String resolvedSubpath = resolveOCFLSubpath(subpath);
         //write user triples
-        writeRDF(session, ((RdfSourceOperation) operation).getTriples(), subpath);
+        writeRDF(session, rdfSourceOp.getTriples(), resolvedSubpath);
 
         //write server props
-        writeRDF(session, operation.getServerManagedProperties(), getInternalFedoraDirectory() + subpath);
+        writeRDF(session, operation.getServerManagedProperties(), getInternalFedoraDirectory() + resolvedSubpath);
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManagerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManagerTest.java
@@ -31,8 +31,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static java.util.UUID.randomUUID;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * Test class for {@link org.fcrepo.persistence.ocfl.OCFLPersistentSessionManager}
@@ -76,11 +74,6 @@ public class OCFLPersistentSessionManagerTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testNormalSession() throws Exception {
-        final String resourceId = "resource1";
-        final String ocflObjectId = "ocflObjectId";
-        when(mockOperation.getResourceId()).thenReturn(resourceId);
-        when(index.getMapping(eq(resourceId))).thenReturn(mapping);
-        when(mapping.getOcflObjectId()).thenReturn(ocflObjectId);
         readWriteSession.persist(mockOperation);
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManagerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManagerTest.java
@@ -21,6 +21,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,6 +64,9 @@ public class OCFLPersistentSessionManagerTest {
 
     @Mock
     private FedoraOCFLMapping mapping;
+
+    @Mock
+    private OCFLObjectSessionFactory objectSessionFactory;
 
     @Before
     public void setUp() {

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManagerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentSessionManagerTest.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.persistence.ocfl;
 
-import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -41,18 +40,13 @@ import static java.util.UUID.randomUUID;
 public class OCFLPersistentSessionManagerTest {
 
     @InjectMocks
-    private OCFLPersistentSessionManager sessionFactory;
+    private OCFLPersistentSessionManager sessionManager;
 
     private PersistentStorageSession readWriteSession;
 
     private PersistentStorageSession readOnlySession;
 
     private final String testSessionId = randomUUID().toString();
-
-    private final String testResourcePath = "/" + randomUUID().toString();
-
-    @Mock
-    private FedoraResource resource;
 
     @Mock
     private ResourceOperation mockOperation;
@@ -68,12 +62,12 @@ public class OCFLPersistentSessionManagerTest {
 
     @Before
     public void setUp() {
-        readWriteSession = this.sessionFactory.getSession(testSessionId);
-        readOnlySession = this.sessionFactory.getReadOnlySession();
+        readWriteSession = this.sessionManager.getSession(testSessionId);
+        readOnlySession = this.sessionManager.getReadOnlySession();
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testNormalSession() throws Exception {
+    public void testUnsupportedOperationOnUnrecognizedOperation() throws Exception {
         readWriteSession.persist(mockOperation);
     }
 
@@ -84,7 +78,7 @@ public class OCFLPersistentSessionManagerTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullSessionId() {
-        this.sessionFactory.getSession(null);
+        this.sessionManager.getSession(null);
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSessionTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.vocabulary.DC;
+import org.apache.jena.vocabulary.RDF;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.operations.RdfSourceOperation;
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+import org.fcrepo.persistence.api.CommitOption;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
+import org.fcrepo.persistence.ocfl.impl.DefaultOCFLObjectSessionFactory;
+import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static org.apache.jena.graph.NodeFactory.createLiteral;
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link OCFLPersistentStorageSession}
+ *
+ * @author dbernstein
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OCFLPersistentStorageSessionTest {
+
+
+    private OCFLPersistentStorageSession session;
+
+    @Mock
+    private FedoraToOCFLObjectIndex index;
+
+    @Mock
+    private FedoraOCFLMapping mapping;
+
+    private OCFLObjectSessionFactory objectSessionFactory;
+
+    private String parentId = "info:fedora/parent";
+    private String resourceId = parentId + "/child1";
+
+    @Mock
+    private RdfSourceOperation rdfSourceOperation;
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws IOException {
+        final var stagingDir = tempFolder.newFolder("ocfl-staging");
+        final var repoDir = tempFolder.newFolder("ocfl-repo");
+        final var workDir = tempFolder.newFolder("ocfl-work");
+
+        this.objectSessionFactory = new DefaultOCFLObjectSessionFactory(stagingDir, repoDir, workDir);
+        session = createSession(index, objectSessionFactory);
+
+    }
+
+    private OCFLPersistentStorageSession createSession(final FedoraToOCFLObjectIndex index,
+                                                       final OCFLObjectSessionFactory objectSessionFactory){
+       return new OCFLPersistentStorageSession(new Random().nextLong() + "", index, objectSessionFactory);
+    }
+
+    @Test
+    public void roundtripCreateContainerCreation() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("ocfl-object-id");
+        when(mapping.getParentFedoraResourceId()).thenReturn(parentId);
+        when(index.getMapping(resourceId)).thenReturn(mapping);
+
+        final Node resourceUri = createURI(resourceId);
+
+        //create some test user triples
+        final String title = "my title";
+        final var dcTitleTriple = Triple.create(resourceUri, DC.title.asNode(), createLiteral(title));
+        final Stream<Triple> userTriples = Stream.of(dcTitleTriple);
+        final DefaultRdfStream userStream = new DefaultRdfStream(resourceUri, userTriples);
+        //create some test server props
+        final Triple rdfSourceTriple = Triple.create(resourceUri, RDF.type.asNode(),RDF_SOURCE.asNode());
+        final Stream<Triple> serverTriples = Stream.of(rdfSourceTriple);
+        final RdfStream serverStream = new DefaultRdfStream(resourceUri, serverTriples);
+
+        when(rdfSourceOperation.getTriples()).thenReturn(userStream);
+        when(rdfSourceOperation.getServerManagedProperties()).thenReturn(serverStream);
+
+        when(rdfSourceOperation.getResourceId()).thenReturn(resourceId);
+        when(rdfSourceOperation.getType()).thenReturn(CREATE);
+
+        //perform the create rdf operation
+        session.persist(rdfSourceOperation);
+
+        final var node = createURI(resourceId);
+
+        //verify get triples within the transaction
+        var retrievedUserStream = session.getTriples(resourceId, null);
+        assertEquals(node, retrievedUserStream.topic());
+        assertEquals(dcTitleTriple, retrievedUserStream.findFirst().get());
+
+        //verify get server props within the transaction
+        var retrievedServerStream = session.getManagedProperties(resourceId, null);
+        assertEquals(node, retrievedServerStream.topic());
+        assertEquals(rdfSourceTriple, retrievedServerStream.findFirst().get());
+
+        //commit to OCFL
+        session.commit(CommitOption.UNVERSIONED);
+
+        //create a new session and verify that the state is the same
+        final OCFLPersistentStorageSession newSession = createSession(index, objectSessionFactory);
+
+        //verify get triples outside of the transaction
+        retrievedUserStream = newSession.getTriples(resourceId, null);
+        assertEquals(node, retrievedUserStream.topic());
+        assertEquals(dcTitleTriple, retrievedUserStream.findFirst().get());
+
+        //verify get server props outside of the transaction
+        retrievedServerStream = newSession.getManagedProperties(resourceId, null);
+        assertEquals(node, retrievedServerStream.topic());
+        assertEquals(rdfSourceTriple, retrievedServerStream.findFirst().get());
+
+
+    }
+
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -17,8 +17,8 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static org.fcrepo.persistence.ocfl.api.CommitOption.NEW_VERSION;
-import static org.fcrepo.persistence.ocfl.api.CommitOption.MUTABLE_HEAD;
+import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
+import static org.fcrepo.persistence.api.CommitOption.UNVERSIONED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -110,7 +110,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void writeNewFile_ToMHead_NewObject() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(MUTABLE_HEAD);
+        session.commit(UNVERSIONED);
 
         assertMutableHeadPopulated(OBJ_ID);
         assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT1);
@@ -152,7 +152,7 @@ public class DefaultOCFLObjectSessionTest {
         });
 
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
-        final String versionId = session.commit(MUTABLE_HEAD);
+        final String versionId = session.commit(UNVERSIONED);
 
         assertEquals("Multiple commits to head should stay on version", "v2", versionId);
         assertMutableHeadPopulated(OBJ_ID);
@@ -163,7 +163,7 @@ public class DefaultOCFLObjectSessionTest {
     public void writeToMHeadThenNewVersion() throws Exception {
         // Write first file to mutable head
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(MUTABLE_HEAD);
+        session.commit(UNVERSIONED);
 
         assertMutableHeadPopulated(OBJ_ID);
 
@@ -214,7 +214,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void read_FromMHead() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(MUTABLE_HEAD);
+        session.commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
         assertStreamMatches(FILE_CONTENT1, session2.read(FILE1_SUBPATH));
@@ -244,7 +244,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void read_FromStagedAndMHead() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(MUTABLE_HEAD);
+        session.commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
         session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
@@ -346,11 +346,11 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void delete_FromMHead() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(MUTABLE_HEAD);
+        session.commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
         session2.delete(FILE1_SUBPATH);
-        session2.commit(MUTABLE_HEAD);
+        session2.commit(UNVERSIONED);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
     }
@@ -385,12 +385,12 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void delete_FromStagedAndMHead() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(MUTABLE_HEAD);
+        session.commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
         session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
         session2.delete(FILE1_SUBPATH);
-        session2.commit(MUTABLE_HEAD);
+        session2.commit(UNVERSIONED);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
         assertFileNotInVersion(OBJ_ID, "v1", FILE1_SUBPATH);
@@ -557,10 +557,10 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void commit_MHead_NoChanges() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(MUTABLE_HEAD);
+        session.commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
-        session2.commit(MUTABLE_HEAD);
+        session2.commit(UNVERSIONED);
 
         final ObjectDetails objDetails = ocflRepository.describeObject(OBJ_ID);
         final var versionMap = objDetails.getVersionMap();

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/NonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/NonRdfSourcePersisterTest.java
@@ -20,15 +20,14 @@ package org.fcrepo.persistence.ocfl.impl;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.DEFAULT_RDF_EXTENSION;
-import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.INTERNAL_FEDORA_DIRECTORY;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.getInternalFedoraDirectory;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.getRDFFileExtension;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
@@ -109,7 +108,7 @@ public class NonRdfSourcePersisterTest {
         assertEquals(inputContent, IOUtils.toString(userContent, StandardCharsets.UTF_8));
 
         //verify server triples
-        verify(session).write(eq(INTERNAL_FEDORA_DIRECTORY + File.separator + "child" + DEFAULT_RDF_EXTENSION), serverTriplesIsCaptor.capture());
+        verify(session).write(eq(getInternalFedoraDirectory() + "child" + getRDFFileExtension()), serverTriplesIsCaptor.capture());
         final InputStream serverTriplesIs = serverTriplesIsCaptor.getValue();
 
         final Model serverModel = createDefaultModel();

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersisterTest.java
@@ -21,8 +21,8 @@ import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
-import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.DEFAULT_RDF_EXTENSION;
-import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.INTERNAL_FEDORA_DIRECTORY;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.getInternalFedoraDirectory;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.getRDFFileExtension;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -89,8 +89,8 @@ public class RDFSourcePersisterTest {
 
         //create some test server triples
         final Stream<Triple> serverTriples = Stream.of(Triple.create(resourceUri,
-                                                                     RDF.type.asNode(),
-                                                                     RDF_SOURCE.asNode()));
+                RDF.type.asNode(),
+                RDF_SOURCE.asNode()));
         final RdfStream serverTriplesStream = new DefaultRdfStream(resourceUri, serverTriples);
 
         when(mapping.getOcflObjectId()).thenReturn("object-id");
@@ -101,7 +101,7 @@ public class RDFSourcePersisterTest {
         persister.persist(session, operation, mapping);
 
         //verify user triples
-        verify(session).write(eq("child" + DEFAULT_RDF_EXTENSION), userTriplesIsCaptor.capture());
+        verify(session).write(eq("child" + getRDFFileExtension()), userTriplesIsCaptor.capture());
         final InputStream userTriplesIs = userTriplesIsCaptor.getValue();
 
         final Model userModel = createDefaultModel();
@@ -111,7 +111,7 @@ public class RDFSourcePersisterTest {
                 DC.title, title));
 
         //verify server triples
-        verify(session).write(eq(INTERNAL_FEDORA_DIRECTORY + "/child" + DEFAULT_RDF_EXTENSION), serverTriplesIsCaptor.capture());
+        verify(session).write(eq(getInternalFedoraDirectory() + "child" + getRDFFileExtension()), serverTriplesIsCaptor.capture());
         final InputStream serverTriplesIs = serverTriplesIsCaptor.getValue();
 
         final Model serverModel = createDefaultModel();


### PR DESCRIPTION
**Implements Implement OCFLPersistentStorageSession.getTriples() and OCFLPersistentStorageSession.getManagedProperties() for unversioned content.**
* * *

**JIRA Ticket**:  https://jira.duraspace.org/browse/FCREPO-3119

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR implements the OCFLPersistentStorageSession.getTriples() and OCFLPersistentStorageSession.getManagedProperties()  methods when the version parameter is null.  Included is a unit test that writes resources to disk and then reads them out  before and after the commit.
  
# What's new?
PersistentStorageSession.commit() now has a CommitOption param. 

# How should this be tested?
Covered by a unit test.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Folks should be aware of the change to the PersistentStorageSession.commit() method as we'll need to translate the users intention to create a new version vs commit to unversioned at the close of a transaction (in the case that autoversioning is not enabled).
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
