### PR TITLE
Automatic rebuild of Fedora to OCFL Index on start

### DIFF
--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -75,6 +75,10 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
 
     <!-- This dependency is for compile-time: it keeps this module independent
          of any given choice of JAX-RS implementation. It must be _after_ the test

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -23,9 +23,7 @@ import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
-import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
 import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndexUtil;
-import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 import org.fcrepo.persistence.ocfl.impl.OCFLPersistentSessionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,13 +52,7 @@ public class RepositoryInitializer {
     private RdfSourceOperationFactory operationFactory;
 
     @Inject
-    private FedoraToOCFLObjectIndex fedoraToOCFLObjectIndex;
-
-    @Inject
     private FedoraToOCFLObjectIndexUtil fedoraToOCFLObjectIndexUtil;
-
-    @Inject
-    private OCFLObjectSessionFactory objectSessionFactory;
 
     /**
      * Initializes the repository
@@ -71,7 +63,7 @@ public class RepositoryInitializer {
         final PersistentStorageSession session = this.sessionManager.getSession("initializationSession" +
                                                                                  System.currentTimeMillis());
 
-        if(!FEDORA_TO_OCFL_INDEX_FILE.exists()) {
+        if (!FEDORA_TO_OCFL_INDEX_FILE.exists()) {
             fedoraToOCFLObjectIndexUtil.rebuild();
         } else {
             LOGGER.info("The Fedora to OCFL Index already exists. Skipping rebuild.");

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOCFLObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOCFLObjectIndex.java
@@ -52,5 +52,10 @@ public interface FedoraToOCFLObjectIndex {
      */
     public FedoraOCFLMapping addMapping(final String fedoraResourceIdentifier, final String fedoraRootObjectIdentifier,
                            final String ocflObjectId);
+
+    /**
+     * Remove all persistent state associated with the index.
+     */
+    public void reset();
 }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOCFLObjectIndexUtil.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOCFLObjectIndexUtil.java
@@ -17,20 +17,17 @@
  */
 package org.fcrepo.persistence.ocfl.api;
 
+
 /**
- * A factory interface for creating {@link org.fcrepo.persistence.ocfl.api.OCFLObjectSession}.
+ * Utility for managing the FedoraToOCFLObjectIndex.
  * @author dbernstein
  * @since 6.0.0
  */
