### PR TITLE
Handle binary HTML test

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -44,10 +44,8 @@ import static javax.ws.rs.core.Variant.mediaTypes;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
-import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.api.FedoraVersioning.MEMENTO_DATETIME_HEADER;
 import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3;
@@ -71,7 +69,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEMAP_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedNamespace;
-import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
 import static org.fcrepo.kernel.api.models.ExternalContent.COPY;
 import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
 import static org.fcrepo.kernel.api.models.ExternalContent.REDIRECT;
@@ -91,7 +88,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -215,10 +211,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     @Inject
     protected HttpRdfService httpRdfService;
 
-    private static final Predicate<Triple> IS_MANAGED_TYPE = t -> t.getPredicate().equals(type.asNode()) &&
-            isManagedNamespace.test(t.getObject().getNameSpace());
-    private static final Predicate<Triple> IS_MANAGED_TRIPLE = IS_MANAGED_TYPE
-        .or(t -> isManagedPredicate.test(createProperty(t.getPredicate().getURI())));
+
 
     protected abstract String externalPath();
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -28,7 +28,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET
 import static org.fcrepo.http.commons.session.TransactionProvider.ATOMIC_ID_HEADER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_ROOT;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -176,7 +175,7 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
             .forEach(key -> templatesMapBuilder.put(key, velocity.getTemplate(getTemplateLocation(key))));
 
         templatesMap = templatesMapBuilder
-            .put(REPOSITORY_NAMESPACE + "RepositoryRoot", velocity.getTemplate(getTemplateLocation("root")))
+            .put(REPOSITORY_ROOT.toString(), velocity.getTemplate(getTemplateLocation("root")))
             .put(NON_RDF_SOURCE.toString(), velocity.getTemplate(getTemplateLocation("binary")))
             .put(RDF_SOURCE.toString(), velocity.getTemplate(getTemplateLocation("resource"))).build();
 
@@ -266,6 +265,9 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
             .map(x -> ((HtmlTemplate) x).value()).filter(templatesMap::containsKey).findFirst()
             .orElseGet(() -> {
                 final List<String> types = multiValueURI(rdf.getResource(subject.getURI()), type);
+                if (types.contains(REPOSITORY_ROOT.toString())) {
+                    return REPOSITORY_ROOT.toString();
+                }
                 return types.stream().filter(templatesMap::containsKey).findFirst().orElse("default");
             });
         LOGGER.debug("Using template: {}", tplName);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -176,11 +176,7 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
             .forEach(key -> templatesMapBuilder.put(key, velocity.getTemplate(getTemplateLocation(key))));
 
         templatesMap = templatesMapBuilder
-            .put(REPOSITORY_ROOT.toString(), velocity.getTemplate(getTemplateLocation("root")))
-            .put(REPOSITORY_NAMESPACE + "Binary", velocity.getTemplate(getTemplateLocation("binary")))
-            .put(REPOSITORY_NAMESPACE + "Version", velocity.getTemplate(getTemplateLocation("resource")))
-            .put(REPOSITORY_NAMESPACE + "Pairtree", velocity.getTemplate(getTemplateLocation("resource")))
-            .put(REPOSITORY_NAMESPACE + "Container", velocity.getTemplate(getTemplateLocation("resource")))
+            .put(REPOSITORY_NAMESPACE + "RepositoryRoot", velocity.getTemplate(getTemplateLocation("root")))
             .put(NON_RDF_SOURCE.toString(), velocity.getTemplate(getTemplateLocation("binary")))
             .put(RDF_SOURCE.toString(), velocity.getTemplate(getTemplateLocation("resource"))).build();
 
@@ -270,9 +266,6 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
             .map(x -> ((HtmlTemplate) x).value()).filter(templatesMap::containsKey).findFirst()
             .orElseGet(() -> {
                 final List<String> types = multiValueURI(rdf.getResource(subject.getURI()), type);
-                if (types.contains(REPOSITORY_NAMESPACE + "RepositoryRoot")) {
-                    return REPOSITORY_NAMESPACE + "RepositoryRoot";
-                }
                 return types.stream().filter(templatesMap::containsKey).findFirst().orElse("default");
             });
         LOGGER.debug("Using template: {}", tplName);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -84,10 +84,10 @@ public class FedoraHtmlIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetBinaryTemplate() throws IOException {
         final String pid = getRandomUniqueId();
+        createObject(pid);
         createDatastream(pid, "file", "binary content");
 
         final HttpGet method = new HttpGet(serverAddress + pid + "/file/fcr:metadata");

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -61,8 +61,8 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
     @Override
     public RdfStream getTriples() {
         final Stream<Triple> extra_triples = Stream.of(
-                new Triple(createURI(id), RDF.Init.type().asNode(), RDF_SOURCE.asNode())
+                new Triple(createURI(getId()), RDF.Init.type().asNode(), RDF_SOURCE.asNode())
         );
-        return new DefaultRdfStream(createURI(id), Stream.concat(super.getTriples(), extra_triples));
+        return new DefaultRdfStream(createURI(getId()), Stream.concat(super.getTriples(), extra_triples));
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -52,7 +52,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     protected final ResourceFactory resourceFactory;
 
-    protected final String id;
+    private final String id;
 
     private String parentId;
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -57,7 +57,6 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl {
 
     @Override
     public FedoraResource getDescribedResource() {
-        // TODO must return the described binary
         final String describedId = this.getId().replaceAll("/" + FCR_METADATA + "$", "");
         try {
             return this.resourceFactory.getResource(tx, describedId);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -46,13 +46,13 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
     @Override
     public Stream<Triple> get(final FedoraResource resource) {
         final List<Triple> triples = new ArrayList<>();
-        final var subject = createURI(FedoraResourceIdConverter.resolveFedoraId(resource));
+        final var subject = createURI(FedoraResourceIdConverter.resolveFedoraId(resource.getDescribedResource()));
         triples.add(Triple.create(subject, CREATED_DATE.asNode(),
                 createLiteral(resource.getCreatedDate().toString())));
         triples.add(Triple.create(subject, LAST_MODIFIED_DATE.asNode(),
                 createLiteral(resource.getLastModifiedDate().toString())));
 
-        resource.getTypes().forEach(triple -> {
+        resource.getDescribedResource().getTypes().forEach(triple -> {
             triples.add(Triple.create(subject, type.asNode(), createURI(triple.toString())));
         });
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3222

Last PR for the above ticket

# What does this Pull Request do?
Creates a `getDescribedResource` method for `NonRdfSourceDescription`s so they can describe the correct resource.

Modifies the `managedPropertyService` to use the `getDescribedResource` to generate correct triples.

Cleans up some redundant logic in `StreamingBaseHtmlProvider`

Removes an un-used Predicate from `ContentExposingResource`, possibly might need to be re-added to a service later.

Uncomments the last test in `FedoraHtmlIT`

This test required the addition of a `createObject()` because it previously tried to 
```
PUT http://localhost:8080/1234-5678/file
```
But we currently  try to load `1234-5678` as a resource to be the parent, this will need to be fixed with the implementation of ghost nodes and can be tested by any number of tests in FedoraLdpIT that use the `createDatastream()` method.

For example:
* https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java#L496
* https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java#L626
* https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java#L762
* https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java#L1124
* as well as many more

# How should this be tested?

Tests pass, but also when you GET the `/fcr:metadata` for a binary the RDF should have the subject of the binary and NOT have a `fedora:NonRdfSourceDescription` type.

# Interested parties
@fcrepo4/committers
