### PR TITLE
Fixes compile errors and anchors the build to a tagged version of the…

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -23,13 +23,14 @@ import static org.apache.commons.lang3.SystemUtils.JAVA_IO_TMPDIR;
 import java.io.File;
 import java.nio.file.Paths;
 
+import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
 import edu.wisc.library.ocfl.core.extension.layout.config.DefaultLayoutConfig;
-import edu.wisc.library.ocfl.core.storage.FileSystemOcflStorage;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
@@ -50,7 +51,6 @@ import edu.wisc.library.ocfl.api.model.VersionDetails;
 import edu.wisc.library.ocfl.api.model.VersionId;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
 import edu.wisc.library.ocfl.core.extension.layout.config.DefaultLayoutConfig;
-import edu.wisc.library.ocfl.core.storage.FileSystemOcflStorage;
 
 /**
  * @author bbpennel

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jgroups.version>4.0.13.Final</jgroups.version>
     <jsonld.version>0.12.1</jsonld.version>
     <logback.version>1.2.3</logback.version>
-    <ocfl-java.version>1.0.0-SNAPSHOT</ocfl-java.version>
+    <ocfl-java.version>0.0.1-SNAPSHOT</ocfl-java.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy-java.version>1.1.7.2</snappy-java.version>
     <spring.version>5.0.9.RELEASE</spring.version>


### PR DESCRIPTION
… ocfl client.

This PR fixes the compile errors caused by changes to the ocfl-java snapshot.   This update will help ensure that future breaking OCFL changes do not affect previously buildable versions.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
