### PR TITLE
Updates jetty-console to 1.62 (java 11 support).

### DIFF
--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -22,7 +22,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     <!-- for standalone operation -->
     <jetty.users.file>${project.build.directory}/test-classes/jetty-users.properties</jetty.users.file>
-    <jetty-console.version>1.61-SNAPSHOT</jetty-console.version>
+    <jetty-console.version>1.62</jetty-console.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This update enables one to build the one-click  without having to build the jetty-console locally.