### PR TITLE
FCREPO-3103. Replace a binary resource (HTTP->PersistentStorageSession) 

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -595,7 +595,7 @@ public class FedoraLdp extends ContentExposingResource {
         if (isBinary(interactionModel, requestContentType.toString(), requestContentType != null,
                 extContent != null)) {
             final Collection<String> checksums = parseDigestHeader(digest);
-            createResourceService.perform(transaction.getId(), fedoraId, slug, false, filename, contentType, links, checksums,
+            createResourceService.perform(transaction.getId(), fedoraId, slug, true, filename, contentType, links, checksums,
                     requestBodyStream, size, extContent);
         } else {
             final Model model = httpRdfService.bodyToInternalModel(externalPath(), requestBodyStream,

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdateResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdateResourceService.java
@@ -22,46 +22,37 @@ import org.fcrepo.kernel.api.models.ExternalContent;
 
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.List;
 
 /**
- * Interface for a service to create a new resource via a POST request.
- * @author whikloj
- * @since 2019-11-05
+ * Interface for a service to update an existing resource via a PUT request.
+ * @author mohideen
+ * @since 2019-11-07
  */
-public interface CreateResourceService {
+public interface UpdateResourceService {
 
     /**
-     * Create a new NonRdfSource resource.
+     * Update an existing resource.
      *
      * @param txId The transaction ID for the request.
      * @param fedoraId The internal identifier of the parent.
-     * @param slug The Slug header or null if none.
-     * @param isContained The new resource is contained by fedoraId (ie. POST).
      * @param filename The filename of the binary.
      * @param contentType The content-type header or null if none.
-     * @param linkHeaders The original LINK headers or null if none.
      * @param digest The binary digest or null if none.
      * @param size The binary size.
      * @param requestBody The request body or null if none.
      * @param externalContent The external content handler or null if none.
      */
-    void perform(final String txId, final String fedoraId, final String slug, final boolean isContained,
-                 final String filename, final String contentType, final List<String> linkHeaders,
-                 final Collection<String> digest, final InputStream requestBody, final long size,
-                 final ExternalContent externalContent);
+    void perform(final String txId, final String fedoraId, final String filename,
+                 final String contentType, final Collection<String> digest, final InputStream requestBody,
+                 final long size, final ExternalContent externalContent);
+
 
     /**
-     * Create a new RdfSource resource.
+     * Update a RdfSource resource.
      *
      * @param txId The transaction ID for the request.
      * @param fedoraId The internal identifier of the parent.
-     * @param slug The Slug header or null if none.
-     * @param isContained The new resource is contained by fedoraId (ie. POST).
-     * @param linkHeaders The original LINK headers or null if none.
      * @param model The request body RDF as a Model
      */
-    void perform(final String txId, final String fedoraId, final String slug, final boolean isContained,
-                 final List<String> linkHeaders, final Model model);
-
+    void perform(final String txId, final String fedoraId, final String contentType, final Model model);
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.operations;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
+
+/**
+ * An abstract operation for interacting with a non-rdf source
+ *
+ * @author bbpennel
+ */
+public abstract class AbstractNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
+
+    protected String resourceId;
+
+    protected InputStream content;
+
+    protected URI externalURI;
+
+    protected String externalType;
+
+    protected String mimeType;
+
+    protected String filename;
+
+    protected Collection<URI> digests;
+
+    protected long contentSize;
+
+    protected AbstractNonRdfSourceOperationBuilder(final String rescId) {
+        this.resourceId = rescId;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder mimeType(final String mimetype) {
+        this.mimeType = mimetype;
+        return this;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder filename(final String filename) {
+        this.filename = filename;
+        return this;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder contentDigests(final Collection<URI> digests) {
+        this.digests = digests;
+        return this;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder contentSize(final long size) {
+        this.contentSize = size;
+        return this;
+    }
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilder.java
@@ -17,11 +17,10 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
-import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
-
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Collection;
+
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
 
 
 /**
@@ -29,20 +28,8 @@ import java.util.Collection;
  *
  * @author bbpennel
  */
-public class CreateNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
+public class CreateNonRdfSourceOperationBuilder extends AbstractNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
 
-    /**
-     * The resource id.
-     */
-    private final String resourceId;
-
-    private String mimeType;
-    private String filename;
-    private Collection<URI> digests;
-    private long contentSize;
-    private InputStream content;
-    private URI externalURI;
-    private String externalType;
 
     /**
      * Constructor for external binary.
@@ -68,37 +55,8 @@ public class CreateNonRdfSourceOperationBuilder implements NonRdfSourceOperation
         this.content = stream;
     }
 
-    /**
-     * Constructor
-     *
-     * @param rescId the internal identifier.
-     */
-    CreateNonRdfSourceOperationBuilder(final String rescId) {
-        this.resourceId = rescId;
-    }
-
-    @Override
-    public CreateNonRdfSourceOperationBuilder mimeType(final String mimetype) {
-        this.mimeType = mimetype;
-        return this;
-    }
-
-    @Override
-    public CreateNonRdfSourceOperationBuilder filename(final String filename) {
-        this.filename = filename;
-        return this;
-    }
-
-    @Override
-    public CreateNonRdfSourceOperationBuilder contentDigests(final Collection<URI> digests) {
-        this.digests = digests;
-        return this;
-    }
-
-    @Override
-    public CreateNonRdfSourceOperationBuilder contentSize(final long size) {
-        this.contentSize = size;
-        return this;
+    protected CreateNonRdfSourceOperationBuilder(final String rescId) {
+        super(rescId);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImpl.java
@@ -33,14 +33,12 @@ public class NonRdfSourceOperationFactoryImpl implements NonRdfSourceOperationFa
 
     @Override
     public NonRdfSourceOperationBuilder updateExternalBinaryBuilder(final String rescId, final String handling, final URI contentUri) {
-        // TODO Auto-generated method stub
-        return null;
+        return new UpdateNonRdfSourceOperationBuilder(rescId, handling, contentUri);
     }
 
     @Override
     public NonRdfSourceOperationBuilder updateInternalBinaryBuilder(final String rescId, final InputStream contentStream) {
-        // TODO Auto-generated method stub
-        return null;
+        return new UpdateNonRdfSourceOperationBuilder(rescId, contentStream);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
@@ -19,6 +19,10 @@ package org.fcrepo.kernel.impl.operations;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
 
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 /**
@@ -28,8 +32,35 @@ import org.fcrepo.kernel.api.operations.ResourceOperationType;
  */
 public class UpdateNonRdfSourceOperation extends AbstractNonRdfSourceOperation {
 
-    protected UpdateNonRdfSourceOperation(final String rescId) {
-        super(rescId);
+    /**
+     * Constructor for external content.
+     *
+     * @param rescId the internal identifier.
+     * @param externalContentURI the URI of the external content.
+     * @param externalHandling the type of external content handling (REDIRECT, PROXY)
+     * @param mimeType the mime-type of the content.
+     * @param filename the filename.
+     * @param digests the checksum digests.
+     */
+    protected UpdateNonRdfSourceOperation(final String rescId, final URI externalContentURI,
+                                            final String externalHandling, final String mimeType, final String filename,
+                                            final Collection<URI> digests) {
+        super(rescId, externalContentURI, externalHandling, mimeType, filename, digests);
+    }
+
+    /**
+     * Constructor for internal binaries.
+     *
+     * @param rescId the internal identifier.
+     * @param content the stream of the content.
+     * @param mimeType the mime-type of the content.
+     * @param contentSize the size of the inputstream.
+     * @param filename the filename.
+     * @param digests the checksum digests.
+     */
+    protected UpdateNonRdfSourceOperation(final String rescId, final InputStream content, final String mimeType,
+                                            final long contentSize, final String filename, final Collection<URI> digests) {
+        super(rescId, content, mimeType, contentSize, filename, digests);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilder.java
@@ -17,72 +17,42 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
-import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
-import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
-
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Collection;
 
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
 
 /**
  * Builder for operations to update non-rdf sources
  *
  * @author bbpennel
  */
-public class UpdateNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
-
-    private final String resourceId;
-
-    private InputStream contentStream;
-
-    private String externalType;
-
-    private URI externalUri;
+public class UpdateNonRdfSourceOperationBuilder extends AbstractNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
 
     protected UpdateNonRdfSourceOperationBuilder(final String rescId, final InputStream stream) {
         this(rescId);
-        this.contentStream = stream;
+        this.content = stream;
     }
 
     protected UpdateNonRdfSourceOperationBuilder(final String rescId, final String handling, final URI contentUri) {
         this(rescId);
         this.externalType = handling;
-        this.externalUri = contentUri;
+        this.externalURI = contentUri;
     }
 
     private UpdateNonRdfSourceOperationBuilder(final String rescId) {
-        this.resourceId = rescId;
+        super(rescId);
     }
 
     @Override
-    public NonRdfSourceOperationBuilder mimeType(final String mimetype) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public NonRdfSourceOperationBuilder filename(final String filename) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public NonRdfSourceOperationBuilder contentDigests(final Collection<URI> digests) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public NonRdfSourceOperationBuilder contentSize(final long size) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public NonRdfSourceOperation build() {
-        // TODO Auto-generated method stub
-        return null;
+    public UpdateNonRdfSourceOperation build() {
+        if (content == null && externalURI != null && externalType != null) {
+            return new UpdateNonRdfSourceOperation(this.resourceId, this.externalURI, this.externalType,
+                    this.mimeType, this.filename, this.digests);
+        } else {
+            return new UpdateNonRdfSourceOperation(this.resourceId, this.content, this.mimeType, this.contentSize,
+                    this.filename, this.digests);
+        }
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -64,6 +64,10 @@ import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 
 import org.slf4j.Logger;
+import java.net.URI;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Link;
 
 
 /**
@@ -292,5 +296,26 @@ public abstract class AbstractService {
      */
     protected Node asLiteral(final String literal, final RDFDatatype type) {
         return ResourceFactory.createTypedLiteral(literal, type).asNode();
+    }
+
+    /**
+     * Get the rel="type" link headers from a list of them.
+     * @param headers a list of string LINK headers.
+     * @return a list of LINK headers with rel="type"
+     */
+    protected List<String> getTypes(final List<String> headers) {
+        final List<String> types = getLinkHeaders(headers) == null ? null : getLinkHeaders(headers).stream()
+                .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
+                .map(URI::toString).collect(Collectors.toList());
+        return types;
+    }
+
+    /**
+     * Converts a list of string LINK headers to actual LINK objects.
+     * @param headers the list of string link headers.
+     * @return the list of LINK headers.
+     */
+    protected List<Link> getLinkHeaders(final List<String> headers) {
+        return headers == null ? null : headers.stream().map(p -> Link.fromUri(p).build()).collect(Collectors.toList());
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -45,7 +45,6 @@ import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 import javax.inject.Inject;
-import javax.ws.rs.core.Link;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -78,8 +77,9 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
     @Override
     public void perform(final String txId, final String fedoraId, final String slug, final boolean isContained,
-                        final String contentType, final List<String> linkHeaders, final Collection<String> digest,
-                        final InputStream requestBody, final ExternalContent externalContent) {
+                        final String filename, final String contentType, final List<String> linkHeaders,
+                        final Collection<String> digest, final InputStream requestBody, final long size,
+                        final ExternalContent externalContent) {
         final PersistentStorageSession pSession = this.psManager.getSession(txId);
         checkAclLinkHeader(linkHeaders);
         // If we are PUTting then fedoraId is the path, we need to locate a containment parent if exists.
@@ -93,7 +93,9 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
                 digest.stream().map(URI::create).collect(Collectors.toCollection(HashSet::new)));
         final NonRdfSourceOperationBuilder builder;
         if (externalContent == null) {
-            builder = nonRdfSourceOperationFactory.createInternalBinaryBuilder(fullPath, requestBody);
+            builder = nonRdfSourceOperationFactory.createInternalBinaryBuilder(fullPath, requestBody)
+                        .filename(filename)
+                        .contentSize(size);
         } else {
             builder = nonRdfSourceOperationFactory.createExternalBinaryBuilder(fullPath, externalContent.getHandling(),
                     URI.create(externalContent.getURL()));
@@ -220,25 +222,5 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             }
         }
         return addToIdentifier(fedoraId, finalSlug);
-    }
-
-    /**
-     * Get the rel="type" link headers from a list of them.
-     * @param headers a list of string LINK headers.
-     * @return a list of LINK headers with rel="type"
-     */
-    private List<String> getTypes(final List<String> headers) {
-        return getLinkHeaders(headers) == null ? null : getLinkHeaders(headers).stream()
-                .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
-                .map(URI::toString).collect(Collectors.toList());
-    }
-
-    /**
-     * Converts a list of string LINK headers to actual LINK objects.
-     * @param headers the list of string link headers.
-     * @return the list of LINK headers.
-     */
-    private List<Link> getLinkHeaders(final List<String> headers) {
-        return headers == null ? null : headers.stream().map(p -> Link.fromUri(p).build()).collect(Collectors.toList());
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
+
+import org.fcrepo.kernel.api.models.ExternalContent;
+import org.apache.jena.rdf.model.Model;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.services.UpdateResourceService;
+import org.fcrepo.kernel.impl.operations.AbstractResourceOperation;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+
+import javax.inject.Inject;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+public class UpdateResourceServiceImpl extends AbstractService implements UpdateResourceService {
+
+    @Inject
+    private PersistentStorageSessionManager psManager;
+
+    @Inject
+    private RdfSourceOperationFactory rdfSourceOperationFactory;
+
+    @Inject
+    private NonRdfSourceOperationFactory nonRdfSourceOperationFactory;
+
+    @Override
+    public void perform(final String txId, final String fedoraId, final String filename,
+            final String contentType, final Collection<String> digest, final InputStream requestBody,
+            final long size, final ExternalContent externalContent) {
+
+        final PersistentStorageSession pSession = this.psManager.getSession(txId);
+        final Collection<URI> uriDigests = digest.stream().map(URI::create).collect(Collectors.toCollection(HashSet::new));
+
+        // TODO: Verify permissions Write or Append permissions on parent.
+
+        final NonRdfSourceOperationBuilder builder;
+        if (externalContent == null) {
+            builder = nonRdfSourceOperationFactory.updateInternalBinaryBuilder(fedoraId, requestBody)
+                        .filename(filename)
+                        .contentSize(size);
+        } else {
+            builder = nonRdfSourceOperationFactory.updateExternalBinaryBuilder(fedoraId, externalContent.getHandling(),
+                    URI.create(externalContent.getURL()));
+        }
+        final ResourceOperation updateOp = builder.contentDigests(uriDigests).mimeType(contentType).build();
+
+        // Set server managed is only on AbstractResourceOperation.
+        ((AbstractResourceOperation)updateOp).setServerManagedProperties(getServerManagedStream(fedoraId));
+
+        try {
+            pSession.persist(updateOp);
+        } catch (PersistentStorageException exc) {
+            throw new RepositoryRuntimeException(String.format("failed to update resource %s", fedoraId), exc);
+        }
+
+    }
+
+    @Override
+    public void perform(final String txId, final String fedoraId, final String contentType, final Model model) {
+        final PersistentStorageSession pSession = this.psManager.getSession(txId);
+
+        final RdfStream stream = fromModel(model.getResource(fedoraId).asNode(), model);
+
+        final ResourceOperation updateOp = rdfSourceOperationFactory.updateBuilder(fedoraId)
+                    .triples(stream).build();
+
+        // Set server managed is only on AbstractResourceOperation.
+        ((AbstractResourceOperation)updateOp).setServerManagedProperties(getServerManagedStream(fedoraId));
+
+        try {
+            pSession.persist(updateOp);
+        } catch (PersistentStorageException exc) {
+            throw new RepositoryRuntimeException(String.format("failed to update resource %s", fedoraId), exc);
+        }
+
+    }
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -152,16 +152,16 @@ public class CreateResourceServiceImplTest {
     public void testNoParentBinary_Post() throws Exception {
         final String fedoraId = UUID.randomUUID().toString();
         when(psSession.getHeaders(fedoraId, null)).thenThrow(PersistentItemNotFoundException.class);
-        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, digests,
-                null, null);
+        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, null, digests,
+                null, 0, null);
     }
 
     @Test
     public void testNoParentBinary_Put() throws Exception {
         final String fedoraId = UUID.randomUUID().toString();
         when(psSession.getHeaders(fedoraId, null)).thenThrow(PersistentItemNotFoundException.class);
-        createResourceService.perform(TX_ID, fedoraId, null, false, null, null, digests,
-                null, null);
+        createResourceService.perform(TX_ID, fedoraId, null, false, null, null, null, digests,
+                null, 0, null);
         verify(psSession).persist(operationCaptor.capture());
         assertEquals(fedoraId, operationCaptor.getValue().getResourceId());
     }
@@ -179,8 +179,8 @@ public class CreateResourceServiceImplTest {
         final String fedoraId = UUID.randomUUID().toString();
         when(resourceHeaders.getTypes()).thenReturn(NON_RDF_SOURCE_TYPES);
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
-        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, digests,
-                null, null);
+        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, null, digests,
+                null, 0, null);
     }
 
     @Test
@@ -211,8 +211,8 @@ public class CreateResourceServiceImplTest {
         final String fedoraId = UUID.randomUUID().toString();
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getTypes()).thenReturn(BASIC_CONTAINER_TYPES);
-        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, digests,
-                null, null);
+        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, null, digests,
+                null, 0, null);
         verify(psSession).persist(operationCaptor.capture());
         final String persistedId = operationCaptor.getValue().getResourceId();
         assertNotEquals(fedoraId, persistedId);
@@ -224,8 +224,8 @@ public class CreateResourceServiceImplTest {
         final String fedoraId = UUID.randomUUID().toString();
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getTypes()).thenReturn(BASIC_CONTAINER_TYPES);
-        createResourceService.perform(TX_ID, fedoraId, null, false, null, null, digests,
-                null, null);
+        createResourceService.perform(TX_ID, fedoraId, null, false, null, null, null, digests,
+                null, 0, null);
         verify(psSession).persist(operationCaptor.capture());
         final String persistedId = operationCaptor.getValue().getResourceId();
         assertEquals(fedoraId, persistedId);
@@ -253,8 +253,8 @@ public class CreateResourceServiceImplTest {
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         when(psSession.getHeaders(childId, null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getTypes()).thenReturn(BASIC_CONTAINER_TYPES);
-        createResourceService.perform(TX_ID, fedoraId, "testSlug", true, null, null, digests,
-                null, null);
+        createResourceService.perform(TX_ID, fedoraId, "testSlug", true, null, null, null, digests,
+                null, 0, null);
         verify(psSession).persist(operationCaptor.capture());
         final String persistedId = operationCaptor.getValue().getResourceId();
         assertNotEquals(fedoraId, persistedId);
@@ -282,8 +282,8 @@ public class CreateResourceServiceImplTest {
         when(psSession.getHeaders(addToIdentifier(fedoraId, "testSlug"), null))
                 .thenThrow(PersistentItemNotFoundException.class);
         when(resourceHeaders.getTypes()).thenReturn(BASIC_CONTAINER_TYPES);
-        createResourceService.perform(TX_ID, fedoraId, "testSlug", true, null, null, digests,
-                null, null);
+        createResourceService.perform(TX_ID, fedoraId, "testSlug", true, null, null, null, digests,
+                null, 0, null);
         verify(psSession).persist(ArgumentMatchers.any(ResourceOperation.class));
     }
 
@@ -291,8 +291,8 @@ public class CreateResourceServiceImplTest {
     public void testNoParentExternal() throws Exception {
         final String fedoraId = UUID.randomUUID().toString();
         when(psSession.getHeaders(fedoraId, null)).thenThrow(PersistentItemNotFoundException.class);
-        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, digests,
-                null, extContent);
+        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, null, digests,
+                null, 0, extContent);
     }
 
     @Test(expected = CannotCreateResourceException.class)
@@ -300,8 +300,8 @@ public class CreateResourceServiceImplTest {
         final String fedoraId = UUID.randomUUID().toString();
         when(resourceHeaders.getTypes()).thenReturn(NON_RDF_SOURCE_TYPES);
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
-        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, digests,
-                null, extContent);
+        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, null, digests,
+                null, 0, extContent);
     }
 
     @Test
@@ -309,8 +309,8 @@ public class CreateResourceServiceImplTest {
         final String fedoraId = UUID.randomUUID().toString();
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getTypes()).thenReturn(BASIC_CONTAINER_TYPES);
-        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, digests,
-                null, extContent);
+        createResourceService.perform(TX_ID, fedoraId, null, true, null, null, null, digests,
+                null, 0, extContent);
         verify(psSession).persist(ArgumentMatchers.any(ResourceOperation.class));
     }
 
@@ -321,8 +321,8 @@ public class CreateResourceServiceImplTest {
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         when(psSession.getHeaders(childId, null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getTypes()).thenReturn(BASIC_CONTAINER_TYPES);
-        createResourceService.perform(TX_ID, fedoraId, "testSlug", true, null, null, digests,
-                null, extContent);
+        createResourceService.perform(TX_ID, fedoraId, "testSlug", true, null, null, null, digests,
+                null, 0, extContent);
         verify(psSession).persist(operationCaptor.capture());
         final String persistedId = operationCaptor.getValue().getResourceId();
         assertNotEquals(fedoraId, persistedId);
@@ -338,8 +338,8 @@ public class CreateResourceServiceImplTest {
         when(psSession.getHeaders(childId, null))
                 .thenThrow(PersistentItemNotFoundException.class);
         when(resourceHeaders.getTypes()).thenReturn(BASIC_CONTAINER_TYPES);
-        createResourceService.perform(TX_ID, fedoraId, "testSlug", true, null, null, digests,
-                null, extContent);
+        createResourceService.perform(TX_ID, fedoraId, "testSlug", true, null, null, null, digests,
+                null, 0, extContent);
         verify(psSession).persist(operationCaptor.capture());
         assertEquals(childId, operationCaptor.getValue().getResourceId());
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImplTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.fcrepo.kernel.api.models.ExternalContent;
+import org.fcrepo.kernel.api.models.ResourceHeaders;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
+import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.impl.operations.NonRdfSourceOperationFactoryImpl;
+import org.fcrepo.kernel.impl.operations.RdfSourceOperationFactoryImpl;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class UpdateResourceServiceImplTest {
+
+    @Mock
+    private PersistentStorageSessionManager psManager;
+
+    private RdfSourceOperationFactory rdfSourceOperationFactory;
+
+    private NonRdfSourceOperationFactory nonRdfSourceOperationFactory;
+
+    @Mock
+    private PersistentStorageSession psSession;
+
+    @Mock
+    private ResourceHeaders resourceHeaders;
+
+    @Mock
+    private NonRdfSourceOperationBuilder builder;
+
+    @Mock
+    private NonRdfSourceOperation operation;
+
+    @Mock
+    private ExternalContent extContent;
+
+    @InjectMocks
+    private UpdateResourceServiceImpl updateResourceService;
+
+    @Mock
+    private InputStream inputStream;
+
+    private final static String txId = "tx1234";
+
+    private final static Collection<String> nonRdfSourceTypes;
+
+    private final Collection<String> digests = Stream.of("urn:sha1:12345abced")
+            .collect(Collectors.toCollection(HashSet::new));
+
+    static {
+        nonRdfSourceTypes = Collections.singleton(NON_RDF_SOURCE.toString());
+    }
+
+    @Before
+    public void setUp() {
+        rdfSourceOperationFactory = Mockito.spy(new RdfSourceOperationFactoryImpl());
+        setField(updateResourceService, "rdfSourceOperationFactory", rdfSourceOperationFactory);
+        nonRdfSourceOperationFactory =  Mockito.spy(new NonRdfSourceOperationFactoryImpl());
+        setField(updateResourceService, "nonRdfSourceOperationFactory", nonRdfSourceOperationFactory);
+        when(psManager.getSession(ArgumentMatchers.any())).thenReturn(psSession);
+    }
+
+    @Test
+    public void testUpdateNonRdfSource() throws Exception {
+        final String fedoraId = UUID.randomUUID().toString();
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
+        when(resourceHeaders.getTypes()).thenReturn(nonRdfSourceTypes);
+        updateResourceService.perform(txId, fedoraId, "filename", "text/plain", digests, inputStream, 0, null);
+        verify(nonRdfSourceOperationFactory).updateInternalBinaryBuilder(fedoraId, inputStream);
+        verify(psSession).persist(ArgumentMatchers.any(ResourceOperation.class));
+    }
+
+    @Test
+    public void testUpdateNonRdfSourceExtContent() throws Exception {
+        final String fedoraId = UUID.randomUUID().toString();
+        final String extUrl = "http://www.example.com/";
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
+        when(resourceHeaders.getTypes()).thenReturn(nonRdfSourceTypes);
+        when(extContent.getURL()).thenReturn(extUrl);
+        when(extContent.getHandling()).thenReturn(ExternalContent.REDIRECT);
+        updateResourceService.perform(txId, fedoraId, null, null, digests, null, 0, extContent);
+        verify(nonRdfSourceOperationFactory).updateExternalBinaryBuilder(fedoraId, ExternalContent.REDIRECT, URI.create(extUrl));
+        verify(psSession).persist(ArgumentMatchers.any(ResourceOperation.class));
+    }
+
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3103

# What does this Pull Request do?
Adds the implementation for updating Binary (NonRDFSource)

# What's new?
- Adds `UpdateResourceService` interface and implementation.
- Implements `UpdateNonRdfSourceOperation` and `UpdateNonRdfSourceOperationBuilder`


# Additional Notes:
Repalces #1579

# Interested parties
@whikloj @bseeger @dbernstein @bbpennel 
