### PR TITLE
FCREPO-3128. Complete TransactionImpl implementation.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/Transactions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/Transactions.java
@@ -73,9 +73,7 @@ public class Transactions extends FedoraBaseResource {
 
         final Response.ResponseBuilder res = created(
                 new URI(translator().toDomain("/tx:" + transaction.getId()).toString()));
-        transaction.getExpires().ifPresent(expires -> {
-            res.expires(from(expires));
-        });
+        res.expires(from(transaction.getExpires()));
         return res.build();
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/TransactionsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/TransactionsTest.java
@@ -18,7 +18,6 @@
 package org.fcrepo.http.api;
 
 import static java.time.Instant.now;
-import static java.util.Optional.of;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -76,7 +75,7 @@ public class TransactionsTest {
         when(mockTxManager.get(AdditionalMatchers.not(ArgumentMatchers.eq("tx:123"))))
             .thenThrow(new RuntimeException("No Transaction found with transactionId"));
         when(mockTransaction.getId()).thenReturn("123");
-        when(mockTransaction.getExpires()).thenReturn(of(now().plusSeconds(100)));
+        when(mockTransaction.getExpires()).thenReturn(now().plusSeconds(100));
         setField(testObj, "txManager", mockTxManager);
     }
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
@@ -19,7 +19,6 @@ package org.fcrepo.kernel.api;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Optional;
 
 /**
  * The Fedora Transaction abstraction
@@ -71,6 +70,11 @@ public interface Transaction {
     public void expire();
 
     /**
+     * Has the transaction expired?
+     */
+    public boolean hasExpired();
+
+    /**
     * Update the expiry by the provided amount
     * @param amountToAdd the amount of time to add
     * @return the new expiration date
@@ -81,7 +85,7 @@ public interface Transaction {
      * Get the date this session expires
      * @return expiration date, if one exists
      */
-    Optional<Instant> getExpires();
+    Instant getExpires();
 
     /**
      * Refresh the transaction to extend its expiration window.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TransactionRuntimeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TransactionRuntimeException.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Runtime exception
+ *
+ * @author mohideen
+ */
+public class TransactionRuntimeException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     */
+    public TransactionRuntimeException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param rootCause the root cause
+     */
+    public TransactionRuntimeException(final Throwable rootCause) {
+        super(rootCause);
+    }
+
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     * @param rootCause the root cause
+     */
+    public TransactionRuntimeException(final String msg, final Throwable rootCause) {
+        super(msg, rootCause);
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -21,6 +21,7 @@ import static java.util.UUID.randomUUID;
 
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
+import org.fcrepo.kernel.api.exception.TransactionRuntimeException;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 
 import java.util.HashMap;
@@ -44,6 +45,8 @@ public class TransactionManagerImpl implements TransactionManager {
         transactions = new HashMap();
     }
 
+    // TODO Add a timer to periadically rollback and cleanup expired transaction?
+
     @Override
     public synchronized Transaction create() {
         String txId = randomUUID().toString();
@@ -62,12 +65,12 @@ public class TransactionManagerImpl implements TransactionManager {
             if(transaction.hasExpired()) {
                 transaction.rollback();
                 transactions.remove(transactionId);
-                throw new RuntimeException("Transaction with transactionId: " + transactionId +
+                throw new TransactionRuntimeException("Transaction with transactionId: " + transactionId +
                     " expired at " + transaction.getExpires() + "!");
             }
             return transaction;
         } else {
-            throw new RuntimeException("No Transaction found with transactionId: " + transactionId);
+            throw new TransactionRuntimeException("No Transaction found with transactionId: " + transactionId);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -60,9 +60,9 @@ public class TransactionManagerImpl implements TransactionManager {
 
     @Override
     public Transaction get(final String transactionId) {
-        if(transactions.containsKey(transactionId)) {
+        if (transactions.containsKey(transactionId)) {
             final Transaction transaction = transactions.get(transactionId);
-            if(transaction.hasExpired()) {
+            if (transaction.hasExpired()) {
                 transaction.rollback();
                 transactions.remove(transactionId);
                 throw new TransactionRuntimeException("Transaction with transactionId: " + transactionId +

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * <p>
+ * TransactionTest class.
+ * </p>
+ *
+ * @author mohideen
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TransactionImplTest {
+
+    private TransactionImpl testTx;
+
+    @Mock
+    private TransactionManagerImpl txManager;
+
+    @Mock
+    private PersistentStorageSessionManager pssManager;
+
+    @Mock
+    private PersistentStorageSession psSession;
+
+    @Before
+    public void setUp() {
+        when(pssManager.getSession("123")).thenReturn(psSession);
+        when(txManager.getPersistentStorageSessionManager()).thenReturn(pssManager);
+        testTx = new TransactionImpl("123", txManager);
+    }
+
+    @Test
+    public void testGetId() {
+        assertEquals("123", testTx.getId());
+    }
+
+    @Test
+    public void testDefaultShortLived() {
+        assertEquals(true, testTx.isShortLived());
+    }
+
+    @Test
+    public void testSetShortLived() {
+        testTx.setShortLived(false);
+        assertEquals(false, testTx.isShortLived());
+    }
+
+    @Test
+    public void testCommit() {
+        testTx.commit();
+        try {
+            verify(psSession).commit();
+        } catch (PersistentStorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testCommitIfShortLived() {
+        testTx.setShortLived(true);
+        testTx.commitIfShortLived();
+        try {
+            verify(psSession).commit();
+        } catch (PersistentStorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testCommitIfShortLivedOnNonShortLived() {
+        testTx.setShortLived(false);
+        testTx.commitIfShortLived();
+        try {
+            verify(psSession, never()).commit();
+        } catch (PersistentStorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testCommitExpired() {
+        testTx.expire();
+        testTx.commit();
+        try {
+            verify(psSession).commit();
+        } catch (PersistentStorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testCommitRolledbackTx() {
+        testTx.rollback();
+        testTx.commit();
+        try {
+            verify(psSession, never()).commit();
+        } catch (PersistentStorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testRollback() {
+        testTx.rollback();
+        try {
+            verify(psSession).rollback();
+        } catch (PersistentStorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testRollbackCommited() {
+        testTx.commit();
+        testTx.rollback();
+        try {
+            verify(psSession, never()).rollback();
+        } catch (PersistentStorageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testExpire() {
+        testTx.expire();
+        assertEquals(true, testTx.hasExpired());
+    }
+
+    @Test
+    public void testRefresh() {
+        final Instant previousExpiry = testTx.getExpires();
+        testTx.refresh();
+        assertTrue(testTx.getExpires().isAfter(previousExpiry));
+    }
+
+    @Test
+    public void testNewTransactionNotExpired() {
+        assertTrue(testTx.getExpires().compareTo(Instant.now()) > 0);
+    }
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
@@ -33,7 +33,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author mohideen
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
-public class TransactionManagerTest {
+public class TransactionManagerImplTest {
 
     private TransactionImpl testTx;
 
@@ -60,6 +60,12 @@ public class TransactionManagerTest {
 
     @Test(expected = RuntimeException.class)
     public void testGetTransactionWithInvalidID() {
-        final TransactionImpl tx = (TransactionImpl) testTxManager.get("invalid-id");
+        testTxManager.get("invalid-id");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetExpiredTransaction() {
+        testTx.expire();
+        testTxManager.get(testTx.getId());
     }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
@@ -19,12 +19,18 @@ package org.fcrepo.kernel.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import org.fcrepo.kernel.api.TransactionManager;
-
+import org.fcrepo.kernel.api.exception.TransactionRuntimeException;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -39,9 +45,17 @@ public class TransactionManagerImplTest {
 
     private TransactionManager testTxManager;
 
+    @Mock
+    private PersistentStorageSessionManager pssManager;
+
+    @Mock
+    private PersistentStorageSession psSession;
+
     @Before
     public void setUp() {
         testTxManager = new TransactionManagerImpl();
+        when(pssManager.getSession(any())).thenReturn(psSession);
+        setField(testTxManager, "pSessionManager", pssManager);
         testTx = (TransactionImpl) testTxManager.create();
     }
 
@@ -58,12 +72,12 @@ public class TransactionManagerImplTest {
         assertEquals(testTx.getId(), tx.getId());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = TransactionRuntimeException.class)
     public void testGetTransactionWithInvalidID() {
         testTxManager.get("invalid-id");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = TransactionRuntimeException.class)
     public void testGetExpiredTransaction() {
         testTx.expire();
         testTxManager.get(testTx.getId());


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3128

# What does this Pull Request do?
Completes the implementation of the TransactionImpl

# What's new?
- Changed `getExpires` method on Transaction Interface to return `Instant` instead of `Optional<Instant>`

# How should this be tested?
Verify that the build and tests pass.

# Additional Notes:
Currently, the only time a Transaction get removed from the TransactionManager's list is when there is a request request to get a transaction which has expired. Do we need to remove transactions on commit/rollback or should we move the finished (commited/rolledback/expired) transaction to a different list. This discussion probably can wait until we move to a database backed transaction store.

# Interested parties
@fcrepo4/committers
