### PR TITLE
Enable Windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
-language: java
-sudo: true
 
-dist: trusty
-jdk:
-  - openjdk11
+jobs:
+  include:
+    - os: linux
+      language: java
+      dist: trusty
+      sudo: true
+      jdk: openjdk11
+    - os: windows
+      language: shell
 
-before_install:  
- - "echo $JAVA_OPTS"
+env:
+  - MAVEN_VERSION=3.6.3
+
+before_install:
+ - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+    choco install openjdk11 --version 11.0.5.10;
+    export JAVA_HOME='/c/Program Files/OpenJDK/openjdk-11.0.5_10'
+    export PATH="${PATH}:${JAVA_HOME}/bin";
+    choco install maven --version ${MAVEN_VERSION};
+    export PATH="${PATH}:/c/ProgramData/chocolatey/lib/maven/apache-maven-3.6.3/bin";
+  fi;
+ - "echo $PATH"
  - "export JAVA_OPTS=-Xmx512m"
  - "mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=${MAVEN_VERSION}"
 
@@ -17,18 +31,20 @@ install:
  - true
 
 before_script:
- - sudo service mysql stop
- - sudo service postgresql stop
- - sudo service acpid stop
- - sudo service atd stop
- - sudo service cron stop
- - sudo service memcached stop
- - sudo service ntp stop
- - sudo service rabbitmq-server stop
- - sudo service resolvconf stop
- - sudo service sshguard stop
- - sudo service ssh stop
-
+ - if [ "$TRAVIS_OS_NAME" = "linux" ]; then 
+     sudo service mysql stop;
+     sudo service postgresql stop;
+     sudo service acpid stop;
+     sudo service atd stop;
+     sudo service cron stop;
+     sudo service memcached stop;
+     sudo service ntp stop;
+     sudo service rabbitmq-server stop;
+     sudo service resolvconf stop;
+     sudo service sshguard stop;
+     sudo service ssh stop;
+   fi
+    
 script:
  - ./mvnw -Dfcrepo.streaming.parallel=true install -B -V
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -58,18 +58,20 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
      */
     public FedoraToOCFLObjectIndexImpl() throws IOException {
         if (FEDORA_TO_OCFL_INDEX_FILE.exists() && FEDORA_TO_OCFL_INDEX_FILE.canRead()) {
-            Files.lines(FEDORA_TO_OCFL_INDEX_FILE.toPath()).filter(l -> {
-                final String m = l.split("\t")[0];
-                return (!fedoraOCFLMappingMap.containsKey(m));
-            }).forEach(l -> {
-                final String[] map = l.split("\t");
-                if (map.length == 3) {
-                    final FedoraOCFLMapping ocflMapping = new FedoraOCFLMapping(map[1], map[2]);
-                    fedoraOCFLMappingMap.put(map[0], ocflMapping);
-                } else {
-                    LOGGER.warn("Expected 3 tab-separated values, found {}. Ignoring line.", map.length);
-                }
-            });
+            try (var lines = Files.lines(FEDORA_TO_OCFL_INDEX_FILE.toPath())) {
+               lines.filter(l -> {
+                    final String m = l.split("\t")[0];
+                    return (!fedoraOCFLMappingMap.containsKey(m));
+                }).forEach(l -> {
+                    final String[] map = l.split("\t");
+                    if (map.length == 3) {
+                        final FedoraOCFLMapping ocflMapping = new FedoraOCFLMapping(map[1], map[2]);
+                        fedoraOCFLMappingMap.put(map[0], ocflMapping);
+                    } else {
+                        LOGGER.warn("Expected 3 tab-separated values, found {}. Ignoring line.", map.length);
+                    }
+                });
+            }
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImpl.java
@@ -120,10 +120,10 @@ public class FedoraToOCFLObjectIndexImpl implements FedoraToOCFLObjectIndex {
                     dir.mkdirs();
                 }
             }
-            final BufferedWriter output = new BufferedWriter(new FileWriter(FEDORA_TO_OCFL_INDEX_FILE, true));
-            output.write(String.format("%s\t%s\t%s\n", fedoraId, fedoraOCFLMapping.getRootObjectIdentifier(),
-                    fedoraOCFLMapping.getOcflObjectId()));
-            output.close();
+            try (var fw = new FileWriter(FEDORA_TO_OCFL_INDEX_FILE, true); var output= new BufferedWriter(fw)) {
+                output.write(String.format("%s\t%s\t%s\n", fedoraId, fedoraOCFLMapping.getRootObjectIdentifier(),
+                        fedoraOCFLMapping.getOcflObjectId()));
+            }
         } catch (IOException exception) {
             LOGGER.warn("Unable to create/write on disk FedoraToOCFL Mapping at {}", FEDORA_TO_OCFL_INDEX_FILE);
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -321,7 +321,7 @@ public class OCFLPersistentStorageUtils {
      * @return The path ( including the final slash ) to the internal Fedora directory within an OCFL object.
      */
     public static String getInternalFedoraDirectory() {
-        return INTERNAL_FEDORA_DIRECTORY + File.separator;
+        return INTERNAL_FEDORA_DIRECTORY + "/";
     }
 
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImplTest.java
@@ -137,8 +137,9 @@ public class FedoraToOCFLObjectIndexImplTest {
     }
 
     private void removeIndexMappingFile() {
-        if (FEDORA_TO_OCFL_INDEX_FILE.exists()) {
-            FEDORA_TO_OCFL_INDEX_FILE.delete();
+        if (FEDORA_TO_OCFL_INDEX_FILE.exists() &&
+                !FEDORA_TO_OCFL_INDEX_FILE.delete()) {
+            throw new RuntimeException("Could not delete file " + FEDORA_TO_OCFL_INDEX_FILE);
         }
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/FedoraToOCFLObjectIndexImplTest.java
@@ -101,7 +101,10 @@ public class FedoraToOCFLObjectIndexImplTest {
 
         assertTrue(FEDORA_TO_OCFL_INDEX_FILE.exists());
 
-        final List<String> lines = Files.lines(FEDORA_TO_OCFL_INDEX_FILE.toPath()).collect(Collectors.toList());
+        final List<String> lines;
+        try (var l = Files.lines(FEDORA_TO_OCFL_INDEX_FILE.toPath())) {
+            lines = l.collect(Collectors.toList());
+        }
 
         assertEquals(4, lines.size());
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/MonotonicInstant.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/MonotonicInstant.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import java.time.Instant;
+
+class MonotonicInstant {
+    Instant baseline = Instant.now();
+    int drift;
+
+    Instant next() {
+        return baseline.plusMillis(drift++);
+    }
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -127,6 +127,8 @@ public class OCFLPersistentStorageSessionTest {
 
     private static final String BINARY_CONTENT = "Some test content";
 
+    private MonotonicInstant timestep;
+
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -138,6 +140,7 @@ public class OCFLPersistentStorageSessionTest {
         final var stagingDir = tempFolder.newFolder("ocfl-staging");
         final var repoDir = tempFolder.newFolder("ocfl-repo");
         final var workDir = tempFolder.newFolder("ocfl-work");
+        this.timestep = new MonotonicInstant();
 
         final var repository = createRepository(repoDir, workDir);
         this.objectSessionFactory = new DefaultOCFLObjectSessionFactory(stagingDir);
@@ -384,6 +387,7 @@ public class OCFLPersistentStorageSessionTest {
 
         //get triples should now fail because the session is effectively closed.
         try {
+            System.out.println("Committing session 1");
             session1.commit();
             fail("session1.commit(...) invocation should fail.");
         } catch (final PersistentStorageException ex) {
@@ -395,8 +399,7 @@ public class OCFLPersistentStorageSessionTest {
 
     private void mockOCFLObjectSession(final OCFLObjectSession objectSession, final CommitOption option) {
         when(objectSession.getDefaultCommitOption()).thenReturn(option);
-        when(objectSession.getCreated()).thenReturn(Instant.now());
-
+        when(objectSession.getCreated()).thenReturn(timestep.next());
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -23,10 +23,6 @@ import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
 import static org.fcrepo.persistence.api.CommitOption.UNVERSIONED;
-
-import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
-import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
-
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.createRepository;
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.mintOCFLObjectId;
 import static org.junit.Assert.assertEquals;
@@ -66,6 +62,8 @@ import org.fcrepo.persistence.api.CommitOption;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.WriteOutcome;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 import org.junit.Before;
@@ -387,7 +385,6 @@ public class OCFLPersistentStorageSessionTest {
 
         //get triples should now fail because the session is effectively closed.
         try {
-            System.out.println("Committing session 1");
             session1.commit();
             fail("session1.commit(...) invocation should fail.");
         } catch (final PersistentStorageException ex) {

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
@@ -162,7 +162,8 @@ public class UpdateNonRdfSourcePersisterTest {
 
         assertEquals(NON_RDF_SOURCE.toString(), resultHeaders.getInteractionModel());
         assertEquals(originalCreation, resultHeaders.getCreatedDate());
-        assertTrue(originalModified.isBefore(resultHeaders.getLastModifiedDate()));
+        assertTrue(originalModified + " is not before " + resultHeaders.getLastModifiedDate(),
+                originalModified.isBefore(resultHeaders.getLastModifiedDate()));
 
         assertEquals(LOCAL_CONTENT_SIZE, resultHeaders.getContentSize());
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
@@ -162,8 +162,11 @@ public class UpdateNonRdfSourcePersisterTest {
 
         assertEquals(NON_RDF_SOURCE.toString(), resultHeaders.getInteractionModel());
         assertEquals(originalCreation, resultHeaders.getCreatedDate());
-        assertTrue(originalModified + " is not before " + resultHeaders.getLastModifiedDate(),
-                originalModified.isBefore(resultHeaders.getLastModifiedDate()));
+
+        // The relationship between the actual resource last modified date and the
+        // client-asserted last modified data is unclear.
+        assertTrue(originalModified.equals(resultHeaders.getLastModifiedDate())
+                || originalModified.isBefore(resultHeaders.getLastModifiedDate()));
 
         assertEquals(LOCAL_CONTENT_SIZE, resultHeaders.getContentSize());
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
@@ -158,7 +158,8 @@ public class UpdateRDFSourcePersisterTest {
 
         assertEquals(BASIC_CONTAINER.toString(), resultHeaders.getInteractionModel());
         assertEquals(originalCreation, resultHeaders.getCreatedDate());
-        assertTrue(originalModified.isBefore(resultHeaders.getLastModifiedDate()));
+        assertTrue(originalModified + " is not before " + resultHeaders.getLastModifiedDate(),
+                originalModified.isBefore(resultHeaders.getLastModifiedDate()));
     }
 
     private RdfStream constructTitleStream(final String resourceId, final String title) {

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
@@ -92,7 +92,7 @@ public class UpdateRDFSourcePersisterTest {
     @Mock
     private FedoraToOCFLObjectIndex index;
 
-   @Mock
+    @Mock
     private OCFLPersistentStorageSession psSession;
 
     @Mock
@@ -158,8 +158,10 @@ public class UpdateRDFSourcePersisterTest {
 
         assertEquals(BASIC_CONTAINER.toString(), resultHeaders.getInteractionModel());
         assertEquals(originalCreation, resultHeaders.getCreatedDate());
-        assertTrue(originalModified + " is not before " + resultHeaders.getLastModifiedDate(),
-                originalModified.isBefore(resultHeaders.getLastModifiedDate()));
+        // The relationship between the actual resource last modified date and the
+        // client-asserted last modified data is unclear.
+        assertTrue(originalModified.equals(resultHeaders.getLastModifiedDate())
+                || originalModified.isBefore(resultHeaders.getLastModifiedDate()));
     }
 
     private RdfStream constructTitleStream(final String resourceId, final String title) {


### PR DESCRIPTION
**JIRA Ticket**: N/A

# What does this Pull Request do?
* Configures Travis to perform a Windows build
* Fixes numerous file closing bugs that caused problems in WIndows
* Modifies tests that have assumptions about monotonically increasing dates/times.  Some servers apparently have coarse-grained clocks, so subsequent invocations of Instant.now() may produce equal values if they occur within the same "clock tick".

# What's new?
The most notable changes relate to tests that involve the ordering of time instants.  In some cases, ordering based on time is needed specifically to support tests, e.g. [here](https://github.com/birkland/fcrepo4/blob/windows-build/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java#L288).  In other cases, [it's not exactly clear](https://github.com/birkland/fcrepo4/blob/windows-build/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java#L161-L164), and I changed test logic to compare dates as `<=` instead of `<` to get the test to pass (but unable to determine the reason for the assertion in the first place)

# How should this be tested?

Try building on Windows, if you have it.  Otherwise, just watch what Travis does

# Interested parties
@awoods @whikloj 