### PR TITLE
Fixes javadoc warning during build

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -99,6 +99,7 @@ public class WebACRolesProvider {
      * Get the roles assigned to this Node.
      *
      * @param resource the subject resource
+     * @param transaction the transaction being acted upon
      * @return a set of roles for each principal
      */
     public Map<String, Collection<String>> getRoles(final FedoraResource resource, final Transaction transaction) {

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -424,6 +424,8 @@ public class WebACRecipesIT extends AbstractResourceIT {
      *  4. Deny(403) on PATCH with SPARQL DELETE statements.
      *  5. Allow(400) on PATCH with empty SPARQL content.
      *  6. Deny(403) on PATCH with non-SPARQL content.
+     *
+     * @throws IOException thrown from injestObj() or *ObjMethod() calls
      */
     @Test
     public void scenario18Test1() throws IOException {
@@ -487,6 +489,8 @@ public class WebACRecipesIT extends AbstractResourceIT {
      *  1. Allow(200) on GET.
      *  2. Allow(204) on PATCH.
      *  3. Deny(403) on DELETE.
+     *
+     * @throws IOException thrown from called functions within this function
      */
     @Test
     public void scenario18Test2() throws IOException {
@@ -532,6 +536,8 @@ public class WebACRecipesIT extends AbstractResourceIT {
      *  1. Allow(200) on GET.
      *  2. Allow(204) on PATCH.
      *  3. Allow(204) on DELETE.
+     *
+     * @throws IOException from functions called from this function
      */
     @Test
     public void scenario18Test3() throws IOException {


### PR DESCRIPTION
- Several @throws javadoc statements added to functions in WebACRecipesIT.java
- One @param javadoc statemnt added to WebACRolesProvider.java, line 102

Resolves https://jira.lyrasis.org/projects/FCREPO/issues/FCREPO-3026 (WebACRecipesIT.java)
WebACRolesProvider.java fix may or may not have a ticket

**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

https://jira.lyrasis.org/projects/FCREPO/issues/FCREPO-3026

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
fix several javadoc warnings during the building of fcrepo-auth-webac

# How should this be tested?
mvn clean install -pl fcrepo-auth-webac

# Interested parties
@fcrepo4/committers
