### PR TITLE
WIP: FCREPO-3103. Replace a binary resource (HTTP->PersistentStorageSession)

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -380,6 +380,7 @@ public class FedoraLdp extends ContentExposingResource {
             @HeaderParam("Digest") final String digest)
             throws InvalidChecksumException, MalformedRdfException, UnsupportedAlgorithmException,
                    PathNotFoundException {
+        LOGGER.debug("Create resource: {}", externalPath);
 
         hasRestrictedPath(externalPath);
 
@@ -417,9 +418,12 @@ public class FedoraLdp extends ContentExposingResource {
         final String externalUri = this.uriInfo.getRequestUri().toString();
         final String fedoraId = identifierConverter().toInternalId(externalUri);
 
-        final String filename = contentDisposition.getFileName();
-
-        final long size = contentDisposition.getSize();
+        String filename = null;
+        long size = -1;
+        if (contentDisposition != null) {
+            filename = contentDisposition.getFileName();
+            size = contentDisposition.getSize();
+        }
 
         // TODO: Refactor to check preconditions
         //evaluateRequestPreconditions(request, servletResponse, resource, transaction);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/ResourceOperation.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/ResourceOperation.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.operations;
 
+import org.fcrepo.kernel.api.RdfStream;
+
 /**
  * Operation for manipulating a resource
  *
@@ -44,4 +46,11 @@ public interface ResourceOperation {
      * @return operation type
      */
     ResourceOperationType getType();
+
+    /**
+     * Get the server managed properties for the resource
+     *
+     * @return server managed properties
+     */
+    RdfStream getServerManagedProperties();
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
@@ -47,9 +47,18 @@ public interface CreateResourceService {
      * @param requestBody The request body or null if none.
      * @param externalContent The external content handler or null if none.
      */
-    void perform(String txId, String userPrincipal, String fedoraId, String slug, boolean isContained,
-            String contentType, String filename, Long contentSize, List<String> linkHeaders,
-            Collection<String> digest, InputStream requestBody, ExternalContent externalContent);
+    void perform(final String txId,
+                 final String userPrincipal,
+                 final String fedoraId,
+                 final String slug,
+                 final boolean isContained,
+                 final String contentType,
+                 final String filename,
+                 final Long contentSize,
+                 final List<String> linkHeaders,
+                 final Collection<String> digest,
+                 final InputStream requestBody,
+                 final ExternalContent externalContent);
 
     /**
      * Create a new RdfSource resource.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdateResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdateResourceService.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import org.apache.jena.rdf.model.Model;
+import org.fcrepo.kernel.api.models.ExternalContent;
+
+import java.io.InputStream;
+import java.util.Collection;
+
+/**
+ * Interface for a service to update an existing resource via a PUT request.
+ * @author mohideen
+ * @since 2019-11-07
+ */
+public interface UpdateResourceService {
+
+    /**
+     * Update an existing resource.
+     *
+     * @param txId The transaction ID for the request.
+     * @param fedoraId The internal identifier of the parent.
+     * @param filename The filename of the binary.
+     * @param contentType The content-type header or null if none.
+     * @param digest The binary digest or null if none.
+     * @param size The binary size.
+     * @param requestBody The request body or null if none.
+     * @param externalContent The external content handler or null if none.
+     */
+    void perform(final String txId, final String fedoraId, final String filename,
+                 final String contentType, final Collection<String> digest, final InputStream requestBody,
+                 final long size, final ExternalContent externalContent);
+
+
+    /**
+     * Update a RdfSource resource.
+     *
+     * @param txId The transaction ID for the request.
+     * @param fedoraId The internal identifier of the parent.
+     * @param model The request body RDF as a Model
+     */
+    void perform(final String txId, final String fedoraId, final String contentType, final Model model);
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperation.java
@@ -71,6 +71,51 @@ public abstract class AbstractNonRdfSourceOperation extends AbstractResourceOper
     }
 
     /**
+     * Constructor for external content.
+     *
+     * @param rescId the internal identifier.
+     * @param externalContentURI the URI of the external content.
+     * @param externalHandling the type of external content handling (REDIRECT, PROXY)
+     * @param mimeType the mime-type of the content.
+     * @param filename the filename.
+     * @param digests the checksum digests.
+     */
+    protected AbstractNonRdfSourceOperation(final String rescId, final URI externalContentURI,
+                                          final String externalHandling, final String mimeType, final String filename,
+                                          final Collection<URI> digests) {
+        super(rescId);
+        this.externalHandlingURI = externalContentURI;
+        this.externalHandlingType = externalHandling;
+        this.mimeType = mimeType;
+        this.filename = filename;
+        this.digests = digests;
+    }
+
+    /**
+     * Constructor for internal binaries.
+     *
+     * @param rescId the internal identifier.
+     * @param content the stream of the content.
+     * @param mimeType the mime-type of the content.
+     * @param contentSize the size of the inputstream.
+     * @param filename the filename.
+     * @param digests the checksum digests.
+     */
+    protected AbstractNonRdfSourceOperation(final String rescId,
+                                            final InputStream content,
+                                            final String mimeType,
+                                            final long contentSize,
+                                            final String filename,
+                                            final Collection<URI> digests) {
+        super(rescId);
+        this.content= content;
+        this.mimeType = mimeType;
+        this.contentSize = contentSize;
+        this.filename = filename;
+        this.digests = digests;
+    }
+
+    /**
      * Basic constructor.
      *
      * @param rescId The internal Fedora ID.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
@@ -21,29 +21,35 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 
-import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
 
 /**
- * Builder for operations to update non-rdf sources
+ * An abstract operation for interacting with a non-rdf source
  *
  * @author bbpennel
  */
-public class UpdateNonRdfSourceOperationBuilder extends AbstractNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
+public abstract class AbstractNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
 
-    protected UpdateNonRdfSourceOperationBuilder(final String rescId, final InputStream stream) {
-        this(rescId);
-        this.content = stream;
-    }
+    protected String resourceId;
 
-    protected UpdateNonRdfSourceOperationBuilder(final String rescId, final String handling, final URI contentUri) {
-        this(rescId);
-        this.externalType = handling;
-        this.externalURI = contentUri;
-    }
+    protected InputStream content;
 
-    private UpdateNonRdfSourceOperationBuilder(final String rescId) {
-        super(rescId);
+    protected URI externalURI;
+
+    protected String externalType;
+
+    protected String mimeType;
+
+    protected String filename;
+
+    protected Collection<URI> digests;
+
+    protected long contentSize;
+
+    protected String userPrincipal;
+
+    protected AbstractNonRdfSourceOperationBuilder(final String rescId) {
+        this.resourceId = rescId;
     }
 
     @Override
@@ -68,23 +74,6 @@ public class UpdateNonRdfSourceOperationBuilder extends AbstractNonRdfSourceOper
     public NonRdfSourceOperationBuilder contentSize(final Long size) {
         this.contentSize = size;
         return this;
-    }
-
-    @Override
-    public NonRdfSourceOperationBuilder userPrincipal(final String userPrincipal) {
-        this.userPrincipal= userPrincipal;
-        return this;
-    }
-
-    @Override
-    public NonRdfSourceOperation build() {
-        if (content == null && externalURI != null && externalType != null) {
-            return new UpdateNonRdfSourceOperation(this.resourceId, this.externalURI, this.externalType,
-                    this.mimeType, this.filename, this.digests);
-        } else {
-            return new UpdateNonRdfSourceOperation(this.resourceId, this.content, this.mimeType, this.contentSize,
-                    this.filename, this.digests);
-        }
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractResourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractResourceOperation.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 
 /**
@@ -32,6 +33,11 @@ public abstract class AbstractResourceOperation implements ResourceOperation {
     private final String rescId;
 
     private String userPrincipal;
+
+    /**
+     * The server managed triples.
+     */
+    private RdfStream serverManagedProperties;
 
     protected AbstractResourceOperation(final String rescId) {
         this.rescId = rescId;
@@ -52,6 +58,20 @@ public abstract class AbstractResourceOperation implements ResourceOperation {
      */
     public void setUserPrincipal(final String userPrincipal) {
         this.userPrincipal = userPrincipal;
+    }
+
+    @Override
+    public RdfStream getServerManagedProperties() {
+        return serverManagedProperties;
+    }
+
+    /**
+     * Set the server managed properties for the resource
+     *
+     * @param serverManagedProperties stream of properties
+     */
+    public void setServerManagedProperties(final RdfStream serverManagedProperties) {
+        this.serverManagedProperties = serverManagedProperties;
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImpl.java
@@ -38,15 +38,13 @@ public class NonRdfSourceOperationFactoryImpl implements NonRdfSourceOperationFa
     public NonRdfSourceOperationBuilder updateExternalBinaryBuilder(final String rescId,
                                                                     final String handling,
                                                                     final URI contentUri) {
-        // TODO Auto-generated method stub
-        return null;
+        return new UpdateNonRdfSourceOperationBuilder(rescId, handling, contentUri);
     }
 
     @Override
     public NonRdfSourceOperationBuilder updateInternalBinaryBuilder(final String rescId,
                                                                     final InputStream contentStream) {
-        // TODO Auto-generated method stub
-        return null;
+        return new UpdateNonRdfSourceOperationBuilder(rescId, contentStream);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
@@ -19,6 +19,10 @@ package org.fcrepo.kernel.impl.operations;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
 
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 /**
@@ -28,8 +32,35 @@ import org.fcrepo.kernel.api.operations.ResourceOperationType;
  */
 public class UpdateNonRdfSourceOperation extends AbstractNonRdfSourceOperation {
 
-    protected UpdateNonRdfSourceOperation(final String rescId) {
-        super(rescId);
+    /**
+     * Constructor for external content.
+     *
+     * @param rescId the internal identifier.
+     * @param externalContentURI the URI of the external content.
+     * @param externalHandling the type of external content handling (REDIRECT, PROXY)
+     * @param mimeType the mime-type of the content.
+     * @param filename the filename.
+     * @param digests the checksum digests.
+     */
+    protected UpdateNonRdfSourceOperation(final String rescId, final URI externalContentURI,
+                                            final String externalHandling, final String mimeType, final String filename,
+                                            final Collection<URI> digests) {
+        super(rescId, externalContentURI, externalHandling, mimeType, filename, digests);
+    }
+
+    /**
+     * Constructor for internal binaries.
+     *
+     * @param rescId the internal identifier.
+     * @param content the stream of the content.
+     * @param mimeType the mime-type of the content.
+     * @param contentSize the size of the inputstream.
+     * @param filename the filename.
+     * @param digests the checksum digests.
+     */
+    protected UpdateNonRdfSourceOperation(final String rescId, final InputStream content, final String mimeType,
+                                            final long contentSize, final String filename, final Collection<URI> digests) {
+        super(rescId, content, mimeType, contentSize, filename, digests);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
@@ -58,8 +58,12 @@ public class UpdateNonRdfSourceOperation extends AbstractNonRdfSourceOperation {
      * @param filename the filename.
      * @param digests the checksum digests.
      */
-    protected UpdateNonRdfSourceOperation(final String rescId, final InputStream content, final String mimeType,
-                                            final long contentSize, final String filename, final Collection<URI> digests) {
+    protected UpdateNonRdfSourceOperation(final String rescId,
+                                          final InputStream content,
+                                          final String mimeType,
+                                          final long contentSize,
+                                          final String filename,
+                                          final Collection<URI> digests) {
         super(rescId, content, mimeType, contentSize, filename, digests);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilder.java
@@ -29,7 +29,8 @@ import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
  *
  * @author bbpennel
  */
-public class UpdateNonRdfSourceOperationBuilder extends AbstractNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
+public class UpdateNonRdfSourceOperationBuilder extends AbstractNonRdfSourceOperationBuilder
+        implements NonRdfSourceOperationBuilder {
 
     protected UpdateNonRdfSourceOperationBuilder(final String rescId, final InputStream stream) {
         this(rescId);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -23,6 +23,7 @@ import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.apache.jena.rdf.model.ResourceFactory.createStatement;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_LASTMODIFIED;
 import static org.fcrepo.kernel.api.RdfLexicon.DEFAULT_INTERACTION_MODEL;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODELS_FULL;
@@ -34,6 +35,8 @@ import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_ACCESS_TO_PROPERTY;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -41,20 +44,29 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
+import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.ACLAuthorizationConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RequestWithAclLinkHeaderException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.slf4j.Logger;
+import java.net.URI;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Link;
 
 
 /**
@@ -237,4 +249,72 @@ public abstract class AbstractService {
                         createResource(currentResourcePath));
     }
 
+    /**
+     * Execute the populateServerManagedTriples and return the stream.
+     * @param fedoraId The current resource ID.
+     * @return The RDF stream of server managed properties.
+     */
+    protected RdfStream getServerManagedStream(final String fedoraId) {
+        populateServerManagedTriples(fedoraId);
+        return new DefaultRdfStream(asNode(fedoraId), serverManagedProperties.stream());
+    }
+
+    /**
+     * Populate server managed properties.
+     * Override in subclasses to add additional triples, always call super() first;
+     */
+    protected void populateServerManagedTriples(final String fedoraId) {
+        final ZonedDateTime now = ZonedDateTime.now();
+        serverManagedProperties.add(new Triple(
+                asNode(fedoraId),
+                asNode(FEDORA_LASTMODIFIED),
+                asLiteral(now.format(DateTimeFormatter.RFC_1123_DATE_TIME), XSDDatatype.XSDdateTime))
+        );
+        // TODO: get current user.
+        // this.serverManagedProperties.add(new Triple(
+        //      asNode(fedoraId),
+        //      asNode(FEDORA_LASTMODIFIEDBY),
+        //      asLiteral(user))
+        // );
+    }
+
+    /**
+     * Utility to turn a resource string to a Node.
+     * @param uri the resource.
+     * @return the resource as a Node.
+     */
+    protected Node asNode(final String uri) {
+        return ResourceFactory.createResource(uri).asNode();
+    }
+
+    /**
+     * Utility to turn a typed literal into a Node.
+     * @param literal The literal value.
+     * @param type The datatype.
+     * @return The literal as a node.
+     */
+    protected Node asLiteral(final String literal, final RDFDatatype type) {
+        return ResourceFactory.createTypedLiteral(literal, type).asNode();
+    }
+
+    /**
+     * Get the rel="type" link headers from a list of them.
+     * @param headers a list of string LINK headers.
+     * @return a list of LINK headers with rel="type"
+     */
+    protected List<String> getTypes(final List<String> headers) {
+        final List<String> types = getLinkHeaders(headers) == null ? null : getLinkHeaders(headers).stream()
+                .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
+                .map(URI::toString).collect(Collectors.toList());
+        return types;
+    }
+
+    /**
+     * Converts a list of string LINK headers to actual LINK objects.
+     * @param headers the list of string link headers.
+     * @return the list of LINK headers.
+     */
+    protected List<Link> getLinkHeaders(final List<String> headers) {
+        return headers == null ? null : headers.stream().map(p -> Link.fromUri(p).build()).collect(Collectors.toList());
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.services;
 
+import static java.util.stream.Collectors.toCollection;
 import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
 
 import org.fcrepo.kernel.api.models.ExternalContent;
@@ -32,6 +33,7 @@ import org.fcrepo.kernel.impl.operations.AbstractResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 
@@ -39,8 +41,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.stream.Collectors;
 
+@Component
 public class UpdateResourceServiceImpl extends AbstractService implements UpdateResourceService {
 
     @Inject
@@ -58,7 +60,7 @@ public class UpdateResourceServiceImpl extends AbstractService implements Update
             final long size, final ExternalContent externalContent) {
 
         final PersistentStorageSession pSession = this.psManager.getSession(txId);
-        final Collection<URI> uriDigests = digest.stream().map(URI::create).collect(Collectors.toCollection(HashSet::new));
+        final Collection<URI> uriDigests = digest.stream().map(URI::create).collect(toCollection(HashSet::new));
 
         // TODO: Verify permissions Write or Append permissions on parent.
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
+
+import org.fcrepo.kernel.api.models.ExternalContent;
+import org.apache.jena.rdf.model.Model;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.services.UpdateResourceService;
+import org.fcrepo.kernel.impl.operations.AbstractResourceOperation;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+
+import javax.inject.Inject;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+public class UpdateResourceServiceImpl extends AbstractService implements UpdateResourceService {
+
+    @Inject
+    private PersistentStorageSessionManager psManager;
+
+    @Inject
+    private RdfSourceOperationFactory rdfSourceOperationFactory;
+
+    @Inject
+    private NonRdfSourceOperationFactory nonRdfSourceOperationFactory;
+
+    @Override
+    public void perform(final String txId, final String fedoraId, final String filename,
+            final String contentType, final Collection<String> digest, final InputStream requestBody,
+            final long size, final ExternalContent externalContent) {
+
+        final PersistentStorageSession pSession = this.psManager.getSession(txId);
+        final Collection<URI> uriDigests = digest.stream().map(URI::create).collect(Collectors.toCollection(HashSet::new));
+
+        // TODO: Verify permissions Write or Append permissions on parent.
+
+        final NonRdfSourceOperationBuilder builder;
+        if (externalContent == null) {
+            builder = nonRdfSourceOperationFactory.updateInternalBinaryBuilder(fedoraId, requestBody)
+                        .filename(filename)
+                        .contentSize(size);
+        } else {
+            builder = nonRdfSourceOperationFactory.updateExternalBinaryBuilder(fedoraId, externalContent.getHandling(),
+                    URI.create(externalContent.getURL()));
+        }
+        final ResourceOperation updateOp = builder.contentDigests(uriDigests).mimeType(contentType).build();
+
+        // Set server managed is only on AbstractResourceOperation.
+        ((AbstractResourceOperation)updateOp).setServerManagedProperties(getServerManagedStream(fedoraId));
+
+        try {
+            pSession.persist(updateOp);
+        } catch (PersistentStorageException exc) {
+            throw new RepositoryRuntimeException(String.format("failed to update resource %s", fedoraId), exc);
+        }
+
+    }
+
+    @Override
+    public void perform(final String txId, final String fedoraId, final String contentType, final Model model) {
+        final PersistentStorageSession pSession = this.psManager.getSession(txId);
+
+        final RdfStream stream = fromModel(model.getResource(fedoraId).asNode(), model);
+
+        final ResourceOperation updateOp = rdfSourceOperationFactory.updateBuilder(fedoraId)
+                    .triples(stream).build();
+
+        // Set server managed is only on AbstractResourceOperation.
+        ((AbstractResourceOperation)updateOp).setServerManagedProperties(getServerManagedStream(fedoraId));
+
+        try {
+            pSession.persist(updateOp);
+        } catch (PersistentStorageException exc) {
+            throw new RepositoryRuntimeException(String.format("failed to update resource %s", fedoraId), exc);
+        }
+
+    }
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -256,7 +256,6 @@ public class CreateResourceServiceImplTest {
         when(resourceHeaders.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
         createResourceService.perform(TX_ID, USER_PRINCIPAL, fedoraId, null, false, CONTENT_TYPE, FILENAME,
                 CONTENT_SIZE, null, DIGESTS, null, null);
-
         verify(psSession).persist(operationCaptor.capture());
         final var operation = (CreateNonRdfSourceOperation) operationCaptor.getValue();
         final String persistedId = operation.getResourceId();

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImplTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.fcrepo.kernel.api.models.ExternalContent;
+import org.fcrepo.kernel.api.models.ResourceHeaders;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
+import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.impl.operations.NonRdfSourceOperationFactoryImpl;
+import org.fcrepo.kernel.impl.operations.RdfSourceOperationFactoryImpl;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class UpdateResourceServiceImplTest {
+
+    @Mock
+    private PersistentStorageSessionManager psManager;
+
+    private RdfSourceOperationFactory rdfSourceOperationFactory;
+
+    private NonRdfSourceOperationFactory nonRdfSourceOperationFactory;
+
+    @Mock
+    private PersistentStorageSession psSession;
+
+    @Mock
+    private ResourceHeaders resourceHeaders;
+
+    @Mock
+    private NonRdfSourceOperationBuilder builder;
+
+    @Mock
+    private NonRdfSourceOperation operation;
+
+    @Mock
+    private ExternalContent extContent;
+
+    @InjectMocks
+    private UpdateResourceServiceImpl updateResourceService;
+
+    @Mock
+    private InputStream inputStream;
+
+    private final static String txId = "tx1234";
+
+    private final static Collection<String> nonRdfSourceTypes;
+
+    private final Collection<String> digests = Stream.of("urn:sha1:12345abced")
+            .collect(Collectors.toCollection(HashSet::new));
+
+    static {
+        nonRdfSourceTypes = Collections.singleton(NON_RDF_SOURCE.toString());
+    }
+
+    @Before
+    public void setUp() {
+        rdfSourceOperationFactory = Mockito.spy(new RdfSourceOperationFactoryImpl());
+        setField(updateResourceService, "rdfSourceOperationFactory", rdfSourceOperationFactory);
+        nonRdfSourceOperationFactory =  Mockito.spy(new NonRdfSourceOperationFactoryImpl());
+        setField(updateResourceService, "nonRdfSourceOperationFactory", nonRdfSourceOperationFactory);
+        when(psManager.getSession(ArgumentMatchers.any())).thenReturn(psSession);
+    }
+
+    @Test
+    public void testUpdateNonRdfSource() throws Exception {
+        final String fedoraId = UUID.randomUUID().toString();
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
+        when(resourceHeaders.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
+        updateResourceService.perform(txId, fedoraId, "filename", "text/plain", digests, inputStream, 0, null);
+        verify(nonRdfSourceOperationFactory).updateInternalBinaryBuilder(fedoraId, inputStream);
+        verify(psSession).persist(ArgumentMatchers.any(ResourceOperation.class));
+    }
+
+    @Test
+    public void testUpdateNonRdfSourceExtContent() throws Exception {
+        final String fedoraId = UUID.randomUUID().toString();
+        final String extUrl = "http://www.example.com/";
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
+        when(resourceHeaders.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
+        when(extContent.getURL()).thenReturn(extUrl);
+        when(extContent.getHandling()).thenReturn(ExternalContent.REDIRECT);
+        updateResourceService.perform(txId, fedoraId, null, null, digests, null, 0, extContent);
+        verify(nonRdfSourceOperationFactory).updateExternalBinaryBuilder(fedoraId, ExternalContent.REDIRECT, URI.create(extUrl));
+        verify(psSession).persist(ArgumentMatchers.any(ResourceOperation.class));
+    }
+
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/UpdateResourceServiceImplTest.java
@@ -122,7 +122,8 @@ public class UpdateResourceServiceImplTest {
         when(extContent.getURL()).thenReturn(extUrl);
         when(extContent.getHandling()).thenReturn(ExternalContent.REDIRECT);
         updateResourceService.perform(txId, fedoraId, null, null, digests, null, 0, extContent);
-        verify(nonRdfSourceOperationFactory).updateExternalBinaryBuilder(fedoraId, ExternalContent.REDIRECT, URI.create(extUrl));
+        verify(nonRdfSourceOperationFactory).updateExternalBinaryBuilder(
+                fedoraId, ExternalContent.REDIRECT, URI.create(extUrl));
         verify(psSession).persist(ArgumentMatchers.any(ResourceOperation.class));
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-3103

# What does this Pull Request do?
Adds the implementation for updating Binary (NonRDFSource)

# What's new?
- Adds `UpdateResourceService` interface and implementation.
- Implements `UpdateNonRdfSourceOperation` and `UpdateNonRdfSourceOperationBuilder`


# Additional Notes:
Repalces #1579

# Interested parties
@whikloj @bseeger @dbernstein @bbpennel 
