### PR TITLE
Implements OCFLPersistentStorageSession.getTriples() by version.

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
@@ -211,6 +211,18 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
         return getRdfStream(identifier, objSession, filePath, version);
     }
 
+    /**
+     * Returns a list of immutable versions associated with the specified fedora identifier
+     * @param fedoraIdentifier
+     * @return
+     * @throws PersistentStorageException
+     */
+     List<Instant> listVersions(final String fedoraIdentifier) throws PersistentStorageException {
+        final FedoraOCFLMapping mapping = fedoraOcflIndex.getMapping(fedoraIdentifier);
+        final OCFLObjectSession objSession = findOrCreateSession(mapping.getOcflObjectId());
+        return OCFLPersistentStorageUtils.listVersions(objSession);
+    }
+
     @Override
     public RdfStream getManagedProperties(final String identifier, final Instant version)
             throws PersistentStorageException {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
@@ -215,7 +215,7 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
      * Returns a list of immutable versions associated with the specified fedora identifier
      * @param fedoraIdentifier The fedora identifier
      * @return The list of instants that map to the underlying versions
-     * @throws PersistentStorageException
+     * @throws PersistentStorageException Due the underlying resource not existing or is otherwise unreadable.
      */
      List<Instant> listVersions(final String fedoraIdentifier) throws PersistentStorageException {
         final FedoraOCFLMapping mapping = fedoraOcflIndex.getMapping(fedoraIdentifier);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java
@@ -213,8 +213,8 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
 
     /**
      * Returns a list of immutable versions associated with the specified fedora identifier
-     * @param fedoraIdentifier
-     * @return
+     * @param fedoraIdentifier The fedora identifier
+     * @return The list of instants that map to the underlying versions
      * @throws PersistentStorageException
      */
      List<Instant> listVersions(final String fedoraIdentifier) throws PersistentStorageException {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageUtils.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.persistence.ocfl;
 
-import edu.wisc.library.ocfl.api.model.VersionDetails;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
@@ -202,7 +201,7 @@ public class OCFLPersistentStorageUtils {
     }
 
     /**
-     * A utility method that returns a list of {@link java.time.Instant} objects representing versions
+     * A utility method that returns a list of  {@link java.time.Instant} objects representing immutable versions
      * accessible from the OCFL Object represented by the session.
      *
      * @param objSession The OCFL object session
@@ -210,8 +209,7 @@ public class OCFLPersistentStorageUtils {
      * @throws PersistentStorageException
      */
     public static List<Instant> listVersions(final OCFLObjectSession objSession) throws PersistentStorageException {
-        final List<VersionDetails> versionList = objSession.listVersions();
-        return versionList.stream().map(versionDetails -> versionDetails.getCreated().toInstant())
+        return  objSession.listVersions().stream().map(versionDetails -> versionDetails.getCreated().toInstant())
                 .collect(Collectors.toList());
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageUtils.java
@@ -94,7 +94,7 @@ public class OCFLPersistentStorageUtils {
      * Returns the OCFL subpath for a given fedora subpath.  This returned subpath
      * does not include any added extendsions.
      * @param fedoraSubpath
-     * @return
+     * @return The resolved OCFL subpath
      */
     public static  String resolveOCFLSubpath(final String fedoraSubpath) {
         if (fedoraSubpath.endsWith(FEDORA_METADATA_SUFFIX)) {
@@ -109,8 +109,8 @@ public class OCFLPersistentStorageUtils {
      * For example:  passing info:fedora/resource1/fcr:metadata would return
      *  info:fedora/resource1 since  info:fedora/resource1 would be the expected
      *  topic.
-     * @param fedoraIdentifier
-     * @return
+     * @param fedoraIdentifier The fedora identifier
+     * @return The resolved topic
      */
     public static  String resolveTopic(final String fedoraIdentifier) {
         if (fedoraIdentifier.endsWith(FEDORA_METADATA_SUFFIX)) {
@@ -156,8 +156,8 @@ public class OCFLPersistentStorageUtils {
      * @param version    The version.  If null, the head state will be returned.
      * @param objSession The OCFL object session
      * @param subpath The path to the desired file.
-     * @return
-     * @throws PersistentStorageException
+     * @return the RDF stream
+     * @throws PersistentStorageException If unable to read the specified rdf stream.
      */
     public static RdfStream getRdfStream(final String identifier,
                                          final OCFLObjectSession objSession,
@@ -206,7 +206,7 @@ public class OCFLPersistentStorageUtils {
      *
      * @param objSession The OCFL object session
      * @return A list of Instant objects
-     * @throws PersistentStorageException
+     * @throws PersistentStorageException On read failure due to the session being closed or some other problem.
      */
     public static List<Instant> listVersions(final OCFLObjectSession objSession) throws PersistentStorageException {
         return  objSession.listVersions().stream().map(versionDetails -> versionDetails.getCreated().toInstant())

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -19,7 +19,9 @@
 package org.fcrepo.persistence.ocfl.api;
 
 import java.io.InputStream;
+import java.util.List;
 
+import edu.wisc.library.ocfl.api.model.VersionDetails;
 import org.fcrepo.persistence.api.CommitOption;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
@@ -103,5 +105,13 @@ public interface OCFLObjectSession {
      * @throws PersistentStorageException if unable to close the session.
      */
     void close() throws PersistentStorageException;
+
+
+    /**
+     * Return the list of versions associated with this OCFL Object in chronological order.
+     * @return The list of versions
+     * @throws PersistentStorageException
+     */
+    List<VersionDetails> listVersions() throws PersistentStorageException;
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -108,7 +108,7 @@ public interface OCFLObjectSession {
 
 
     /**
-     * Return the list of versions associated with this OCFL Object in chronological order.
+     * Return the list of immutable versions associated with this OCFL Object in chronological order.
      * @return The list of versions
      * @throws PersistentStorageException
      */

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -110,7 +110,8 @@ public interface OCFLObjectSession {
     /**
      * Return the list of immutable versions associated with this OCFL Object in chronological order.
      * @return The list of versions
-     * @throws PersistentStorageException
+     * @throws PersistentStorageException If the versions cannot be read due to the underlying session being closed
+     *                                    or for some other reason.
      */
     List<VersionDetails> listVersions() throws PersistentStorageException;
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -20,7 +20,6 @@ package org.fcrepo.persistence.ocfl.impl;
 import static edu.wisc.library.ocfl.api.OcflOption.OVERWRITE;
 import static edu.wisc.library.ocfl.api.OcflOption.MOVE_SOURCE;
 import static java.lang.System.getProperty;
-import static java.util.Collections.sort;
 import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
 import static java.lang.String.format;
 import static org.fcrepo.persistence.api.CommitOption.UNVERSIONED;
@@ -402,20 +401,11 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
     public List<VersionDetails> listVersions() throws PersistentStorageException {
         assertSessionOpen();
         //get a list of all versions in the object.
-        final List<VersionDetails> versionList = this.ocflRepository.describeObject(this.objectIdentifier)
+        return this.ocflRepository.describeObject(this.objectIdentifier)
                                                                     .getVersionMap().values().stream()
-                                                                    // TODO uncomment when VersionDetails.isMutable()
-                                                                    // is available
-                                                                    //.filter(v -> !v.isMutable())
+                                                                    .filter(v -> !v.isMutable())
+                                                                    .sorted(VERSION_COMPARATOR)
                                                                     .collect(Collectors.toList());
-        //TODO remove following four lines once VersionDetails.isMutable() is available
-        //remove the last element in the list if it is a staged (ie not immutable) change.
-        if(this.ocflRepository.hasStagedChanges(this.objectIdentifier)){
-            versionList.remove(versionList.size()-1);
-        }
-
-        sort(versionList, VERSION_COMPARATOR);
-        return versionList;
     }
 
     private static final VersionComparator VERSION_COMPARATOR = new VersionComparator();

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSessionTest.java
@@ -46,6 +46,7 @@ import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +74,6 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class OCFLPersistentStorageSessionTest {
-
 
     private static final String OCFL_OBJECT_ID = "ocfl-object-id";
 
@@ -533,7 +533,41 @@ public class OCFLPersistentStorageSessionTest {
     @Ignore
     @Test(expected = PersistentStorageException.class)
     public void rollbackSucceedsWhenRollingBackCommittedVersions() throws Exception {
-
     }
 
+    @Test
+    public void getTriplesFromPreviousVersion() throws Exception {
+        DefaultOCFLObjectSession.setGlobaDefaultCommitOption(NEW_VERSION);
+        mockMappingAndIndex(OCFL_OBJECT_ID, resourceId, parentId, mapping);
+
+        final Node resourceUri = createURI(resourceId);
+
+        //mock the operation
+        final String title = "my title";
+        final var dcTitleTriple = Triple.create(resourceUri, DC.title.asNode(), createLiteral(title));
+        final Stream<Triple> userTriples = Stream.of(dcTitleTriple);
+        final DefaultRdfStream userStream = new DefaultRdfStream(resourceUri, userTriples);
+
+        mockResourceOperation(rdfSourceOperation, userStream, new DefaultRdfStream(resourceUri, Stream.empty()), resourceId);
+
+        //perform the create rdf operation
+        session.persist(rdfSourceOperation);
+
+        //commit to new version
+        session.commit();
+
+
+        //create a new session and verify that the state is the same
+        final OCFLPersistentStorageSession newSession = createSession(index, objectSessionFactory);
+
+        //get the newly created version
+        final List<Instant> versions = newSession.listVersions(resourceId);
+        final Instant version = versions.get(versions.size() - 1);
+
+        //verify get triples from version
+        final RdfStream retrievedUserStream = newSession.getTriples(resourceId, version);
+        final var node = createURI(resourceId);
+        assertEquals(node, retrievedUserStream.topic());
+        assertEquals(dcTitleTriple, retrievedUserStream.findFirst().get());
+    }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -31,7 +31,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
+import edu.wisc.library.ocfl.api.model.VersionDetails;
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
@@ -600,6 +602,32 @@ public class DefaultOCFLObjectSessionTest {
 
         session.close();
     }
+
+    @Test
+    public void listVersions() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.commit(NEW_VERSION);
+        session.close();
+
+        final var session1 = makeNewSession();
+
+        session1.commit(NEW_VERSION);
+        session1.close();
+
+        final var session2 = makeNewSession();
+        session2.commit(UNVERSIONED);
+        session2.close();
+
+        final var session3 = makeNewSession();
+
+        final List<VersionDetails> versions = session3.listVersions();
+        session3.close();
+
+        assertEquals("First version in list is not \"v1\"", "v1", versions.get(0).getVersionId().toString());
+        assertEquals("Second version in list is not \"v2\"", "v2", versions.get(1).getVersionId().toString());
+        assertEquals("There should be exactly two versions",2, versions.size());
+    }
+
 
     private static InputStream fileStream(final String content) {
         return new ByteArrayInputStream(content.getBytes());


### PR DESCRIPTION
**Implements OCFLPersistentStorageSession.getTriples() by version.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3126

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Adds support for getTriples() using an Instant to identify a version
# What's new?
In addition I have added a listVersions(fedoraIdentifier) method to the OCFLPersistentStorageSession.java to help with testing.   If we decide we need this method for memento related operations,  we can promote it to the PersistentStorageSession interface.  In order to support retrieving triples by version, I've also added the OCFLObjectSession.listVersions() method.  

# How should this be tested?
Covered by unit tests.

# Additional Notes:
There is a TODO in the implementation of OCFLObjectSession.listVersions() that calls for making use of the soon-to-arrive VersionDetails.isMutable()  method.

# Interested parties
@fcrepo4/committers
