### PR TITLE
Cleanup OCFL after tests

### DIFF
--- a/fcrepo-auth-common/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-auth-common/src/test/resources/spring-test/fcrepo-config.xml
@@ -8,6 +8,9 @@
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+  <!-- Establish OCFL storage paths -->
+  <bean id="temporaryOcflRepositoryHelper" class="org.fcrepo.persistence.ocfl.TemporaryOCFLRepositoryHelper" />
+
   <context:annotation-config />
 
   <context:property-placeholder />

--- a/fcrepo-auth-webac/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-auth-webac/src/test/resources/spring-test/fcrepo-config.xml
@@ -8,6 +8,9 @@
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+  <!-- Establish OCFL storage paths -->
+  <bean id="temporaryOcflRepositoryHelper" class="org.fcrepo.persistence.ocfl.TemporaryOCFLRepositoryHelper" />
+
   <!-- Master context for the test application. -->
   <context:property-placeholder location="classpath:application.properties"/>
   <context:annotation-config />

--- a/fcrepo-http-api/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-http-api/src/test/resources/spring-test/fcrepo-config.xml
@@ -12,6 +12,9 @@
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
   <!-- Master context for the test application. -->
+  
+  <!-- Establish OCFL storage paths -->
+  <bean id="temporaryOcflRepositoryHelper" class="org.fcrepo.persistence.ocfl.TemporaryOCFLRepositoryHelper" />
 
   <!-- Context that supports the actual ModeShape JCR itself -->
 

--- a/fcrepo-integration-rdf/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-integration-rdf/src/test/resources/spring-test/fcrepo-config.xml
@@ -11,6 +11,9 @@
     http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
+  <!-- Establish OCFL storage paths -->
+  <bean id="temporaryOcflRepositoryHelper" class="org.fcrepo.persistence.ocfl.TemporaryOCFLRepositoryHelper" />
+
   <!-- Master context for the test application. -->
   
   <context:property-placeholder />

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/TemporaryOCFLRepositoryHelper.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/TemporaryOCFLRepositoryHelper.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl;
+
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_STAGING_PROPERTY;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_STORAGE_ROOT_PROPERTY;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_WORK_PROPERTY;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.io.FileUtils;
+
+/**
+ * Utility which sets up a temporary base directory for OCFL, establishes
+ * system properties to make use of it, and cleans up on shutdown.
+ *
+ * @author bbpennel
+ */
+public class TemporaryOCFLRepositoryHelper {
+
+    /**
+     * Initialize the helper
+     *
+     * @throws IOException thrown if the base directory cannot be created
+     */
+    public TemporaryOCFLRepositoryHelper() throws IOException {
+        final Path ocflBase = Files.createDirectory(Paths.get("target/ocfl_base"));
+        final Path ocflStagingDir = ocflBase.resolve("staging");
+        final Path ocflStorageRootDir = ocflBase.resolve("storage_root");
+        final Path ocflWorkDir = ocflBase.resolve("work");
+
+        System.setProperty(OCFL_STAGING_PROPERTY, ocflStagingDir.toString());
+        System.setProperty(OCFL_STORAGE_ROOT_PROPERTY, ocflStorageRootDir.toString());
+        System.setProperty(OCFL_WORK_PROPERTY, ocflWorkDir.toString());
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() ->
+                FileUtils.deleteQuietly(ocflBase.toFile())));
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -17,23 +17,22 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_STORAGE_ROOT_DIR;
-import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_WORK_DIR;
-import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.STAGING_DIR;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.getOCFLStagingDir;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.getOCFLStorageRootDir;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.getOCFLWorkDir;
 
 import java.io.File;
 
