### PR TITLE
Changes to get closer to running

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -107,7 +107,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
      */
     @VisibleForTesting
     public FedoraResource getResourceFromPath(final String externalPath) {
-        final String fedoraId = identifierConverter().toInternalId(externalPath);
+        final String fedoraId = identifierConverter().toInternalId(identifierConverter().toDomain(externalPath));
         try {
             final FedoraResource fedoraResource = resourceFactory.getResource(transaction, fedoraId);
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -97,7 +97,7 @@ public class HttpIdentifierConverter {
     public String toInternalId(final String httpUri) {
         LOGGER.debug("Translating http URI {} to Fedora ID", httpUri);
 
-        final String path = getPath(toDomain(httpUri));
+        final String path = getPath(httpUri);
         if (path != null) {
 
             // Take the URL and remove any hash uris, or fcr: endpoints.
@@ -166,12 +166,8 @@ public class HttpIdentifierConverter {
      * @param path the external path.
      * @return the full url.
      */
-    private String toDomain(final String path) {
+    public String toDomain(final String path) {
 
-        if (path.startsWith("http:") || path.startsWith("https:")) {
-            // Already a full URI so return it.
-            return path;
-        }
         final String realPath;
         if (path == null) {
             realPath = "";

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -97,7 +97,7 @@ public class HttpIdentifierConverter {
     public String toInternalId(final String httpUri) {
         LOGGER.debug("Translating http URI {} to Fedora ID", httpUri);
 
-        final String path = getPath(httpUri);
+        final String path = getPath(toDomain(httpUri));
         if (path != null) {
 
             // Take the URL and remove any hash uris, or fcr: endpoints.
@@ -159,6 +159,41 @@ public class HttpIdentifierConverter {
      */
     private UriBuilder uriBuilder() {
         return UriBuilder.fromUri(uriBuilder.toTemplate());
+    }
+
+    /**
+     * Convert a path to a full url using the UriBuilder template.
+     * @param path the external path.
+     * @return the full url.
+     */
+    private String toDomain(final String path) {
+
+        if (path.startsWith("http:") || path.startsWith("https:")) {
+            // Already a full URI so return it.
+            return path;
+        }
+        final String realPath;
+        if (path == null) {
+            realPath = "";
+        } else if (path.startsWith("/")) {
+            realPath = path.substring(1);
+        } else {
+            realPath = path;
+        }
+
+        final UriBuilder uri = uriBuilder();
+
+        if (realPath.contains("#")) {
+
+            final String[] split = realPath.split("#", 2);
+
+            uri.resolveTemplate("path", split[0], false);
+            uri.fragment(split[1]);
+        } else {
+            uri.resolveTemplate("path", realPath, false);
+
+        }
+        return uri.build().toString();
     }
 
     /**

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
@@ -50,10 +50,11 @@ public class HttpIdentifierConverterTest {
         converter = new HttpIdentifierConverter(uriBuilder);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBlankUri() {
         final String testUri = "";
         final String fedoraId = converter.toInternalId(testUri);
+        assertEquals("info:fedora/", fedoraId);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -113,6 +114,16 @@ public class HttpIdentifierConverterTest {
         assertEquals("info:fedora/" + baseUid, fedoraId);
         final String httpUri = converter.toExternalId(fedoraId);
         assertEquals(testUri, httpUri);
+    }
+
+    @Test
+    public void testFirstLevelExternalPath() {
+        final String baseUid = getUniqueId();
+        final String testUri = "/" + baseUid;
+        final String fedoraId = converter.toInternalId(testUri);
+        assertEquals("info:fedora/" + baseUid, fedoraId);
+        final String httpUri = converter.toExternalId(fedoraId);
+        assertEquals(uriBase + testUri, httpUri);
     }
 
     @Test

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
@@ -50,11 +50,20 @@ public class HttpIdentifierConverterTest {
         converter = new HttpIdentifierConverter(uriBuilder);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testBlankUri() {
         final String testUri = "";
         final String fedoraId = converter.toInternalId(testUri);
-        assertEquals("info:fedora/", fedoraId);
+    }
+
+    /**
+     * Test that a blank string toDomain becomes a /
+     */
+    @Test
+    public void testBlankToDomain() {
+        final String testUri = "";
+        final String fedoraUri = converter.toDomain(testUri);
+        assertEquals(uriBase + "/", fedoraUri);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -120,7 +129,7 @@ public class HttpIdentifierConverterTest {
     public void testFirstLevelExternalPath() {
         final String baseUid = getUniqueId();
         final String testUri = "/" + baseUid;
-        final String fedoraId = converter.toInternalId(testUri);
+        final String fedoraId = converter.toInternalId(converter.toDomain(testUri));
         assertEquals("info:fedora/" + baseUid, fedoraId);
         final String httpUri = converter.toExternalId(fedoraId);
         assertEquals(uriBase + testUri, httpUri);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -41,7 +41,7 @@ public class TransactionManagerImpl implements TransactionManager {
     private final HashMap<String, Transaction> transactions;
 
     @Inject
-    private static PersistentStorageSessionManager pSessionManager;
+    private PersistentStorageSessionManager pSessionManager;
 
     TransactionManagerImpl() {
         transactions = new HashMap();
@@ -77,6 +77,6 @@ public class TransactionManagerImpl implements TransactionManager {
     }
 
     protected PersistentStorageSessionManager getPersistentStorageSessionManager() {
-        return TransactionManagerImpl.pSessionManager;
+        return pSessionManager;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -49,7 +49,7 @@ import org.springframework.stereotype.Component;
 public class ResourceFactoryImpl implements ResourceFactory {
 
     @Inject
-    private static PersistentStorageSessionManager persistentStorageSessionManager;
+    private PersistentStorageSessionManager persistentStorageSessionManager;
 
     @Override
     public FedoraResource getResource(final String identifier)

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
@@ -17,14 +17,11 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import org.springframework.stereotype.Component;
-
 /**
  * A mapping that links the parent fedora resource to its corresponding OCFL object.
  *
  * @author dbernstein
  */
-@Component
 public class FedoraOCFLMapping {
     private String parentFedoraResourceId;
     private String ocflObjectId;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOCFLMapping.java
@@ -17,11 +17,14 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import org.springframework.stereotype.Component;
+
 /**
  * A mapping that links the parent fedora resource to its corresponding OCFL object.
  *
  * @author dbernstein
  */
+@Component
 public class FedoraOCFLMapping {
     private String parentFedoraResourceId;
     private String ocflObjectId;


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?
In trying to get the system to respond to a GET request to the repo root I found some small issues.
1. We pass in the path part only, so the HttpIdentifierConverter needs to handle that scenario as well as a full URI.
2. We need a ResourceFactory Injected into the HTTP layer to get resources, that or we need to start radically altering how to "get" a resource up from the base.
3. Some of the `private static` fields had Inject annotations on them and it seems like this is not allowed. So I made them non-static.

After all this I am getting to [here in OCFLPersistentStorageSession](https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/OCFLPersistentStorageSession.java#L204) but it fails as its `null` because we don't have an implementation of the `FedoraToOCFLObjectIndex` interface to inject yet.

I'm not clear what this is and how its different from the FedoraOCFLMapping, but this is where the request fails.

# Interested parties
@fcrepo4/committers
