### PR TITLE
Add rdf:type ldp:RDFSource to Rdf source resources

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -26,7 +26,8 @@ import static org.apache.jena.sparql.util.graph.GraphUtils.multiValueURI;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
 import static org.fcrepo.http.commons.session.TransactionProvider.ATOMIC_ID_HEADER;
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -167,8 +168,8 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
             .put(REPOSITORY_NAMESPACE + "Version", velocity.getTemplate(getTemplateLocation("resource")))
             .put(REPOSITORY_NAMESPACE + "Pairtree", velocity.getTemplate(getTemplateLocation("resource")))
             .put(REPOSITORY_NAMESPACE + "Container", velocity.getTemplate(getTemplateLocation("resource")))
-            .put(LDP_NAMESPACE + "NonRdfSource", velocity.getTemplate(getTemplateLocation("binary")))
-            .put(LDP_NAMESPACE + "RdfSource", velocity.getTemplate(getTemplateLocation("resource"))).build();
+            .put(NON_RDF_SOURCE.toString(), velocity.getTemplate(getTemplateLocation("binary")))
+            .put(RDF_SOURCE.toString(), velocity.getTemplate(getTemplateLocation("resource"))).build();
 
         LOGGER.trace("Assembled template map.");
         LOGGER.trace("HtmlProvider initialization complete.");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -71,7 +71,6 @@ public class FedoraHtmlIT extends AbstractResourceIT {
         assertEquals(200, getStatus(method));
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetContainerTemplate() throws IOException {
         final String pid = getRandomUniqueId();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -26,15 +26,11 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.exception.ItemNotFoundException;
-import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
-import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
-import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 
 /**
@@ -64,16 +60,9 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
 
     @Override
     public RdfStream getTriples() {
-        try {
-            final var triples = getSession().getTriples(id, getMementoDatetime());
-            final Stream<Triple> extra_triples = Stream.of(
-                    new Triple(createURI(id), RDF.Init.type().asNode(), RDF_SOURCE.asNode())
-            );
-            return new DefaultRdfStream(createURI(id), Stream.concat(triples, extra_triples));
-        } catch (final PersistentItemNotFoundException e) {
-            throw new ItemNotFoundException("Unable to retrieve triples for " + getId(), e);
-        } catch (final PersistentStorageException e) {
-            throw new RepositoryRuntimeException(e);
-        }
+        final Stream<Triple> extra_triples = Stream.of(
+                new Triple(createURI(id), RDF.Init.type().asNode(), RDF_SOURCE.asNode())
+        );
+        return new DefaultRdfStream(createURI(id), Stream.concat(super.getTriples(), extra_triples));
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -51,7 +51,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     protected final ResourceFactory resourceFactory;
 
-    private final String id;
+    protected final String id;
 
     private String parentId;
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3222

**Note**: this PR only partially resolves the above ticket.

# What does this Pull Request do?
* Fixes the StreamingBaseHtmlProvider to use the correct `ldp:RDFSource` and `ldp:NonRDFSource` types for template matching. 
* Adds the `ldp:RDFSource` type to all `Container`s
* Re-instates one of the `FedoraHtmlIT` tests

# How should this be tested?

Before the PR an RDF source (like a `ldp:BasicContainer`) would have only that type, after this PR it will also have the `ldp:RDFSource` type.

# Interested parties
@fcrepo4/committers
