### PR TITLE
Translate internal IDs to external URIs for GET

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static java.net.URI.create;
 import static java.text.MessageFormat.format;
 import static java.util.stream.Collectors.toSet;
-import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.empty;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CACHE_CONTROL;
@@ -237,19 +236,15 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * This method returns an HTTP response with content body appropriate to the following arguments.
      *
      * @param limit is the number of child resources returned in the response, -1 for all
-     * @param rdfStream to which response RDF will be concatenated
      * @param resource the fedora resource
      * @return HTTP response
      * @throws IOException in case of error extracting content
      */
-    protected Response getContent(final int limit,
-                                  final RdfStream rdfStream,
-                                  final FedoraResource resource) throws IOException {
-
+    protected Response getContent(final int limit, final FedoraResource resource) throws IOException {
+        final RdfStream rdfStream = httpRdfService.bodyToExternalStream(getUri(resource()).toString(),
+                getResourceTriples(limit, resource), identifierConverter());
         final var outputStream = new RdfNamespacedStream(
-                    new DefaultRdfStream(rdfStream.topic(), concat(rdfStream,
-                        getResourceTriples(limit, resource))),
-                    namespaceRegistry.getNamespaces());
+                    rdfStream, namespaceRegistry.getNamespaces());
         setVaryAndPreferenceAppliedHeaders(servletResponse, prefer, resource);
         return ok(outputStream).build();
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -266,12 +266,9 @@ public class FedoraAcl extends ContentExposingResource {
         checkCacheControlHeaders(request, servletResponse, aclResource, transaction);
 
         LOGGER.info("GET resource '{}'", externalPath);
-        try (final RdfStream rdfStream = new DefaultRdfStream(asNode(aclResource))) {
+        addResourceHttpHeaders(aclResource);
+        return getContent(getChildrenLimit(), aclResource);
 
-            addResourceHttpHeaders(aclResource);
-            return getContent(getChildrenLimit(), rdfStream, aclResource);
-
-        }
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -297,9 +297,7 @@ public class FedoraLdp extends ContentExposingResource {
                 return getBinaryContent(rangeValue, binary);
             }
         } else {
-            try (final var rdfStream = new DefaultRdfStream(asNode(resource()))) {
-                return getContent(getChildrenLimit(), rdfStream, resource());
-            }
+            return getContent(getChildrenLimit(), resource());
         }
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -71,7 +71,6 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.jena.riot.Lang;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.LinkFormatStream;
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.ItemExistsException;
 import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
@@ -79,7 +78,6 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
 
@@ -296,9 +294,7 @@ public class FedoraVersioning extends ContentExposingResource {
             versionLinks.add(linkBuilder.build());
             return ok(new LinkFormatStream(versionLinks.stream())).build();
         } else {
-            try (final RdfStream rdfStream = new DefaultRdfStream(asNode(theTimeMap))) {
-                return getContent(getChildrenLimit(), rdfStream, theTimeMap);
-            }
+            return getContent(getChildrenLimit(), theTimeMap);
         }
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -40,7 +40,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -50,6 +49,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
@@ -57,7 +57,6 @@ import javax.ws.rs.ext.Provider;
 import com.google.common.collect.ImmutableMap;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -65,17 +64,18 @@ import org.apache.velocity.context.Context;
 import org.apache.velocity.tools.generic.EscapeTool;
 import org.apache.velocity.tools.generic.FieldTool;
 import org.fcrepo.http.api.FedoraLdp;
-import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.http.commons.responses.ViewHelpers;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.RdfLexicon;
 import org.fcrepo.kernel.api.TransactionManager;
-import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.glassfish.jersey.uri.UriTemplate;
+import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.slf4j.Logger;
 
 /**
@@ -99,13 +99,25 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
     @Inject
     HttpServletRequest request;
 
+    @Inject
+    private ResourceFactory resourceFactory;
+
+    private HttpIdentifierConverter identifierConverter;
+
     private Transaction transaction() {
-        return transactionManager.get(request.getHeader(ATOMIC_ID_HEADER));
+        if (request.getHeader(ATOMIC_ID_HEADER) != null) {
+            return transactionManager.get(request.getHeader(ATOMIC_ID_HEADER));
+        }
+        return null;
     }
 
-    private IdentifierConverter<Resource, FedoraResource> translator() {
-        return new HttpResourceConverter(transaction(),
-                uriInfo.getBaseUriBuilder().clone().path(FedoraLdp.class));
+    private HttpIdentifierConverter identifierConverter() {
+        if (identifierConverter == null) {
+            final UriBuilder uriBuilder =
+                    uriInfo.getBaseUriBuilder().clone().path(FedoraLdp.class);
+            identifierConverter = new HttpIdentifierConverter(uriBuilder);
+        }
+        return identifierConverter;
     }
 
     private static final EscapeTool escapeTool = new EscapeTool();
@@ -210,18 +222,18 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
      * @return FedoraResource if exists or null
      */
     private FedoraResource getResourceFromSubject(final String subjectUri) {
-        final UriTemplate uriTemplate =
-            new UriTemplate(uriInfo.getBaseUriBuilder().clone().path(FedoraLdp.class).toTemplate());
-        final Map<String, String> values = new HashMap<>();
-        uriTemplate.match(subjectUri, values);
-        if (values.containsKey("path")) {
-            try {
-                return translator().convert(translator().toDomain(values.get("path")));
-            } catch (final RuntimeException e) {
-                throw e;
+
+        try {
+            if (transaction() == null) {
+                return resourceFactory.getResource(
+                        identifierConverter().toInternalId(subjectUri));
+            } else {
+                return resourceFactory.getResource(transaction(),
+                        identifierConverter().toInternalId(subjectUri));
             }
+        } catch (final PathNotFoundException e) {
+            throw new RepositoryRuntimeException(e);
         }
-        return null;
     }
 
     private Context getContext(final Model model, final Node subject) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3161

# What does this Pull Request do?
Translates internal Fedora IDs back into external URIs when GETting a resource.

# What's new?
* Adds new translation function to the HttpRdfService.
* Modifies the `getContent` service to remove the RdfStream argument (as it was always an empty stream anyways)
* Modifies the `getResource` function in the StreamingHtmlProvider to properly get the resource.

# How should this be tested?

Before the PR
1. PUT a resource.
1. GET the resource
1. Notice the address has the form "info:fedora/XXXX"

Build this PR
1. PUT a resource.
1. GET the resource
1. Notice the address has the form "http://localhost:8080/(fcrepo)/rest/XXXX"

# Interested parties
@fcrepo4/committers