-public interface OCFLObjectSessionFactory {
+public interface FedoraToOCFLObjectIndexUtil {
 
     /**
-     * Create new session.
-     * @param ocflId The OCFL Object identifier
-     * @param persistentStorageSessionId The id of the persistent storage session associated with this session.
-     * @return The newly created session.
+     * Rebuild the index.
      */
-    OCFLObjectSession create(final String ocflId, final String persistentStorageSessionId);
-
-
+    public void rebuild();
 }
+

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -21,6 +21,7 @@ package org.fcrepo.persistence.ocfl.api;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
+import java.util.stream.Stream;
 
 import edu.wisc.library.ocfl.api.model.VersionDetails;
 import org.fcrepo.persistence.api.CommitOption;
@@ -38,6 +39,7 @@ public interface OCFLObjectSession {
      * The default commit option configured for the OCFL Object represented by this session.
      * If no default commit option has been defined for the specific OCFL Object, the
      * value returned will be the system defined global default commit option.
+     *
      * @return The default commit option
      */
     CommitOption getDefaultCommitOption();
@@ -123,5 +125,17 @@ public interface OCFLObjectSession {
      * The instant at which the session was created.
      * @return
      */
+
     Instant getCreated();
+
+    /**
+     * Lists the subpaths associated with the HEAD (ie the latest committed state)
+     *
+     * @return the subpaths as a stream
+     * @throws PersistentStorageException If subpaths cannot be listed due to the underlying session being closed
+     *                                    or for some other reason.
+     */
+
+    Stream<String> listHeadSubpaths() throws PersistentStorageException;
+
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -125,7 +125,6 @@ public interface OCFLObjectSession {
      * The instant at which the session was created.
      * @return
      */
-
     Instant getCreated();
 
     /**
@@ -135,7 +134,6 @@ public interface OCFLObjectSession {
      * @throws PersistentStorageException If subpaths cannot be listed due to the underlying session being closed
      *                                    or for some other reason.
      */
-
     Stream<String> listHeadSubpaths() throws PersistentStorageException;
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSessionFactory.java
@@ -31,6 +31,4 @@ public interface OCFLObjectSessionFactory {
      * @return The newly created session.
      */
     OCFLObjectSession create(final String ocflId, final String persistentStorageSessionId);
-
-
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import edu.wisc.library.ocfl.api.model.VersionDetails;
 import org.apache.commons.io.FileUtils;
@@ -419,6 +420,15 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
                                                                     .filter(v -> !v.isMutable())
                                                                     .sorted(VERSION_COMPARATOR)
                                                                     .collect(Collectors.toList());
+    }
+
+    @Override
+    public Stream<String> listHeadSubpaths() throws PersistentStorageException {
+        assertSessionOpen();
+
+        return this.ocflRepository.describeObject(objectIdentifier)
+                .getHeadVersion().getFiles()
+                .stream().map(f -> f.getPath());
     }
 
     @Override

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -426,8 +426,8 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
     public Stream<String> listHeadSubpaths() throws PersistentStorageException {
         assertSessionOpen();
 
-        return this.ocflRepository.describeObject(objectIdentifier)
-                .getHeadVersion().getFiles()
+        return this.ocflRepository.describeVersion(ObjectVersionId.head(this.objectIdentifier))
+                .getFiles()
                 .stream().map(f -> f.getPath());
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -67,7 +67,7 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
                 ocflStagingDir);
 
         ocflStagingDir.mkdirs();
-       this.ocflStagingDir = ocflStagingDir;
+        this.ocflStagingDir = ocflStagingDir;
     }
 
     @Override

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -17,23 +17,20 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_STORAGE_ROOT_DIR;
-import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_WORK_DIR;
 import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.STAGING_DIR;
 
 import java.io.File;
 
-import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
-import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.layout.config.DefaultLayoutConfig;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
 
 /**
  * A default implemenntation of the {@link org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory} interface.
@@ -48,6 +45,7 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
 
     private File ocflStagingDir;
 
+    @Inject
     private MutableOcflRepository ocflRepository;
 
     /**
@@ -56,31 +54,20 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
      * are not set, default directories will be created in java.io.tmpdir.
      */
     public DefaultOCFLObjectSessionFactory() {
-        this(STAGING_DIR, OCFL_STORAGE_ROOT_DIR, OCFL_WORK_DIR);
+        this(STAGING_DIR);
     }
 
     /**
      * Constructor
      *
      * @param ocflStagingDir     The OCFL staging directory
-     * @param ocflStorageRootDir The OCFL storage root directory
-     * @param ocflWorkDir        The OCFL work directory
      */
-    public DefaultOCFLObjectSessionFactory(final File ocflStagingDir, final File ocflStorageRootDir,
-                                           final File ocflWorkDir) {
-        LOGGER.info("Fedora OCFL persistence directories:\n- {}\n- {}\n- {}",
-                ocflStagingDir, ocflStorageRootDir, ocflWorkDir);
+    public DefaultOCFLObjectSessionFactory(final File ocflStagingDir) {
+        LOGGER.info("Fedora OCFL persistence staging directory:\n- {}",
+                ocflStagingDir);
 
         ocflStagingDir.mkdirs();
-        ocflStorageRootDir.mkdirs();
-        ocflWorkDir.mkdirs();
-
-        this.ocflStagingDir = ocflStagingDir;
-        this.ocflRepository = new OcflRepositoryBuilder()
-                .layoutConfig(DefaultLayoutConfig.nTupleHashConfig())
-                .buildMutable(FileSystemOcflStorage.builder().build(
-                        ocflStorageRootDir.toPath()), ocflWorkDir.toPath());
-
+       this.ocflStagingDir = ocflStagingDir;
     }
 
     @Override

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -18,13 +18,14 @@
 package org.fcrepo.persistence.ocfl.impl;
 
 import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.FEDORA_TO_OCFL_INDEX_FILE;
-
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import javax.inject.Inject;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -46,6 +47,9 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
     private static Logger LOGGER = LoggerFactory.getLogger(FedoraToOCFLObjectIndexImpl.class);
 
     private Map<String, FedoraOCFLMapping> fedoraOCFLMappingMap = Collections.synchronizedMap(new HashMap<>());
+
+    @Inject
+    private OCFLObjectSessionFactory objectSessionFactory;
 
     /**
      * Constructor.
@@ -127,6 +131,14 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
             output.close();
         } catch (IOException exception) {
             LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}", FEDORA_TO_OCFL_INDEX_FILE);
+        }
+    }
+
+    @Override
+    public void reset() {
+        fedoraOCFLMappingMap.clear();
+        if (FEDORA_TO_OCFL_INDEX_FILE.exists()) {
+            FEDORA_TO_OCFL_INDEX_FILE.delete();
         }
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -20,12 +20,10 @@ package org.fcrepo.persistence.ocfl.impl;
 import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.FEDORA_TO_OCFL_INDEX_FILE;
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
-import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import javax.inject.Inject;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -47,9 +45,6 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
     private static Logger LOGGER = LoggerFactory.getLogger(FedoraToOCFLObjectIndexImpl.class);
 
     private Map<String, FedoraOCFLMapping> fedoraOCFLMappingMap = Collections.synchronizedMap(new HashMap<>());
-
-    @Inject
-    private OCFLObjectSessionFactory objectSessionFactory;
 
     /**
      * Constructor.

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import edu.wisc.library.ocfl.api.OcflRepository;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndexUtil;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+import java.util.stream.Stream;
+
+import static org.fcrepo.persistence.common.ResourceHeaderSerializationUtils.deserializeHeaders;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.getSidecarSubpath;
+
+/**
+ * An implementation of {@link FedoraToOCFLObjectIndexUtil}
+ *
+ * @author dbernstein
+ * @since 6.0.0
+ */
+@Component
+public class FedoraToOCFLObjectIndexUtilImpl implements FedoraToOCFLObjectIndexUtil {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(FedoraToOCFLObjectIndexUtilImpl.class);
+
+    @Inject
+    private OCFLObjectSessionFactory objectSessionFactory;
+
+    @Inject
+    private FedoraToOCFLObjectIndex fedoraToOCFLObjectIndex;
+
+    @Inject
+    private OcflRepository ocflRepository;
+
+    /**
+     * Default constructor
+     */
+    public FedoraToOCFLObjectIndexUtilImpl() {
+    }
+
+
+    @Override
+    public void rebuild() {
+
+        final Stream<String> ocflIds = ocflRepository.listObjectIds();
+        LOGGER.info("Initiating index rebuild.");
+        fedoraToOCFLObjectIndex.reset();
+        LOGGER.debug("Reading object ids...");
+        ocflIds.forEach(ocflId -> {
+            try {
+                LOGGER.debug("Reading {}", ocflId);
+                final var objSession = objectSessionFactory.create(ocflId, null);
+                final var sidecarSubpath = getSidecarSubpath(ocflId);
+                final var headers = deserializeHeaders(objSession.read(sidecarSubpath));
+                final var fedoraIdentifier = headers.getId();
+                fedoraToOCFLObjectIndex.addMapping(fedoraIdentifier, fedoraIdentifier, ocflId);
+                LOGGER.debug("Index entry created for {}", ocflId);
+            } catch (final PersistentStorageException e) {
+                throw new RepositoryRuntimeException("Failed to rebuild fedora-to-ocfl index: " + e.getMessage(), e);
+            }
+        });
+        LOGGER.info("Index rebuild complete");
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImpl.java
@@ -51,14 +51,7 @@ public class FedoraToOCFLObjectIndexUtilImpl implements FedoraToOCFLObjectIndexU
 
     @Inject
     private OcflRepository ocflRepository;
-
-    /**
-     * Default constructor
-     */
-    public FedoraToOCFLObjectIndexUtilImpl() {
-    }
-
-
+    
     @Override
     public void rebuild() {
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistenceConfig.java
@@ -18,8 +18,6 @@
 package org.fcrepo.persistence.ocfl.impl;
 
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,8 +34,6 @@ import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.create
 
 @Configuration
 public class OCFLPersistenceConfig {
-
-    private static final Logger log = LoggerFactory.getLogger(OCFLPersistenceConfig.class);
 
     /**
      * Create an OCFL Repository

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistenceConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_STORAGE_ROOT_DIR;
+import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.OCFL_WORK_DIR;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.createRepository;
+
+/**
+ * A Configuration for OCFL dependencies
+ *
+ * @author dbernstein
+ * @since 6.0.0
+ */
+
+@Configuration
+public class OCFLPersistenceConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(OCFLPersistenceConfig.class);
+
+    /**
+     * Create an OCFL Repository
+     * @return the repository
+     */
+    @Bean
+    public MutableOcflRepository repository() {
+        return createRepository(OCFL_STORAGE_ROOT_DIR, OCFL_WORK_DIR);
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -282,6 +282,15 @@ public class OCFLPersistentStorageUtils {
     }
 
     /**
+     * Returns true of the subpath is a sidecar file
+     * @param subpath The subpath to be evaluated
+     * @return True if the subpath is a sidecar file.
+     */
+    public static boolean isSidecarSubpath(final String subpath) {
+        return subpath.startsWith(getInternalFedoraDirectory()) && subpath.endsWith(RESOURCE_HEADER_EXTENSION);
+    }
+
+    /**
      * A utility method that returns a list of  {@link java.time.Instant} objects representing immutable versions
      * accessible from the OCFL Object represented by the session.
      *

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -17,6 +17,10 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
+import edu.wisc.library.ocfl.core.extension.layout.config.DefaultLayoutConfig;
+import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
@@ -121,8 +125,9 @@ public class OCFLPersistentStorageUtils {
         final var lastPathSegment = rootObjectId.substring(rootObjectId.lastIndexOf("/") + 1);
 
         String subPath;
-
-        if (fedoraSubpath == "") {
+        if (FEDORA_ID_PREFIX.equals(rootFedoraObjectId) && "".equals(fedoraSubpath)) {
+            subPath = DEFAULT_REPOSITORY_ROOT_OCFL_OBJECT_ID;
+        } else if ("".equals(fedoraSubpath)) {
             subPath = lastPathSegment;
         } else if (fedoraSubpath.endsWith(FCR_ACL)) {
             subPath = fedoraSubpath.replaceAll("/?" + FCR_ACL + "$", "-acl");
@@ -272,7 +277,7 @@ public class OCFLPersistentStorageUtils {
      *                  retrieve.
      * @return The subpath to the (sidecar) metadata file.
      */
-    protected static String getSidecarSubpath(final String subpath) {
+    public static String getSidecarSubpath(final String subpath) {
         return getInternalFedoraDirectory() + subpath + RESOURCE_HEADER_EXTENSION;
     }
 
@@ -338,4 +343,21 @@ public class OCFLPersistentStorageUtils {
 
         return bareFedoraIdentifier;
     }
+
+    /**
+     * Create a new ocfl repository
+     * @param ocflStorageRootDir The ocfl storage root directory
+     * @param ocflWorkDir The ocfl work directory
+     * @return the repository
+     */
+    public static MutableOcflRepository createRepository(final File ocflStorageRootDir, final File ocflWorkDir) {
+        ocflStorageRootDir.mkdirs();
+        ocflWorkDir.mkdirs();
+        return new OcflRepositoryBuilder()
+                .layoutConfig(DefaultLayoutConfig.nTupleHashConfig())
+                .storage((FileSystemOcflStorage.builder().repositoryRoot(ocflStorageRootDir.toPath()).build()))
+                .workDir(ocflWorkDir.toPath())
+                .buildMutable();
+    }
+
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -362,6 +362,9 @@ public class OCFLPersistentStorageUtils {
     public static MutableOcflRepository createRepository(final File ocflStorageRootDir, final File ocflWorkDir) {
         ocflStorageRootDir.mkdirs();
         ocflWorkDir.mkdirs();
+
+        log.info("Fedora OCFL persistence directories:\n- {}\n- {}", ocflStorageRootDir, ocflWorkDir);
+
         return new OcflRepositoryBuilder()
                 .layoutConfig(DefaultLayoutConfig.nTupleHashConfig())
                 .storage((FileSystemOcflStorage.builder().repositoryRoot(ocflStorageRootDir.toPath()).build()))

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -31,8 +31,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.io.IOUtils;
@@ -629,6 +631,25 @@ public class DefaultOCFLObjectSessionTest {
         assertEquals("First version in list is not \"v1\"", "v1", versions.get(0).getVersionId().toString());
         assertEquals("Second version in list is not \"v2\"", "v2", versions.get(1).getVersionId().toString());
         assertEquals("There should be exactly two versions",2, versions.size());
+    }
+
+    @Test
+    public void listHeadSubpaths() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
+        session.commit(NEW_VERSION);
+        session.close();
+
+        final var session2 = makeNewSession();
+
+        final List<String> subpaths = session2.listHeadSubpaths().collect(Collectors.toList());
+
+        session2.close();
+
+        assertEquals("Expected 2 subpaths", 2, subpaths.size());
+        Arrays.asList(FILE1_SUBPATH, FILE2_SUBPATH).stream().forEach(subpath -> {
+            assertTrue(format("Expected subpath %s to be presented", subpath), subpaths.contains(subpath));
+        });
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -87,8 +87,9 @@ public class DefaultOCFLObjectSessionTest {
 
         ocflRepository = new OcflRepositoryBuilder()
                 .layoutConfig(DefaultLayoutConfig.flatPairTreeConfig())
-                .buildMutable(FileSystemOcflStorage.builder().build(
-                        repoDir), workDir);
+                .workDir(workDir)
+                .storage(FileSystemOcflStorage.builder().repositoryRoot(repoDir).build())
+                .buildMutable();
 
         session = makeNewSession();
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImplTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import org.fcrepo.kernel.api.operations.CreateResourceOperation;
+import org.fcrepo.kernel.api.operations.RdfSourceOperation;
+import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.createRepository;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+/**
+ * @author dbernstein
+ * @since 6.0.0
+ */
+public class FedoraToOCFLObjectIndexUtilImplTest {
+
+    private static final String RESOURCE_ID_1 = "info:fedora/resource";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testRebuild() throws Exception {
+
+        final var repoDir = tempFolder.newFolder("ocfl-repo");
+        final var workDir = tempFolder.newFolder("ocfl-work");
+        final var staging = tempFolder.newFolder("ocfl-staging");
+        final var repository = createRepository(repoDir, workDir);
+
+        final var index = new FedoraToOCFLObjectIndexImpl();
+
+        final var ocflObjectSessionFactory = new DefaultOCFLObjectSessionFactory(staging);
+        setField(ocflObjectSessionFactory, "ocflRepository", repository);
+
+        final var sessionManager = new OCFLPersistentSessionManager();
+        setField(sessionManager, "fedoraOcflIndex", index);
+        setField(sessionManager, "objectSessionFactory", ocflObjectSessionFactory);
+
+        final var util = new FedoraToOCFLObjectIndexUtilImpl();
+        setField(util, "ocflRepository", repository);
+        setField(util, "fedoraToOCFLObjectIndex", index);
+        setField(util, "objectSessionFactory", ocflObjectSessionFactory);
+
+        final var session1Id = "session1";
+        final var resource1 = "info:fedora/resource1";
+        final var session = sessionManager.getSession(session1Id);
+
+        final var operation = mock(RdfSourceOperation.class, withSettings().extraInterfaces(
+                CreateResourceOperation.class));
+        when(operation.getResourceId()).thenReturn(resource1);
+        when(operation.getType()).thenReturn(CREATE);
+        session.persist(operation);
+        session.commit();
+
+        assertNotNull(index.getMapping(resource1));
+
+        index.reset();
+
+        try {
+            index.getMapping(resource1);
+            fail(resource1 + " should not exist in index");
+        } catch (final FedoraOCFLMappingNotFoundException e) {
+            //do nothing - expected
+        }
+
+        ocflObjectSessionFactory.create(resource1, session1Id);
+
+        util.rebuild();
+
+        assertNotNull(index.getMapping(resource1));
+
+    }
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImplTest.java
@@ -21,12 +21,12 @@ import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 
+import static java.lang.System.currentTimeMillis;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.createRepository;
 import static org.junit.Assert.assertNotNull;
@@ -42,17 +42,14 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
  */
 public class FedoraToOCFLObjectIndexUtilImplTest {
 
-    private static final String RESOURCE_ID_1 = "info:fedora/resource";
-
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
-
     @Test
     public void testRebuild() throws Exception {
+        final var targetDir = new File("target");
+        final var dataDir = new File(targetDir, "test-fcrepo-data-" + currentTimeMillis());
+        final var repoDir = new File(dataDir,"ocfl-repo");
+        final var workDir = new File(dataDir,"ocfl-work");
+        final var staging = new File(dataDir,"ocfl-staging");
 
-        final var repoDir = tempFolder.newFolder("ocfl-repo");
-        final var workDir = tempFolder.newFolder("ocfl-work");
-        final var staging = tempFolder.newFolder("ocfl-staging");
         final var repository = createRepository(repoDir, workDir);
 
         final var index = new FedoraToOCFLObjectIndexImpl();
@@ -105,7 +102,6 @@ public class FedoraToOCFLObjectIndexUtilImplTest {
             //do nothing - expected
         }
 
-        ocflObjectSessionFactory.create(resource1, session1Id);
         util.rebuild();
         assertNotNull(index.getMapping(resource1));
         assertNotNull(index.getMapping(resource2));

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -27,6 +27,7 @@ import static org.fcrepo.persistence.api.CommitOption.UNVERSIONED;
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
 
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.createRepository;
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.mintOCFLObjectId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -137,7 +139,9 @@ public class OCFLPersistentStorageSessionTest {
         final var repoDir = tempFolder.newFolder("ocfl-repo");
         final var workDir = tempFolder.newFolder("ocfl-work");
 
-        this.objectSessionFactory = new DefaultOCFLObjectSessionFactory(stagingDir, repoDir, workDir);
+        final var repository = createRepository(repoDir, workDir);
+        this.objectSessionFactory = new DefaultOCFLObjectSessionFactory(stagingDir);
+        setField(this.objectSessionFactory, "ocflRepository", repository);
         session = createSession(index, objectSessionFactory);
         DefaultOCFLObjectSession.setGlobaDefaultCommitOption(UNVERSIONED);
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <jgroups.version>4.0.13.Final</jgroups.version>
     <jsonld.version>0.12.1</jsonld.version>
     <logback.version>1.2.3</logback.version>
-    <ocfl-java.version>0.0.1-SNAPSHOT</ocfl-java.version>
+    <ocfl-java.version>0.0.2-SNAPSHOT</ocfl-java.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy-java.version>1.1.7.2</snappy-java.version>
     <spring.version>5.0.9.RELEASE</spring.version>


### PR DESCRIPTION
**Automatic rebuild of Fedora to OCFL Index on start**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3195

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Enables automatic rebuild on start when fedora to ocfl index file is not present.

# What's new?
*  FedoraToOCFLIndexUtil component which implements the index rebuild logic.
*  Integration test covering the functionality.
* Minor related fixes.
* Update to the ocfl-java client to support the new feature.


# How should this be tested?

```
# fire up fedora
java -Dfcrepo.ocfl.staging.dir=target/fcrepo-data/staging -Dfcrepo.ocfl.storage.root.dir=target/fcrepo-data/ocfl-root -Dfcrepo.ocfl.work.dir=target/fcrepo-data/work  -jar fcrepo-webapp/target/fcrepo-webapp-6.0.0-SNAPSHOT-jetty-console.jar --headless

#  create a resource
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test -v  -H "Content-Type: text/turtle"  -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'My Test RDF'"
# kill fedora process

# delete the work directory
rm -rf target/fcrepo-data/work

# restart fedora

# verify the resource is accessible
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test -i

```


# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
