### PR TITLE
Added unique PathNotFoundExceptionMapper and mock test for that file

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.slf4j.Logger;
+
+
+/**
+ * Catch PathNotFoundException
+ *
+ * @author robyj
+ */
+@Provider
+public class PathNotFoundExceptionMapper implements
+        ExceptionMapper<PathNotFoundException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER =
+        getLogger(PathNotFoundExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final PathNotFoundException e) {
+
+        LOGGER.debug("Exception intercepted by PathNotFoundExceptionMapper: {}\n", e.getMessage());
+        debugException(this, e, LOGGER);
+        return Response.status(Response.Status.NOT_FOUND).
+                entity("Error: " + e.getMessage()).build();
+    }
+}
+

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapperTest.java
@@ -17,10 +17,8 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 import javax.ws.rs.core.Response;
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapperTest.java
@@ -49,7 +49,6 @@ public class PathNotFoundExceptionMapperTest {
         final PathNotFoundException input = new PathNotFoundException("xyz");
         final Response actual = testObj.toResponse(input);
         assertEquals(NOT_FOUND.getStatusCode(), actual.getStatus());
-        assertEquals(actual.getEntity(),"Error: xyz");
-        assertNotEquals(INTERNAL_SERVER_ERROR.getStatusCode(), actual.getStatus());
+        assertEquals(actual.getEntity(), "Error: xyz");
     }
 }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import javax.ws.rs.core.Response;
+
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * PathNotFoundExceptionMapperTest class.
+ *
+ * @author robyj
+ */
+public class PathNotFoundExceptionMapperTest {
+
+    private PathNotFoundExceptionMapper testObj;
+
+    @Before
+    public void setUp() {
+        testObj = new PathNotFoundExceptionMapper();
+    }
+
+    @Test
+    public void testToResponse() {
+        final PathNotFoundException input = new PathNotFoundException("xyz");
+        final Response actual = testObj.toResponse(input);
+        assertEquals(NOT_FOUND.getStatusCode(), actual.getStatus());
+        assertEquals(actual.getEntity(),"Error: xyz");
+        assertNotEquals(INTERNAL_SERVER_ERROR.getStatusCode(), actual.getStatus());
+    }
+}


### PR DESCRIPTION
Resolves https://jira.lyrasis.org/browse/FCREPO-3177


* * *

https://jira.lyrasis.org/browse/FCREPO-3177

# What does this Pull Request do?
Solves the issue where using GET to get info on a non-existant item returns a 500 server error code, it should return a 404 error code. This code adds a specific exception handler for the PathNotFoundException that returns a 404 server error code whereas before it fell through to a WildcardException that would return a 500 error code. There is also a mockito test unit for the new exception handler


# How should this be tested?
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/blah
 


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
