### PR TITLE
FCREPO-3179 - POST to Create Binaries and descriptions

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -88,7 +88,6 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -482,10 +481,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (resource instanceof Binary) {
             final Binary binary = (Binary)resource;
 
-            if (binary.isProxy()) {
-                servletResponse.addHeader(CONTENT_LOCATION, binary.getProxyURL());
-            } else if (binary.isRedirect()) {
-                servletResponse.addHeader(CONTENT_LOCATION, binary.getRedirectURL());
+            if (binary.isProxy() || binary.isRedirect()) {
+                servletResponse.addHeader(CONTENT_LOCATION, binary.getExternalURL());
             }
         }
     }
@@ -909,32 +906,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         return contentTypeToLang(contentTypeString) != null;
     }
 
-    protected void replaceResourceBinaryWithStream(final Binary result,
-                                                   final InputStream requestBodyStream,
-                                                   final ContentDisposition contentDisposition,
-                                                   final MediaType contentType,
-                                                   final Collection<String> checksums,
-                                                   final String externalHandling,
-                                                   final String externalUrl) throws InvalidChecksumException {
-        final Collection<URI> checksumURIs = checksums == null ?
-                new HashSet<>() : checksums.stream().map(checksum -> checksumURI(checksum)).collect(Collectors.toSet());
-        final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
-        final String originalContentType = contentType != null ? contentType.toString() : "";
-
-        if (externalHandling != null) {
-            result.setExternalContent(originalContentType,
-                    checksumURIs,
-                    originalFileName,
-                    externalHandling,
-                    externalUrl);
-        } else {
-            result.setContent(requestBodyStream,
-                    originalContentType,
-                    checksumURIs,
-                    originalFileName,
-                    storagePolicyDecisionPoint);
-        }
-    }
 
     protected void patchResourcewithSparql(final FedoraResource resource,
             final String requestBody,

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -94,9 +94,24 @@ abstract public class FedoraBaseResource extends AbstractResource {
         return this.resourceFactory.getResource(fedoraId);
     }
 
-    protected FedoraResource getFedoraResource(final Transaction transaction, final String fedoraId)
-            throws PathNotFoundException {
-        return this.resourceFactory.getResource(transaction, fedoraId);
+    /**
+     * Gets a fedora resource by id. Uses the provided transaction if it is uncommitted,
+     * or uses a new transaction.
+     *
+     * @param transaction the fedora transaction
+     * @param fedoraId identifier of the resource
+     * @return the requested FedoraResource
+     */
+    protected FedoraResource getFedoraResource(final Transaction transaction, final String fedoraId) {
+        try {
+            if (transaction.isCommitted()) {
+                return getFedoraResource(fedoraId);
+            } else {
+                return resourceFactory.getResource(transaction, fedoraId);
+            }
+        } catch (final PathNotFoundException e) {
+            throw new PathNotFoundRuntimeException(e);
+        }
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -94,6 +94,11 @@ abstract public class FedoraBaseResource extends AbstractResource {
         return this.resourceFactory.getResource(fedoraId);
     }
 
+    protected FedoraResource getFedoraResource(final Transaction transaction, final String fedoraId)
+            throws PathNotFoundException {
+        return this.resourceFactory.getResource(transaction, fedoraId);
+    }
+
     /**
      * This is a helper method for using the idTranslator to convert this resource into an associated Jena Node.
      *
@@ -121,7 +126,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
             }
 
             return fedoraResource;
-        } catch (PathNotFoundException exc) {
+        } catch (final PathNotFoundException exc) {
             throw new PathNotFoundRuntimeException(exc);
         }
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -465,7 +465,7 @@ public class FedoraLdp extends ContentExposingResource {
         // TODO: How to generate a response.
         LOGGER.debug("Finished creating resource with path: {}", externalPath());
         transaction.commitIfShortLived();
-        return createUpdateResponse(getFedoraResource(fedoraId), created);
+        return createUpdateResponse(getFedoraResource(transaction, fedoraId), created);
 
     }
 
@@ -613,20 +613,7 @@ public class FedoraLdp extends ContentExposingResource {
         LOGGER.debug("Finished creating resource with path: {}", externalPath());
         transaction.commitIfShortLived();
 
-        final FedoraResource resource;
-        try {
-            // Need to commit transaction before retrieving the resource for the response,
-            // otherwise the session will have expired in some cases.
-            if (transaction.isShortLived()) {
-                resource = getFedoraResource(newFedoraId);
-            } else {
-                resource = getFedoraResource(transaction, newFedoraId);
-            }
-        } catch (final PathNotFoundException e) {
-            // We just created this resource, so something major must have happened.
-            throw new PathNotFoundRuntimeException(e);
-        }
-
+        final var resource = getFedoraResource(transaction, newFedoraId);
         return createUpdateResponse(resource, true);
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -445,8 +445,8 @@ public class FedoraLdpTest {
         when(mockResource.isProxy()).thenReturn(false);
         when(mockResource.isRedirect()).thenReturn(true);
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
-        when(mockResource.getRedirectURL()).thenReturn(url);
-        when(mockResource.getRedirectURI()).thenReturn(URI.create(url));
+        when(mockResource.getExternalURL()).thenReturn(url);
+        when(mockResource.getExternalURI()).thenReturn(URI.create(url));
         final Response actual = testObj.head();
         assertEquals(TEMPORARY_REDIRECT.getStatusCode(), actual.getStatus());
         assertEquals(new URI(url), actual.getLocation());
@@ -778,8 +778,8 @@ public class FedoraLdpTest {
         when(mockResource.isProxy()).thenReturn(false);
         when(mockResource.isRedirect()).thenReturn(true);
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
-        when(mockResource.getRedirectURI()).thenReturn(URI.create(url));
-        when(mockResource.getRedirectURL()).thenReturn(url);
+        when(mockResource.getExternalURI()).thenReturn(URI.create(url));
+        when(mockResource.getExternalURL()).thenReturn(url);
         when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
         final Response actual = testObj.getResource(null);
         assertEquals(TEMPORARY_REDIRECT.getStatusCode(), actual.getStatus());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1781,7 +1781,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testIngestWithBinary() throws IOException {
         final HttpPost method = postObjMethod();
         method.addHeader(CONTENT_TYPE, "application/octet-stream");
@@ -1793,15 +1792,16 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final int status = getStatus(response);
             assertEquals("Didn't get a CREATED response! Got content:\n" + content, CREATED.getStatusCode(), status);
             assertIdentifierness(content);
-            final String location = getLocation(response);
-            assertNotEquals(serverAddress + "/objects", location);
-            assertEquals("Object wasn't created!", OK.getStatusCode(), getStatus(new HttpGet(location)));
-            final Link link = Link.valueOf(response.getFirstHeader(LINK).getValue());
-
-            assertEquals("describedby", link.getRel());
-            assertTrue("Expected an anchor to the newly created resource", link.getParams().containsKey("anchor"));
-            assertEquals("Expected anchor at the newly created resource", location, link.getParams().get("anchor"));
-            assertEquals("Expected describedBy link", location + "/" + FCR_METADATA, link.getUri().toString());
+            // TODO reanble once GET implemented
+            // final String location = getLocation(response);
+            // assertEquals("Object wasn't created!", OK.getStatusCode(), getStatus(new HttpGet(location)));
+            // final Link link = Link.valueOf(response.getFirstHeader(LINK).getValue());
+            //
+            // assertEquals("describedby", link.getRel());
+            // assertTrue("Expected an anchor to the newly created resource", link.getParams().containsKey("anchor"));
+            // assertEquals("Expected anchor at the newly created resource", location,
+            // link.getParams().get("anchor"));
+            // assertEquals("Expected describedBy link", location + "/" + FCR_METADATA, link.getUri().toString());
         }
     }
 
@@ -1835,7 +1835,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
      * with a SHA1 sum of the binary content
      */
     @Test
-@Ignore
     public void testIngestWithBinaryAndChecksum() {
         final HttpPost method = postObjMethod();
         final File img = new File("src/test/resources/test-objects/img.png");

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
@@ -38,6 +38,11 @@ public interface Transaction {
     void commitIfShortLived();
 
     /**
+     * @return returns true if this transaction has already been committed
+     */
+    boolean isCommitted();
+
+    /**
      * Rollback the transaction
      */
     void rollback();
@@ -51,15 +56,14 @@ public interface Transaction {
 
     /**
      * Check if the transaction is short-lived.
-     * 
+     *
      * @return is the transaction short-lived.
      */
     boolean isShortLived();
 
-
     /**
      * Set transaction short-lived state.
-     * 
+     *
      * @param shortLived boolean true (short-lived) or false (not short-lived)
      */
     void setShortLived(boolean shortLived);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Binary.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Binary.java
@@ -95,40 +95,20 @@ public interface Binary extends FedoraResource {
     Boolean isRedirect();
 
     /**
-     * Get the URL that this resource is a Proxy for
-     * @return String containing URL of object to proxy
+     * @return the external url for this binary if present, or null.
      */
-    String getProxyURL();
+    String getExternalURL();
 
     /**
-     * Set the URL that this resource is a proxy for
-     * @param url - the url of the resource this is a proxy for
+     * @return Get the external uri for this binary if present, or null
      */
-    @Deprecated
-    void setProxyURL(String url);
-
-    /**
-     * Get the URL this resource should redirect to
-     * @return String containing URL of object to redirect to
-     */
-    String getRedirectURL();
-
-    /**
-     * Get URL as a URI
-     *
-     * @return URI containing the object to redirect to.
-     */
-    default URI getRedirectURI() {
-        return URI.create(getRedirectURL());
+    default URI getExternalURI() {
+        final var externalUrl = getExternalURL();
+        if (externalUrl == null) {
+            return null;
+        }
+        return URI.create(externalUrl);
     }
-
-    /**
-     * Set the URL that this is a redirect to
-     *
-     * @param url - the url of the resource this redirects to
-     */
-    @Deprecated
-    void setRedirectURL(String url);
 
     /**
      * @return The MimeType of content associated with this datastream.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -84,6 +84,11 @@ public class TransactionImpl implements Transaction {
     }
 
     @Override
+    public synchronized boolean isCommitted() {
+        return commited;
+    }
+
+    @Override
     public synchronized void rollback() {
         failIfCommited();
         if (this.rolledback) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -17,13 +17,20 @@
  */
 package org.fcrepo.kernel.impl.models;
 
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
+import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
+
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.models.Binary;
+import org.fcrepo.kernel.api.models.ExternalContent;
+import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
@@ -35,6 +42,18 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
  * @author bbpennel
  */
 public class BinaryImpl extends FedoraResourceImpl implements Binary {
+
+    private String externalHandling;
+
+    private String externalUrl;
+
+    private Long contentSize;
+
+    private String filename;
+
+    private String mimeType;
+
+    private Collection<URI> digests;
 
     /**
      * Construct the binary
@@ -81,62 +100,93 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
 
     @Override
     public long getContentSize() {
-        // TODO Auto-generated method stub
-        return 0;
+        return contentSize;
     }
 
     @Override
     public URI getContentDigest() {
-        // TODO Auto-generated method stub
-        return null;
+        // Returning the first digest for the time being
+        if (digests == null) {
+            return null;
+        }
+        final var digest = digests.stream().findFirst();
+        return digest.isPresent() ? digest.get() : null;
     }
 
     @Override
     public Boolean isProxy() {
-        // TODO Auto-generated method stub
-        return null;
+        return PROXY.equals(externalHandling);
     }
 
     @Override
     public Boolean isRedirect() {
-        // TODO Auto-generated method stub
-        return null;
+        return ExternalContent.REDIRECT.equals(externalHandling);
     }
 
     @Override
-    public String getProxyURL() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public void setProxyURL(final String url) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public String getRedirectURL() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public void setRedirectURL(final String url) {
-        // TODO Auto-generated method stub
-
+    public String getExternalURL() {
+        return externalUrl;
     }
 
     @Override
     public String getMimeType() {
-        // TODO Auto-generated method stub
-        return null;
+        return mimeType;
     }
 
     @Override
     public String getFilename() {
-        // TODO Auto-generated method stub
-        return null;
+        return filename;
     }
 
+    @Override
+    public FedoraResource getDescription() {
+        try {
+            final var descId = getId() + "/" + FCR_METADATA;
+            return resourceFactory.getResource(tx, descId);
+        } catch (final PathNotFoundException e) {
+            throw new PathNotFoundRuntimeException(e);
+        }
+    }
+
+    /**
+     * @param externalHandling the externalHandling to set
+     */
+    protected void setExternalHandling(final String externalHandling) {
+        this.externalHandling = externalHandling;
+    }
+
+    /**
+     * @param externalUrl the externalUrl to set
+     */
+    protected void setExternalUrl(final String externalUrl) {
+        this.externalUrl = externalUrl;
+    }
+
+    /**
+     * @param contentSize the contentSize to set
+     */
+    protected void setContentSize(final Long contentSize) {
+        this.contentSize = contentSize;
+    }
+
+    /**
+     * @param filename the filename to set
+     */
+    protected void setFilename(final String filename) {
+        this.filename = filename;
+    }
+
+    /**
+     * @param mimeType the mimeType to set
+     */
+    protected void setMimeType(final String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    /**
+     * @param digests the digests to set
+     */
+    protected void setDigests(final Collection<URI> digests) {
+        this.digests = digests;
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -47,7 +47,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     private final PersistentStorageSessionManager pSessionManager;
 
-    private final ResourceFactory resourceFactory;
+    protected final ResourceFactory resourceFactory;
 
     private final String id;
 
@@ -70,7 +70,7 @@ public class FedoraResourceImpl implements FedoraResource {
     private String etag;
 
     // The transaction this representation of the resource belongs to
-    private final Transaction tx;
+    protected final Transaction tx;
 
     protected FedoraResourceImpl(final String id,
             final Transaction tx,
@@ -107,8 +107,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public FedoraResource getOriginalResource() {
-        // TODO Auto-generated method stub
-        return null;
+        return this;
     }
 
     @Override
@@ -229,8 +228,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public FedoraResource getDescription() {
-        // TODO Auto-generated method stub
-        return null;
+        return this;
     }
 
     @Override
@@ -240,7 +238,11 @@ public class FedoraResourceImpl implements FedoraResource {
     }
 
     private PersistentStorageSession getSession() {
-        return pSessionManager.getSession(tx.getId());
+        if (tx == null) {
+            return pSessionManager.getReadOnlySession();
+        } else {
+            return pSessionManager.getSession(tx.getId());
+        }
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -233,8 +233,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public FedoraResource getDescribedResource() {
-        // TODO Auto-generated method stub
-        return null;
+        return this;
     }
 
     private PersistentStorageSession getSession() {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.models;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+
+/**
+ * Implementation of a non-rdf source description
+ *
+ * @author bbpennel
+ */
+public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl {
+
+    /**
+     * Construct a description resource
+     *
+     * @param id
+     * @param tx
+     * @param pSessionManager
+     * @param resourceFactory
+     */
+    public NonRdfSourceDescriptionImpl(final String id,
+            final Transaction tx,
+            final PersistentStorageSessionManager pSessionManager,
+            final ResourceFactory resourceFactory) {
+        super(id, tx, pSessionManager, resourceFactory);
+    }
+
+    @Override
+    public FedoraResource getDescribedResource() {
+        // TODO must return the described binary
+        return this;
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -32,10 +32,10 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl {
     /**
      * Construct a description resource
      *
-     * @param id
-     * @param tx
-     * @param pSessionManager
-     * @param resourceFactory
+     * @param id internal identifier
+     * @param tx transaction
+     * @param pSessionManager session manager
+     * @param resourceFactory resource factory
      */
     public NonRdfSourceDescriptionImpl(final String id,
             final Transaction tx,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.impl.models;
 
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -94,10 +95,10 @@ public class ResourceFactoryImpl implements ResourceFactory {
         try {
             psSession.getHeaders(fedoraId, version);
             return true;
-        } catch (PersistentItemNotFoundException e) {
+        } catch (final PersistentItemNotFoundException e) {
             // Object doesn't exist.
             return false;
-        } catch (PersistentStorageException e) {
+        } catch (final PersistentStorageException e) {
             // Other error, pass along.
             throw new RepositoryRuntimeException(e);
         } finally {
@@ -105,7 +106,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
                 // Commit session (if read-only) so it doesn't hang around.
                 try {
                     psSession.commit();
-                } catch (PersistentStorageException e) {
+                } catch (final PersistentStorageException e) {
                     LOGGER.error("Error committing session, message: {}", e.getMessage());
                 }
             }
@@ -126,6 +127,9 @@ public class ResourceFactoryImpl implements ResourceFactory {
         }
         if (NON_RDF_SOURCE.getURI().equals(ixModel)) {
             return BinaryImpl.class;
+        }
+        if (FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI.equals(ixModel)) {
+            return NonRdfSourceDescriptionImpl.class;
         }
         // TODO add the rest of the types
         throw new ResourceTypeException("Could not identify the resource type for interaction model " + ixModel);
@@ -179,7 +183,13 @@ public class ResourceFactoryImpl implements ResourceFactory {
         resc.setStateToken(headers.getStateToken());
 
         if (resc instanceof Binary) {
-            // set binary headers
+            final var binary = (BinaryImpl) resc;
+            binary.setContentSize(headers.getContentSize());
+            binary.setExternalHandling(headers.getExternalHandling());
+            binary.setExternalUrl(headers.getExternalUrl());
+            binary.setDigests(headers.getDigests());
+            binary.setFilename(headers.getFilename());
+            binary.setMimeType(headers.getMimeType());
         }
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
@@ -44,7 +44,6 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ResourceTypeException;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.Container;
-import org.fcrepo.kernel.api.models.ExternalContent;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3179

# What does this Pull Request do?
Binaries and their descriptions should not be created via POST.

# What's new?
* Implementation and creation of descriptions (Non-RDF source descriptions)
* Filling out and cleanup of Binary classes.
  * getProxyUrl and getRedirectUrl were merged since they are now identical
* Some fixes regarding committing transactions for POST
* Avoid NPE if no content disposition provided during binary creation.

# How should this be tested?
There are updated and reenabled tests. There are not many ways to manually test this until GET is implemented for binaries.

# Additional Notes:
Note: digests are not evaluated yet.

# Interested parties
@fcrepo4/committers