-import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
 import edu.wisc.library.ocfl.core.extension.layout.config.DefaultLayoutConfig;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 
 /**
  * A default implemenntation of the {@link org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory} interface.
@@ -56,7 +55,7 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
      * are not set, default directories will be created in java.io.tmpdir.
      */
     public DefaultOCFLObjectSessionFactory() {
-        this(STAGING_DIR, OCFL_STORAGE_ROOT_DIR, OCFL_WORK_DIR);
+        this(getOCFLStagingDir(), getOCFLStorageRootDir(), getOCFLWorkDir());
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -17,7 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.FEDORA_TO_OCFL_INDEX_FILE;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.getFedoraToOCFLIndexFile;
 
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
@@ -58,8 +58,8 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
      * @throws IOException If we can't access the file.
      */
     public FedoraToOCFLObjectIndexImpl() throws IOException {
-        if (FEDORA_TO_OCFL_INDEX_FILE.exists() && FEDORA_TO_OCFL_INDEX_FILE.canRead()) {
-            Files.lines(FEDORA_TO_OCFL_INDEX_FILE.toPath()).filter(l -> {
+        if (getFedoraToOCFLIndexFile().exists() && getFedoraToOCFLIndexFile().canRead()) {
+            Files.lines(getFedoraToOCFLIndexFile().toPath()).filter(l -> {
                 final String m = l.split("\t")[0];
                 return (!fedoraOCFLMappingMap.containsKey(m));
             }).forEach(l -> {
@@ -115,18 +115,18 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
      */
     private void writeMappingToDisk(final String fedoraId, final FedoraOCFLMapping fedoraOCFLMapping) {
         try {
-            if (!FEDORA_TO_OCFL_INDEX_FILE.exists()) {
-                final File dir = FEDORA_TO_OCFL_INDEX_FILE.getParentFile();
+            if (!getFedoraToOCFLIndexFile().exists()) {
+                final File dir = getFedoraToOCFLIndexFile().getParentFile();
                 if (!dir.exists()) {
                     dir.mkdirs();
                 }
             }
-            final BufferedWriter output = new BufferedWriter(new FileWriter(FEDORA_TO_OCFL_INDEX_FILE, true));
+            final BufferedWriter output = new BufferedWriter(new FileWriter(getFedoraToOCFLIndexFile(), true));
             output.write(String.format("%s\t%s\t%s\n", fedoraId, fedoraOCFLMapping.getRootObjectIdentifier(),
                     fedoraOCFLMapping.getOcflObjectId()));
             output.close();
-        } catch (IOException exception) {
-            LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}", FEDORA_TO_OCFL_INDEX_FILE);
+        } catch (final IOException exception) {
+            LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}", getFedoraToOCFLIndexFile());
         }
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLConstants.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLConstants.java
@@ -31,11 +31,60 @@ import java.nio.file.Paths;
  */
 public final class OCFLConstants {
 
-    public static final File STAGING_DIR = resolveDir("fcrepo.ocfl.staging.dir");
-    public static final File OCFL_STORAGE_ROOT_DIR = resolveDir("fcrepo.ocfl.storage.root.dir");
-    public static final File OCFL_WORK_DIR = resolveDir("fcrepo.ocfl.work.dir");
-    public static final File FEDORA_TO_OCFL_INDEX_FILE = new File(OCFL_WORK_DIR.toString() + File.separator +
-            "fedoraToOcflIndex.tsv");
+    public static final String OCFL_STAGING_PROPERTY = "fcrepo.ocfl.staging.dir";
+
+    public static final String OCFL_STORAGE_ROOT_PROPERTY = "fcrepo.ocfl.storage.root.dir";
+
+    public static final String OCFL_WORK_PROPERTY = "fcrepo.ocfl.work.dir";
+
+    private static File ocflStagingDir;
+
+    private static File ocflStorageRootDir;
+
+    private static File ocflWorkDir;
+
+    private static File fedoraToOcflIndexFile;
+
+    /**
+     * @return the staging directory for OCFL
+     */
+    public static File getOCFLStagingDir() {
+        if (ocflStagingDir == null) {
+            ocflStagingDir = resolveDir(OCFL_STAGING_PROPERTY);
+        }
+        return ocflStagingDir;
+    }
+
+    /**
+     * @return the OCFL storage root directory
+     */
+    public static File getOCFLStorageRootDir() {
+        if (ocflStorageRootDir == null) {
+            ocflStorageRootDir = resolveDir(OCFL_STORAGE_ROOT_PROPERTY);
+        }
+        return ocflStorageRootDir;
+    }
+
+    /**
+     * @return the OCFL work directory
+     */
+    public static File getOCFLWorkDir() {
+        if (ocflWorkDir == null) {
+            ocflWorkDir = resolveDir(OCFL_WORK_PROPERTY);
+        }
+        return ocflWorkDir;
+    }
+
+    /**
+     * @return the index file for fedora to OCFL mappings
+     */
+    public static File getFedoraToOCFLIndexFile() {
+        if (fedoraToOcflIndexFile == null) {
+            fedoraToOcflIndexFile = new File(getOCFLWorkDir().toString(),
+                    "fedoraToOcflIndex.tsv");
+        }
+        return fedoraToOcflIndexFile;
+    }
 
     /**
      * Return the system property key path as file or a file of the temporary directory + "system property key"

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImplTest.java
@@ -17,7 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.FEDORA_TO_OCFL_INDEX_FILE;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.getFedoraToOCFLIndexFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -91,7 +91,7 @@ public class FedoraToOCFLObjectIndexImplTest {
 
     @Test
     public void testSaveToIndex() throws Exception {
-        assertFalse(FEDORA_TO_OCFL_INDEX_FILE.exists());
+        assertFalse(getFedoraToOCFLIndexFile().exists());
 
         final FedoraToOCFLObjectIndexImpl index = new FedoraToOCFLObjectIndexImpl();
 
@@ -99,28 +99,28 @@ public class FedoraToOCFLObjectIndexImplTest {
         index.addMapping(RESOURCE_ID_2, ROOT_RESOURCE_ID, OCFL_ID);
         index.addMapping(RESOURCE_ID_3, RESOURCE_ID_3, OCFL_ID_RESOURCE_3);
 
-        assertTrue(FEDORA_TO_OCFL_INDEX_FILE.exists());
+        assertTrue(getFedoraToOCFLIndexFile().exists());
 
-        final List<String> lines = Files.lines(FEDORA_TO_OCFL_INDEX_FILE.toPath()).collect(Collectors.toList());
+        final List<String> lines = Files.lines(getFedoraToOCFLIndexFile().toPath()).collect(Collectors.toList());
 
         assertEquals(4, lines.size());
     }
 
     @Test
     public void testReadFromIndex() throws Exception {
-        assertFalse(FEDORA_TO_OCFL_INDEX_FILE.exists());
+        assertFalse(getFedoraToOCFLIndexFile().exists());
 
-        final BufferedWriter output = new BufferedWriter(new FileWriter(FEDORA_TO_OCFL_INDEX_FILE, true));
+        final BufferedWriter output = new BufferedWriter(new FileWriter(getFedoraToOCFLIndexFile(), true));
         output.write(String.format("%s\t%s\t%s\n", RESOURCE_ID_2, ROOT_RESOURCE_ID, OCFL_ID));
         output.close();
 
-        assertTrue(FEDORA_TO_OCFL_INDEX_FILE.exists());
+        assertTrue(getFedoraToOCFLIndexFile().exists());
 
         final FedoraToOCFLObjectIndexImpl index = new FedoraToOCFLObjectIndexImpl();
         try {
             index.getMapping(RESOURCE_ID_1);
             fail();
-        } catch (FedoraOCFLMappingNotFoundException e) {
+        } catch (final FedoraOCFLMappingNotFoundException e) {
             // We're okay
         }
 
@@ -131,14 +131,14 @@ public class FedoraToOCFLObjectIndexImplTest {
         try {
             index.getMapping(RESOURCE_ID_3);
             fail();
-        } catch (FedoraOCFLMappingNotFoundException e) {
+        } catch (final FedoraOCFLMappingNotFoundException e) {
             // We're okay
         }
     }
 
     private void removeIndexMappingFile() {
-        if (FEDORA_TO_OCFL_INDEX_FILE.exists()) {
-            FEDORA_TO_OCFL_INDEX_FILE.delete();
+        if (getFedoraToOCFLIndexFile().exists()) {
+            getFedoraToOCFLIndexFile().delete();
         }
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: N/A

# What does this Pull Request do?
Adds a utility which sets up an OCFL base directory and related system properties in a location that gets cleaned up when shutdown occurs.

# What's new?
Also switches OCFL directory constants over to directories so that the values can more reliably be programmatically changed, as in the case of tests.

# How should this be tested?
Running the tests and verifying that no OCFL junk is left over (used to go into a java temp dir)

# Additional Notes:

# Interested parties
@awoods 
