### PR TITLE
Enable currently passing integration tests

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -90,7 +90,6 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.springframework.test.context.ContextConfiguration;
@@ -102,7 +101,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author awoods
  * @author ajs6f
  */
-@Ignore //TODO Fix these tests
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/spring-test/test-container.xml")
 public abstract class AbstractResourceIT {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/DirtyContextBeforeAndAfterClassTestExecutionListener.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/DirtyContextBeforeAndAfterClassTestExecutionListener.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.integration.http.api;
 
-import org.junit.Ignore;
 import org.springframework.core.Ordered;
 import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
 import org.springframework.test.context.TestContext;
@@ -29,7 +28,6 @@ import org.springframework.test.context.support.AbstractTestExecutionListener;
  *
  * @author bbpennel
  */
-@Ignore //TODO Fix these tests
 public class DirtyContextBeforeAndAfterClassTestExecutionListener
         extends AbstractTestExecutionListener {
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -58,7 +58,6 @@ import org.junit.Test;
  * @author whikloj
  * @since 2018-07-10
  */
-@Ignore //TODO Fix these tests
 public class ExternalContentHandlerIT extends AbstractResourceIT {
 
     private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
@@ -73,6 +72,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
     private static final String TEST_MD5_DIGEST_HEADER_VALUE = "md5=baed005300234f3d1503c50a48ce8e6f";
 
+    @Ignore //TODO Fix this test
     @Test
     public void testRemoteUriContentType() throws Exception {
         final HttpPost method = postObjMethod();
@@ -102,6 +102,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalDatastreamProxyWithWantDigestForLocalFile() throws IOException {
 
@@ -127,6 +128,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         checkExternalDataStreamResponseHeader(getObjMethod, fileUri, expectedDigestHeaderValue);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalDatastreamCopyWithWantDigestForLocalFile() throws IOException {
 
@@ -152,6 +154,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         checkExternalDataStreamResponseHeader(getObjMethod, null, expectedDigestHeaderValue);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalDatastreamProxyWithWantDigest() throws IOException {
 
@@ -178,6 +181,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         checkExternalDataStreamResponseHeader(getObjMethod, dsUrl, expectedDigestHeaderValue);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalDatastreamCopyWithWantDigest() throws IOException {
 
@@ -204,6 +208,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         checkExternalDataStreamResponseHeader(getObjMethod, null, expectedDigestHeaderValue);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalDatastreamProxyWithWantDigestMultipleForLocalFile() throws IOException {
 
@@ -275,6 +280,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testHeadExternalDatastreamRedirect() throws IOException, ParseException {
 
@@ -300,6 +306,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetExternalDatastream() throws IOException, ParseException {
         final String id = getRandomUniqueId();
@@ -340,6 +347,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testRedirectWithWantDigest() throws IOException {
 
@@ -390,6 +398,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
                 TEST_SHA_DIGEST_HEADER_VALUE, TEST_MD5_DIGEST_HEADER_VALUE);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalMessageBodyRedirect() throws IOException {
 
@@ -413,6 +422,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalMessageBodyCopyLocalFile() throws Exception {
         final String entityStr = "Hello there, this is the original object speaking.";
@@ -440,6 +450,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalMessageBodyCopy() throws IOException {
         // create a random binary object
@@ -469,6 +480,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testExternalMessageBodyProxy() throws IOException {
         // Create a resource
@@ -499,6 +511,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPostExternalContentProxy() throws Exception {
         // Create a resource
@@ -572,6 +585,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCopyNotFoundHttpContent() throws Exception {
         final String nonexistentPath = serverAddress + getRandomUniqueId();
@@ -587,6 +601,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCopyUnreachableHttpContent() throws Exception {
         final String nonexistentPath = "http://" + getRandomUniqueId() + ".example.com/";
@@ -602,6 +617,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testProxyNotFoundHttpContent() throws Exception {
         final String nonexistentPath = serverAddress + getRandomUniqueId();
@@ -622,6 +638,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testProxyUnreachableHttpContent() throws Exception {
         final String nonexistentPath = "http://" + getRandomUniqueId() + ".example.com/";
@@ -642,6 +659,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testRedirectUnreachableHttpContent() throws Exception {
         final String nonexistentPath = "http://" + getRandomUniqueId() + ".example.com/";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
@@ -59,7 +59,6 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 /**
  * @author bbpennel
  */
-@Ignore //TODO Fix these tests
 @RunWith(SpringJUnit4ClassRunner.class)
 @DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @TestExecutionListeners(listeners = { DependencyInjectionTestExecutionListener.class,
@@ -121,6 +120,7 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
         System.clearProperty("fcrepo.external.content.allowed");
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testAllowedPath() throws Exception {
         final HttpPost method = postObjMethod();
@@ -163,6 +163,7 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testAllowedFilePath() throws Exception {
         final String fileContent = "content";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -62,7 +62,6 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
  * @author lsitu
  * @author 4/20/2018
  */
-@Ignore //TODO Fix these tests
 public class FedoraAclIT extends AbstractResourceIT {
 
     private String subjectUri;
@@ -77,6 +76,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         subjectUri = serverAddress + id;
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithoutBody() throws Exception {
         createObjectAndClose(id);
@@ -91,6 +91,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclOnAclResource() throws Exception {
         createObjectAndClose(id);
@@ -110,6 +111,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclOnBinary() throws Exception {
         createDatastream(id, "x", "some content");
@@ -132,6 +134,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPatchAcl() throws Exception {
         createObjectAndClose(id);
@@ -153,6 +156,7 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAndRetrieveAcl() throws Exception {
         createObjectAndClose(id);
@@ -171,6 +175,7 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPutACLBadRdf() throws IOException {
         createObjectAndClose(id);
@@ -181,6 +186,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(put));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDeleteAcl() throws Exception {
         createObjectAndClose(id);
@@ -213,6 +219,7 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetDefaultRootAcl() throws Exception {
         final String rootAclUri = serverAddress + FCR_ACL;
@@ -242,6 +249,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDeleteDefaultRootAcl() {
         final String rootAclUri = serverAddress + FCR_ACL;
@@ -249,6 +257,7 @@ public class FedoraAclIT extends AbstractResourceIT {
                 CONFLICT.getStatusCode(), getStatus(new HttpDelete(rootAclUri)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPatchDefaultRootAcl() {
         final String rootAclUri = serverAddress + FCR_ACL;
@@ -256,6 +265,7 @@ public class FedoraAclIT extends AbstractResourceIT {
                 CONFLICT.getStatusCode(), getStatus(new HttpPatch(rootAclUri)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetUserDefinedDefaultRootAcl() throws Exception {
         System.setProperty(ROOT_AUTHORIZATION_PROPERTY, "./target/test-classes/test-root-authorization.ttl");
@@ -274,6 +284,7 @@ public class FedoraAclIT extends AbstractResourceIT {
             }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testAddModifyDeleteUserDefinedDefaultRootAcl() throws Exception {
         final String rootAclUri = serverAddress + FCR_ACL;
@@ -305,6 +316,7 @@ public class FedoraAclIT extends AbstractResourceIT {
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(rootAclUri)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithBody() throws Exception {
         createObjectAndClose(id);
@@ -340,6 +352,7 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithoutAccessToSetsDefaultTarget() throws Exception {
         createObjectAndClose(id);
@@ -374,6 +387,7 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithAccessTo() throws Exception {
         createObjectAndClose(id);
@@ -419,6 +433,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithAccessToClass() throws Exception {
         createObjectAndClose(id);
@@ -464,6 +479,7 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithBothAccessToandAccessToClassIsNotAllowed() throws Exception {
         createObjectAndClose(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraCrudConcurrentIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraCrudConcurrentIT.java
@@ -32,7 +32,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.BasicHttpEntity;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -44,7 +43,6 @@ import org.junit.Test;
  *
  * @author lsitu
  */
-@Ignore //TODO Fix these tests
 public class FedoraCrudConcurrentIT extends AbstractResourceIT {
 
     private static final String TEST_ACTIVATION_PROPERTY = "fcrepo.test.http.concurrent";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
@@ -72,12 +72,12 @@ import org.apache.jena.sparql.core.DatasetGraph;
  * @author awoods
  * @author ajs6f
  */
-@Ignore //TODO Fix these tests
 public class FedoraFixityIT extends AbstractResourceIT {
 
     private static final RDFDatatype IntegerType = TypeMapper.getInstance().getTypeByClass(Integer.class);
     private static final RDFDatatype StringType = TypeMapper.getInstance().getTypeByClass(String.class);
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCheckDatastreamFixity() throws IOException {
         final String id = getRandomUniqueId();
@@ -99,6 +99,7 @@ public class FedoraFixityIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCheckDatastreamFixityMD5() throws IOException {
         final String id = getRandomUniqueId();
@@ -131,6 +132,7 @@ public class FedoraFixityIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testFixityHeaders() throws IOException {
         final String id = getRandomUniqueId();
@@ -161,6 +163,7 @@ public class FedoraFixityIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testResponseContentTypes() throws IOException {
         final String id = getRandomUniqueId();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -35,7 +35,6 @@ import org.junit.Test;
  *
  * @author awoods
  */
-@Ignore //TODO Fix these tests
 public class FedoraHtmlIT extends AbstractResourceIT {
 
     @Test
@@ -72,6 +71,7 @@ public class FedoraHtmlIT extends AbstractResourceIT {
         assertEquals(200, getStatus(method));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetContainerTemplate() throws IOException {
         final String pid = getRandomUniqueId();
@@ -85,6 +85,7 @@ public class FedoraHtmlIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetBinaryTemplate() throws IOException {
         final String pid = getRandomUniqueId();
@@ -98,6 +99,7 @@ public class FedoraHtmlIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetRootTemplate() throws IOException {
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -195,7 +195,6 @@ import nu.validator.saxtree.TreeBuilder;
  * @author cabeer
  * @author ajs6f
  */
-//@Ignore //TODO Fix these tests
 public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final Node DC_IDENTIFIER = DC_11.identifier.asNode();
@@ -567,7 +566,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadRdfResourceHeaders() throws IOException {
         final String id = getRandomUniqueId();
         createObject(id).close();
@@ -596,7 +594,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testOptions() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -696,7 +693,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetRDFSource() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -713,7 +709,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetRDFSourceWithPreferMinimal() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -743,7 +738,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetRDFSourceWithPreferRepresentation() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -850,7 +844,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
      * format being requested.
      */
     @Test
-@Ignore
     public void testGetRDFSourceWrongAccept() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -937,7 +930,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteContainerWithIncorrectDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -1001,7 +993,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testEmptyPatch() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -1387,7 +1378,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutBinary() throws IOException {
 
         final String id = getRandomUniqueId();
@@ -1758,7 +1748,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutMalformedRDFOnObject() throws IOException {
         final String content = "this is not legitimate RDF";
         final String id = getRandomUniqueId();
@@ -1772,7 +1761,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testIngest() throws IOException {
         final String id = getRandomUniqueId();
         try (final CloseableHttpResponse response = createObject(id)) {
@@ -1840,7 +1828,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testIngestWithSlug() throws IOException {
         final HttpPost method = postObjMethod();
         method.addHeader("Slug", getRandomUniqueId());
@@ -1855,7 +1842,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testIngestWithRepeatedSlug() {
         final String id = getRandomUniqueId();
         assertEquals(CREATED.getStatusCode(), getStatus(putObjMethod(id)));
@@ -2075,7 +2061,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testIngestOnSubtree() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -2128,7 +2113,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     // TODO It's not clear what this test is actually testing, or why it sleeps while running
             public
             void testCreateManyObjects() throws IOException, InterruptedException {
@@ -2144,7 +2128,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteWithBadEtag() throws IOException {
         try (final CloseableHttpResponse response = execute(postObjMethod())) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
@@ -2273,7 +2256,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetObjectGraphHtml() throws IOException {
         final HttpGet getObjMethod = new HttpGet(getLocation(postObjMethod()));
         getObjMethod.addHeader(ACCEPT, "text/html");
@@ -2281,7 +2263,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetObjectGraphVariants() throws IOException {
         final String location = getLocation(postObjMethod());
         for (final Variant variant : POSSIBLE_RDF_VARIANTS) {
@@ -2377,7 +2358,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetObjectGraphWithBadLimit() throws IOException {
         final String id = getRandomUniqueId();
         getLocation(createObject(id));
@@ -2390,7 +2370,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetObjectGraphMinimal() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id, BASIC_CONTAINER_LINK_HEADER);
@@ -3054,7 +3033,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     // TODO there is no actual use of the JCR namespace in this test-- what is it testing?
             public
             void testUpdateWithSparqlQueryJcrNS() throws IOException {
@@ -3105,7 +3083,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCreateResourceWithoutContentType() {
         assertEquals(CREATED.getStatusCode(), getStatus(new HttpPut(serverAddress + getRandomUniqueId())));
     }
@@ -3241,7 +3218,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testResponseContentTypes() throws Exception {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -3253,7 +3229,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDescribeRdfCached() throws IOException {
         try (final CloseableHttpClient cachClient = CachingHttpClientBuilder.create().setCacheConfig(DEFAULT).build()) {
             final String location = getLocation(postObjMethod());
@@ -3273,13 +3248,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testValidHTMLForRepo() throws IOException, SAXException {
         validateHTML("");
     }
 
     @Test
-@Ignore
     public void testValidHTMLForObject() throws IOException, SAXException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -3542,7 +3515,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCreateAndReplaceGraphMinimal() throws IOException {
         LOGGER.trace("Entering testCreateAndReplaceGraphMinimal()...");
         final HttpPost httpPost = postObjMethod("/");
@@ -3569,7 +3541,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testAclHeaderWithPost() throws IOException {
         final String pid = getRandomUniqueId();
         final HttpPost httpPost = postObjMethod("/");
@@ -3582,7 +3553,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testAclHeaderWithPut() throws IOException {
         final String pid = getRandomUniqueId();
         final String location = serverAddress + pid;
@@ -3686,7 +3656,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testJsonLdProfileExpanded() throws IOException {
         // Create a resource
         final HttpPost method = postObjMethod();
@@ -3722,7 +3691,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testJsonLdProfileFlattened() throws IOException {
         // Create a resource
         final HttpPost method = postObjMethod();
@@ -3870,7 +3838,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutReferenceRoot() throws Exception {
         final HttpPut httpPut = putObjMethod(getRandomUniqueId());
         httpPut.addHeader(CONTENT_TYPE, "text/turtle");
@@ -4405,7 +4372,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutFedoraPath() throws IOException {
         final HttpPut httpPut = putObjMethod("/fedora:path");
         try (final CloseableHttpResponse response = execute(httpPut)) {
@@ -4415,7 +4381,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteWithFedoraPath() throws IOException {
         final String id = getRandomUniqueId() + "/fedora:delete";
         final HttpDelete httpDelete = deleteObjMethod(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
@@ -43,7 +43,7 @@ import org.junit.Test;
  * @author awoods
  * @author ajs6f
  */
-@Ignore //TODO Fix these tests
+@Ignore //TODO: Possibly remove these tests - COPY and MOVE may not be supported
 public class FedoraNodesIT extends AbstractResourceIT {
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
@@ -88,7 +88,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Mike Durbin
  */
-@Ignore //TODO Fix these tests
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FedoraRelaxedLdpIT extends AbstractResourceIT {
 
@@ -106,6 +105,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     }
 
 
+    @Ignore //TODO Fix this test
     @Test
     public void testBasicPutRoundtrip() throws IOException {
         final String subjectURI;
@@ -127,6 +127,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(put));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateResourceWithSpecificCreationInformationIsAllowed() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
@@ -144,6 +145,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testUpdateNonRdfResourceWithSpecificInformationIsAllowed() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
@@ -171,6 +173,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testValidSparqlUpdate() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
@@ -201,6 +204,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testInvalidSparqlUpdate() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
@@ -230,6 +234,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testUpdateResourceWithSpecificModificationInformationIsAllowed() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
@@ -259,6 +264,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
      * Tests a lossless roundtrip of a resource.
      * @throws IOException if an error occurs while reading or writing to repository over HTTP
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testRoundtripping() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -131,7 +131,6 @@ import org.junit.rules.TemporaryFolder;
  * @author lsitu
  * @author bbpennel
  */
-@Ignore //TODO Fix these tests
 public class FedoraVersioningIT extends AbstractResourceIT {
 
     private static final String BINARY_CONTENT = "binary content";
@@ -162,6 +161,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         subjectUri = serverAddress + id;
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDeleteTimeMapNotAllowed() throws Exception {
         createVersionedContainer(id);
@@ -172,6 +172,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                      getStatus(new HttpDelete(serverAddress + id + "/" + FCR_VERSIONS)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapResponse() throws Exception {
         createVersionedContainer(id);
@@ -180,6 +181,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         verifyTimemapResponse(subjectUri, id, MEMENTO_DATETIME);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapResponseMultipleMementos() throws Exception {
         createVersionedContainer(id);
@@ -196,6 +198,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         verifyTimemapResponse(subjectUri, id, mementos, memento3, memento2);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapRDFSubject() throws Exception {
         createVersionedContainer(id);
@@ -209,6 +212,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersion() throws Exception {
         createVersionedContainer(id);
@@ -228,6 +232,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionFromResourceWithHashURI() throws Exception {
         final HttpPost createMethod = postObjMethod();
@@ -254,6 +259,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionFromResourceWithBlankNode() throws Exception {
         final HttpPost createMethod = postObjMethod();
@@ -293,6 +299,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * thereby changing the time.
      * @throws java.lang.Exception exception thrown during this function
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionWithLastModifiedDateTimestamp() throws Exception {
         try {
@@ -339,6 +346,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 BAD_REQUEST.getStatusCode(), getStatus(post));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionWithMementoDatetimeFormat() throws Exception {
         createVersionedContainer(id);
@@ -377,6 +385,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(post2));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionWithDatetime() throws Exception {
         createVersionedContainer(id);
@@ -394,6 +403,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateContainerWithoutServerManagedTriples() throws Exception {
         createVersionedContainer(id);
@@ -417,6 +427,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      *
      * @throws Exception in case of error with test
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionWithBody() throws Exception {
         createVersionedContainer(id);
@@ -440,6 +451,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionWithDatetimeAndBody() throws Exception {
         createVersionedContainer(id);
@@ -474,6 +486,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionDuplicateMementoDatetime() throws Exception {
         createVersionedContainer(id);
@@ -505,6 +518,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionWithDatetimeAndEmptyBody() throws Exception {
         createVersionedContainer(id);
@@ -522,6 +536,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDeleteAndPostContainerMemento() throws Exception {
         createVersionedContainer(id);
@@ -539,6 +554,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDeleteAndPostBinaryMemento() throws Exception {
         createVersionedBinary(id);
@@ -556,6 +572,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDeleteAndPostDescriptionMemento() throws Exception {
         createVersionedBinary(id);
@@ -575,6 +592,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testMementoContainmentReferences() throws Exception {
         createVersionedContainer(id);
@@ -606,6 +624,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testHeadOnMemento() throws Exception {
 
@@ -628,6 +647,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         checkResponseWithInvalidMementoID(headMethodInvalid);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetOnMemento() throws Exception {
 
@@ -650,6 +670,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         checkResponseWithInvalidMementoID(getMementoInvalid);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetOnMementoWithAcceptDatetimePresent() throws Exception {
         createVersionedContainer(id);
@@ -664,6 +685,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                      getStatus(getMemento));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testHeadOnMementoWithAcceptDatetimePresent() throws Exception {
         createVersionedContainer(id);
@@ -678,6 +700,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 getStatus(headMemento));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testOptionsOnMemento() throws Exception {
 
@@ -701,6 +724,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         checkResponseWithInvalidMementoID(optionsMementoInvalid);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testMementoExternalReference() throws Exception {
         createVersionedContainer(id);
@@ -745,6 +769,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDescriptionMementoReference() throws Exception {
         // Create binary with description referencing other resource
@@ -812,6 +837,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(405, getStatus(new HttpPatch(serverAddress + id + "/" + FCR_VERSIONS)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapResponseForBinary() throws Exception {
         createVersionedBinary(id);
@@ -832,6 +858,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapResponseForBinaryDescription() throws Exception {
         createVersionedBinary(id);
@@ -945,6 +972,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(1, response.getHeaders("Accept-Post").length);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionOfBinary() throws Exception {
         createVersionedBinary(id);
@@ -969,6 +997,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionOfBinaryWithDatetimeAndContentType() throws Exception {
         createVersionedBinary(id);
@@ -987,6 +1016,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionOfBinaryWithBody() throws Exception {
         createVersionedBinary(id);
@@ -1004,6 +1034,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionOfBinaryWithDatetimeAndBody() throws Exception {
         createVersionedBinary(id);
@@ -1024,6 +1055,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionOfBinaryDescription() throws Exception {
         createVersionedBinary(id);
@@ -1070,6 +1102,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     /*
      * Attempt to create binary description with container triples
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionOfBinaryDescriptionInvalidTriples() throws Exception {
         final String containerId = getRandomUniqueId();
@@ -1091,6 +1124,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionBinaryDescriptionWithBodyAndDatetime() throws Exception {
         createVersionedBinary(id);
@@ -1114,6 +1148,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionHistoricBinaryAndDescription() throws Exception {
         createVersionedBinary(id, "text/plain", BINARY_CONTENT);
@@ -1150,6 +1185,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testAddAndRetrieveVersion() throws Exception {
         createVersionedContainer(id);
@@ -1181,6 +1217,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testInvalidVersionDatetime() throws Exception {
         final String invalidDate = "blah";
@@ -1197,6 +1234,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(postReq));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testTimeMapResponseContentTypes() throws Exception {
         createVersionedContainer(id);
@@ -1209,6 +1247,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetVersionResponseContentTypes() throws Exception {
         createVersionedContainer(id);
@@ -1222,6 +1261,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDatetimeNegotiationLDPRv() throws Exception {
         final CloseableHttpClient customClient = createClient(true);
@@ -1274,6 +1314,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDatetimeNegotiationExactMatch() throws Exception {
         final CloseableHttpClient customClient = createClient(true);
@@ -1317,6 +1358,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDatetimeNegotiationNoMementos() throws Exception {
         final CloseableHttpClient customClient = createClient(true);
@@ -1335,6 +1377,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetWithDateTimeNegotiation() throws Exception {
         final CloseableHttpClient customClient = createClient(true);
@@ -1366,6 +1409,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             BAD_REQUEST.getStatusCode(), getStatus(customClient.execute(getMethod3)));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testFixityOnVersionedResource() throws Exception {
         createVersionedBinary(id);
@@ -1378,6 +1422,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testOptionsMemento() throws Exception {
         createVersionedContainer(id);
@@ -1390,6 +1435,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPatchOnMemento() throws Exception {
         createVersionedContainer(id);
@@ -1418,6 +1464,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(405, getStatus(anyPatch));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPostOnMemento() throws Exception {
         createVersionedContainer(id);
@@ -1446,6 +1493,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(405, getStatus(anyPost));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPutOnMemento() throws Exception {
         createVersionedContainer(id);
@@ -1474,6 +1522,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(405, getStatus(anyPut));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetLDPRSMementoHeaders() throws Exception {
         createVersionedContainer(id);
@@ -1497,6 +1546,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetLDPNRMementoHeaders() throws Exception {
         createVersionedBinary(id, "text/plain", "This is some versioned content");
@@ -1523,6 +1573,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * Verify binary description timemap RDF representation can be retrieved with and without
      * accompanying binary memento
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testFcrepo2792() throws Exception {
         // 1. Create versioned resource
@@ -1565,6 +1616,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testOptionsTimeMap() throws Exception {
         createVersionedContainer(id);
@@ -1576,6 +1628,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateExternalBinaryProxyVersion() throws Exception {
         // Create binary to use as content for proxying
@@ -1601,6 +1654,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateHistoricExternalBinaryProxyVersion() throws Exception {
         // Create two binaries to use as content for proxying
@@ -1640,6 +1694,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateHistoricExternalBinaryRedirectVersion() throws Exception {
         // Create two binaries to use as content for proxying
@@ -1676,6 +1731,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateHistoricExternalBinaryCopyVersion() throws Exception {
         final String newContent = "new content";
@@ -1706,6 +1762,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void versionedResourcesCreatedByDefault() throws Exception {
         final String id = getRandomUniqueId();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
@@ -50,7 +50,6 @@ import org.junit.Test;
 /**
  * @author bbpennel
  */
-@Ignore //TODO Fix these tests
 public class LDPContainerIT extends AbstractResourceIT {
 
     private final String PCDM_HAS_MEMBER = "http://pcdm.org/models#hasMember";
@@ -61,6 +60,7 @@ public class LDPContainerIT extends AbstractResourceIT {
 
     private static final String INDIRECT_CONTAINER_LINK_HEADER = "<" + INDIRECT_CONTAINER.getURI() + ">;rel=\"type\"";
 
+    @Ignore //TODO Fix this test
     @Test
     public void testIndirectContainerDefaults() throws Exception {
         final String id = getRandomUniqueId();
@@ -84,6 +84,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 resc.hasProperty(INSERTED_CONTENT_RELATION, MEMBER_SUBJECT));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testIndirectContainerOverrides() throws Exception {
         final String parentId = getRandomUniqueId();
@@ -115,6 +116,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 resc.hasProperty(INSERTED_CONTENT_RELATION, MEMBER_SUBJECT));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testIndirectContainerDefaultsAfterPUT() throws Exception {
         final String parentId = getRandomUniqueId();
@@ -152,6 +154,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 resc.hasProperty(INSERTED_CONTENT_RELATION, MEMBER_SUBJECT));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testIndirectContainerDefaultsAfterPatch() throws Exception {
         final String parentId = getRandomUniqueId();
@@ -206,6 +209,7 @@ public class LDPContainerIT extends AbstractResourceIT {
         executeAndClose(putIndirect);
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDirectContainerDefaults() throws Exception {
         final String id = getRandomUniqueId();
@@ -225,6 +229,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDirectContainerOverrides() throws Exception {
         final String parentId = getRandomUniqueId();
@@ -250,6 +255,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDirectContainerDefaultsAfterPUT() throws Exception {
         final String parentId = getRandomUniqueId();
@@ -281,6 +287,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 resc.hasProperty(HAS_MEMBER_RELATION, LDP_MEMBER));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testDirectContainerDefaultsAfterPatch() throws Exception {
         final String parentId = getRandomUniqueId();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 /**
  * @author dbernstein
  */
-@Ignore //TODO Fix these tests
 public class StateTokensIT extends AbstractResourceIT {
 
     private static final String X_STATE_TOKEN_HEADER = "X-State-Token";
@@ -64,6 +63,7 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testAclGetHasStateTokenRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -83,6 +83,7 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testAclHeadHasStateTokenRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -102,6 +103,7 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testLdpcvGetHasStateTokenRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -112,6 +114,7 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testLdpcvHeadHasStateTokenRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -122,6 +125,7 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetHasStateTokenNonRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -137,6 +141,7 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testHeadHasStateTokenNonRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -152,6 +157,7 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPutWithStateTokenOnNonRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -185,6 +191,7 @@ public class StateTokensIT extends AbstractResourceIT {
 
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPatchWithStateTokenOnRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -223,6 +230,7 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testPatchWithStateTokenOnAcl() throws IOException {
         final String id = getRandomUniqueId();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
@@ -61,7 +61,6 @@ import org.junit.Test;
  *
  * @author awoods
  */
-@Ignore //TODO Fix these tests
 public class TransactionsIT extends AbstractResourceIT {
 
     public static final long REAP_INTERVAL = 1000;
@@ -70,6 +69,7 @@ public class TransactionsIT extends AbstractResourceIT {
 
     public static final String DEFAULT_TIMEOUT = Long.toString(ofMinutes(3).toMillis());
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateTransaction() throws IOException {
         final String location = createTransaction();
@@ -78,12 +78,14 @@ public class TransactionsIT extends AbstractResourceIT {
                 compile("tx:[0-9a-f-]+$").matcher(location).find());
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testRequestsInTransactionThatDoestExist() {
         /* create a tx */
         assertEquals(GONE.getStatusCode(), getStatus(new HttpPost(serverAddress + "tx:123/objects")));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateAndTimeoutTransaction() throws IOException, InterruptedException {
 
@@ -110,6 +112,7 @@ public class TransactionsIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateDoStuffAndRollbackTransaction() throws IOException {
         /* create a tx */
@@ -140,6 +143,7 @@ public class TransactionsIT extends AbstractResourceIT {
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPost(txLocation + "/fcr:tx/fcr:rollback")));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testTransactionKeepAlive() throws IOException {
         /* create a tx */
@@ -149,6 +153,7 @@ public class TransactionsIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateDoStuffAndCommitTransaction() throws IOException {
         /* create a tx */
@@ -177,6 +182,7 @@ public class TransactionsIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCreateDoStuffAndCommitTransactionSeparateConnections() throws IOException {
         /* create a tx */
@@ -213,6 +219,7 @@ public class TransactionsIT extends AbstractResourceIT {
      *
      * @throws IOException exception thrown during this function
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testIngestNewWithSparqlPatchWithinTransaction() throws IOException {
         final String objectInTxCommit = getRandomUniqueId();
@@ -250,6 +257,7 @@ public class TransactionsIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testGetNonExistingObject() throws IOException {
         final String txLocation = createTransaction();
@@ -263,6 +271,7 @@ public class TransactionsIT extends AbstractResourceIT {
      *
      * @throws IOException exception thrown during this function
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testTransactionHijackingNotPossible() throws IOException {
 
@@ -298,6 +307,7 @@ public class TransactionsIT extends AbstractResourceIT {
      *
      * @throws IOException exception thrown during this function
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testTransactionHijackingNotPossibleAnoymous() throws IOException {
 
@@ -332,6 +342,7 @@ public class TransactionsIT extends AbstractResourceIT {
      *
      * @throws IOException exception thrown during this function
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testNoCachingHeadersDuringTransaction() throws IOException {
         final String txLocation = createTransaction();
@@ -357,6 +368,7 @@ public class TransactionsIT extends AbstractResourceIT {
      * Test for issue https://jira.duraspace.org/browse/FCREPO-2975
      * @throws java.lang.Exception exception thrown during this function
      */
+    @Ignore //TODO Fix this test
     @Test
     public void testHeadAndDeleteInTransaction() throws Exception {
         final String id = getRandomUniqueId();
@@ -430,6 +442,7 @@ public class TransactionsIT extends AbstractResourceIT {
                 NO_CONTENT.getStatusCode(), getStatus(new HttpPost(deleterTxLocation + "/fcr:tx/fcr:commit")));
     }
 
+    @Ignore //TODO Fix this test
     @Test
     public void testCacheHeadersInTransaction() throws IOException {
         /* create a tx */

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
@@ -69,7 +69,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlTextArea;
  *
  * @author cbeer
  */
-@Ignore // TODO FIX THESE TESTS
 public class FedoraHtmlResponsesIT extends AbstractResourceIT {
 
     private WebClient webClient;
@@ -103,6 +102,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
                         namespaceLabel);
     }
 
+    @Ignore // TODO FIX THIS TEST
     @Test
     public void testCreateNewNodeWithProvidedId() throws IOException {
         createAndVerifyObjectWithIdFromRootPage(newPid());
@@ -139,6 +139,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
         }
     }
 
+    @Ignore // TODO FIX THIS TEST
     @Test
     public void testCreateNewNodeWithGeneratedId() throws IOException {
 
@@ -153,6 +154,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
         assertTrue("Didn't see new information in page!", !page1.asText().equals(page.asText()));
     }
 
+    @Ignore // TODO FIX THIS TEST
     @Test
     public void testCreateNewBasicContainer() throws IOException {
         final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "basic container");
@@ -160,6 +162,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
                 "http://www.w3.org/ns/ldp#BasicContainer"));
     }
 
+    @Ignore // TODO FIX THIS TEST
     @Test
     public void testCreateNewDirectContainer() throws IOException {
         final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "direct container");
@@ -167,6 +170,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
                 "http://www.w3.org/ns/ldp#DirectContainer"));
     }
 
+    @Ignore // TODO FIX THIS TEST
     @Test
     public void testCreateNewIndirectContainer() throws IOException {
         final HtmlPage newPage = createAndVerifyObjectWithIdFromRootPage(newPid(), "indirect container");
@@ -224,6 +228,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
         assertEquals(NOT_FOUND.getStatusCode(), status);
     }
 
+    @Ignore // TODO FIX THIS TEST
     @Test
     public void testCreateNewObjectAndDeleteIt() throws IOException {
         final boolean throwExceptionOnFailingStatusCode = webClient.getOptions().isThrowExceptionOnFailingStatusCode();
@@ -243,6 +248,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
         webClient.getOptions().setThrowExceptionOnFailingStatusCode(throwExceptionOnFailingStatusCode);
     }
 
+    @Ignore // TODO FIX THIS TEST
     @Test
     public void testVersionsListWorksWhenNoVersionsPresent() throws IOException {
         final boolean throwExceptionOnFailingStatusCode = webClient.getOptions().isThrowExceptionOnFailingStatusCode();

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
@@ -57,7 +57,6 @@ import javax.ws.rs.core.Link;
  *
  * @author fasseg
  */
-@Ignore // TODO FIX THESE TESTS
 public class SanityCheckIT {
 
     /**
@@ -108,6 +107,7 @@ public class SanityCheckIT {
         return response;
     }
 
+    @Ignore // TODO FIX THIS TEST
     @Test
     public void testConstraintLink() throws Exception {
         // Create a resource


### PR DESCRIPTION
Only updating tests in:
- fcrepo-http-api, and
- fcrepo-webapp

Resolves: https://jira.lyrasis.org/browse/FCREPO-3217

# What does this Pull Request do?
Re-enables integration tests that are currently passing.

Below is a record of the integration test results after updating test classes in the above modules:
```
fcrepo-http-api

[WARNING] Tests run: 207, Failures: 0, Errors: 0, Skipped: 172

* After ExternalContentHandlerIT
[WARNING] Tests run: 228, Failures: 0, Errors: 0, Skipped: 190

* After ExternalContentPathValidatorIT
[WARNING] Tests run: 232, Failures: 0, Errors: 0, Skipped: 191

* After FedoraAclIT
[WARNING] Tests run: 249, Failures: 0, Errors: 0, Skipped: 207

* After FedoraCrudConcurrentIT - no JIRA needed
[WARNING] Tests run: 249, Failures: 0, Errors: 0, Skipped: 206

* After FedoraFixityIT
[WARNING] Tests run: 253, Failures: 0, Errors: 0, Skipped: 210

* After FedoraHtmlIT
[WARNING] Tests run: 258, Failures: 0, Errors: 0, Skipped: 212

* After FedoraLdpIT
[WARNING] Tests run: 258, Failures: 0, Errors: 0, Skipped: 178

* After FedoraNotesIT - potentiall remove these tests!

* After FedoraRelaxedLdpIT
[WARNING] Tests run: 264, Failures: 0, Errors: 0, Skipped: 184

* After FedoraVersioningIT
[WARNING] Tests run: 328, Failures: 0, Errors: 0, Skipped: 241

* After StateTokensIT
[WARNING] Tests run: 345, Failures: 0, Errors: 0, Skipped: 256

* After TransactionsIT
[WARNING] Tests run: 359, Failures: 0, Errors: 0, Skipped: 270

===============================
fcrepo-webapp

Before any
[WARNING] Tests run: 2, Failures: 0, Errors: 0, Skipped: 2

* After FedoraHtmlResponsesIT
[WARNING] Tests run: 14, Failures: 0, Errors: 0, Skipped: 12

* After SanityCheck
[WARNING] Tests run: 16, Failures: 0, Errors: 0, Skipped: 12
```

# How should this be tested?
No new functionality.
A successful build is a successful test.

# Interested parties
@fcrepo4/committers
