### PR TITLE
Persist FedoraToOCFLIndex to disk

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -17,11 +17,11 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static java.lang.System.getProperty;
-import static org.apache.commons.lang3.SystemUtils.JAVA_IO_TMPDIR;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_STORAGE_ROOT_DIR;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_WORK_DIR;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.STAGING_DIR;
 
 import java.io.File;
-import java.nio.file.Paths;
 
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
@@ -46,24 +46,9 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultOCFLObjectSessionFactory.class);
 
-    private static final File STAGING_DIR = resolveDir("fcrepo.ocfl.staging.dir");
-    private static final File OCFL_STORAGE_ROOT_DIR = resolveDir("fcrepo.ocfl.storage.root.dir");
-    private static final File OCFL_WORK_DIR = resolveDir("fcrepo.ocfl.work.dir");
-
     private File ocflStagingDir;
 
     private MutableOcflRepository ocflRepository;
-
-    private static final File resolveDir(final String systemPropertyKey) {
-        final String path = getProperty(systemPropertyKey);
-        if (path != null) {
-            return new File(path);
-        } else {
-            //return default
-
-            return Paths.get(JAVA_IO_TMPDIR, systemPropertyKey).toFile();
-        }
-    }
 
     /**
      * Default Constructor.  You can set the ocfl staging, storage root, and work directories by setting the following

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -17,9 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static org.apache.commons.lang3.SystemUtils.JAVA_IO_TMPDIR;
-
-import static java.lang.System.getProperty;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.FEDORA_TO_OCFL_INDEX_FILE;
 
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
@@ -32,8 +30,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,12 +43,6 @@ import java.util.Map;
 @Component
 public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
 
-    private Path indexFilePath = getProperty("fcrepo.ocfl.work.dir") == null ?
-            Paths.get(JAVA_IO_TMPDIR, "fcrepo.ocfl.work.dir", "fedoraToOcflIndex.tsv") :
-            Paths.get(getProperty("fcrepo.ocfl.work.dir"), "fedoraToOcflIndex.tsv");
-
-    private File indexFile = indexFilePath.toFile();
-
     private static Logger LOGGER = LoggerFactory.getLogger(FedoraToOCFLObjectIndexImpl.class);
 
     private Map<String, FedoraOCFLMapping> fedoraOCFLMappingMap = Collections.synchronizedMap(new HashMap<>());
@@ -62,8 +52,8 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
      * @throws IOException If we can't access the file.
      */
     public FedoraToOCFLObjectIndexImpl() throws IOException {
-        if (indexFile.exists() && indexFile.canRead()) {
-            Files.lines(indexFile.toPath()).filter(l -> {
+        if (FEDORA_TO_OCFL_INDEX_FILE.exists() && FEDORA_TO_OCFL_INDEX_FILE.canRead()) {
+            Files.lines(FEDORA_TO_OCFL_INDEX_FILE.toPath()).filter(l -> {
                 final String m = l.split("\t")[0];
                 return (!fedoraOCFLMappingMap.containsKey(m));
             }).forEach(l -> {
@@ -115,21 +105,20 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
      */
     private void writeMappingToDisk(final String fedoraId, final FedoraOCFLMapping fedoraOCFLMapping) {
         try {
-            if (!indexFile.exists()) {
-                final String dirName = indexFile.toPath().toAbsolutePath().toString().substring(0,
-                        indexFile.toPath().toAbsolutePath().toString().lastIndexOf(File.separator));
+            if (!FEDORA_TO_OCFL_INDEX_FILE.exists()) {
+                final String dirName = FEDORA_TO_OCFL_INDEX_FILE.toPath().toAbsolutePath().toString().substring(0,
+                        FEDORA_TO_OCFL_INDEX_FILE.toPath().toAbsolutePath().toString().lastIndexOf(File.separator));
                 final File dir = new File(dirName);
                 if (!dir.exists()) {
                     dir.mkdirs();
                 }
-                indexFile.createNewFile();
             }
-            final BufferedWriter output = new BufferedWriter(new FileWriter(indexFile, true));
+            final BufferedWriter output = new BufferedWriter(new FileWriter(FEDORA_TO_OCFL_INDEX_FILE, true));
             output.write(String.format("%s\t%s\t%s\n", fedoraId, fedoraOCFLMapping.getRootObjectIdentifier(),
                     fedoraOCFLMapping.getOcflObjectId()));
             output.close();
         } catch (IOException exception) {
-            LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}", indexFile.toString());
+            LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}", FEDORA_TO_OCFL_INDEX_FILE.toString());
         }
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -124,7 +124,8 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
                     fedoraOCFLMapping.getOcflObjectId()));
             output.close();
         } catch (IOException exception) {
-            LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}", FEDORA_TO_OCFL_INDEX_FILE.toString());
+            LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}",
+                    FEDORA_TO_OCFL_INDEX_FILE.toString());
         }
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -124,8 +124,7 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
                     fedoraOCFLMapping.getOcflObjectId()));
             output.close();
         } catch (IOException exception) {
-            LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}",
-                    FEDORA_TO_OCFL_INDEX_FILE.toString());
+            LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}", FEDORA_TO_OCFL_INDEX_FILE);
         }
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -48,7 +48,13 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
     private Map<String, FedoraOCFLMapping> fedoraOCFLMappingMap = Collections.synchronizedMap(new HashMap<>());
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * On disk index file is a text file with 3 values per line separated by tabs.
+     * 1. fedora identifier (ie. info:fedora/parent/object1 or info:fedora/object1)
+     * 2. fedora root object ID (ie. info:fedora/parent or info:fedora/object1). Used for root of Archival groups.
+     * 3. OCFL object ID (ie. parent/object1 or object1)
+     *
      * @throws IOException If we can't access the file.
      */
     public FedoraToOCFLObjectIndexImpl() throws IOException {
@@ -61,6 +67,8 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
                 if (map.length == 3) {
                     final FedoraOCFLMapping ocflMapping = new FedoraOCFLMapping(map[1], map[2]);
                     fedoraOCFLMappingMap.put(map[0], ocflMapping);
+                } else {
+                    LOGGER.warn("Expected 3 tab-separated values, found {}. Ignoring line.", map.length);
                 }
             });
         }
