### PR TITLE
implemented the listing of resource versions

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -77,6 +77,7 @@ import static org.fcrepo.kernel.api.models.ExternalContent.COPY;
 import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
 import static org.fcrepo.kernel.api.models.ExternalContent.REDIRECT;
 import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
+import org.fcrepo.kernel.api.utils.FedoraResourceIdConverter;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -434,7 +435,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     protected URI getUri(final FedoraResource resource) {
         try {
-            final String uri = identifierConverter().toExternalId(resource.getId());
+            final String uri = identifierConverter()
+                    .toExternalId(FedoraResourceIdConverter.resolveFedoraId(resource));
             return new URI(uri);
         } catch (final URISyntaxException e) {
             throw new BadRequestException(e);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -260,7 +260,7 @@ public class FedoraAcl extends ContentExposingResource {
                 return ok(output).build();
             }
 
-            throw new ItemNotFoundException("not found");
+            throw new ItemNotFoundException(String.format("No ACL found at %s", externalPath));
         }
 
         checkCacheControlHeaders(request, servletResponse, aclResource, transaction);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -282,16 +282,16 @@ public class FedoraVersioning extends ContentExposingResource {
                                      .build());
             });
             // Based on the dates of the above mementos, add the range to the below link.
-            final Instant[] Mementos = Arrays.stream(children).map(FedoraResource::getMementoDatetime)
+            final Instant[] mementos = Arrays.stream(children).map(FedoraResource::getMementoDatetime)
                 .sorted(Comparator.naturalOrder())
                 .toArray(Instant[]::new);
             final Builder linkBuilder =
                 Link.fromUri(parentUri + "/" + FCR_VERSIONS).rel("self").type(APPLICATION_LINK_FORMAT);
-            if (Mementos.length >= 2) {
+            if (mementos.length >= 2) {
                 // There are 2 or more Mementos so make a range.
-                linkBuilder.param("from", MEMENTO_RFC_1123_FORMATTER.format(Mementos[0].atZone(ZoneId.of("UTC"))));
+                linkBuilder.param("from", MEMENTO_RFC_1123_FORMATTER.format(mementos[0].atZone(ZoneId.of("UTC"))));
                 linkBuilder.param("until",
-                    MEMENTO_RFC_1123_FORMATTER.format(Mementos[Mementos.length - 1].atZone(ZoneId.of("UTC"))));
+                    MEMENTO_RFC_1123_FORMATTER.format(mementos[mementos.length - 1].atZone(ZoneId.of("UTC"))));
             }
             versionLinks.add(linkBuilder.build());
             return ok(new LinkFormatStream(versionLinks.stream())).build();

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -17,18 +17,17 @@
  */
 package org.fcrepo.http.commons.api.rdf;
 
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
-import static org.slf4j.LoggerFactory.getLogger;
-
 import org.glassfish.jersey.uri.UriTemplate;
 import org.slf4j.Logger;
 
 import javax.ws.rs.core.UriBuilder;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Convert between HTTP URIs (LDP paths) and internal Fedora ID using a
@@ -67,6 +66,10 @@ public class HttpIdentifierConverter {
         return internalUri;
     }
 
