### PR TITLE
FCREPO-3103 - PUT binaries

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -101,6 +101,11 @@ public class ExternalContentHandler implements ExternalContent {
     }
 
     @Override
+    public URI getURI() {
+        return link != null ? link.getUri() : null;
+    }
+
+    @Override
     public boolean isCopy() {
         return handling != null && handling.equals(COPY);
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -115,6 +115,15 @@ abstract public class FedoraBaseResource extends AbstractResource {
     }
 
     /**
+     * @param transaction the transaction in which to check
+     * @param fedoraId identifier of the object to check
+     * @return Returns true if an object with the provided id exists
+     */
+    protected boolean doesResourceExist(final Transaction transaction, final String fedoraId) {
+        return resourceFactory.doesResourceExist(transaction, fedoraId, null);
+    }
+
+    /**
      * This is a helper method for using the idTranslator to convert this resource into an associated Jena Node.
      *
      * @param resource to be converted into a Jena Node

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -19,9 +19,9 @@ package org.fcrepo.http.api;
 
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.Response.ok;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
-import static javax.ws.rs.core.Response.ok;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
 import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_LINK_FORMAT;
@@ -48,9 +48,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
@@ -69,7 +67,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.jena.riot.Lang;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.LinkFormatStream;
@@ -84,6 +82,8 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * @author cabeer
@@ -228,9 +228,7 @@ public class FedoraVersioning extends ContentExposingResource {
                                                   final String digest)
             throws InvalidChecksumException, UnsupportedAlgorithmException {
 
-        final Collection<String> checksums = parseDigestHeader(digest);
-        final Collection<URI> checksumURIs = checksums == null ? new HashSet<>() : checksums.stream().map(
-                checksum -> checksumURI(checksum)).collect(Collectors.toSet());
+        final Collection<URI> checksumURIs = parseDigestHeader(digest);
 
         // Create internal binary either from supplied body or copy external uri
         if (extContent == null || extContent.isCopy()) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2071,7 +2071,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetDatastream() throws IOException, ParseException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -2094,7 +2093,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetLongRange() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -3038,16 +3036,15 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testUpdateBinaryWithoutContentType() throws IOException {
         final String id = getRandomUniqueId();
+        assertEquals(CREATED.getStatusCode(), getStatus(putObjMethod(id)));
         createDatastream(id, "x", "xyz");
         final HttpPut httpPut = new HttpPut(serverAddress + id + "/x");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpPut));
     }
 
     @Test
-@Ignore
     public void testCreateBinaryUpperCaseMimeType() throws IOException {
         final String subjectURI = serverAddress + getRandomUniqueId();
         final HttpPut createMethod = new HttpPut(subjectURI);
@@ -3110,7 +3107,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCreateBinaryCSV() throws IOException {
         final String subjectURI = serverAddress + getRandomUniqueId();
         final HttpPut createMethod = new HttpPut(subjectURI);
@@ -3322,7 +3318,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testNonRDFSourceInteraction() throws IOException {
         final String id = getRandomUniqueId();
         final HttpPut put = putObjMethod(id, "text/turtle", "<> a <http://example.com/Foo> .");
@@ -3774,7 +3769,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutEmptyBody() throws IOException {
         final HttpPut httpPut = putObjMethod(getRandomUniqueId());
         httpPut.addHeader(CONTENT_TYPE, "application/ld+json");
@@ -3785,9 +3779,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutOgg() throws IOException {
         final String id = getRandomUniqueId();
+        execute(putObjMethod(id));
         createDatastream(id, "x", "OggS");
     }
 
@@ -3877,21 +3871,18 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCreationResponseDefault() {
         testCreationResponse(null, null, CREATED, "text/plain");
         testCreationResponse(null, "application/ld+json", NOT_ACCEPTABLE, "text/html");
     }
 
     @Test
-@Ignore
     public void testCreationResponseMinimal() {
         testCreationResponse("minimal", null, CREATED, null);
         testCreationResponse("minimal", "application/ld+json", CREATED, null);
     }
 
     @Test
-@Ignore
     public void testCreationResponseRepresentation() {
         testCreationResponse("representation", null, CREATED, "text/turtle");
         testCreationResponse("representation", "application/ld+json", CREATED, "application/ld+json");
@@ -4022,7 +4013,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testConcurrentUpdatesToBinary() throws IOException, InterruptedException {
         // create a binary
         final String path = getRandomUniqueId();
@@ -4165,7 +4155,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
 
     @Test
-@Ignore
+    @Ignore
     public void testBinaryLastModified() throws Exception {
         final String objid = getRandomUniqueId();
         final String objURI = serverAddress + objid;

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ExternalContent.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ExternalContent.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.api.models;
 
 import java.io.InputStream;
+import java.net.URI;
 
 /**
  * Interface for the ExternalContent information class.
@@ -46,6 +47,12 @@ public interface ExternalContent {
      * @return a String of the URL that was in the Link header
      */
     public String getURL();
+
+    /**
+     * Retrieve URI in link header
+     * @return a URI to the external content
+     */
+    public URI getURI();
 
     /**
      * Returns whether or not the handling parameter is "copy"

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
@@ -21,6 +21,7 @@ import org.apache.jena.rdf.model.Model;
 import org.fcrepo.kernel.api.models.ExternalContent;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 
@@ -51,7 +52,7 @@ public interface CreateResourceService {
      */
     String perform(String txId, String userPrincipal, String fedoraId, String slug, boolean isContained,
             String contentType, String filename, Long contentSize, List<String> linkHeaders,
-            Collection<String> digest, InputStream requestBody, ExternalContent externalContent);
+            Collection<URI> digest, InputStream requestBody, ExternalContent externalContent);
 
     /**
      * Create a new RdfSource resource.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplaceBinariesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplaceBinariesService.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
+import org.fcrepo.kernel.api.models.ExternalContent;
+
+/**
+ * Interface for service to replace existing binaries
+ *
+ * @author mohideen
+ */
+public interface ReplaceBinariesService {
+
+    /**
+     * Replace an existing binary.
+     *
+     * @param txId The transaction ID for the request.
+     * @param userPrincipal the user performing the service
+     * @param fedoraId The internal identifier of the parent.
+     * @param filename The filename of the binary.
+     * @param contentType The content-type header or null if none.
+     * @param digests The binary digest or null if none.
+     * @param size The binary size.
+     * @param contentBody The request body or null if none.
+     * @param externalContent The external content handler or null if none.
+     */
+    void perform(String txId,
+                 String userPrincipal,
+                 String fedoraId,
+                 String filename,
+                 String contentType,
+                 Collection<URI> digests,
+                 InputStream contentBody,
+                 Long size,
+                 ExternalContent externalContent);
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.operations;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
+
+/**
+ * An abstract operation for interacting with a non-rdf source
+ *
+ * @author bbpennel
+ */
+public abstract class AbstractNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
+
+    protected String resourceId;
+
+    protected InputStream content;
+
+    protected URI externalURI;
+
+    protected String externalType;
+
+    protected String mimeType;
+
+    protected String filename;
+
+    protected Collection<URI> digests;
+
+    protected Long contentSize;
+
+    protected String userPrincipal;
+
+    /**
+     * Constructor for external binary.
+     *
+     * @param rescId the internal identifier
+     * @param handling the external content handling type.
+     * @param externalUri the external content URI.
+     */
+    protected AbstractNonRdfSourceOperationBuilder(final String rescId, final String handling,
+            final URI externalUri) {
+        this.resourceId = rescId;
+        this.externalURI = externalUri;
+        this.externalType = handling;
+    }
+
+    /**
+     * Constructor for internal binary.
+     *
+     * @param rescId the internal identifier.
+     * @param stream the content stream.
+     */
+    protected AbstractNonRdfSourceOperationBuilder(final String rescId, final InputStream stream) {
+        this.resourceId = rescId;
+        this.content = stream;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder mimeType(final String mimetype) {
+        this.mimeType = mimetype;
+        return this;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder filename(final String filename) {
+        this.filename = filename;
+        return this;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder contentDigests(final Collection<URI> digests) {
+        this.digests = digests;
+        return this;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder contentSize(final Long size) {
+        this.contentSize = size;
+        return this;
+    }
+
+    @Override
+    public NonRdfSourceOperationBuilder userPrincipal(final String userPrincipal) {
+        this.userPrincipal = userPrincipal;
+        return this;
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderImpl.java
@@ -29,25 +29,10 @@ import java.util.Collection;
  *
  * @author bbpennel
  */
-public class CreateNonRdfSourceOperationBuilderImpl implements CreateNonRdfSourceOperationBuilder {
-
-    /**
-     * The resource id.
-     */
-    private final String resourceId;
+public class CreateNonRdfSourceOperationBuilderImpl extends AbstractNonRdfSourceOperationBuilder
+        implements CreateNonRdfSourceOperationBuilder {
 
     private String parentId;
-
-    private String userPrincipal;
-
-    private String mimeType;
-    private String filename;
-    private Collection<URI> digests;
-
-    private Long contentSize;
-    private InputStream content;
-    private URI externalURI;
-    private String externalType;
 
     /**
      * Constructor for external binary.
@@ -58,9 +43,7 @@ public class CreateNonRdfSourceOperationBuilderImpl implements CreateNonRdfSourc
      */
     protected CreateNonRdfSourceOperationBuilderImpl(final String rescId, final String handling,
             final URI externalUri) {
-        this(rescId);
-        this.externalURI = externalUri;
-        this.externalType = handling;
+        super(rescId, handling, externalUri);
     }
 
     /**
@@ -70,47 +53,32 @@ public class CreateNonRdfSourceOperationBuilderImpl implements CreateNonRdfSourc
      * @param stream the content stream.
      */
     protected CreateNonRdfSourceOperationBuilderImpl(final String rescId, final InputStream stream) {
-        this(rescId);
-        this.content = stream;
-    }
-
-    /**
-     * Constructor
-     *
-     * @param rescId the internal identifier.
-     */
-    private CreateNonRdfSourceOperationBuilderImpl(final String rescId) {
-        this.resourceId = rescId;
+        super(rescId, stream);
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilderImpl mimeType(final String mimetype) {
-        this.mimeType = mimetype;
-        return this;
+    public CreateNonRdfSourceOperationBuilder mimeType(final String mimeType) {
+        return (CreateNonRdfSourceOperationBuilder) super.mimeType(mimeType);
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilderImpl filename(final String filename) {
-        this.filename = filename;
-        return this;
+    public CreateNonRdfSourceOperationBuilder filename(final String filename) {
+        return (CreateNonRdfSourceOperationBuilder) super.filename(filename);
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilderImpl contentDigests(final Collection<URI> digests) {
-        this.digests = digests;
-        return this;
+    public CreateNonRdfSourceOperationBuilder contentDigests(final Collection<URI> digests) {
+        return (CreateNonRdfSourceOperationBuilder) super.contentDigests(digests);
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilderImpl contentSize(final Long size) {
-        this.contentSize = size;
-        return this;
+    public CreateNonRdfSourceOperationBuilder contentSize(final Long size) {
+        return (CreateNonRdfSourceOperationBuilder) super.contentSize(size);
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilderImpl userPrincipal(final String userPrincipal) {
-        this.userPrincipal = userPrincipal;
-        return this;
+    public CreateNonRdfSourceOperationBuilder userPrincipal(final String userPrincipal) {
+        return (CreateNonRdfSourceOperationBuilder) super.userPrincipal(userPrincipal);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImpl.java
@@ -17,14 +17,12 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
-import org.fcrepo.kernel.api.operations.CreateNonRdfSourceOperationBuilder;
-import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
-import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
-import org.springframework.stereotype.Component;
-
 import java.io.InputStream;
 import java.net.URI;
 
+import org.fcrepo.kernel.api.operations.CreateNonRdfSourceOperationBuilder;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
+import org.springframework.stereotype.Component;
 
 /**
  * Factory for operations to update non-rdf sources
@@ -35,18 +33,16 @@ import java.net.URI;
 public class NonRdfSourceOperationFactoryImpl implements NonRdfSourceOperationFactory {
 
     @Override
-    public NonRdfSourceOperationBuilder updateExternalBinaryBuilder(final String rescId,
+    public UpdateNonRdfSourceOperationBuilder updateExternalBinaryBuilder(final String rescId,
                                                                     final String handling,
                                                                     final URI contentUri) {
-        // TODO Auto-generated method stub
-        return null;
+        return new UpdateNonRdfSourceOperationBuilder(rescId, handling, contentUri);
     }
 
     @Override
-    public NonRdfSourceOperationBuilder updateInternalBinaryBuilder(final String rescId,
+    public UpdateNonRdfSourceOperationBuilder updateInternalBinaryBuilder(final String rescId,
                                                                     final InputStream contentStream) {
-        // TODO Auto-generated method stub
-        return null;
+        return new UpdateNonRdfSourceOperationBuilder(rescId, contentStream);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
@@ -19,6 +19,9 @@ package org.fcrepo.kernel.impl.operations;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
 
+import java.io.InputStream;
+import java.net.URI;
+
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 /**
@@ -28,8 +31,26 @@ import org.fcrepo.kernel.api.operations.ResourceOperationType;
  */
 public class UpdateNonRdfSourceOperation extends AbstractNonRdfSourceOperation {
 
-    protected UpdateNonRdfSourceOperation(final String rescId) {
-        super(rescId);
+    /**
+     * Constructor for internal binaries.
+     *
+     * @param rescId the internal identifier.
+     * @param content the stream of the content.
+     */
+    protected UpdateNonRdfSourceOperation(final String rescId, final InputStream content) {
+        super(rescId, content);
+    }
+
+    /**
+     * Constructor for external content.
+     *
+     * @param rescId the internal identifier.
+     * @param externalContentURI the URI of the external content.
+     * @param externalHandling the type of external content handling (REDIRECT, PROXY)
+     */
+    protected UpdateNonRdfSourceOperation(final String rescId, final URI externalContentURI,
+            final String externalHandling) {
+        super(rescId, externalContentURI, externalHandling);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilder.java
@@ -17,77 +17,38 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
-import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
-import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
-
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Collection;
-
 
 /**
  * Builder for operations to update non-rdf sources
  *
  * @author bbpennel
  */
-public class UpdateNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
-
-    private final String resourceId;
-
-    private InputStream contentStream;
-
-    private String externalType;
-
-    private URI externalUri;
-
+public class UpdateNonRdfSourceOperationBuilder extends AbstractNonRdfSourceOperationBuilder {
     protected UpdateNonRdfSourceOperationBuilder(final String rescId, final InputStream stream) {
-        this(rescId);
-        this.contentStream = stream;
+        super(rescId, stream);
     }
 
     protected UpdateNonRdfSourceOperationBuilder(final String rescId, final String handling, final URI contentUri) {
-        this(rescId);
-        this.externalType = handling;
-        this.externalUri = contentUri;
-    }
-
-    private UpdateNonRdfSourceOperationBuilder(final String rescId) {
-        this.resourceId = rescId;
+        super(rescId, handling, contentUri);
     }
 
     @Override
-    public NonRdfSourceOperationBuilder mimeType(final String mimetype) {
-        // TODO Auto-generated method stub
-        return null;
-    }
+    public UpdateNonRdfSourceOperation build() {
+        final UpdateNonRdfSourceOperation operation;
+        if (externalURI != null && externalType != null) {
+            operation = new UpdateNonRdfSourceOperation(resourceId, externalURI, externalType);
+        } else {
+            operation = new UpdateNonRdfSourceOperation(resourceId, content);
+        }
 
-    @Override
-    public NonRdfSourceOperationBuilder filename(final String filename) {
-        // TODO Auto-generated method stub
-        return null;
-    }
+        operation.setUserPrincipal(userPrincipal);
+        operation.setDigests(digests);
+        operation.setFilename(filename);
+        operation.setContentSize(contentSize);
+        operation.setMimeType(mimeType);
 
-    @Override
-    public NonRdfSourceOperationBuilder contentDigests(final Collection<URI> digests) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public NonRdfSourceOperationBuilder contentSize(final Long size) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public NonRdfSourceOperationBuilder userPrincipal(final String userPrincipal) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public NonRdfSourceOperation build() {
-        // TODO Auto-generated method stub
-        return null;
+        return operation;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static java.lang.String.format;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
+import javax.inject.Inject;
+
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.models.ExternalContent;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
+import org.fcrepo.kernel.api.services.ReplaceBinariesService;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementation of a service for replacing/updating binary resources
+ *
+ * @author bbpennel
+ */
+@Component
+public class ReplaceBinariesServiceImpl extends AbstractService implements ReplaceBinariesService {
+
+    @Inject
+    private PersistentStorageSessionManager psManager;
+
+    @Inject
+    private NonRdfSourceOperationFactory factory;
+
+    @Override
+    public void perform(final String txId,
+                        final String userPrincipal,
+                        final String fedoraId,
+                        final String filename,
+                        final String contentType,
+                        final Collection<URI> digests,
+                        final InputStream contentBody,
+                        final Long size,
+                        final ExternalContent externalContent) {
+        try {
+            final PersistentStorageSession pSession = this.psManager.getSession(txId);
+
+            hasRestrictedPath(fedoraId);
+
+            String mimeType = contentType;
+            final NonRdfSourceOperationBuilder builder;
+            if (externalContent == null) {
+                builder = factory.updateInternalBinaryBuilder(fedoraId, contentBody);
+            } else {
+                builder = factory.updateExternalBinaryBuilder(fedoraId,
+                        externalContent.getHandling(),
+                        externalContent.getURI());
+
+                if (externalContent.getContentType() != null) {
+                    mimeType = externalContent.getContentType();
+                }
+            }
+
+            builder.mimeType(mimeType)
+                   .contentSize(size)
+                   .filename(filename)
+                   .contentDigests(digests)
+                   .userPrincipal(userPrincipal);
+            final var replaceOp = builder.build();
+
+            pSession.persist(replaceOp);
+        } catch (final PersistentStorageException ex) {
+            throw new RepositoryRuntimeException(format("failed to replace binary %s",
+                  fedoraId), ex);
+        }
+    }
+
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.operations;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.apache.commons.io.IOUtils.toInputStream;
+import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
+import org.apache.commons.io.IOUtils;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
+import org.junit.Test;
+
+/**
+ * @author bbpennel
+ */
+public class UpdateNonRdfSourceOperationBuilderTest {
+
+    private final String RESOURCE_ID = "info:fedora/test-subject";
+
+    private final String MIME_TYPE = "text/plain";
+
+    private final String FILENAME = "someFile.txt";
+
+    private final Long FILESIZE = 123l;
+
+    private final Collection<URI> DIGESTS = asList(URI.create("urn:sha1:1234abcd"), URI.create("urn:md5:zyxw9876"));
+
+    @Test
+    public void buildExternalBinary() {
+        final URI uri = URI.create("http://example.org/test/location");
+
+        final NonRdfSourceOperationBuilder builder =
+                new UpdateNonRdfSourceOperationBuilder(RESOURCE_ID, PROXY, uri);
+        builder.mimeType(MIME_TYPE)
+                .contentDigests(DIGESTS)
+                .contentSize(FILESIZE)
+                .filename(FILENAME);
+
+        final NonRdfSourceOperation op = builder.build();
+        assertEquals(uri, op.getContentUri());
+        assertEquals(PROXY, op.getExternalHandling());
+        assertEquals(MIME_TYPE, op.getMimeType());
+        assertEquals(FILENAME, op.getFilename());
+        assertEquals(FILESIZE, op.getContentSize());
+        assertEquals(DIGESTS, op.getContentDigests());
+        assertNull(op.getContentStream());
+    }
+
+    @Test
+    public void buildInternalBinary() throws Exception {
+        final String contentString = "This is some test data";
+        final InputStream stream = toInputStream(contentString, UTF_8);
+
+        final NonRdfSourceOperationBuilder builder =
+                new UpdateNonRdfSourceOperationBuilder(RESOURCE_ID, stream);
+        builder.mimeType(MIME_TYPE)
+                .contentDigests(DIGESTS)
+                .contentSize(FILESIZE)
+                .filename(FILENAME);
+
+        final NonRdfSourceOperation op = builder.build();
+        assertEquals(contentString, IOUtils.toString(op.getContentStream(), UTF_8));
+        assertEquals(MIME_TYPE, op.getMimeType());
+        assertEquals(FILENAME, op.getFilename());
+        assertEquals(FILESIZE, op.getContentSize());
+        assertEquals(DIGESTS, op.getContentDigests());
+        assertNull(op.getExternalHandling());
+        assertNull(op.getContentUri());
+    }
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.services;
 
+import static java.util.Collections.singleton;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
@@ -46,11 +47,9 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
@@ -86,7 +85,6 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class CreateResourceServiceImplTest {
@@ -140,7 +138,7 @@ public class CreateResourceServiceImplTest {
 
     private final Model model = ModelFactory.createDefaultModel();
 
-    private static final Collection<String> DIGESTS = Collections.singleton("urn:sha1:12345abced");
+    private static final Collection<URI> DIGESTS = singleton(URI.create("urn:sha1:12345abced"));
 
     @Before
     public void setUp() {
@@ -644,9 +642,7 @@ public class CreateResourceServiceImplTest {
         assertEquals(CONTENT_SIZE, nonRdfOperation.getContentSize());
         assertEquals(FILENAME, nonRdfOperation.getFilename());
         assertEquals(CONTENT_TYPE, nonRdfOperation.getMimeType());
-        assertTrue(DIGESTS.containsAll(
-                nonRdfOperation.getContentDigests().stream().map(URI::toString).collect(Collectors.toList())));
-
+        assertTrue(DIGESTS.containsAll(nonRdfOperation.getContentDigests()));
     }
 
     private void assertExternalBinaryPropertiesPresent(final ResourceOperation operation) {

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.apache.commons.io.IOUtils.toInputStream;
+import static org.fcrepo.kernel.api.models.ExternalContent.COPY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.net.URI;
+import java.util.Collection;
+
+import org.apache.commons.io.IOUtils;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.models.ExternalContent;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.impl.operations.NonRdfSourceOperationFactoryImpl;
+import org.fcrepo.kernel.impl.operations.UpdateNonRdfSourceOperation;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ReplaceBinariesServiceImplTest {
+
+    private static final String USER_PRINCIPAL = "fedoraUser";
+
+    private static final String FEDORA_ID = "info:fedora/resource1";
+
+    private static final String TX_ID = "tx-1234";
+
+    private final String MIME_TYPE = "text/plain";
+
+    private final String FILENAME = "someFile.txt";
+
+    private final Long FILESIZE = 123l;
+
+    private final Collection<URI> DIGESTS = asList(URI.create("urn:sha1:1234abcd"), URI.create("urn:md5:zyxw9876"));
+
+    @Mock
+    private Transaction tx;
+
+    @Mock
+    private PersistentStorageSession pSession;
+
+    @Mock
+    private PersistentStorageSessionManager psManager;
+
+    @Mock
+    private ExternalContent externalContent;
+
+    private NonRdfSourceOperationFactory factory;
+
+    @InjectMocks
+    private ReplaceBinariesServiceImpl service;
+
+    @Captor
+    private ArgumentCaptor<UpdateNonRdfSourceOperation> operationCaptor;
+
+    @Before
+    public void setup() {
+        factory = new NonRdfSourceOperationFactoryImpl();
+        setField(service, "factory", factory);
+        when(psManager.getSession(anyString())).thenReturn(pSession);
+    }
+
+    @Test
+    public void replaceInternalBinary() throws Exception {
+        final String contentString = "This is some test data";
+        final var stream = toInputStream(contentString, UTF_8);
+
+        service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, MIME_TYPE, DIGESTS, stream, FILESIZE,
+                null);
+        verify(pSession).persist(operationCaptor.capture());
+        final NonRdfSourceOperation op = operationCaptor.getValue();
+
+        assertEquals(FEDORA_ID, operationCaptor.getValue().getResourceId());
+        assertEquals(contentString, IOUtils.toString(op.getContentStream(), UTF_8));
+        assertPropertiesPopulated(op);
+    }
+
+    @Test
+    public void replaceExternalBinary() throws Exception {
+        final URI uri = URI.create("http://example.org/test/location");
+        when(externalContent.getURI()).thenReturn(uri);
+        when(externalContent.getHandling()).thenReturn(COPY);
+
+        service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, MIME_TYPE, DIGESTS, null, FILESIZE,
+                externalContent);
+        verify(pSession).persist(operationCaptor.capture());
+        final NonRdfSourceOperation op = operationCaptor.getValue();
+
+        assertEquals(FEDORA_ID, operationCaptor.getValue().getResourceId());
+        assertEquals(uri, op.getContentUri());
+        assertEquals(COPY, op.getExternalHandling());
+        assertPropertiesPopulated(op);
+
+        assertNull(op.getContentStream());
+    }
+
+    // Check that the content type from the external content link is given preference
+    @Test
+    public void replaceExternalBinary_WithExternalContentType() throws Exception {
+        final URI uri = URI.create("http://example.org/test/location");
+        when(externalContent.getURI()).thenReturn(uri);
+        when(externalContent.getHandling()).thenReturn(COPY);
+        when(externalContent.getContentType()).thenReturn(MIME_TYPE);
+
+        service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, "application/octet-stream",
+                DIGESTS, null, FILESIZE, externalContent);
+        verify(pSession).persist(operationCaptor.capture());
+        final NonRdfSourceOperation op = operationCaptor.getValue();
+
+        assertEquals(FEDORA_ID, operationCaptor.getValue().getResourceId());
+        assertEquals(uri, op.getContentUri());
+        assertEquals(COPY, op.getExternalHandling());
+        assertPropertiesPopulated(op);
+
+        assertNull(op.getContentStream());
+    }
+
+    @Test(expected = RepositoryRuntimeException.class)
+    public void replaceBinary_PersistFailure() throws Exception {
+        doThrow(new PersistentStorageException("Boom")).when(pSession)
+                .persist(any(ResourceOperation.class));
+
+        final var stream = toInputStream("Some content", UTF_8);
+
+        service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, MIME_TYPE, DIGESTS, stream, FILESIZE,
+                null);
+    }
+
+    private void assertPropertiesPopulated(final NonRdfSourceOperation op) {
+        assertEquals(MIME_TYPE, op.getMimeType());
+        assertEquals(FILENAME, op.getFilename());
+        assertEquals(FILESIZE, op.getContentSize());
+        assertEquals(DIGESTS, op.getContentDigests());
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3103

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Support PUT of binaries

# What's new?
* Remove duplicate parseDigestHeader, and change to return Collection<URI> since that is what is needed everywhere.
* Populate http resource headers during GET request
* Fix evaluation to determine if resource being created is a binary to not incorrectly assume it is a binary when no content type is provided
* Resolve some failures when content type is not provided
* Replace placeholder 'resource exists' checks with real ones for PUT
* Don't default content type to turtle when creating a binary
* Reenable a number of tests, in some cases explicitly create parent objects which were being produced as pairtrees before
* Implements UpdateNonRdfSource operation/builder/factory, and service for replacing binaries
* Refactor common functionality of NonRdfSource operation into parent class.
* Allow ExternalContent to return its URI instance directly

# How should this be tested?
Tests, and creating/updating via one click using PUT

```
# Create resource with PUT
fcrepo4$ curl -ufedoraAdmin:fedoraAdmin -XPUT -H"Content-type: text/xml" --data-binary "@pom.xml" http://localhost:8080/rest/testpom
fcrepo4$ curl -ufedoraAdmin:fedoraAdmin -I http://localhost:8080/rest/testpom
HTTP/1.1 200 OK
Date: Thu, 30 Jan 2020 18:08:40 GMT
ETag: "DC044CB93213C475C5AC6D7629033271"
X-State-Token: DC044CB93213C475C5AC6D7629033271
Last-Modified: Thu, 30 Jan 2020 18:08:38 GMT
Content-Type: text/xml
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Thu, 30 Jan 2020 18:05:43 GMT"; modification-date="Thu, 30 Jan 2020 18:08:38 GMT"; size=26356
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8080/rest/testpom/fcr:metadata>; rel="describedby"
Accept-External-Content-Handling: copy,redirect,proxy
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Link: <http://localhost:8080/rest/testpom/fcr:acl>; rel="acl"
Content-Length: 26356
Server: Jetty(9.4.24.v20191120)

# Replace the pom with a different one
fcrepo4$ curl -ufedoraAdmin:fedoraAdmin -XPUT -H"Content-type: text/xml" --data-binary "@fcrepo-http-api/pom.xml" http://localhost:8080/rest/testpom
fcrepo4$ curl -ufedoraAdmin:fedoraAdmin -I http://localhost:8080/rest/testpom
HTTP/1.1 200 OK
Date: Thu, 30 Jan 2020 18:08:13 GMT
ETag: "883F888B260184BADD6F21C3B909A1DC"
X-State-Token: 883F888B260184BADD6F21C3B909A1DC
Last-Modified: Thu, 30 Jan 2020 18:07:42 GMT
Content-Type: text/xml
Accept-Ranges: bytes
Content-Disposition: attachment; filename=""; creation-date="Thu, 30 Jan 2020 18:05:43 GMT"; modification-date="Thu, 30 Jan 2020 18:07:42 GMT"; size=6921
Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
Link: <http://localhost:8080/rest/testpom/fcr:metadata>; rel="describedby"
Accept-External-Content-Handling: copy,redirect,proxy
Allow: DELETE,HEAD,GET,PUT,OPTIONS
Link: <http://localhost:8080/rest/testpom/fcr:acl>; rel="acl"
Content-Length: 6921
Server: Jetty(9.4.24.v20191120)

```

# Additional Notes:
n/a

# Interested parties
@fcrepo4/committers