@@ -106,9 +114,7 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
     private void writeMappingToDisk(final String fedoraId, final FedoraOCFLMapping fedoraOCFLMapping) {
         try {
             if (!FEDORA_TO_OCFL_INDEX_FILE.exists()) {
-                final String dirName = FEDORA_TO_OCFL_INDEX_FILE.toPath().toAbsolutePath().toString().substring(0,
-                        FEDORA_TO_OCFL_INDEX_FILE.toPath().toAbsolutePath().toString().lastIndexOf(File.separator));
-                final File dir = new File(dirName);
+                final File dir = FEDORA_TO_OCFL_INDEX_FILE.getParentFile();
                 if (!dir.exists()) {
                     dir.mkdirs();
                 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLConstants.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLConstants.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.apache.commons.lang3.SystemUtils.JAVA_IO_TMPDIR;
+
+import static java.lang.System.getProperty;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+/**
+ * OCFL Constants.
+ * @author whikloj
+ * @since 6.0.0
+ */
+public final class OCFLConstants {
+
+    public static final File STAGING_DIR = resolveDir("fcrepo.ocfl.staging.dir");
+    public static final File OCFL_STORAGE_ROOT_DIR = resolveDir("fcrepo.ocfl.storage.root.dir");
+    public static final File OCFL_WORK_DIR = resolveDir("fcrepo.ocfl.work.dir");
+    public static final File FEDORA_TO_OCFL_INDEX_FILE = new File(OCFL_WORK_DIR.toString() + File.separator +
+            "fedoraToOcflIndex.tsv");
+
+    /**
+     * Return the system property key path as file or a file of the temporary directory + "system property key"
+     * @param systemPropertyKey The system property
+     * @return The file
+     */
+    private static File resolveDir(final String systemPropertyKey) {
+        final String path = getProperty(systemPropertyKey);
+        if (path != null) {
+            return new File(path);
+        } else {
+            //return default
+            return Paths.get(JAVA_IO_TMPDIR, systemPropertyKey).toFile();
+        }
+    }
+
+    private OCFLConstants() {
+        // This method left intentionally blank.
+    }
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImplTest.java
@@ -17,21 +17,16 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static org.apache.commons.lang3.SystemUtils.JAVA_IO_TMPDIR;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.FEDORA_TO_OCFL_INDEX_FILE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import static java.lang.System.getProperty;
-
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.FileWriter;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -51,11 +46,6 @@ public class FedoraToOCFLObjectIndexImplTest {
     private static final String ROOT_RESOURCE_ID = "info:fedora/parent";
     private static final String OCFL_ID = "ocfl-id";
     private static final String OCFL_ID_RESOURCE_3 = "ocfl-id-resource-3";
-
-    private final Path indexMappingPath = getProperty("fcrepo.ocfl.work.dir") == null ?
-            Paths.get(JAVA_IO_TMPDIR, "fcrepo.ocfl.work.dir", "fedoraToOcflIndex.tsv") :
-            Paths.get(getProperty("fcrepo.ocfl.work.dir"), "fedoraToOcflIndex.tsv");
-    private File indexFile = indexMappingPath.toFile();
 
     @Before
     public void setup() {
@@ -101,7 +91,7 @@ public class FedoraToOCFLObjectIndexImplTest {
 
     @Test
     public void testSaveToIndex() throws Exception {
-        assertFalse(indexFile.exists());
+        assertFalse(FEDORA_TO_OCFL_INDEX_FILE.exists());
 
         final FedoraToOCFLObjectIndexImpl index = new FedoraToOCFLObjectIndexImpl();
 
@@ -109,22 +99,22 @@ public class FedoraToOCFLObjectIndexImplTest {
         index.addMapping(RESOURCE_ID_2, ROOT_RESOURCE_ID, OCFL_ID);
         index.addMapping(RESOURCE_ID_3, RESOURCE_ID_3, OCFL_ID_RESOURCE_3);
 
-        assertTrue(indexFile.exists());
+        assertTrue(FEDORA_TO_OCFL_INDEX_FILE.exists());
 
-        final List<String> lines = Files.lines(indexFile.toPath()).collect(Collectors.toList());
+        final List<String> lines = Files.lines(FEDORA_TO_OCFL_INDEX_FILE.toPath()).collect(Collectors.toList());
 
         assertEquals(4, lines.size());
     }
 
     @Test
     public void testReadFromIndex() throws Exception {
-        assertFalse(indexFile.exists());
+        assertFalse(FEDORA_TO_OCFL_INDEX_FILE.exists());
 
-        final BufferedWriter output = new BufferedWriter(new FileWriter(indexFile, true));
+        final BufferedWriter output = new BufferedWriter(new FileWriter(FEDORA_TO_OCFL_INDEX_FILE, true));
         output.write(String.format("%s\t%s\t%s\n", RESOURCE_ID_2, ROOT_RESOURCE_ID, OCFL_ID));
         output.close();
 
-        assertTrue(indexFile.exists());
+        assertTrue(FEDORA_TO_OCFL_INDEX_FILE.exists());
 
         final FedoraToOCFLObjectIndexImpl index = new FedoraToOCFLObjectIndexImpl();
         try {
@@ -147,8 +137,8 @@ public class FedoraToOCFLObjectIndexImplTest {
     }
 
     private void removeIndexMappingFile() {
-        if (indexFile.exists()) {
-            indexFile.delete();
+        if (FEDORA_TO_OCFL_INDEX_FILE.exists()) {
+            FEDORA_TO_OCFL_INDEX_FILE.delete();
         }
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3171

# What does this Pull Request do?
A simple text file containing the FedoraToOCFLObjectIndex so we can reload it between runs of Fedora.

# How should this be tested?

Try both of these steps before and after PR.
1. Stand up Fedora
1. Create a resource.
1. `GET` the resource
1. Shutdown Fedora
1. Start Fedora, this step will throw errors before the PR.
1. `GET` the resource again, this step will only work after the PR.

# Additional Notes:

This is not good I'm sure. My skill with creating and read/writing to files with java is weak so please provide any improvements you can think of.

# Interested parties
@fcrepo4/committers
