### PR TITLE
FCREPO-3079 - GET binary

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -242,16 +242,10 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                                   final RdfStream rdfStream,
                                   final FedoraResource resource) throws IOException {
 
-        final RdfNamespacedStream outputStream;
-
-        if (resource instanceof Binary) {
-            return getBinaryContent(rangeValue, resource);
-        } else {
-            outputStream = new RdfNamespacedStream(
+        final var outputStream = new RdfNamespacedStream(
                     new DefaultRdfStream(rdfStream.topic(), concat(rdfStream,
                         getResourceTriples(limit, resource))),
                     namespaceRegistry.getNamespaces());
-        }
         setVaryAndPreferenceAppliedHeaders(servletResponse, prefer, resource);
         return ok(outputStream).build();
     }
@@ -369,7 +363,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @return Binary blob
      * @throws IOException if io exception occurred
      */
-    private Response getBinaryContent(final String rangeValue, final FedoraResource resource)
+    protected Response getBinaryContent(final String rangeValue, final FedoraResource resource)
             throws IOException {
             final Binary binary = (Binary)resource;
             final CacheControl cc = new CacheControl();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -230,15 +230,13 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     /**
      * This method returns an HTTP response with content body appropriate to the following arguments.
      *
-     * @param rangeValue starting and ending byte offsets, see {@link Range}
      * @param limit is the number of child resources returned in the response, -1 for all
      * @param rdfStream to which response RDF will be concatenated
      * @param resource the fedora resource
      * @return HTTP response
      * @throws IOException in case of error extracting content
      */
-    protected Response getContent(final String rangeValue,
-                                  final int limit,
+    protected Response getContent(final int limit,
                                   final RdfStream rdfStream,
                                   final FedoraResource resource) throws IOException {
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -234,7 +234,6 @@ public class FedoraAcl extends ContentExposingResource {
     /**
      * GET to retrieve the ACL resource.
      *
-     * @param rangeValue the range value
      * @return a binary or the triples for the specified node
      * @throws IOException if IO exception occurred
      */
@@ -242,7 +241,7 @@ public class FedoraAcl extends ContentExposingResource {
     @Produces({ TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
                 N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
                 TURTLE_X, TEXT_HTML_WITH_CHARSET })
-    public Response getResource(@HeaderParam("Range") final String rangeValue)
+    public Response getResource()
             throws IOException, ItemNotFoundException {
 
         LOGGER.info("GET resource '{}'", externalPath);
@@ -270,7 +269,7 @@ public class FedoraAcl extends ContentExposingResource {
         try (final RdfStream rdfStream = new DefaultRdfStream(asNode(aclResource))) {
 
             addResourceHttpHeaders(aclResource);
-            return getContent(rangeValue, getChildrenLimit(), rdfStream, aclResource);
+            return getContent(getChildrenLimit(), rdfStream, aclResource);
 
         }
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -265,35 +265,33 @@ public class FedoraLdp extends ContentExposingResource {
 
         checkCacheControlHeaders(request, servletResponse, resource(), transaction);
 
+        final ImmutableList<MediaType> acceptableMediaTypes = ImmutableList.copyOf(headers
+                .getAcceptableMediaTypes());
+
         LOGGER.info("GET resource '{}'", externalPath);
-        try (final RdfStream rdfStream = new DefaultRdfStream(asNode(resource()))) {
-
-            // If requesting a binary, check the mime-type if "Accept:" header is present.
-            // (This needs to be done before setting up response headers, as getContent
-            // returns a response - so changing headers after that won't work so nicely.)
-            final ImmutableList<MediaType> acceptableMediaTypes = ImmutableList.copyOf(headers
-                    .getAcceptableMediaTypes());
-
-            if (resource() instanceof Binary && acceptableMediaTypes.size() > 0) {
-
+        if (resource() instanceof Binary) {
+            final Binary binary = (Binary) resource();
+            if (!acceptableMediaTypes.isEmpty()) {
                 final MediaType mediaType = getBinaryResourceMediaType(resource());
-
-                // Respect the Want-Digest header for fixity check
-                final String wantDigest = headers.getHeaderString(WANT_DIGEST);
-                if (!isNullOrEmpty(wantDigest)) {
-                    servletResponse.addHeader(DIGEST, handleWantDigestHeader((Binary)resource(), wantDigest));
-                }
 
                 if (acceptableMediaTypes.stream().noneMatch(t -> t.isCompatible(mediaType))) {
                     return notAcceptable(VariantListBuilder.newInstance().mediaTypes(mediaType).build()).build();
                 }
             }
 
-            addResourceHttpHeaders(resource());
+            // Respect the Want-Digest header for fixity check
+            final String wantDigest = headers.getHeaderString(WANT_DIGEST);
+            if (!isNullOrEmpty(wantDigest)) {
+                servletResponse.addHeader(DIGEST, handleWantDigestHeader(binary, wantDigest));
+            }
 
-            if (resource() instanceof Binary && ((Binary)resource()).isRedirect()) {
-                return temporaryRedirect(((Binary) resource()).getExternalURI()).build();
+            if (binary.isRedirect()) {
+                return temporaryRedirect(binary.getExternalURI()).build();
             } else {
+                return getBinaryContent(rangeValue, binary);
+            }
+        } else {
+            try (final var rdfStream = new DefaultRdfStream(asNode(resource()))) {
                 return getContent(rangeValue, getChildrenLimit(), rdfStream, resource());
             }
         }
@@ -586,7 +584,12 @@ public class FedoraLdp extends ContentExposingResource {
             final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
             final var binaryType = requestContentType != null ? requestContentType : DEFAULT_NON_RDF_CONTENT_TYPE;
             final var contentType = extContent == null ? binaryType.toString() : extContent.getContentType();
-            final var contentSize = contentDisposition != null ? contentDisposition.getSize() : null;
+            final Long contentSize;
+            if (contentDisposition == null || contentDisposition.getSize() == -1) {
+                contentSize = null;
+            } else {
+                contentSize = contentDisposition.getSize();
+            }
 
             newFedoraId = createResourceService.perform(transaction.getId(),
                                                         getUserPrincipal(),
@@ -595,7 +598,7 @@ public class FedoraLdp extends ContentExposingResource {
                                                         true,
                                                         contentType,
                                                         originalFileName,
-                    contentSize,
+                                                        contentSize,
                                                         links,
                                                         checksums,
                                                         requestBodyStream,

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -292,7 +292,7 @@ public class FedoraLdp extends ContentExposingResource {
             }
         } else {
             try (final var rdfStream = new DefaultRdfStream(asNode(resource()))) {
-                return getContent(rangeValue, getChildrenLimit(), rdfStream, resource());
+                return getContent(getChildrenLimit(), rdfStream, resource());
             }
         }
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -250,7 +250,6 @@ public class FedoraVersioning extends ContentExposingResource {
     /**
      * Get the list of versions for the object
      *
-     * @param rangeValue starting and ending byte offsets
      * @param acceptValue the rdf media-type
      * @return List of versions for the object as RDF
      * @throws IOException in case of error extracting content
@@ -260,8 +259,7 @@ public class FedoraVersioning extends ContentExposingResource {
     @Produces({ TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
         N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
         TURTLE_X, TEXT_HTML_WITH_CHARSET, APPLICATION_LINK_FORMAT })
-    public Response getVersionList(@HeaderParam("Range") final String rangeValue,
-        @HeaderParam("Accept") final String acceptValue) throws IOException {
+    public Response getVersionList(@HeaderParam("Accept") final String acceptValue) throws IOException {
 
         final FedoraResource theTimeMap = resource().getTimeMap();
         checkCacheControlHeaders(request, servletResponse, theTimeMap, transaction);
@@ -301,7 +299,7 @@ public class FedoraVersioning extends ContentExposingResource {
             return ok(new LinkFormatStream(versionLinks.stream())).build();
         } else {
             try (final RdfStream rdfStream = new DefaultRdfStream(asNode(theTimeMap))) {
-                return getContent(rangeValue, getChildrenLimit(), rdfStream, theTimeMap);
+                return getContent(getChildrenLimit(), rdfStream, theTimeMap);
             }
         }
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Binary.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Binary.java
@@ -36,14 +36,6 @@ public interface Binary extends FedoraResource {
     InputStream getContent();
 
     /**
-     * Set the content stream for this resource.
-     *
-     * @param content Inputstream
-     */
-    @Deprecated
-    void setContentStream(InputStream content);
-
-    /**
      * Sets the content of this Datastream.
      *
      * @param content  InputStream of binary content to be stored
@@ -59,20 +51,6 @@ public interface Binary extends FedoraResource {
                     StoragePolicyDecisionPoint storagePolicyDecisionPoint)
             throws InvalidChecksumException;
 
-    /**
-     * Sets the external content reference for this datastream
-     *
-     * @param contentType MIME type of content (optional)
-     * @param checksums Collection of checksum URIs of the content (optional)
-     * @param originalFileName Original file name of the content (optional)
-     * @param externalHandling What type of handling the external resource needs (proxy or redirect)
-     * @param externalUrl Url for the external resourcej
-     * @throws InvalidChecksumException if invalid checksum exception occurred
-     */
-    @Deprecated
-    void setExternalContent(String contentType, Collection<URI> checksums,
-                    String originalFileName, String externalHandling, String externalUrl)
-            throws InvalidChecksumException;
     /**
      * @return The size in bytes of content associated with this datastream.
      */

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -26,14 +26,18 @@ import java.util.Collection;
 
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.ExternalContent;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 
 /**
@@ -70,30 +74,20 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
 
     @Override
     public InputStream getContent() {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public void setContentStream(final InputStream content) {
-        // TODO Auto-generated method stub
-
+        try {
+            return getSession().getBinaryContent(getId(), getMementoDatetime());
+        } catch (final PersistentItemNotFoundException e) {
+            throw new ItemNotFoundException("Unable to find content for " + getId()
+                    + " version " + getMementoDatetime(), e);
+        } catch (final PersistentStorageException e) {
+            throw new RepositoryRuntimeException(e);
+        }
     }
 
     @Override
     public void setContent(final InputStream content, final String contentType, final Collection<URI> checksums,
             final String originalFileName, final StoragePolicyDecisionPoint storagePolicyDecisionPoint)
             throws InvalidChecksumException {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public void setExternalContent(final String contentType,
-                                   final Collection<URI> checksums,
-                                   final String originalFileName,
-                                   final String externalHandling,
-                                   final String externalUrl) throws InvalidChecksumException {
         // TODO Auto-generated method stub
 
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -236,7 +236,7 @@ public class FedoraResourceImpl implements FedoraResource {
         return this;
     }
 
-    private PersistentStorageSession getSession() {
+    protected PersistentStorageSession getSession() {
         if (tx == null) {
             return pSessionManager.getReadOnlySession();
         } else {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java
@@ -20,6 +20,7 @@ package org.fcrepo.persistence.ocfl.impl;
 import static java.lang.String.format;
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.getSidecarSubpath;
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.resolveVersionId;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.getBinaryStream;
 
 import java.io.InputStream;
 import java.time.Instant;
@@ -253,9 +254,16 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
 
     @Override
     public InputStream getBinaryContent(final String identifier, final Instant version)
-            throws PersistentItemNotFoundException {
-        // TODO Auto-generated method stub
-        return null;
+            throws PersistentStorageException {
+        ensureCommitNotStarted();
+
+        final var mapping = getFedoraOCFLMapping(identifier);
+        final var rootIdentifier = mapping.getRootObjectIdentifier();
+        final var objSession = findOrCreateSession(mapping.getOcflObjectId());
+        final var fedoraSubpath = relativizeSubpath(rootIdentifier, identifier);
+        final var ocflSubpath = resolveOCFLSubpath(rootIdentifier, fedoraSubpath);
+
+        return getBinaryStream(objSession, ocflSubpath, version);
     }
 
     @Override

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -192,6 +192,13 @@ public class OCFLPersistentStorageUtils {
         return version == null ? objSession.read(subpath) : objSession.read(subpath, version);
     }
 
+    public static InputStream getBinaryStream(final OCFLObjectSession objSession,
+            final String subpath,
+            final Instant version) throws PersistentStorageException {
+        final String versionId = resolveVersionId(objSession, version);
+        return readFile(objSession, subpath, versionId);
+    }
+
     /**
      * Get an RDF stream for the specified file.
      *

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -192,9 +192,17 @@ public class OCFLPersistentStorageUtils {
         return version == null ? objSession.read(subpath) : objSession.read(subpath, version);
     }
 
+    /**
+     * Get the content of the specified binary file.
+     *
+     * @param objSession The OCFL object session
+     * @param subpath The path to the desired file
+     * @param version The version. If null, the head state will be returned.
+     * @return the binary content stream
+     * @throws PersistentStorageException If unable to read the specified binary stream.
+     */
     public static InputStream getBinaryStream(final OCFLObjectSession objSession,
-            final String subpath,
-            final Instant version) throws PersistentStorageException {
+            final String subpath, final Instant version) throws PersistentStorageException {
         final String versionId = resolveVersionId(objSession, version);
         return readFile(objSession, subpath, versionId);
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
@@ -39,7 +40,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Random;
@@ -47,12 +50,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.vocabulary.DC;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
@@ -118,6 +123,8 @@ public class OCFLPersistentStorageSessionTest {
     private RdfSourceOperation rdfSourceOperation;
 
     private RdfSourceOperation rdfSourceOperation2;
+
+    private static final String BINARY_CONTENT = "Some test content";
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -590,5 +597,98 @@ public class OCFLPersistentStorageSessionTest {
         final var node = createURI(RESOURCE_ID);
         assertEquals(node, retrievedUserStream.topic());
         assertEquals(dcTitleTriple, retrievedUserStream.findFirst().get());
+    }
+
+    @Test
+    public void getBinaryContent() throws Exception {
+        mockMappingAndIndex(mintOCFLObjectId(RESOURCE_ID), RESOURCE_ID, ROOT_OBJECT_ID, mapping);
+
+        // create the binary
+        final var binOperation = mockNonRdfSourceOperation(BINARY_CONTENT, USER_PRINCIPAL, RESOURCE_ID);
+
+        // perform the create non-rdf source operation
+        session.persist(binOperation);
+
+        // commit to OCFL
+        session.commit();
+
+        // create a new session and verify the returned rdf stream.
+        final var newSession = createSession(index, objectSessionFactory);
+        final var result = IOUtils.toString(newSession.getBinaryContent(RESOURCE_ID, null), UTF_8);
+
+        assertEquals(BINARY_CONTENT, result);
+    }
+
+    @Test
+    public void getBinaryContentFailsIfAlreadyCommitted() throws Exception {
+        mockMappingAndIndex(mintOCFLObjectId(RESOURCE_ID), RESOURCE_ID, ROOT_OBJECT_ID, mapping);
+
+        // create the binary
+        final var binOperation = mockNonRdfSourceOperation(BINARY_CONTENT, USER_PRINCIPAL, RESOURCE_ID);
+
+        // perform the create non-rdf source operation
+        session.persist(binOperation);
+
+        // commit to OCFL
+        session.commit();
+
+        try {
+            session.getBinaryContent(RESOURCE_ID, null);
+            fail("Get must fail due to session having been committed");
+        } catch (final PersistentStorageException ex) {
+            // expected failure, handled with catch since the persist can throw same error
+        }
+    }
+
+    @Test
+    public void getBinaryContentVersion() throws Exception {
+        DefaultOCFLObjectSession.setGlobaDefaultCommitOption(NEW_VERSION);
+        // SEE getTriplesFromPreviousVersion
+        mockMappingAndIndex(mintOCFLObjectId(RESOURCE_ID), RESOURCE_ID, ROOT_OBJECT_ID, mapping);
+
+        // create the binary
+        final var binOperation = mockNonRdfSourceOperation(BINARY_CONTENT, USER_PRINCIPAL, RESOURCE_ID);
+        // perform the create non-rdf source operation
+        session.persist(binOperation);
+        // commit to OCFL
+        session.commit();
+
+        // create a new session and verify that the state is the same
+        final var newSession = createSession(index, objectSessionFactory);
+
+        final var versions = newSession.listVersions(RESOURCE_ID);
+        final var version1 = versions.get(versions.size() - 1);
+        assertEquals(BINARY_CONTENT,
+                IOUtils.toString(newSession.getBinaryContent(RESOURCE_ID, version1), UTF_8));
+    }
+
+    @Test
+    public void getBinaryContentUncommitted() throws Exception {
+        mockMappingAndIndex(mintOCFLObjectId(RESOURCE_ID), RESOURCE_ID, ROOT_OBJECT_ID, mapping);
+
+        // create the binary
+        final var binOperation = mockNonRdfSourceOperation(BINARY_CONTENT, USER_PRINCIPAL, RESOURCE_ID);
+
+        // perform the create non-rdf source operation
+        session.persist(binOperation);
+
+        // create a new session and verify the returned rdf stream.
+        final var result = IOUtils.toString(session.getBinaryContent(RESOURCE_ID, null), UTF_8);
+
+        assertEquals(BINARY_CONTENT, result);
+    }
+
+    private NonRdfSourceOperation mockNonRdfSourceOperation(final String content,
+            final String userPrincipal, final String resourceId) {
+        final var binOperation = mock(NonRdfSourceOperation.class,
+                withSettings().extraInterfaces(CreateResourceOperation.class));
+
+        final var contentStream = new ByteArrayInputStream(content.getBytes());
+        when(binOperation.getContentStream()).thenReturn(contentStream);
+        when(binOperation.getContentSize()).thenReturn((long) content.length());
+        when(binOperation.getResourceId()).thenReturn(resourceId);
+        when(binOperation.getType()).thenReturn(CREATE);
+        when(binOperation.getUserPrincipal()).thenReturn(userPrincipal);
+        return binOperation;
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.withSettings;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Random;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3079

# What does this Pull Request do?
Enables retrieval of binaries at the persistence and http layers.

# What's new?
* Implements getBinaryContent at persistence layer
* Reorganization of @GET method to skip unnecessary creation of rdf stream when getting binary content, and to separate binary from rdf retrieval, similar to how the HEAD method is organized.
  * this included removing binary retrieval from the `getContent` method, and removing the `Range` parameter from various API methods that were only receiving it to pass it to `getContent` (where it was ignored since they didn't retrieve binaries)
* Fix issue with content size of binaries when content disposition is present but no content size specified
* Removes some more unused binary
* Reenables some binary related integration tests
  * many still can't be enabled because they depend on `PUT`

# How should this be tested?
Various tests, and should be able to POST to create a binary with one click, and then perform a GET on it to retrieve the file.

# Additional Notes:
Still doesn't support digest related features, and still many binary retrieval integration tests disabled.

# Interested parties
@fcrepo4/committers
