### PR TITLE
Stage object sessions in their own subdirectories.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -555,7 +555,7 @@ public class FedoraLdp extends ContentExposingResource {
 
         final String interactionModel = checkInteractionModel(links);
 
-        final String fedoraId = identifierConverter().toInternalId(externalPath());
+        final String fedoraId = identifierConverter().toInternalId(identifierConverter().toDomain(externalPath()));
 
         if (isBinary(interactionModel, requestContentType.toString(), requestContentType != null,
                 extContent != null)) {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -88,7 +88,6 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
 
         final File stagingDirectory = new File(this.ocflStagingDir,
                 persistentStorageSessionId == null ? "read-only" : persistentStorageSessionId);
-        stagingDirectory.mkdirs();
         return new DefaultOCFLObjectSession(ocflId, stagingDirectory.toPath(), this.ocflRepository);
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -169,7 +169,6 @@ public class DefaultOCFLObjectSessionTest {
 
         assertMutableHeadPopulated(OBJ_ID);
 
-        stagingPath = tempFolder.newFolder("obj1-staging").toPath();
         session = new DefaultOCFLObjectSession(OBJ_ID, stagingPath, ocflRepository);
 
         // Commit changes to new version in second commit
@@ -323,10 +322,12 @@ public class DefaultOCFLObjectSessionTest {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
 
         assertEquals(1, stagingPath.toFile().listFiles().length);
+        assertEquals(1, stagingPath.resolve(OBJ_ID).toFile().listFiles().length);
 
         session.delete(FILE1_SUBPATH);
 
-        assertEquals(0, stagingPath.toFile().listFiles().length);
+        assertEquals(1, stagingPath.toFile().listFiles().length);
+        assertEquals(0, stagingPath.resolve(OBJ_ID).toFile().listFiles().length);
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.io.IOUtils;
@@ -629,6 +630,21 @@ public class DefaultOCFLObjectSessionTest {
         assertEquals("There should be exactly two versions",2, versions.size());
     }
 
+    @Test
+    public void ensureFilesDontStageTogether() throws Exception {
+        final String obj1ID = UUID.randomUUID().toString();
+        final String obj2ID = UUID.randomUUID().toString();
+        final var session1 = new DefaultOCFLObjectSession(obj1ID, stagingPath, ocflRepository);
+        final var session2 = new DefaultOCFLObjectSession(obj2ID, stagingPath, ocflRepository);
+        session1.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session2.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
+        session1.commit(NEW_VERSION);
+        session2.commit(NEW_VERSION);
+        assertFileInVersion(obj1ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
+        assertFileNotInVersion(obj1ID, "v1", FILE2_SUBPATH);
+        assertFileInVersion(obj2ID, "v1", FILE2_SUBPATH, FILE_CONTENT2);
+        assertFileNotInVersion(obj2ID, "v1", FILE1_SUBPATH);
+    }
 
     private static InputStream fileStream(final String content) {
         return new ByteArrayInputStream(content.getBytes());


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3174

# What does this Pull Request do?
Currently all storage requests generate operations that need to be checked for changes. These all share the exact same directory so when we do the check of operations the first operation persists all files to its OCFL object. This causes an error.

# How should this be tested?

It still doesn't work but I was `POST`ing a new resource and would get a error related to rolling back the transaction. With this change you should get an error related to adding cache control headers. (See next PR for work on that)

# Interested parties
@fcrepo4/committers
