### PR TITLE
Changed the name of the object metadata files

### DIFF
--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexUtilImplTest.java
@@ -20,16 +20,23 @@ package org.fcrepo.persistence.ocfl.impl;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndexUtil;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 
 import static java.lang.System.currentTimeMillis;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.createRepository;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,8 +49,12 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
  */
 public class FedoraToOCFLObjectIndexUtilImplTest {
 
-    @Test
-    public void testRebuild() throws Exception {
+    private PersistentStorageSessionManager sessionManager;
+    private FedoraToOCFLObjectIndex index;
+    private FedoraToOCFLObjectIndexUtil util;
+
+    @Before
+    public void setup() throws IOException {
         final var targetDir = new File("target");
         final var dataDir = new File(targetDir, "test-fcrepo-data-" + currentTimeMillis());
         final var repoDir = new File(dataDir,"ocfl-repo");
@@ -52,58 +63,116 @@ public class FedoraToOCFLObjectIndexUtilImplTest {
 
         final var repository = createRepository(repoDir, workDir);
 
-        final var index = new FedoraToOCFLObjectIndexImpl();
+        index = new FedoraToOCFLObjectIndexImpl();
+        index.reset();
 
         final var ocflObjectSessionFactory = new DefaultOCFLObjectSessionFactory(staging);
         setField(ocflObjectSessionFactory, "ocflRepository", repository);
 
-        final var sessionManager = new OCFLPersistentSessionManager();
+        sessionManager = new OCFLPersistentSessionManager();
         setField(sessionManager, "fedoraOcflIndex", index);
         setField(sessionManager, "objectSessionFactory", ocflObjectSessionFactory);
 
-        final var util = new FedoraToOCFLObjectIndexUtilImpl();
+        util = new FedoraToOCFLObjectIndexUtilImpl();
         setField(util, "ocflRepository", repository);
         setField(util, "fedoraToOCFLObjectIndex", index);
         setField(util, "objectSessionFactory", ocflObjectSessionFactory);
+    }
 
+    @Test
+    public void rebuildWhenRepoContainsArchivalGroupObject() throws Exception {
         final var session1Id = "session1";
         final var resource1 = "info:fedora/resource1";
         final var resource2 =  resource1 + "/resource2";
 
         final var session = sessionManager.getSession(session1Id);
 
-        final var operation = mock(RdfSourceOperation.class, withSettings().extraInterfaces(
-                CreateResourceOperation.class));
-        when(operation.getResourceId()).thenReturn(resource1);
-        when(operation.getType()).thenReturn(CREATE);
-        when(((CreateResourceOperation)operation).isArchivalGroup()).thenReturn(true);
-        session.persist(operation);
+        createResource(session, resource1, true);
+        createChildResource(session, resource1, resource2);
 
-        final var operation2 = mock(NonRdfSourceOperation.class, withSettings().extraInterfaces(
-                CreateResourceOperation.class));
-        when(operation2.getResourceId()).thenReturn(resource2);
-        when(operation2.getType()).thenReturn(CREATE);
-        final var bytes = "test".getBytes();
-        final var stream = new ByteArrayInputStream(bytes);
-        when(operation2.getContentSize()).thenReturn((long)bytes.length);
-        when(operation2.getContentStream()).thenReturn(stream);
-        when(operation2.getMimeType()).thenReturn("text/plain");
-        when(operation2.getFilename()).thenReturn("test");
-        when(((CreateResourceOperation)operation2).getParentId()).thenReturn(resource1);
-        session.persist(operation2);
         session.commit();
-        assertNotNull(index.getMapping(resource1));
+
+        assertIndexContains("resource1", resource1);
+        assertIndexContains("resource1", resource2);
+
         index.reset();
 
+        assertIndexDoesNotContain(resource1);
+        assertIndexDoesNotContain(resource2);
+
+        util.rebuild();
+
+        assertIndexContains("resource1", resource1);
+        assertIndexContains("resource1", resource2);
+    }
+
+    @Test
+    public void rebuildWhenRepoContainsNonArchivalGroupObject() throws Exception {
+        final var session1Id = "session1";
+        final var resource1 = "info:fedora/resource1";
+        final var resource2 =  resource1 + "/resource2";
+
+        final var session = sessionManager.getSession(session1Id);
+
+        createResource(session, resource1, false);
+        createChildResource(session, resource1, resource2);
+
+        session.commit();
+
+        assertIndexContains("resource1", resource1);
+        assertIndexContains("resource1_resource2", resource2);
+
+        index.reset();
+
+        assertIndexDoesNotContain(resource1);
+        assertIndexDoesNotContain(resource2);
+
+        util.rebuild();
+
+        assertIndexContains("resource1", resource1);
+        assertIndexContains("resource1_resource2", resource2);
+    }
+
+    private void assertIndexDoesNotContain(final String resourceId) {
         try {
-            index.getMapping(resource1);
-            fail(resource1 + " should not exist in index");
+            index.getMapping(resourceId);
+            fail(resourceId + " should not exist in index");
         } catch (final FedoraOCFLMappingNotFoundException e) {
             //do nothing - expected
         }
-
-        util.rebuild();
-        assertNotNull(index.getMapping(resource1));
-        assertNotNull(index.getMapping(resource2));
     }
+
+    private void assertIndexContains(final String expectedOcflId, final String resourceId)
+            throws FedoraOCFLMappingNotFoundException {
+        assertEquals(expectedOcflId, index.getMapping(resourceId).getOcflObjectId());
+    }
+
+    private void createResource(final PersistentStorageSession session,
+                                final String resourceId, final boolean isArchivalGroup)
+            throws PersistentStorageException {
+        final var operation = mock(RdfSourceOperation.class, withSettings().extraInterfaces(
+                CreateResourceOperation.class));
+        when(operation.getResourceId()).thenReturn(resourceId);
+        when(operation.getType()).thenReturn(CREATE);
+        when(((CreateResourceOperation)operation).isArchivalGroup()).thenReturn(isArchivalGroup);
+        session.persist(operation);
+    }
+
+    private void createChildResource(final PersistentStorageSession session,
+                                     final String parentId, final String childId)
+            throws PersistentStorageException {
+        final var operation = mock(NonRdfSourceOperation.class, withSettings().extraInterfaces(
+                CreateResourceOperation.class));
+        when(operation.getResourceId()).thenReturn(childId);
+        when(operation.getType()).thenReturn(CREATE);
+        final var bytes = "test".getBytes();
+        final var stream = new ByteArrayInputStream(bytes);
+        when(operation.getContentSize()).thenReturn((long)bytes.length);
+        when(operation.getContentStream()).thenReturn(stream);
+        when(operation.getMimeType()).thenReturn("text/plain");
+        when(operation.getFilename()).thenReturn("test");
+        when(((CreateResourceOperation)operation).getParentId()).thenReturn(parentId);
+        session.persist(operation);
+    }
+
 }


### PR DESCRIPTION
**JIRA Ticket**: [FCREPO-3195](https://jira.lyrasis.org/browse/FCREPO-3195) && [FCREPO-3210](https://jira.lyrasis.org/browse/FCREPO-3210)

# What does this Pull Request do?

Fixes the problem @awoods reported with rebuilds not working correctly due to the difference between the Fedora object id and the OCFL object id. The rebuild logic now does not make any assumptions about the naming of sidecar files. It iterates over each sidecar in an ocfl object, if it discovers the object is an archival group, it updates the index mappings accordingly.

# How should this be tested?

Follow @awoods steps as described in [FCREPO-3210](https://jira.lyrasis.org/browse/FCREPO-3210)

# Interested parties
@awoods @bbpennel @dbernstein 
