### PR TITLE
Add delete persister

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
@@ -36,6 +36,7 @@ import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.fcrepo.persistence.ocfl.api.Persister;
 import org.fcrepo.persistence.ocfl.impl.DefaultOCFLObjectSession;
+import org.fcrepo.persistence.ocfl.impl.DeleteResourcePersister;
 import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
 import org.fcrepo.persistence.ocfl.impl.RDFSourcePersister;
 
@@ -63,6 +64,7 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
 
     static {
         PERSISTER_LIST.add(new RDFSourcePersister());
+        PERSISTER_LIST.add(new DeleteResourcePersister());
         //TODO add new persisters here as they are implemented.
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageUtils.java
@@ -17,6 +17,15 @@
  */
 package org.fcrepo.persistence.ocfl;
 
+import static org.apache.jena.riot.RDFFormat.NTRIPLES;
+import static org.apache.jena.riot.system.StreamRDFWriter.getWriterStream;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.system.StreamRDF;
 import org.fcrepo.kernel.api.RdfStream;
@@ -25,25 +34,17 @@ import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-
-import static java.lang.String.format;
-import static org.apache.jena.riot.RDFFormat.NTRIPLES;
-import static org.apache.jena.riot.system.StreamRDFWriter.getWriterStream;
-
 /**
  * A set of utility functions for supporting OCFL persistence activities.
  *
  * @author dbernstein
  * @since 6.0.0
  */
-public class OCFLPeristentStorageUtils {
+public class OCFLPersistentStorageUtils {
 
-    private static final Logger log = LoggerFactory.getLogger(OCFLPeristentStorageUtils.class);
+    private static final Logger log = LoggerFactory.getLogger(OCFLPersistentStorageUtils.class);
 
-    private OCFLPeristentStorageUtils() {
+    private OCFLPersistentStorageUtils() {
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * Delete Resource Persister
  * @author whikloj
  */
-public class DeleteResourcePersister extends AbstractPersister<ResourceOperation> {
+public class DeleteResourcePersister extends AbstractPersister {
 
     private static final Logger log = LoggerFactory.getLogger(DeleteResourcePersister.class);
 
@@ -38,14 +38,14 @@ public class DeleteResourcePersister extends AbstractPersister<ResourceOperation
      * Constructor.
      */
     public DeleteResourcePersister() {
-        super(DELETE);
+        super(ResourceOperation.class, DELETE);
     }
 
     @Override
     public void persist(final OCFLObjectSession session, final ResourceOperation operation, final FedoraOCFLMapping mapping)
             throws PersistentStorageException {
         log.debug("Deleting {} from {}", operation.getResourceId(), mapping.getOcflObjectId());
-        if (mapping.getParentFedoraResourceId() == operation.getResourceId()) {
+        if (mapping.getParentFedoraResourceId().equals(operation.getResourceId())) {
             // We are at the root of the object.
             session.deleteObject();
         } else {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.DELETE;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.relativizeSubpath;
+
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Delete Resource Persister
+ * @author whikloj
+ */
+public class DeleteResourcePersister extends AbstractPersister<ResourceOperation> {
+
+    private static final Logger log = LoggerFactory.getLogger(DeleteResourcePersister.class);
+
+    /**
+     * Constructor.
+     */
+    public DeleteResourcePersister() {
+        super(DELETE);
+    }
+
+    @Override
+    public void persist(final OCFLObjectSession session, final ResourceOperation operation, final FedoraOCFLMapping mapping)
+            throws PersistentStorageException {
+        log.debug("Deleting {} from {}", operation.getResourceId(), mapping.getOcflObjectId());
+        if (mapping.getParentFedoraResourceId() == operation.getResourceId()) {
+            // We are at the root of the object.
+            session.deleteObject();
+        } else {
+            final String subpath = relativizeSubpath(mapping.getParentFedoraResourceId(), operation.getResourceId());
+            session.delete(subpath);
+        }
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersister.java
@@ -19,9 +19,9 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
-import static org.fcrepo.persistence.ocfl.OCFLPeristentStorageUtils.INTERNAL_FEDORA_DIRECTORY;
-import static org.fcrepo.persistence.ocfl.OCFLPeristentStorageUtils.relativizeSubpath;
-import static org.fcrepo.persistence.ocfl.OCFLPeristentStorageUtils.writeRDF;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.INTERNAL_FEDORA_DIRECTORY;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.relativizeSubpath;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.writeRDF;
 
 import static java.util.Arrays.asList;
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.fcrepo.persistence.ocfl.api.Persister;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Delete Persister tests.
+ * @author whikloj
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class DeleteResourcePersisterTest {
+
+    @Mock
+    private FedoraOCFLMapping mapping;
+
+    @Mock
+    private OCFLObjectSession session;
+
+    @Mock
+    private ResourceOperation operation;
+
+    private final Persister persister = new DeleteResourcePersister();
+
+    @Test
+    public void testDeleteSubPath() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getParentFedoraResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        persister.persist(session, operation, mapping);
+        verify(session).delete("some-subpath");
+    }
+
+    @Test
+    public void testDeleteFullObject() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getParentFedoraResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        persister.persist(session, operation, mapping);
+        verify(session).deleteObject();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNotPartOfObject() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getParentFedoraResourceId()).thenReturn("info:fedora/some-wrong-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        persister.persist(session, operation, mapping);
+    }
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersisterTest.java
@@ -21,8 +21,8 @@ import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
-import static org.fcrepo.persistence.ocfl.OCFLPeristentStorageUtils.DEFAULT_RDF_EXTENSION;
-import static org.fcrepo.persistence.ocfl.OCFLPeristentStorageUtils.INTERNAL_FEDORA_DIRECTORY;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.DEFAULT_RDF_EXTENSION;
+import static org.fcrepo.persistence.ocfl.OCFLPersistentStorageUtils.INTERNAL_FEDORA_DIRECTORY;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -49,6 +49,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+<<<<<<<HEAD:fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersisterTest.java
+        =======
+        >>>>>>>Add delete persister:fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersisterTest.java
 
 /**
  * @author dbernstein

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersisterTest.java
@@ -50,10 +50,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-<<<<<<<HEAD:fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/RDFSourcePersisterTest.java
-        =======
-        >>>>>>>Add delete persister:fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersisterTest.java
-
 /**
  * @author dbernstein
  * @since 6.0.0


### PR DESCRIPTION
Fix typo in class name

**JIRA Ticket**: https://jira.duraspace.org/projects/FCREPO/issues/FCREPO-3100

# What does this Pull Request do?
Adds a Delete Resource persister to do the deletion from the persistence layer.

Also fixes a small typo in a utility class name, sorry for all the import changes due to the class renaming.

# How should this be tested?

Review, unit tests included

# Interested parties
@fcrepo4/committers
