### PR TITLE
Add Repository Root type to Repository Root

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -29,6 +29,7 @@ import static org.fcrepo.http.commons.session.TransactionProvider.ATOMIC_ID_HEAD
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
+import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_ROOT;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -162,7 +163,7 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
             .forEach(key -> templatesMapBuilder.put(key, velocity.getTemplate(getTemplateLocation(key))));
 
         templatesMap = templatesMapBuilder
-            .put(REPOSITORY_NAMESPACE + "RepositoryRoot", velocity.getTemplate(getTemplateLocation("root")))
+            .put(REPOSITORY_ROOT.toString(), velocity.getTemplate(getTemplateLocation("root")))
             .put(REPOSITORY_NAMESPACE + "Binary", velocity.getTemplate(getTemplateLocation("binary")))
             .put(REPOSITORY_NAMESPACE + "Version", velocity.getTemplate(getTemplateLocation("resource")))
             .put(REPOSITORY_NAMESPACE + "Pairtree", velocity.getTemplate(getTemplateLocation("resource")))

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -99,7 +99,6 @@ public class FedoraHtmlIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetRootTemplate() throws IOException {
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -173,6 +173,8 @@ public final class RdfLexicon {
     // REPOSITORY INFORMATION
     public static final Property HAS_TRANSACTION_SERVICE =
             createProperty(REPOSITORY_NAMESPACE + "hasTransactionProvider");
+    public static final Resource REPOSITORY_ROOT =
+            createResource(REPOSITORY_NAMESPACE + "RepositoryRoot");
 
     // OTHER SERVICES
     public static final Property HAS_FIXITY_SERVICE =

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -63,13 +63,6 @@ public class RepositoryInitializer {
     @Inject
     private FedoraToOCFLObjectIndexUtil fedoraToOCFLObjectIndexUtil;
 
-    private static Stream<Triple> REPOSITORY_ROOT_TRIPLES = Stream.of(
-            new Triple(createURI(FEDORA_ID_PREFIX), RDF.type.asNode(), REPOSITORY_ROOT.asNode())
-    );
-
-    private static RdfStream REPOSITORY_ROOT_STREAM = new DefaultRdfStream(createURI(FEDORA_ID_PREFIX),
-            REPOSITORY_ROOT_TRIPLES);
-
     /**
      * Initializes the repository
      */
@@ -90,8 +83,14 @@ public class RepositoryInitializer {
                 session.getHeaders(FEDORA_ID_PREFIX, null);
             } catch (PersistentItemNotFoundException e) {
                 LOGGER.info("Repository root ({}) not found. Creating...", FEDORA_ID_PREFIX);
+                final Stream<Triple> repositoryRootTriples = Stream.of(
+                        new Triple(createURI(FEDORA_ID_PREFIX), RDF.type.asNode(), REPOSITORY_ROOT.asNode())
+                );
+
+                final RdfStream repositoryRootStream = new DefaultRdfStream(createURI(FEDORA_ID_PREFIX),
+                        repositoryRootTriples);
                 final RdfSourceOperation operation = this.operationFactory.createBuilder(FEDORA_ID_PREFIX,
-                        BASIC_CONTAINER.getURI()).parentId(FEDORA_ID_PREFIX).triples(REPOSITORY_ROOT_STREAM).build();
+                        BASIC_CONTAINER.getURI()).parentId(FEDORA_ID_PREFIX).triples(repositoryRootStream).build();
 
                 session.persist(operation);
                 session.commit();

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -17,9 +17,14 @@
  */
 package org.fcrepo.persistence.ocfl;
 
+
+import org.apache.jena.graph.Triple;
+import org.apache.jena.vocabulary.RDF;
+import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -32,9 +37,13 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import static  org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_ROOT;
 import static org.fcrepo.persistence.ocfl.impl.OCFLConstants.FEDORA_TO_OCFL_INDEX_FILE;
+
+import java.util.stream.Stream;
 
 /**
  * This class is responsible for initializing the repository on start-up.
@@ -53,6 +62,13 @@ public class RepositoryInitializer {
 
     @Inject
     private FedoraToOCFLObjectIndexUtil fedoraToOCFLObjectIndexUtil;
+
+    private static Stream<Triple> REPOSITORY_ROOT_TRIPLES = Stream.of(
+            new Triple(createURI(FEDORA_ID_PREFIX), RDF.type.asNode(), REPOSITORY_ROOT.asNode())
+    );
+
+    private static RdfStream REPOSITORY_ROOT_STREAM = new DefaultRdfStream(createURI(FEDORA_ID_PREFIX),
+            REPOSITORY_ROOT_TRIPLES);
 
     /**
      * Initializes the repository
@@ -75,7 +91,7 @@ public class RepositoryInitializer {
             } catch (PersistentItemNotFoundException e) {
                 LOGGER.info("Repository root ({}) not found. Creating...", FEDORA_ID_PREFIX);
                 final RdfSourceOperation operation = this.operationFactory.createBuilder(FEDORA_ID_PREFIX,
-                        BASIC_CONTAINER.getURI()).parentId(FEDORA_ID_PREFIX).build();
+                        BASIC_CONTAINER.getURI()).parentId(FEDORA_ID_PREFIX).triples(REPOSITORY_ROOT_STREAM).build();
 
                 session.persist(operation);
                 session.commit();


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3222

**Note**: This PR does not completely resolve the above ticket

# What does this Pull Request do?
Adds the `http://fedora.info/definitions/v4/repository#RepositoryRoot` type to the repository root when it is initialized.
Also makes that type a static constant.

# How should this be tested?

Before the PR, your root object had only the `ldp:BasicContainer` type.
After the PR, it also has the above mentioned `RepositoryRoot` type.

# Interested parties
@fcrepo4/committers
