### PR TITLE
Ensures that POSTs without explicit Content-Type headers use turtle b…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -66,7 +66,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
     protected SecurityContext securityContext;
 
     @Inject
-    protected ResourceFactory resourceFactory;
+    private ResourceFactory resourceFactory;
 
     protected IdentifierConverter<Resource, FedoraResource> idTranslator;
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -90,7 +90,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
         return identifierConverter;
     }
 
-    protected FedoraResource getResourceHead(final String fedoraId) throws PathNotFoundException {
+    protected FedoraResource getFedoraResource(final String fedoraId) throws PathNotFoundException {
         return this.resourceFactory.getResource(fedoraId);
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -581,15 +581,13 @@ public class FedoraLdp extends ContentExposingResource {
         }
 
         LOGGER.debug("Finished creating resource: {}", newFedoraId);
-        final FedoraResource resource;
+        transaction.commit();
         try {
-            resource = resourceFactory.getResource(transaction, newFedoraId);
+            return createUpdateResponse(getResourceHead(newFedoraId), true);
         } catch (PathNotFoundException e) {
             // We just created this resource, so something major must have happened.
             throw new RepositoryRuntimeException("Failure to find newly created resource", e);
         }
-        transaction.commit();
-        return createUpdateResponse(resource, true);
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -451,7 +451,7 @@ public class FedoraLdp extends ContentExposingResource {
         // TODO: How to generate a response.
         LOGGER.debug("Finished creating resource with path: {}", externalPath());
         transaction.commit();
-        return createUpdateResponse(getResourceHead(fedoraId), created);
+        return createUpdateResponse(getFedoraResource(fedoraId), created);
 
     }
 
@@ -583,7 +583,7 @@ public class FedoraLdp extends ContentExposingResource {
         LOGGER.debug("Finished creating resource: {}", newFedoraId);
         transaction.commit();
         try {
-            return createUpdateResponse(getResourceHead(newFedoraId), true);
+            return createUpdateResponse(getFedoraResource(newFedoraId), true);
         } catch (PathNotFoundException e) {
             // We just created this resource, so something major must have happened.
             throw new RepositoryRuntimeException("Failure to find newly created resource", e);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -251,7 +251,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadObject() throws IOException {
         final String id = getRandomUniqueId();
         createObject(id).close();
@@ -260,7 +259,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadDefaultContainer() throws IOException {
         final String id = getRandomUniqueId();
         createObject(id).close();
@@ -273,7 +271,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadBasicContainer() throws IOException {
         final String id = getRandomUniqueId();
 
@@ -288,25 +285,21 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadTurtleContentType() throws IOException {
         testHeadDefaultContentType(RDFMediaType.TURTLE_WITH_CHARSET);
     }
 
     @Test
-@Ignore
     public void testHeadRDFContentType() throws IOException {
         testHeadDefaultContentType(RDFMediaType.RDF_XML);
     }
 
     @Test
-@Ignore
     public void testHeadJSONLDContentType() throws IOException {
         testHeadDefaultContentType(RDFMediaType.JSON_LD);
     }
 
     @Test
-@Ignore
     public void testHeadDefaultContentType() throws IOException {
         testHeadDefaultContentType(null);
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -229,6 +229,6 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
      * @return the list of LINK headers.
      */
     private List<Link> getLinkHeaders(final List<String> headers) {
-        return headers == null ? null : headers.stream().map(p -> Link.fromUri(p).build()).collect(Collectors.toList());
+        return headers == null ? null : headers.stream().map(p -> Link.valueOf(p)).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
…y default.

Resolves:  https://jira.lyrasis.org/browse/FCREPO-3188

**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3188


* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
* Ensures that POSTs without an explicit Content-Type header do not fail. Rather, they assume text/turtle.
* Formerly @Ignore'd integration tests now work.  In the process of reenabling the integration tests, I also fixed a bug related to link header parsing.

# How should this be tested?

`
# create the resource
curl -v -XPOST -H "Slug: blah" -ufedoraAdmin:fedoraAdmin -H "Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel=\"type\"" http://localhost:8080/rest

#Verify that the operation succeeds and a subsequent GET returns the resource. content type text/turtle
`
curl -I -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/blah
`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