+    private static String trimTrailingSlashes(final String string) {
+        return string.replaceAll("/+$", "");
+    }
+
     /**
      * Create a new identifier converter within the given session with the given URI template
      * @param uriBuilder the uri builder
@@ -101,7 +104,7 @@ public class HttpIdentifierConverter {
         if (path != null) {
 
             // Take the URL and remove any hash uris, or fcr: endpoints.
-            final String fedoraId = truncateSuffixes(path);
+            final String fedoraId = trimTrailingSlashes(truncateSuffixes(path));
 
             return FEDORA_ID_PREFIX + fedoraId.replaceFirst("\\/", "");
         }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.fcrepo.kernel.api.exception.ItemNotFoundException;
+import org.slf4j.Logger;
+
+
+/**
+ * Catch ItemNotFoundException
+ *
+ * @author pwinckles
+ */
+@Provider
+public class ItemNotFoundExceptionMapper implements
+        ExceptionMapper<ItemNotFoundException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER =
+        getLogger(ItemNotFoundExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final ItemNotFoundException e) {
+
+        LOGGER.debug("Exception intercepted by ItemNotFoundExceptionMapper: {}\n", e.getMessage());
+        debugException(this, e, LOGGER);
+        return Response.status(Response.Status.NOT_FOUND).
+                entity("Error: " + e.getMessage()).build();
+    }
+}
+

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapper.java
@@ -56,9 +56,12 @@ public class RepositoryRuntimeExceptionMapper implements
     @Override
     public Response toResponse(final RepositoryRuntimeException e) {
         final Throwable cause = e.getCause();
-        @SuppressWarnings("unchecked")
-        final ExceptionMapper<Throwable> exceptionMapper =
-                (ExceptionMapper<Throwable>) providers.getExceptionMapper(cause.getClass());
+        ExceptionMapper<Throwable> exceptionMapper = null;
+
+        if (cause != null) {
+            exceptionMapper = providers.getExceptionMapper((Class<Throwable>) cause.getClass());
+        }
+
         if (exceptionMapper != null) {
             return exceptionMapper.toResponse(cause);
         }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapperTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.core.Response;
+import org.fcrepo.kernel.api.exception.ItemNotFoundException;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * ItemNotFoundExceptionMapperTest class.
+ *
+ * @author pwinckles
+ */
+public class ItemNotFoundExceptionMapperTest {
+
+    private ItemNotFoundExceptionMapper testObj;
+
+    @Before
+    public void setUp() {
+        testObj = new ItemNotFoundExceptionMapper();
+    }
+
+    @Test
+    public void testToResponse() {
+        final ItemNotFoundException input = new ItemNotFoundException("xyz");
+        final Response actual = testObj.toResponse(input);
+        assertEquals(NOT_FOUND.getStatusCode(), actual.getStatus());
+        assertEquals(actual.getEntity(), "Error: xyz");
+    }
+}

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapperTest.java
@@ -69,4 +69,12 @@ public class RepositoryRuntimeExceptionMapperTest {
         final Response response = testObj.toResponse(ex);
         assertEquals(500, response.getStatus());
     }
+
+    @Test
+    public void testToResponseWithNoWrappedException() {
+        when(mockProviders.getExceptionMapper(Exception.class)).thenReturn(null);
+        final RepositoryRuntimeException ex = new RepositoryRuntimeException("!");
+        final Response response = testObj.toResponse(ex);
+        assertEquals(500, response.getStatus());
+    }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -133,6 +133,8 @@ public final class RdfLexicon {
             createResource(REPOSITORY_NAMESPACE + "Pairtree");
     public static final Resource ARCHIVAL_GROUP =
             createResource(REPOSITORY_NAMESPACE + "ArchivalGroup");
+    public static final Resource TIME_MAP =
+            createResource(REPOSITORY_NAMESPACE + "TimeMap");
 
     // Linked Data Platform
     public static final Property PAGE =
@@ -267,6 +269,7 @@ public final class RdfLexicon {
      * Memento TimeMap type.
      */
     public static final String VERSIONING_TIMEMAP_TYPE = MEMENTO_NAMESPACE + "TimeMap";
+    public static final Resource VERSIONING_TIMEMAP = createResource(VERSIONING_TIMEMAP_TYPE);
 
     /**
      * Memento TimeGate type.
@@ -283,6 +286,9 @@ public final class RdfLexicon {
      */
     public static final Resource VERSIONED_RESOURCE =
         createResource(MEMENTO_NAMESPACE + "OriginalResource");
+
+    public static final Property MEMENTO_ORIGINAL_RESOURCE =
+        createProperty(MEMENTO_NAMESPACE + "original");
 
     /*
      * Interaction Models.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
@@ -52,6 +52,18 @@ public interface ResourceFactory {
             throws PathNotFoundException;
 
     /**
+     * Get a FedoraResource for existing resource
+     *
+     * @param transaction The transaction this request is part of.
+     * @param identifier The path or identifier for the resource.
+     * @param version The version datetime or null for head.
+     * @return The resource.
+     * @throws PathNotFoundException If the identifier cannot be found.
+     */
+    public FedoraResource getResource(final Transaction transaction, final String identifier, final Instant version)
+            throws PathNotFoundException;
+
+    /**
      * Get a resource as a particular type without a transaction
      *
      * @param <T> type for the resource
@@ -62,6 +74,20 @@ public interface ResourceFactory {
      */
     public <T extends FedoraResource> T getResource(final String identifier,
             final Class<T> clazz) throws PathNotFoundException;
+
+    /**
+     * Get a resource as a particular type
+     *
+     * @param <T> type for the resource
+     * @param transaction The transaction this request is part of.
+     * @param identifier The path or identifier for the resource.
+     * @param version The version datetime or null for head.
+     * @param clazz class the resource will be cast to
+     * @return The resource.
+     * @throws PathNotFoundException If the identifier cannot be found.
+     */
+    public <T extends FedoraResource> T getResource(final Transaction transaction, final String identifier,
+            final Instant version, final Class<T> clazz) throws PathNotFoundException;
 
     /**
      * Get a resource as a particular type

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/FedoraResourceIdConverter.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/FedoraResourceIdConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.utils;
+
+import org.fcrepo.kernel.api.FedoraTypes;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.TimeMap;
+import org.fcrepo.kernel.api.services.VersionService;
+
+/**
+ * Converts an internal Fedora Resource ID into and internal ID that includes suffixes, such as "fcr:versions".
+ */
+public final class FedoraResourceIdConverter {
+
+    private FedoraResourceIdConverter() {
+
+    }
+
+    /**
+     * Converts an internal Fedora Resource ID into an internal ID that includes suffixes, such as "fcr:versions".
+     * If no suffixes are needed, the internal ID is returned unchanged.
+     *
+     * @param resource the Fedora Resource
+     * @return internal id with suffixes
+     */
+    public static String resolveFedoraId(final FedoraResource resource) {
+        if (resource instanceof TimeMap) {
+            return resource.getId() + "/" + FedoraTypes.FCR_VERSIONS;
+        } else if (resource.isMemento()) {
+            return resource.getId() + "/" +
+                    FedoraTypes.FCR_VERSIONS + "/" +
+                    VersionService.MEMENTO_LABEL_FORMATTER.format(resource.getMementoDatetime());
+        }
+        return resource.getId();
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/FedoraResourceIdConverter.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/FedoraResourceIdConverter.java
@@ -28,7 +28,7 @@ import org.fcrepo.kernel.api.services.VersionService;
 public final class FedoraResourceIdConverter {
 
     private FedoraResourceIdConverter() {
-
+        // Intentionally left blank
     }
 
     /**

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/FedoraResourceIdConverterTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/FedoraResourceIdConverterTest.java
@@ -18,6 +18,8 @@
 package org.fcrepo.kernel.api.utils;
 
 import java.time.Instant;
+
+import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -31,7 +33,7 @@ import static org.mockito.Mockito.when;
 public class FedoraResourceIdConverterTest {
 
     private final String id = "fedora:info/test-id";
-    private final String fcrVersions = "/fcr:versions";
+    private final String fcrVersions = "/" + FedoraTypes.FCR_VERSIONS;
 
     @Test
     public void doNotChangeIdWhenNotATimeMap() {

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/FedoraResourceIdConverterTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/FedoraResourceIdConverterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.utils;
+
+import java.time.Instant;
+import org.fcrepo.kernel.api.models.Binary;
+import org.fcrepo.kernel.api.models.Container;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.TimeMap;
+import org.fcrepo.kernel.api.services.VersionService;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FedoraResourceIdConverterTest {
+
+    private final String id = "fedora:info/test-id";
+    private final String fcrVersions = "/fcr:versions";
+
+    @Test
+    public void doNotChangeIdWhenNotATimeMap() {
+        final var resolvedId = FedoraResourceIdConverter.resolveFedoraId(resource(id, Container.class));
+        assertEquals(id, resolvedId);
+    }
+
+    @Test
+    public void changeIdWhenTimeMap() {
+        final var resolvedId = FedoraResourceIdConverter.resolveFedoraId(resource(id, TimeMap.class));
+        assertEquals(id + fcrVersions, resolvedId);
+    }
+
+    @Test
+    public void changeIdWhenMemento() {
+        final var timestamp = "20200226183405";
+        final var now = Instant.from(VersionService.MEMENTO_LABEL_FORMATTER.parse(timestamp));
+        final var resource = memento(id, now, Binary.class);
+
+        final var resolvedId = FedoraResourceIdConverter.resolveFedoraId(resource);
+        assertEquals(id + fcrVersions + "/" + timestamp, resolvedId);
+    }
+
+    private <T extends FedoraResource> T memento(final String resourceId, final Instant instant, final Class<T> clazz) {
+        final var mock = mock(clazz);
+        when(mock.getId()).thenReturn(resourceId);
+        when(mock.isMemento()).thenReturn(true);
+        when(mock.getMementoDatetime()).thenReturn(instant);
+        return mock;
+    }
+
+    private <T extends FedoraResource> T resource(final String resourceId, final Class<T> clazz) {
+        final var mock = mock(clazz);
+        when(mock.getId()).thenReturn(resourceId);
+        when(mock.isMemento()).thenReturn(false);
+        return mock;
+    }
+
+}

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -58,6 +58,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -151,7 +151,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
      *
      * @param transaction the transaction
      * @param identifier identifier for the new instance
-     * @param version The version datetime or null for head.
+     * @param version The version datetime or null for head
      * @return new FedoraResource instance
      * @throws PathNotFoundException
      */
@@ -196,6 +196,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
         resc.setEtag(headers.getStateToken());
         resc.setStateToken(headers.getStateToken());
 
+        // If there's a version, then it's a memento
         if (version != null) {
             resc.setIsMemento(true);
             resc.setMementoDatetime(version);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.models;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.impl.StatementImpl;
+import org.fcrepo.kernel.api.RdfLexicon;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.exception.ItemNotFoundException;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.TimeMap;
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+import org.fcrepo.kernel.api.utils.FedoraResourceIdConverter;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+
+/**
+ * FedoraResource implementation that represents a Memento TimeMap of the base resource.
+ */
+public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
+
+    private static final List<URI> TYPES = List.of(
+            URI.create(RdfLexicon.TIME_MAP.getURI()),
+            URI.create(RdfLexicon.VERSIONING_TIMEMAP.getURI())
+    );
+
+    private final FedoraResource parent;
+    private List<Instant> versions;
+
+    protected TimeMapImpl(
+            final FedoraResource parent,
+            final Transaction tx,
+            final PersistentStorageSessionManager pSessionManager,
+            final ResourceFactory resourceFactory) {
+        super(parent.getId(), tx, pSessionManager, resourceFactory);
+
+        this.parent = parent;
+        setCreatedBy(parent.getCreatedBy());
+        setCreatedDate(parent.getCreatedDate());
+        setLastModifiedBy(parent.getLastModifiedBy());
+        setLastModifiedDate(parent.getLastModifiedDate());
+        setParentId(parent.getId());
+        setEtag(parent.getEtagValue());
+        setStateToken(parent.getStateToken());
+        setTypes(TYPES);
+    }
+
+    @Override
+    public RdfStream getTriples() {
+        final var timeMapResource = asResource(this);
+        final var model = ModelFactory.createDefaultModel();
+        model.add(new StatementImpl(timeMapResource, RdfLexicon.MEMENTO_ORIGINAL_RESOURCE,
+                asResource(getOriginalResource())));
+        getChildren().map(this::asResource).forEach(child -> {
+            model.add(new StatementImpl(timeMapResource, RdfLexicon.CONTAINS, child));
+        });
+        return DefaultRdfStream.fromModel(timeMapResource.asNode(), model);
+    }
+
+    @Override
+    public Stream<FedoraResource> getChildren(final Boolean recursive) {
+        return getVersions().stream().map(version -> {
+            try {
+                return resourceFactory.getResource(tx, getId(), version);
+            } catch (PathNotFoundException e) {
+                throw new PathNotFoundRuntimeException(e);
+            }
+        });
+    }
+
+    @Override
+    public FedoraResource getOriginalResource() {
+        return parent;
+    }
+
+    @Override
+    public FedoraResource getTimeMap() {
+        return this;
+    }
+
+    private List<Instant> getVersions() {
+        if (versions == null) {
+            try {
+                versions = getSession().listVersions(getId());
+            } catch (final PersistentItemNotFoundException e) {
+                throw new ItemNotFoundException("Unable to retrieve versions for " + getId(), e);
+            } catch (final PersistentStorageException e) {
+                throw new RepositoryRuntimeException(e);
+            }
+        }
+        return versions;
+    }
+
+    private Resource asResource(final FedoraResource fedoraResource) {
+        return org.apache.jena.rdf.model.ResourceFactory.createResource(
+                FedoraResourceIdConverter.resolveFedoraId(fedoraResource));
+    }
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -50,24 +50,24 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
             URI.create(RdfLexicon.VERSIONING_TIMEMAP.getURI())
     );
 
-    private final FedoraResource parent;
+    private final FedoraResource originalResource;
     private List<Instant> versions;
 
     protected TimeMapImpl(
-            final FedoraResource parent,
+            final FedoraResource originalResource,
             final Transaction tx,
             final PersistentStorageSessionManager pSessionManager,
             final ResourceFactory resourceFactory) {
-        super(parent.getId(), tx, pSessionManager, resourceFactory);
+        super(originalResource.getId(), tx, pSessionManager, resourceFactory);
 
-        this.parent = parent;
-        setCreatedBy(parent.getCreatedBy());
-        setCreatedDate(parent.getCreatedDate());
-        setLastModifiedBy(parent.getLastModifiedBy());
-        setLastModifiedDate(parent.getLastModifiedDate());
-        setParentId(parent.getId());
-        setEtag(parent.getEtagValue());
-        setStateToken(parent.getStateToken());
+        this.originalResource = originalResource;
+        setCreatedBy(originalResource.getCreatedBy());
+        setCreatedDate(originalResource.getCreatedDate());
+        setLastModifiedBy(originalResource.getLastModifiedBy());
+        setLastModifiedDate(originalResource.getLastModifiedDate());
+        setParentId(originalResource.getId());
+        setEtag(originalResource.getEtagValue());
+        setStateToken(originalResource.getStateToken());
         setTypes(TYPES);
     }
 
@@ -96,7 +96,7 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
 
     @Override
     public FedoraResource getOriginalResource() {
-        return parent;
+        return originalResource;
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -21,6 +21,7 @@ import org.apache.jena.graph.Triple;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.ManagedPropertiesService;
+import org.fcrepo.kernel.api.utils.FedoraResourceIdConverter;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -45,7 +46,7 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
     @Override
     public Stream<Triple> get(final FedoraResource resource) {
         final List<Triple> triples = new ArrayList<>();
-        final var subject = createURI(resource.getId());
+        final var subject = createURI(FedoraResourceIdConverter.resolveFedoraId(resource));
         triples.add(Triple.create(subject, CREATED_DATE.asNode(),
                 createLiteral(resource.getCreatedDate().toString())));
         triples.add(Triple.create(subject, LAST_MODIFIED_DATE.asNode(),

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.models;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.fcrepo.kernel.api.RdfLexicon;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.services.VersionService;
+import org.fcrepo.kernel.api.utils.FedoraResourceIdConverter;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TimeMapImplTest {
+
+    @Mock
+    private PersistentStorageSessionManager sessionManager;
+
+    @Mock
+    private PersistentStorageSession session;
+
+    @Mock
+    private ResourceFactory resourceFactory;
+
+    private final String defaultId = "fedora:info/resource";
+
+    private TimeMapImpl timeMap;
+
+    @Before
+    public void setup() {
+        timeMap = createTimeMap(defaultId);
+
+        when(sessionManager.getReadOnlySession()).thenReturn(session);
+    }
+
+    @Test
+    public void copyParentPropsWhenCreatingTimeMap() {
+        final var parent = createParent("fedora:info/id");
+        final var timeMap = new TimeMapImpl(parent, null, sessionManager, resourceFactory);
+
+        assertEquals(parent.getId(), timeMap.getId());
+        assertEquals(parent.getCreatedBy(), timeMap.getCreatedBy());
+        assertEquals(parent.getCreatedDate(), timeMap.getCreatedDate());
+        assertEquals(parent.getLastModifiedBy(), timeMap.getLastModifiedBy());
+        assertEquals(parent.getLastModifiedDate(), timeMap.getLastModifiedDate());
+        assertEquals(parent.getEtagValue(), timeMap.getEtagValue());
+        assertEquals(parent.getStateToken(), timeMap.getStateToken());
+        assertSame(parent, timeMap.getOriginalResource());
+        assertSame(timeMap, timeMap.getTimeMap());
+    }
+
+    @Test
+    public void shouldHaveTimeMapTypes() {
+        assertThat(timeMap.getTypes(), contains(
+                URI.create(RdfLexicon.TIME_MAP.getURI()),
+                URI.create(RdfLexicon.VERSIONING_TIMEMAP.getURI())));
+    }
+
+    @Test
+    public void returnChildMementosWhenExist() throws PersistentStorageException, PathNotFoundException {
+        final var version1 = instant("20200225131900");
+        final var version2 = instant("20200226131900");
+
+        mockListVersions(defaultId, version1, version2);
+
+        final var children = timeMap.getChildren();
+
+        assertThat(children.map(FedoraResource::getMementoDatetime)
+                .collect(Collectors.toList()), contains(version1, version2));
+    }
+
+    @Test
+    public void returnNoMementosWhenNoneExist() throws PersistentStorageException, PathNotFoundException {
+        mockListVersions(defaultId);
+
+        final var children = timeMap.getChildren();
+
+        assertEquals(0, children.count());
+    }
+
+    @Test
+    public void returnTriples() throws PersistentStorageException, PathNotFoundException {
+        final var version1 = instant("20200225131900");
+        final var version2 = instant("20200226131900");
+
+        final var mementos = mockListVersions(defaultId, version1, version2);
+
+        final var triples = timeMap.getTriples();
+
+        final var timeMapUri = node(timeMap);
+
+        assertThat(triples.collect(Collectors.toList()), contains(
+                Triple.create(timeMapUri, RdfLexicon.CONTAINS.asNode(), node(mementos.get(1))),
+                Triple.create(timeMapUri, RdfLexicon.CONTAINS.asNode(), node(mementos.get(0))),
+                Triple.create(timeMapUri, RdfLexicon.MEMENTO_ORIGINAL_RESOURCE.asNode(),
+                        NodeFactory.createURI(defaultId))));
+    }
+
+    private List<FedoraResource> mockListVersions(final String id, final Instant... versions)
+            throws PersistentStorageException, PathNotFoundException {
+        if (versions.length == 0) {
+            when(session.listVersions(id)).thenReturn(Collections.emptyList());
+        } else {
+            when(session.listVersions(id)).thenReturn(List.of(versions));
+        }
+
+        final var mementos = new ArrayList<FedoraResource>();
+
+        for (var version : versions) {
+            final var memento = createMemento(id, version);
+            mementos.add(memento);
+            when(resourceFactory.getResource(null, id, version)).thenReturn(memento);
+        }
+
+        return mementos;
+    }
+
+    private Node node(final FedoraResource memento) {
+        return NodeFactory.createURI(FedoraResourceIdConverter.resolveFedoraId(memento));
+    }
+
+    private Instant instant(final String instantStr) {
+        return Instant.from(VersionService.MEMENTO_LABEL_FORMATTER.parse(instantStr));
+    }
+
+    private FedoraResource createMemento(final String id, final Instant version) {
+        final var mock = mock(FedoraResource.class);
+        when(mock.getId()).thenReturn(id);
+        when(mock.isMemento()).thenReturn(true);
+        when(mock.getMementoDatetime()).thenReturn(version);
+        return mock;
+    }
+
+    private TimeMapImpl createTimeMap(final String id) {
+        return new TimeMapImpl(createParent(id), null, sessionManager, resourceFactory);
+    }
+
+    private FedoraResource createParent(final String id) {
+        final var parent = new ContainerImpl(id, null, sessionManager, resourceFactory);
+
+        parent.setCreatedBy("createdBy");
+        parent.setCreatedDate(Instant.now());
+        parent.setLastModifiedBy("modifiedBy");
+        parent.setLastModifiedDate(Instant.now());
+        parent.setEtag("etag");
+        parent.setStateToken("stateToken");
+
+        return parent;
+    }
+
+}

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
@@ -19,6 +19,7 @@ package org.fcrepo.persistence.api;
 
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.List;
 
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
@@ -83,6 +84,16 @@ public interface PersistentStorageSession {
      * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
     public InputStream getBinaryContent(final String identifier, final Instant version)
+            throws PersistentStorageException;
+
+    /**
+     * Returns a list of immutable versions associated with the specified fedora identifier
+     *
+     * @param identifier identifier for the resource.
+     * @return The list of instants that map to the underlying versions
+     * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
+     */
+    List<Instant> listVersions(final String identifier)
             throws PersistentStorageException;
 
     /**

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -18,15 +18,14 @@
 
 package org.fcrepo.persistence.ocfl.api;
 
+import org.fcrepo.persistence.api.CommitOption;
+import org.fcrepo.persistence.api.WriteOutcome;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
-
-import edu.wisc.library.ocfl.api.model.VersionDetails;
-import org.fcrepo.persistence.api.CommitOption;
-import org.fcrepo.persistence.api.WriteOutcome;
-import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 /**
  * A session for building and tracking the state of an OCFL object within a persistence session.
@@ -112,14 +111,24 @@ public interface OCFLObjectSession {
      */
     void close() throws PersistentStorageException;
 
-
     /**
      * Return the list of immutable versions associated with this OCFL Object in chronological order.
      * @return The list of versions
      * @throws PersistentStorageException If the versions cannot be read due to the underlying session being closed
      *                                    or for some other reason.
      */
-    List<VersionDetails> listVersions() throws PersistentStorageException;
+    List<OCFLVersion> listVersions() throws PersistentStorageException;
+
+    /**
+     * Return the list of immutable versions associated with this OCFL Object subpath in chronological order. Only
+     * versions where the subpath changed are returned.
+     *
+     * @param subpath path relative to the object; if the subpath is blank all of the object versions are listed
+     * @return The list of versions
+     * @throws PersistentStorageException If the versions cannot be read due to the underlying session being closed
+     *                                    or for some other reason.
+     */
+    List<OCFLVersion> listVersions(String subpath) throws PersistentStorageException;
 
     /**
      * The instant at which the session was created.

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLVersion.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLVersion.java
@@ -25,7 +25,7 @@ import java.time.Instant;
 public interface OCFLVersion {
 
     /**
-     * @return the OFCL object i
+     * @return the OFCL object id
      */
     String getOcflObjectId();
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLVersion.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLVersion.java
@@ -15,35 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.persistence.api.exceptions;
+package org.fcrepo.persistence.ocfl.api;
+
+import java.time.Instant;
 
 /**
- * If an item is not found in the storage.
- *
- * @author whikloj
- * @since 2019-09-24
+ * Contains details about an OCFL version
  */
-public class PersistentItemNotFoundException extends PersistentStorageException {
-
-    private static final long serialVersionUID = 1L;
+public interface OCFLVersion {
 
     /**
-     * Basic constructor
-     *
-     * @param msg The text of the exception.
+     * @return the OFCL object i
      */
-    public PersistentItemNotFoundException(final String msg) {
-        super(msg);
-    }
+    String getOcflObjectId();
 
     /**
-     * Constructor
-     *
-     * @param msg message
-     * @param e cause
+     * @return the OCFL version id
      */
-    public PersistentItemNotFoundException(final String msg, final Throwable e) {
-        super(msg, e);
-    }
+    String getOcflVersionId();
+
+    /**
+     * @return the instant, second granularity, the version was created
+     */
+    Instant getCreated();
+
+    /**
+     * @return who created the version; may be null
+     */
+    String getCreatedBy();
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -33,6 +33,7 @@ import org.fcrepo.persistence.api.WriteOutcome;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.fcrepo.persistence.ocfl.api.OCFLVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,17 +85,27 @@ public class OCFLPersistentStorageUtils {
     private static final String FEDORA_METADATA_SUFFIX = "/" + FedoraTypes.FCR_METADATA;
 
     /**
-     * Returns the relative subpath of the resourceId based on the root object's resource id.
+     * Maps a Fedora resource id to a subpath and then converts it into an OCFL subpath. This method
+     * is a wrapper around {@link #relativizeSubpath} and {@link #resolveOCFLSubpath}.
      *
      * @param rootFedoraObjectId The fedora root object identifier
      * @param fedoraResourceId   The identifier of the resource whose subpath you wish to resolve.
+     * @return The resolved OCFL subpath
+     */
+    public static String resovleOCFLSubpathFromResourceId(final String rootFedoraObjectId,
+                                                          final String fedoraResourceId) {
+        final var fedoraSubpath = relativizeSubpath(rootFedoraObjectId, fedoraResourceId);
+        return resolveOCFLSubpath(rootFedoraObjectId, fedoraSubpath);
+    }
+
+    /**
+     * Returns the relative subpath of the resourceId based on the root object's resource id.
+     *
+     * @param rootObjectId The fedora root object identifier
+     * @param resourceId   The identifier of the resource whose subpath you wish to resolve.
      * @return The resolved subpath
      */
-    public static String relativizeSubpath(final String rootFedoraObjectId, final String fedoraResourceId) {
-
-        final var resourceId = trimTrailingSlashes(fedoraResourceId);
-        final var rootObjectId = trimTrailingSlashes(rootFedoraObjectId);
-
+    public static String relativizeSubpath(final String rootObjectId, final String resourceId) {
         if (resourceId.equals(rootObjectId)) {
             return "";
         } else if (resourceId.startsWith(rootObjectId) && resourceId.charAt(rootObjectId.length()) == '/') {
@@ -106,26 +117,19 @@ public class OCFLPersistentStorageUtils {
                 rootObjectId));
     }
 
-    private static String trimTrailingSlashes(final String string) {
-        return string.replaceAll("/+$", "");
-    }
-
     /**
      * Returns the OCFL subpath for a given fedora subpath. This returned subpath
      * does not include any added extensions.
      *
-     * @param rootFedoraObjectId  The fedora object root identifier
+     * @param rootObjectId  The fedora object root identifier
      * @param fedoraSubpath subpath of file within ocfl object
      * @return The resolved OCFL subpath
      */
-    public static  String resolveOCFLSubpath(final String rootFedoraObjectId, final String fedoraSubpath) {
-
-        final var rootObjectId = trimTrailingSlashes(rootFedoraObjectId);
-
+    public static  String resolveOCFLSubpath(final String rootObjectId, final String fedoraSubpath) {
         final var lastPathSegment = rootObjectId.substring(rootObjectId.lastIndexOf("/") + 1);
 
         String subPath;
-        if (FEDORA_ID_PREFIX.equals(rootFedoraObjectId) && "".equals(fedoraSubpath)) {
+        if (FEDORA_ID_PREFIX.equals(rootObjectId) && "".equals(fedoraSubpath)) {
             subPath = DEFAULT_REPOSITORY_ROOT_OCFL_OBJECT_ID;
         } else if ("".equals(fedoraSubpath)) {
             subPath = lastPathSegment;
@@ -251,13 +255,8 @@ public class OCFLPersistentStorageUtils {
             return objSession.listVersions()
                     .stream()
                     .filter(vd -> {
-                        //filter by comparing Epoch seconds since
-                        //Memento has second granularity while OCFL versions are
-                        //millisecond granularity
-                        return vd.getCreated()
-                                .toInstant()
-                                .toEpochMilli() / 1000 == version.toEpochMilli() / 1000;
-                    }).map(vd -> vd.getVersionId().toString()) //return the versionId the matches
+                        return vd.getCreated().equals(version);
+                    }).map(OCFLVersion::getOcflVersionId)
                     .findFirst()
                     .orElseThrow(() -> {
                         //otherwise throw an exception.
@@ -295,11 +294,15 @@ public class OCFLPersistentStorageUtils {
      * accessible from the OCFL Object represented by the session.
      *
      * @param objSession The OCFL object session
+     * @param subpath The subpath within the object to list versions of; if blank all of the versions of the object are
+     *                listed
      * @return A list of Instant objects
      * @throws PersistentStorageException On read failure due to the session being closed or some other problem.
      */
-    public static List<Instant> listVersions(final OCFLObjectSession objSession) throws PersistentStorageException {
-        return  objSession.listVersions().stream().map(versionDetails -> versionDetails.getCreated().toInstant())
+    public static List<Instant> listVersions(final OCFLObjectSession objSession, final String subpath)
+            throws PersistentStorageException {
+        return  objSession.listVersions(subpath).stream()
+                .map(OCFLVersion::getCreated)
                 .collect(Collectors.toList());
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -119,7 +119,8 @@ public class OCFLPersistentStorageUtils {
 
     /**
      * Returns the OCFL subpath for a given fedora subpath. This returned subpath
-     * does not include any added extensions.
+     * does not include any added extensions. It is expected that the rootObjectId
+     * DOES NOT contain a trailing slash at this point.
      *
      * @param rootObjectId  The fedora object root identifier
      * @param fedoraSubpath subpath of file within ocfl object

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLVersionImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLVersionImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import org.fcrepo.persistence.ocfl.api.OCFLVersion;
+
+import java.time.Instant;
+
+/**
+ * Default OCFLVersion impl
+ */
+public class OCFLVersionImpl implements OCFLVersion {
+
+    private String ocflObjectId;
+    private String ocflVersionId;
+    private Instant created;
+    private String createdBy;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOcflObjectId() {
+        return ocflObjectId;
+    }
+
+    /**
+     * @param ocflObjectId OCFL object id
+     * @return this object for chaining
+     */
+    public OCFLVersionImpl setOcflObjectId(final String ocflObjectId) {
+        this.ocflObjectId = ocflObjectId;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOcflVersionId() {
+        return ocflVersionId;
+    }
+
+    /**
+     * @param ocflVersionId OCFL version id
+     * @return this object for chaining
+     */
+    public OCFLVersionImpl setOcflVersionId(final String ocflVersionId) {
+        this.ocflVersionId = ocflVersionId;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Instant getCreated() {
+        return created;
+    }
+
+    /**
+     * @param created Instant version was created
+     * @return this object for chaining
+     */
+    public OCFLVersionImpl setCreated(final Instant created) {
+        this.created = created;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    /**
+     * @param createdBy who created the version
+     * @return this object for chaining
+     */
+    public OCFLVersionImpl setCreatedBy(final String createdBy) {
+        this.createdBy = createdBy;
+        return this;
+    }
+
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtilsTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtilsTest.java
@@ -38,13 +38,6 @@ public class OCFLPersistentStorageUtilsTest {
     }
 
     @Test
-    public void testRelativizeSubpathWhereRootAndResourceHaveTrailingSlashes() {
-        final var rootObjectId = "info:fedora/test/object/";
-        final var resourceId = "info:fedora/test/object/resource/";
-        assertEquals("resource", relativizeSubpath(rootObjectId, resourceId));
-    }
-
-    @Test
     public void testRelativizeSubpath() {
         final var rootObjectId = "info:fedora/test/object";
         final var resourceId = "info:fedora/test/object/resource";

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>1.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.github.stefanbirkner</groupId>
         <artifactId>system-rules</artifactId>
         <version>${system-rules.version}</version>


### PR DESCRIPTION
**JIRA Ticket**: [FCREPO-3237](https://jira.lyrasis.org/browse/FCREPO-3237)

# What does this Pull Request do?
Allows resource versions to be listed.

# How should this be tested?

Note that `fcrepo.autoversioning.enabled` must be enabled.

```
mvn -Dfcrepo.autoversioning.enabled=true jetty:run

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test-ag-2 -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -H'Link: <http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'AG Parent'"

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test-ag-2/child1 -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'AG Child 1'"

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test-ag-2/child2 -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "testing"

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test-ag-2/child2 -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "updated"

curl -u fedoraAdmin:fedoraAdmin -v -H "Accept: text/turtle" http://localhost:8080/rest/test-ag-2/fcr:versions

@prefix memento:  <http://mementoweb.org/ns#> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .

<info:fedora/test-ag-2/fcr:versions>
        ldp:contains         <info:fedora/test-ag-2/fcr:versions/20200226203011> ;
        ldp:contains         <info:fedora/test-ag-2/fcr:versions/20200226202947> ;
        ldp:contains         <info:fedora/test-ag-2/fcr:versions/20200226202936> ;
        ldp:contains         <info:fedora/test-ag-2/fcr:versions/20200226202926> ;
        memento:original     <info:fedora/test-ag-2> ;
        fedora:created       "2020-02-26T20:29:26.774214Z" ;
        fedora:lastModified  "2020-02-26T20:29:26.774214Z" ;
        rdf:type             fedora:TimeMap ;
        rdf:type             memento:TimeMap .

curl -u fedoraAdmin:fedoraAdmin -v -H "Accept: application/link-format" http://localhost:8080/rest/test-ag-2/fcr:versions

<http://localhost:8080/rest/test-ag-2>; rel="original",
<http://localhost:8080/rest/test-ag-2>; rel="timegate",
<http://localhost:8080/rest/test-ag-2/fcr:versions/20200226202926>; rel="memento"; datetime="Wed, 26 Feb 2020 20:29:26 GMT",
<http://localhost:8080/rest/test-ag-2/fcr:versions/20200226202936>; rel="memento"; datetime="Wed, 26 Feb 2020 20:29:36 GMT",
<http://localhost:8080/rest/test-ag-2/fcr:versions/20200226202947>; rel="memento"; datetime="Wed, 26 Feb 2020 20:29:47 GMT",
<http://localhost:8080/rest/test-ag-2/fcr:versions/20200226203011>; rel="memento"; datetime="Wed, 26 Feb 2020 20:30:11 GMT",
<http://localhost:8080/rest/test-ag-2/fcr:versions>; rel="self"; from="Wed, 26 Feb 2020 20:29:26 GMT"; until="Wed, 26 Feb 2020 20:30:11 GMT"; type="application/link-format",

curl -u fedoraAdmin:fedoraAdmin -v -H "Accept: text/turtle" http://localhost:8080/rest/test-ag-2/child1/fcr:versions

@prefix memento:  <http://mementoweb.org/ns#> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .

<info:fedora/test-ag-2/child1/fcr:versions>
        ldp:contains         <info:fedora/test-ag-2/child1/fcr:versions/20200226202936> ;
        memento:original     <info:fedora/test-ag-2/child1> ;
        fedora:created       "2020-02-26T20:29:36.544215Z" ;
        fedora:lastModified  "2020-02-26T20:29:36.544215Z" ;
        rdf:type             fedora:TimeMap ;
        rdf:type             memento:TimeMap .

curl -u fedoraAdmin:fedoraAdmin -v -H "Accept: text/turtle" http://localhost:8080/rest/test-ag-2/child2/fcr:versions

@prefix memento:  <http://mementoweb.org/ns#> .
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .

<info:fedora/test-ag-2/child2/fcr:versions>
        ldp:contains         <info:fedora/test-ag-2/child2/fcr:versions/20200226203011> ;
        ldp:contains         <info:fedora/test-ag-2/child2/fcr:versions/20200226202947> ;
        memento:original     <info:fedora/test-ag-2/child2> ;
        fedora:created       "2020-02-26T20:29:47.229216Z" ;
        fedora:lastModified  "2020-02-26T20:30:11.037218Z" ;
        rdf:type             fedora:TimeMap ;
        rdf:type             memento:TimeMap .
```

# Additional Notes:

* Resource URIs are incorrect, except when `application/link-format` is used. This PR does not solve a general problem that exists mapping between different types of IDs.
* The integration tests are NOT reenabled. They still don't work because 1) the URIs are wrong and 2) you can't create versions on demand yet (just through auto-versioning).

# Interested parties
@dbernstein @awoods @whikloj 
