### PR TITLE
resource version creation

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -182,7 +182,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
 
         createContainerMementoWithBody(subjectUri);
-//        createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         verifyTimemapResponse(subjectUri, id, now());
     }
 
@@ -434,7 +433,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
 
         final String mementoUri = createContainerMementoWithBody(subjectUri);
-//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         assertMementoUri(mementoUri, subjectUri);
         final Node mementoSubject = createURI(subjectUri);
         final Node subject = createURI(subjectUri);
@@ -470,7 +468,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
 
         final String mementoUri = createContainerMementoWithBody(subjectUri);
-//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
 
         assertEquals("Expected delete to succeed",
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
@@ -479,7 +476,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
 
         final String recreatedUri = createContainerMementoWithBody(subjectUri);
-//        final String recreatedUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         assertEquals("Recreated memento must exist",
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
@@ -490,7 +486,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedBinary(id);
 
         final String mementoUri = createLDPNRMementoWithExistingBody();
-//        final String mementoUri = createLDPNRMementoWithExistingBody(MEMENTO_DATETIME);
 
         assertEquals("Expected delete to succeed",
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
@@ -499,7 +494,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
 
         final String recreatedUri = createLDPNRMementoWithExistingBody();
-//        final String recreatedUri = createLDPNRMementoWithExistingBody(MEMENTO_DATETIME);
         assertEquals("Recreated memento must exist",
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
@@ -512,7 +506,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String descId = id + "/" + FCR_METADATA;
         final String descUri = serverAddress + descId;
         final String mementoUri = createMementoWithExistingBody(descId, false);
-//        final String mementoUri = createMementoWithExistingBody(descId, MEMENTO_DATETIME, false);
 
         assertEquals("Expected delete to succeed",
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
@@ -521,7 +514,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
 
         final String recreatedUri = createContainerMementoWithBody(descUri);
-//        final String recreatedUri = createContainerMementoWithBody(descUri, MEMENTO_DATETIME);
         assertEquals("Recreated memento must exist",
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
@@ -536,7 +528,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         // create memento
         final String mementoUri = createContainerMementoWithBody(subjectUri);
-//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
 
         // Remove the child resource
         assertEquals("Expected delete to succeed",
@@ -567,7 +558,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String mementoDateTime =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String mementoUri = createLDPRSMementoWithExistingBody();
-//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: HEAD request on existing memento
         final HttpHead headMethod = new HttpHead(mementoUri);
@@ -591,7 +581,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String mementoDateTime =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String mementoUri = createLDPRSMementoWithExistingBody();
-//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: GET request on existing memento
         final HttpGet getMemento = new HttpGet(mementoUri);
@@ -614,7 +603,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String mementoDateTime =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String mementoUri = createLDPRSMementoWithExistingBody();
-//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
         // Status 200: GET request on existing memento
         final HttpGet getMemento = new HttpGet(mementoUri);
         getMemento.addHeader(ACCEPT_DATETIME, mementoDateTime);
@@ -630,7 +618,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String mementoDateTime =
                 MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String mementoUri = createLDPRSMementoWithExistingBody();
-//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
         // Status 200: HEAD request on existing memento
         final HttpHead headMemento = new HttpHead(mementoUri);
         headMemento.addHeader(ACCEPT_DATETIME, mementoDateTime);
@@ -647,7 +634,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String mementoDateTime =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String mementoUri = createLDPRSMementoWithExistingBody();
-//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: OPTIONS request on existing memento
         final HttpOptions optionsMemento = new HttpOptions(mementoUri);
@@ -681,7 +667,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         // create memento
         final String mementoUri = createContainerMementoWithBody(subjectUri);
-//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
 
         // Remove the referencing resource
         assertEquals("Expected delete to succeed",
@@ -1010,8 +995,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedBinary(id);
 
         final String mementoUri = createMemento(subjectUri);
-//        final String mementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
-//                OCTET_STREAM_TYPE, null);
         assertMementoUri(mementoUri, subjectUri);
 
         // Verify that the memento has the updated binary
@@ -1030,8 +1013,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedBinary(id);
 
         final String mementoUri = createMemento(subjectUri);
-//        final String mementoUri = createMemento(subjectUri, null,
-//                OCTET_STREAM_TYPE, BINARY_UPDATED);
         assertMementoUri(mementoUri, subjectUri);
 
         final HttpGet httpGet = new HttpGet(mementoUri);
@@ -1049,8 +1030,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedBinary(id);
 
         final String mementoUri = createMemento(subjectUri);
-//        final String mementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
-//                "text/plain", BINARY_UPDATED);
         assertMementoUri(mementoUri, subjectUri);
 
         // Verify that the memento has the updated binary
@@ -1117,7 +1096,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String descriptionUri = subjectUri + "/fcr:metadata";
 
         final String mementoUri = createContainerMementoWithBody(descriptionUri);
-//        final String mementoUri = createContainerMementoWithBody(descriptionUri, MEMENTO_DATETIME);
         assertMementoUri(mementoUri, descriptionUri);
 
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
@@ -1142,12 +1120,9 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String descriptionUri = subjectUri + "/fcr:metadata";
 
         final String binaryMementoUri = createMemento(subjectUri);
-//        final String binaryMementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
-//                null, "content");
         assertMementoUri(binaryMementoUri, subjectUri);
 
         final String mementoUri = createContainerMementoWithBody(descriptionUri);
-//        final String mementoUri = createContainerMementoWithBody(descriptionUri, MEMENTO_DATETIME);
         assertMementoUri(mementoUri, descriptionUri);
 
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
@@ -1222,7 +1197,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testGetVersionResponseContentTypes() throws Exception {
         createVersionedContainer(id);
         final String versionUri = createContainerMementoWithBody(subjectUri);
-//        final String versionUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
 
         final String[] rdfResponseTypes = rdfTypes.toArray(new String[rdfTypes.size()]);
         for (final String type : rdfResponseTypes) {
@@ -1241,11 +1215,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String memento1 =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
         final String version1Uri = createLDPRSMementoWithExistingBody();
-//        final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
-        final String memento2 =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2016-06-17T11:41:00Z", Instant::from));
         final String version2Uri = createLDPRSMementoWithExistingBody();
-//        final String version2Uri = createLDPRSMementoWithExistingBody(memento2);
 
         // Request datetime between memento1 and memento2
         final String request1Datetime =
@@ -1296,7 +1267,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         // Create a current memento
         final String version1Uri = createMemento(originalUri);
-//        final String version1Uri = createMemento(originalUri, null, "text/turtle", null);
         final HttpHead httpHead = new HttpHead(version1Uri);
         final String version1Datetime;
         try (final CloseableHttpResponse response = customClient.execute(httpHead)) {
@@ -1308,7 +1278,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             Instant.from(MEMENTO_RFC_1123_FORMATTER.parse(version1Datetime)).minus(5, ChronoUnit.SECONDS);
         final String version2Datetime = MEMENTO_RFC_1123_FORMATTER.format(version2Instant);
         final String version2Uri = createLDPRSMementoWithExistingBody();
-//        final String version2Uri = createLDPRSMementoWithExistingBody(version2Datetime);
 
         // Attempt to retrieve older memento
         final HttpGet getVersion2 = getObjMethod(id);
@@ -1369,7 +1338,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         // Create memento
         final String mementoUri = createLDPRSMementoWithExistingBody();
-//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 302: GET memento with datetime negotiation
         final HttpGet getMethod2 = getObjMethod(id);
@@ -1417,7 +1385,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
 
         final String mementoUri = createContainerMementoWithBody(subjectUri);
-//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         final HttpPatch patch = new HttpPatch(mementoUri);
         patch.addHeader(CONTENT_TYPE, "application/sparql-update");
         patch.setEntity(new StringEntity(
@@ -1447,7 +1414,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
 
         final String mementoUri = createContainerMementoWithBody(subjectUri);
-//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         final String body = createContainerMementoBodyContent(subjectUri, N3);
         final HttpPost post = new HttpPost(mementoUri);
         post.addHeader(CONTENT_TYPE, N3);
@@ -1477,7 +1443,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
 
         final String mementoUri = createContainerMementoWithBody(subjectUri);
-//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         final String body = createContainerMementoBodyContent(subjectUri, N3);
         final HttpPut put = new HttpPut(mementoUri);
         put.addHeader(CONTENT_TYPE, N3);
@@ -1509,7 +1474,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String memento1 =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
         final String version1Uri = createLDPRSMementoWithExistingBody();
-//        final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
         final HttpGet getRequest = new HttpGet(version1Uri);
 
         try (final CloseableHttpResponse response = execute(getRequest)) {
@@ -1534,7 +1498,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String memento1 =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
         final String version1Uri = createLDPNRMementoWithExistingBody();
-//        final String version1Uri = createLDPNRMementoWithExistingBody(memento1);
         final HttpGet getRequest = new HttpGet(version1Uri);
 
         try (final CloseableHttpResponse response = execute(getRequest)) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -25,7 +25,6 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.HttpHeaders.LOCATION;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.FOUND;
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
@@ -97,7 +96,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Link;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
@@ -124,8 +122,7 @@ import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.DC;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.fcrepo.persistence.api.CommitOption;
-import org.fcrepo.persistence.ocfl.impl.DefaultOCFLObjectSession;
+import org.fcrepo.persistence.ocfl.impl.DefaultOCFLObjectSessionFactory;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -160,10 +157,13 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
+    private DefaultOCFLObjectSessionFactory objectSessionFactory;
+
     @Before
     public void init() {
         id = getRandomUniqueId();
         subjectUri = serverAddress + id;
+        objectSessionFactory = getBean(DefaultOCFLObjectSessionFactory.class);
     }
 
     @Ignore //TODO Fix this test
@@ -177,97 +177,99 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                      getStatus(new HttpDelete(serverAddress + id + "/" + FCR_VERSIONS)));
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapResponse() throws Exception {
         createVersionedContainer(id);
 
-        createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
-        verifyTimemapResponse(subjectUri, id, MEMENTO_DATETIME);
+        createContainerMementoWithBody(subjectUri);
+//        createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        verifyTimemapResponse(subjectUri, id, now());
     }
 
     @Test
     public void getTimeMapForContainerWithSingleVersion() throws Exception {
-        DefaultOCFLObjectSession.setGlobaDefaultCommitOption(CommitOption.NEW_VERSION);
+        objectSessionFactory.setAutoVersioningEnabled(true);
         try {
             createVersionedContainer(id);
             verifyTimemapResponse(subjectUri, id, now());
         } finally {
-            DefaultOCFLObjectSession.setGlobaDefaultCommitOption(CommitOption.UNVERSIONED);
+            objectSessionFactory.setAutoVersioningEnabled(false);
         }
     }
 
     @Test
     public void getTimeMapFromBinaryWithMultipleVersions() throws Exception {
-        DefaultOCFLObjectSession.setGlobaDefaultCommitOption(CommitOption.NEW_VERSION);
+        objectSessionFactory.setAutoVersioningEnabled(true);
         try {
             final var v1 = now();
             createVersionedBinary(id, OCTET_STREAM_TYPE, "v1");
-            Thread.sleep(1000);
+            TimeUnit.SECONDS.sleep(1);
 
             final var v2 = now();
-            createVersionedBinary(id, OCTET_STREAM_TYPE, "v2");
-            Thread.sleep(1000);
+            putVersionedBinary(id, OCTET_STREAM_TYPE, "v2", true);
+            TimeUnit.SECONDS.sleep(1);
 
             final var v3 = now();
-            createVersionedBinary(id, OCTET_STREAM_TYPE, "v3");
-            Thread.sleep(1000);
+            putVersionedBinary(id, OCTET_STREAM_TYPE, "v3", true);
+            TimeUnit.SECONDS.sleep(1);
 
             verifyTimemapResponse(subjectUri, id, new String[]{v1, v2, v3}, v1, v3);
         } finally {
-            DefaultOCFLObjectSession.setGlobaDefaultCommitOption(CommitOption.UNVERSIONED);
+            objectSessionFactory.setAutoVersioningEnabled(false);
         }
     }
 
     @Test
     public void getTimeMapFromAgWithChildrenWithDifferentVersions() throws Exception {
-        DefaultOCFLObjectSession.setGlobaDefaultCommitOption(CommitOption.NEW_VERSION);
+        objectSessionFactory.setAutoVersioningEnabled(true);
         try {
             final var childId1 = id + "/child1";
             final var childId2 = id + "/child2";
 
             final var v1 = now();
             createVersionedArchivalGroup(id);
-            Thread.sleep(1000);
+            TimeUnit.SECONDS.sleep(1);
 
             final var v2 = now();
             putVersionedBinary(childId1, OCTET_STREAM_TYPE, "v2", false);
-            Thread.sleep(1000);
+            TimeUnit.SECONDS.sleep(1);
 
             final var v3 = now();
             putVersionedBinary(childId2, OCTET_STREAM_TYPE, "v3", false);
-            Thread.sleep(1000);
+            TimeUnit.SECONDS.sleep(1);
 
             final var v4 = now();
             putVersionedBinary(childId1, OCTET_STREAM_TYPE, "v4", true);
-            Thread.sleep(1000);
+            TimeUnit.SECONDS.sleep(1);
 
             verifyTimemapResponse(subjectUri, id, new String[]{v1, v2, v3, v4}, v1, v4);
             verifyTimemapResponse(subjectUri + "/child1", childId1, new String[]{v2, v4}, v2, v4);
             verifyTimemapResponse(subjectUri + "/child2", childId2, v3);
         } finally {
-            DefaultOCFLObjectSession.setGlobaDefaultCommitOption(CommitOption.UNVERSIONED);
+            objectSessionFactory.setAutoVersioningEnabled(false);
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapResponseMultipleMementos() throws Exception {
         createVersionedContainer(id);
-        final String memento1 =
-            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 00, 00, 00).atOffset(ZoneOffset.UTC));
-        final String memento2 =
-            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2015, 8, 13, 18, 30, 0).atOffset(ZoneOffset.UTC));
-        final String memento3 =
-            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(1980, 5, 31, 9, 15, 30).atOffset(ZoneOffset.UTC));
-        createContainerMementoWithBody(subjectUri, memento1);
-        createContainerMementoWithBody(subjectUri, memento2);
-        createContainerMementoWithBody(subjectUri, memento3);
-        final String[] mementos = { memento1, memento2, memento3 };
-        verifyTimemapResponse(subjectUri, id, mementos, memento3, memento2);
+        final var v1 = now();
+        createMemento(subjectUri);
+        TimeUnit.SECONDS.sleep(1);
+
+        putVersionedContainer(id, "2", true);
+        final var v2 = now();
+        createMemento(subjectUri);
+        TimeUnit.SECONDS.sleep(1);
+
+        putVersionedContainer(id, "3", true);
+        final var v3 = now();
+        createMemento(subjectUri);
+
+        verifyTimemapResponse(subjectUri, id, new String[] {v1, v2, v3}, v1, v3);
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("returning an internal ID rather than URI")
     @Test
     public void testGetTimeMapRDFSubject() throws Exception {
         createVersionedContainer(id);
@@ -281,12 +283,12 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersion() throws Exception {
         createVersionedContainer(id);
 
-        final String mementoUri = createContainerMementoWithBody(subjectUri, null);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
         assertMementoUri(mementoUri, subjectUri);
 
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
@@ -301,7 +303,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionFromResourceWithHashURI() throws Exception {
         final HttpPost createMethod = postObjMethod();
@@ -313,7 +315,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
         }
 
-        final String mementoUri = createContainerMementoWithBody(subjectUri, null);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
         assertMementoUri(mementoUri, subjectUri);
 
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
@@ -328,7 +330,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionFromResourceWithBlankNode() throws Exception {
         final HttpPost createMethod = postObjMethod();
@@ -341,7 +343,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
         }
 
-        final String mementoUri = createMemento(subjectUri, null, null, null);
+        final String mementoUri = createMemento(subjectUri);
         assertMementoUri(mementoUri, subjectUri);
 
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
@@ -368,7 +370,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * thereby changing the time.
      * @throws java.lang.Exception exception thrown during this function
      */
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionWithLastModifiedDateTimestamp() throws Exception {
         try {
@@ -387,7 +389,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                     LocalDateTime.of(2018, 9, 21, 5, 30, 03, 500000000).atZone(ZoneOffset.UTC));
 
 
-            final String memento = createMemento(subjectUri, null, null, null);
+            final String memento = createMemento(subjectUri);
 
             assertMementoEqualsOriginal(memento);
 
@@ -402,130 +404,37 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
 
         // Bad request with Slug header to create memento
-        final String mementoDateTime = "Tue, 3 Jun 2008 11:05:30 GMT";
-        final String body = createContainerMementoBodyContent(subjectUri, N3);
         final HttpPost post = postObjMethod(id + "/" + FCR_VERSIONS);
-
         post.addHeader("Slug", "version_label");
-        post.addHeader(MEMENTO_DATETIME_HEADER, mementoDateTime);
-        post.addHeader(CONTENT_TYPE, N3);
-        post.setEntity(new StringEntity(body));
 
         assertEquals("Created memento with Slug!",
                 BAD_REQUEST.getStatusCode(), getStatus(post));
     }
 
-    @Ignore //TODO Fix this test
     @Test
-    public void testCreateVersionWithMementoDatetimeFormat() throws Exception {
+    public void testCreateVersionWithMementoDateTimeHeader() throws Exception {
         createVersionedContainer(id);
 
-        // Create memento with RFC-1123 date-time format
+        // Bad request with Memento-Datetime header to create memento
         final String mementoDateTime = "Tue, 3 Jun 2008 11:05:30 GMT";
         final String body = createContainerMementoBodyContent(subjectUri, N3);
-
         final HttpPost post = postObjMethod(id + "/" + FCR_VERSIONS);
 
         post.addHeader(MEMENTO_DATETIME_HEADER, mementoDateTime);
         post.addHeader(CONTENT_TYPE, N3);
         post.setEntity(new StringEntity(body));
 
-        assertEquals("Unable to create memento with RFC-1123 date-time format!",
-                CREATED.getStatusCode(), getStatus(post));
-
-        // Create memento with RFC-1123 date-time format in wrong value
-        final String dateTime1 = "Tue, 13 Jun 2008 11:05:35 ANYTIMEZONE";
-        final HttpPost post1 = postObjMethod(id + "/" + FCR_VERSIONS);
-
-        post1.addHeader(CONTENT_TYPE, N3);
-        post1.setEntity(new StringEntity(body));
-        post1.addHeader(MEMENTO_DATETIME_HEADER, dateTime1);
-
-        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(post1));
-
-        // Create memento in date-time format other than RFC-1123
-        final String dateTime2 = "2000-01-01T01:01:01.11Z";
-        final HttpPost post2 = postObjMethod(id + "/" + FCR_VERSIONS);
-
-        post2.addHeader(CONTENT_TYPE, N3);
-        post2.setEntity(new StringEntity(body));
-        post2.addHeader(MEMENTO_DATETIME_HEADER, dateTime2);
-
-        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(post2));
+        assertEquals("Created memento with Memento-Datetime!",
+                BAD_REQUEST.getStatusCode(), getStatus(post));
     }
 
-    @Ignore //TODO Fix this test
-    @Test
-    public void testCreateVersionWithDatetime() throws Exception {
-        createVersionedContainer(id);
-
-        final HttpPost createVersionMethod = postObjMethod(id + "/" + FCR_VERSIONS);
-        createVersionMethod.addHeader(CONTENT_TYPE, N3);
-        createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, MEMENTO_DATETIME);
-
-        // Attempt to create memento with no body
-        try (final CloseableHttpResponse response = execute(createVersionMethod)) {
-            assertEquals("Didn't get a BAD_REQUEST response!", BAD_REQUEST.getStatusCode(), getStatus(response));
-
-            // Request must fail with constrained exception due to empty body
-            assertConstrainedByPresent(response);
-        }
-    }
-
-    @Ignore //TODO Fix this test
-    @Test
-    public void testCreateContainerWithoutServerManagedTriples() throws Exception {
-        createVersionedContainer(id);
-
-        final HttpPost createMethod = postObjMethod(id + "/" + FCR_VERSIONS);
-        createMethod.addHeader(CONTENT_TYPE, N3);
-        createMethod.setEntity(new StringEntity("<" + subjectUri + "> <info:test#label> \"part\""));
-        createMethod.addHeader(MEMENTO_DATETIME_HEADER, MEMENTO_DATETIME);
-
-        // Attempt to create memento with partial record
-        try (final CloseableHttpResponse response = execute(createMethod)) {
-            assertEquals("Didn't get a BAD_REQUEST response!", BAD_REQUEST.getStatusCode(), getStatus(response));
-
-            // Request must fail with constrained exception due to empty body
-            assertConstrainedByPresent(response);
-        }
-    }
-
-    /**
-     * POST to create LDPCv without memento-datetime must ignore body
-     *
-     * @throws Exception in case of error with test
-     */
-    @Ignore //TODO Fix this test
-    @Test
-    public void testCreateVersionWithBody() throws Exception {
-        createVersionedContainer(id);
-
-        final String mementoUri = createContainerMementoWithBody(subjectUri, null);
-        assertMementoUri(mementoUri, subjectUri);
-
-        final HttpGet httpGet = new HttpGet(mementoUri);
-        try (final CloseableDataset dataset = getDataset(httpGet)) {
-            final DatasetGraph results = dataset.asDatasetGraph();
-
-            final Node mementoSubject = createURI(subjectUri);
-
-            assertTrue("Memento created without datetime must retain original state",
-                    results.contains(ANY, mementoSubject, TEST_PROPERTY_NODE, createLiteral("foo")));
-            assertFalse("Memento created without datetime must ignore updates",
-                    results.contains(ANY, mementoSubject, TEST_PROPERTY_NODE, createLiteral("bar")));
-
-            // memento should be the same as original, in this case
-            assertMementoEqualsOriginal(mementoUri);
-        }
-    }
-
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionWithDatetimeAndBody() throws Exception {
         createVersionedContainer(id);
 
-        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
+//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         assertMementoUri(mementoUri, subjectUri);
         final Node mementoSubject = createURI(subjectUri);
         final Node subject = createURI(subjectUri);
@@ -557,60 +466,11 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     @Ignore //TODO Fix this test
     @Test
-    public void testCreateVersionDuplicateMementoDatetime() throws Exception {
-        createVersionedContainer(id);
-
-        // Create first memento
-        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
-
-        // Attempt to create second memento with same datetime, which should fail
-        final HttpPost createVersionMethod = postObjMethod(id + "/" + FCR_VERSIONS);
-        createVersionMethod.addHeader(CONTENT_TYPE, N3);
-        final String body = "<" + subjectUri + "> <info:test#label> \"far\"";
-        createVersionMethod.setEntity(new StringEntity(body));
-        createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, MEMENTO_DATETIME);
-
-        try (final CloseableHttpResponse response = execute(createVersionMethod)) {
-            assertEquals("Duplicate memento datetime should return 409 status",
-                    CONFLICT.getStatusCode(), getStatus(response));
-        }
-
-        final Node mementoSubject = createURI(subjectUri);
-        // Verify first memento content persists
-        try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
-            final DatasetGraph results = dataset.asDatasetGraph();
-
-            assertTrue("Memento must have first updated property",
-                    results.contains(ANY, mementoSubject, TEST_PROPERTY_NODE, createLiteral("bar")));
-            assertFalse("Memento must not have second updated property",
-                    results.contains(ANY, mementoSubject, TEST_PROPERTY_NODE, createLiteral("far")));
-        }
-    }
-
-    @Ignore //TODO Fix this test
-    @Test
-    public void testCreateVersionWithDatetimeAndEmptyBody() throws Exception {
-        createVersionedContainer(id);
-
-        final HttpPost createVersionMethod = new HttpPost(subjectUri + "/" + FCR_VERSIONS);
-        createVersionMethod.setEntity(new StringEntity(""));
-        createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, MEMENTO_DATETIME);
-
-        // Create new memento of resource with updated body
-        try (final CloseableHttpResponse response = execute(createVersionMethod)) {
-            assertEquals("Didn't get a BAD_REQUEST response!", BAD_REQUEST.getStatusCode(), getStatus(response));
-            final String responseMsg = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
-            assertTrue("Expected error message indicating empty body provided, received: " + responseMsg,
-                    responseMsg.contains("Cannot create historic memento from an empty body"));
-        }
-    }
-
-    @Ignore //TODO Fix this test
-    @Test
     public void testDeleteAndPostContainerMemento() throws Exception {
         createVersionedContainer(id);
 
-        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
+//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
 
         assertEquals("Expected delete to succeed",
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
@@ -618,7 +478,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals("Deleted memento must be removed",
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
 
-        final String recreatedUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String recreatedUri = createContainerMementoWithBody(subjectUri);
+//        final String recreatedUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         assertEquals("Recreated memento must exist",
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
@@ -628,7 +489,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testDeleteAndPostBinaryMemento() throws Exception {
         createVersionedBinary(id);
 
-        final String mementoUri = createLDPNRMementoWithExistingBody(MEMENTO_DATETIME);
+        final String mementoUri = createLDPNRMementoWithExistingBody();
+//        final String mementoUri = createLDPNRMementoWithExistingBody(MEMENTO_DATETIME);
 
         assertEquals("Expected delete to succeed",
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
@@ -636,7 +498,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals("Deleted memento must be removed",
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
 
-        final String recreatedUri = createLDPNRMementoWithExistingBody(MEMENTO_DATETIME);
+        final String recreatedUri = createLDPNRMementoWithExistingBody();
+//        final String recreatedUri = createLDPNRMementoWithExistingBody(MEMENTO_DATETIME);
         assertEquals("Recreated memento must exist",
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
@@ -648,7 +511,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         final String descId = id + "/" + FCR_METADATA;
         final String descUri = serverAddress + descId;
-        final String mementoUri = createMementoWithExistingBody(descId, MEMENTO_DATETIME, false);
+        final String mementoUri = createMementoWithExistingBody(descId, false);
+//        final String mementoUri = createMementoWithExistingBody(descId, MEMENTO_DATETIME, false);
 
         assertEquals("Expected delete to succeed",
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(mementoUri)));
@@ -656,7 +520,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals("Deleted memento must be removed",
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(mementoUri)));
 
-        final String recreatedUri = createContainerMementoWithBody(descUri, MEMENTO_DATETIME);
+        final String recreatedUri = createContainerMementoWithBody(descUri);
+//        final String recreatedUri = createContainerMementoWithBody(descUri, MEMENTO_DATETIME);
         assertEquals("Recreated memento must exist",
                 OK.getStatusCode(), getStatus(new HttpGet(recreatedUri)));
     }
@@ -670,7 +535,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createObjectAndClose(id + "/x");
 
         // create memento
-        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
+//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
 
         // Remove the child resource
         assertEquals("Expected delete to succeed",
@@ -700,7 +566,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
         final String mementoDateTime =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
-        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
+        final String mementoUri = createLDPRSMementoWithExistingBody();
+//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: HEAD request on existing memento
         final HttpHead headMethod = new HttpHead(mementoUri);
@@ -723,7 +590,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
         final String mementoDateTime =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
-        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
+        final String mementoUri = createLDPRSMementoWithExistingBody();
+//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: GET request on existing memento
         final HttpGet getMemento = new HttpGet(mementoUri);
@@ -745,7 +613,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
         final String mementoDateTime =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
-        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
+        final String mementoUri = createLDPRSMementoWithExistingBody();
+//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
         // Status 200: GET request on existing memento
         final HttpGet getMemento = new HttpGet(mementoUri);
         getMemento.addHeader(ACCEPT_DATETIME, mementoDateTime);
@@ -760,7 +629,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
         final String mementoDateTime =
                 MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
-        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
+        final String mementoUri = createLDPRSMementoWithExistingBody();
+//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
         // Status 200: HEAD request on existing memento
         final HttpHead headMemento = new HttpHead(mementoUri);
         headMemento.addHeader(ACCEPT_DATETIME, mementoDateTime);
@@ -776,7 +646,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
         final String mementoDateTime =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
-        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
+        final String mementoUri = createLDPRSMementoWithExistingBody();
+//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 200: OPTIONS request on existing memento
         final HttpOptions optionsMemento = new HttpOptions(mementoUri);
@@ -809,7 +680,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         executeAndClose(updateObjectGraphMethod);
 
         // create memento
-        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
+//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
 
         // Remove the referencing resource
         assertEquals("Expected delete to succeed",
@@ -859,7 +731,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         executeAndClose(updateObjectGraphMethod);
 
         // Create memento
-        final String mementoUri = createMemento(subjectUri, null, null, null);
+        final String mementoUri = createMemento(subjectUri);
         assertMementoUri(mementoUri, subjectUri);
 
         // Delete referenced resource
@@ -906,7 +778,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(405, getStatus(new HttpPatch(serverAddress + id + "/" + FCR_VERSIONS)));
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapResponseForBinary() throws Exception {
         createVersionedBinary(id);
@@ -927,7 +798,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetTimeMapResponseForBinaryDescription() throws Exception {
         createVersionedBinary(id);
@@ -1109,12 +979,12 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(1, response.getHeaders("Accept-Post").length);
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionOfBinary() throws Exception {
         createVersionedBinary(id);
 
-        final String mementoUri = createMemento(subjectUri, null, null, null);
+        final String mementoUri = createMemento(subjectUri);
         assertMementoUri(mementoUri, subjectUri);
 
         final HttpGet httpGet = new HttpGet(mementoUri);
@@ -1134,13 +1004,14 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionOfBinaryWithDatetimeAndContentType() throws Exception {
         createVersionedBinary(id);
 
-        final String mementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
-                OCTET_STREAM_TYPE, null);
+        final String mementoUri = createMemento(subjectUri);
+//        final String mementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
+//                OCTET_STREAM_TYPE, null);
         assertMementoUri(mementoUri, subjectUri);
 
         // Verify that the memento has the updated binary
@@ -1153,13 +1024,14 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionOfBinaryWithBody() throws Exception {
         createVersionedBinary(id);
 
-        final String mementoUri = createMemento(subjectUri, null,
-                OCTET_STREAM_TYPE, BINARY_UPDATED);
+        final String mementoUri = createMemento(subjectUri);
+//        final String mementoUri = createMemento(subjectUri, null,
+//                OCTET_STREAM_TYPE, BINARY_UPDATED);
         assertMementoUri(mementoUri, subjectUri);
 
         final HttpGet httpGet = new HttpGet(mementoUri);
@@ -1171,13 +1043,14 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionOfBinaryWithDatetimeAndBody() throws Exception {
         createVersionedBinary(id);
 
-        final String mementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
-                "text/plain", BINARY_UPDATED);
+        final String mementoUri = createMemento(subjectUri);
+//        final String mementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
+//                "text/plain", BINARY_UPDATED);
         assertMementoUri(mementoUri, subjectUri);
 
         // Verify that the memento has the updated binary
@@ -1192,7 +1065,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
+    @Ignore("get memento not implemented")
     @Test
     public void testCreateVersionOfBinaryDescription() throws Exception {
         createVersionedBinary(id);
@@ -1209,7 +1082,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertEquals(patchResp.getStatusLine().toString(), NO_CONTENT.getStatusCode(), getStatus(patchResp));
         }
 
-        final String mementoUri = createContainerMementoWithBody(descriptionUri, null);
+        final String mementoUri = createContainerMementoWithBody(descriptionUri);
         assertMementoUri(mementoUri, descriptionUri);
 
         setDescriptionProperty(id, null, DC.title.getURI(), "Updated");
@@ -1236,31 +1109,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(NOT_FOUND.getStatusCode(), getStatus(new HttpGet(hypotheticalBinaryUri)));
     }
 
-    /*
-     * Attempt to create binary description with container triples
-     */
-    @Ignore //TODO Fix this test
-    @Test
-    public void testCreateVersionOfBinaryDescriptionInvalidTriples() throws Exception {
-        final String containerId = getRandomUniqueId();
-        final String containerSubjectUri = serverAddress + containerId;
-        createObjectAndClose(containerId);
-
-        createVersionedBinary(id);
-
-        final String descriptionUri = subjectUri + "/fcr:metadata";
-
-        final String containerBody = createContainerMementoBodyContent(containerSubjectUri, "text/n3");
-        final HttpPost createMethod = postObjMethod(descriptionUri);
-        createMethod.addHeader(CONTENT_TYPE, "text/n3");
-        createMethod.setEntity(new StringEntity(containerBody));
-
-        // Attempt to create memento with partial record
-        try (final CloseableHttpResponse response = execute(createMethod)) {
-            assertEquals("Didn't get a BAD_REQUEST response!", BAD_REQUEST.getStatusCode(), getStatus(response));
-        }
-    }
-
     @Ignore //TODO Fix this test
     @Test
     public void testCreateVersionBinaryDescriptionWithBodyAndDatetime() throws Exception {
@@ -1268,7 +1116,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         final String descriptionUri = subjectUri + "/fcr:metadata";
 
-        final String mementoUri = createContainerMementoWithBody(descriptionUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(descriptionUri);
+//        final String mementoUri = createContainerMementoWithBody(descriptionUri, MEMENTO_DATETIME);
         assertMementoUri(mementoUri, descriptionUri);
 
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
@@ -1292,11 +1141,13 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         final String descriptionUri = subjectUri + "/fcr:metadata";
 
-        final String binaryMementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
-                null, "content");
+        final String binaryMementoUri = createMemento(subjectUri);
+//        final String binaryMementoUri = createMemento(subjectUri, MEMENTO_DATETIME,
+//                null, "content");
         assertMementoUri(binaryMementoUri, subjectUri);
 
-        final String mementoUri = createContainerMementoWithBody(descriptionUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(descriptionUri);
+//        final String mementoUri = createContainerMementoWithBody(descriptionUri, MEMENTO_DATETIME);
         assertMementoUri(mementoUri, descriptionUri);
 
         try (final CloseableDataset dataset = getDataset(new HttpGet(mementoUri))) {
@@ -1335,7 +1186,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
                     ANY, title.asNode(), createLiteral("First Title")));
         }
         logger.debug("Posting version v0.0.1");
-        final String mementoUri = createContainerMementoWithBody(subjectUri, null);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
         assertMementoUri(mementoUri, subjectUri);
 
         logger.debug("Replacing the title");
@@ -1354,24 +1205,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
-    @Test
-    public void testInvalidVersionDatetime() throws Exception {
-        final String invalidDate = "blah";
-        createVersionedContainer(id);
-
-        // Create memento body
-        final String body = createContainerMementoBodyContent(subjectUri, N3);
-
-        final HttpPost postReq = postObjMethod(serverAddress + id + "/" + FCR_VERSIONS);
-        postReq.addHeader(MEMENTO_DATETIME_HEADER, invalidDate);
-        postReq.addHeader(CONTENT_TYPE, N3);
-        postReq.setEntity(new StringEntity(body));
-
-        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(postReq));
-    }
-
-    @Ignore //TODO Fix this test
     @Test
     public void testTimeMapResponseContentTypes() throws Exception {
         createVersionedContainer(id);
@@ -1388,7 +1221,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testGetVersionResponseContentTypes() throws Exception {
         createVersionedContainer(id);
-        final String versionUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String versionUri = createContainerMementoWithBody(subjectUri);
+//        final String versionUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
 
         final String[] rdfResponseTypes = rdfTypes.toArray(new String[rdfTypes.size()]);
         for (final String type : rdfResponseTypes) {
@@ -1406,10 +1240,12 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedContainer(id);
         final String memento1 =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
-        final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
+        final String version1Uri = createLDPRSMementoWithExistingBody();
+//        final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
         final String memento2 =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2016-06-17T11:41:00Z", Instant::from));
-        final String version2Uri = createLDPRSMementoWithExistingBody(memento2);
+        final String version2Uri = createLDPRSMementoWithExistingBody();
+//        final String version2Uri = createLDPRSMementoWithExistingBody(memento2);
 
         // Request datetime between memento1 and memento2
         final String request1Datetime =
@@ -1459,7 +1295,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final String originalUri = createVersionedContainer(id);
 
         // Create a current memento
-        final String version1Uri = createMemento(originalUri, null, "text/turtle", null);
+        final String version1Uri = createMemento(originalUri);
+//        final String version1Uri = createMemento(originalUri, null, "text/turtle", null);
         final HttpHead httpHead = new HttpHead(version1Uri);
         final String version1Datetime;
         try (final CloseableHttpResponse response = customClient.execute(httpHead)) {
@@ -1470,7 +1307,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         final Instant version2Instant =
             Instant.from(MEMENTO_RFC_1123_FORMATTER.parse(version1Datetime)).minus(5, ChronoUnit.SECONDS);
         final String version2Datetime = MEMENTO_RFC_1123_FORMATTER.format(version2Instant);
-        final String version2Uri = createLDPRSMementoWithExistingBody(version2Datetime);
+        final String version2Uri = createLDPRSMementoWithExistingBody();
+//        final String version2Uri = createLDPRSMementoWithExistingBody(version2Datetime);
 
         // Attempt to retrieve older memento
         final HttpGet getVersion2 = getObjMethod(id);
@@ -1530,7 +1368,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             NOT_ACCEPTABLE.getStatusCode(), getStatus(customClient.execute(getMethod1)));
 
         // Create memento
-        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
+        final String mementoUri = createLDPRSMementoWithExistingBody();
+//        final String mementoUri = createLDPRSMementoWithExistingBody(mementoDateTime);
 
         // Status 302: GET memento with datetime negotiation
         final HttpGet getMethod2 = getObjMethod(id);
@@ -1551,7 +1390,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testFixityOnVersionedResource() throws Exception {
         createVersionedBinary(id);
 
-        final String mementoUri = createMemento(subjectUri, null, null, null);
+        final String mementoUri = createMemento(subjectUri);
 
         final HttpGet checkFixity = new HttpGet(mementoUri + "/" + FCR_FIXITY);
         try (final CloseableHttpResponse response = execute(checkFixity)) {
@@ -1563,7 +1402,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testOptionsMemento() throws Exception {
         createVersionedContainer(id);
-        final String mementoUri = createContainerMementoWithBody(subjectUri, null);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
 
         final HttpOptions optionsRequest = new HttpOptions(mementoUri);
         try (final CloseableHttpResponse optionsResponse = execute(optionsRequest)) {
@@ -1577,7 +1416,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testPatchOnMemento() throws Exception {
         createVersionedContainer(id);
 
-        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
+//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         final HttpPatch patch = new HttpPatch(mementoUri);
         patch.addHeader(CONTENT_TYPE, "application/sparql-update");
         patch.setEntity(new StringEntity(
@@ -1606,7 +1446,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testPostOnMemento() throws Exception {
         createVersionedContainer(id);
 
-        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
+//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         final String body = createContainerMementoBodyContent(subjectUri, N3);
         final HttpPost post = new HttpPost(mementoUri);
         post.addHeader(CONTENT_TYPE, N3);
@@ -1635,7 +1476,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testPutOnMemento() throws Exception {
         createVersionedContainer(id);
 
-        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
+        final String mementoUri = createContainerMementoWithBody(subjectUri);
+//        final String mementoUri = createContainerMementoWithBody(subjectUri, MEMENTO_DATETIME);
         final String body = createContainerMementoBodyContent(subjectUri, N3);
         final HttpPut put = new HttpPut(mementoUri);
         put.addHeader(CONTENT_TYPE, N3);
@@ -1666,7 +1508,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         final String memento1 =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
-        final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
+        final String version1Uri = createLDPRSMementoWithExistingBody();
+//        final String version1Uri = createLDPRSMementoWithExistingBody(memento1);
         final HttpGet getRequest = new HttpGet(version1Uri);
 
         try (final CloseableHttpResponse response = execute(getRequest)) {
@@ -1690,7 +1533,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         final String memento1 =
             MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2001-06-10T16:41:00Z", Instant::from));
-        final String version1Uri = createLDPNRMementoWithExistingBody(memento1);
+        final String version1Uri = createLDPNRMementoWithExistingBody();
+//        final String version1Uri = createLDPNRMementoWithExistingBody(memento1);
         final HttpGet getRequest = new HttpGet(version1Uri);
 
         try (final CloseableHttpResponse response = execute(getRequest)) {
@@ -1723,7 +1567,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertEquals(OK.getStatusCode(), getStatus(new HttpGet(descTimemapUri)));
 
         // 3. create a binary version against binary timemap
-        final String mementoUri = createMemento(subjectUri, null, null, null);
+        final String mementoUri = createMemento(subjectUri);
         final String descMementoUri = mementoUri.replace("fcr:versions", "fcr:metadata/fcr:versions");
 
         final Node timemapSubject = createURI(descTimemapUri);
@@ -1739,7 +1583,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         TimeUnit.SECONDS.sleep(1);
 
         // 5. Create a second binary description memento
-        final String descMementoUri2 = createMemento(descriptionUri, null, null, null);
+        final String descMementoUri2 = createMemento(descriptionUri);
 
         // 6. verify that the binary description timemap availabe (returns 404 in fcrepo-2792)
         try (final CloseableDataset dataset = getDataset(new HttpGet(descTimemapUri))) {
@@ -1753,7 +1597,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testOptionsTimeMap() throws Exception {
         createVersionedContainer(id);
@@ -1778,7 +1621,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         createVersionedExternalBinaryMemento(id, "proxy", proxiedUri);
 
         // Create a version of the external binary using the second binary as content
-        final String mementoUri = createMemento(subjectUri, null, null, null);
+        final String mementoUri = createMemento(subjectUri);
 
         // Verify that the historic version exists and proxies the old content
         final HttpGet httpGet1 = new HttpGet(mementoUri);
@@ -1899,7 +1742,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void versionedResourcesCreatedByDefault() throws Exception {
         final String id = getRandomUniqueId();
@@ -1943,15 +1785,15 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertTrue("Should allow DELETE", methods.contains(HttpDelete.METHOD_NAME));
     }
 
-    private String createLDPRSMementoWithExistingBody(final String mementoDateTime) throws Exception {
-        return createMementoWithExistingBody(id, mementoDateTime, false);
+    private String createLDPRSMementoWithExistingBody() throws Exception {
+        return createMementoWithExistingBody(id, false);
     }
 
-    private String createLDPNRMementoWithExistingBody(final String mementoDateTime) throws Exception {
-        return createMementoWithExistingBody(id, mementoDateTime, true);
+    private String createLDPNRMementoWithExistingBody() throws Exception {
+        return createMementoWithExistingBody(id, true);
     }
 
-    private String createMementoWithExistingBody(final String id, final String mementoDateTime, final boolean isLDPNR)
+    private String createMementoWithExistingBody(final String id, final boolean isLDPNR)
         throws Exception {
         final HttpGet getRequest = getObjMethod(id);
         if (!isLDPNR) {
@@ -1959,28 +1801,14 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
         try (final CloseableHttpResponse response = execute(getRequest)) {
             if (getStatus(response) == OK.getStatusCode()) {
-                // Resource exists so get the body to put back with header
-                final String body = EntityUtils.toString(response.getEntity());
-                final String mimeType =
-                    response.getFirstHeader(CONTENT_TYPE).getValue();
-                return createMemento(serverAddress + id, mementoDateTime, mimeType, body);
+                return createMemento(serverAddress + id);
             }
         }
         return null;
     }
 
-    private String createMemento(final String subjectUri, final String mementoDateTime, final String contentType,
-            final String body) throws Exception {
+    private String createMemento(final String subjectUri) throws Exception {
         final HttpPost createVersionMethod = new HttpPost(subjectUri + "/" + FCR_VERSIONS);
-        if (contentType != null) {
-            createVersionMethod.addHeader(CONTENT_TYPE, contentType);
-        }
-        if (body != null) {
-            createVersionMethod.setEntity(new StringEntity(body));
-        }
-        if (mementoDateTime != null && !mementoDateTime.isEmpty()) {
-            createVersionMethod.addHeader(MEMENTO_DATETIME_HEADER, mementoDateTime);
-        }
 
         // Create new memento of resource with updated body
         try (final CloseableHttpResponse response = execute(createVersionMethod)) {
@@ -1991,11 +1819,11 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    private String createContainerMementoWithBody(final String subjectUri, final String mementoDateTime)
+    private String createContainerMementoWithBody(final String subjectUri)
             throws Exception {
 
-        final String body = createContainerMementoBodyContent(subjectUri, N3);
-        return createMemento(subjectUri, mementoDateTime, N3, body);
+        createContainerMementoBodyContent(subjectUri, N3);
+        return createMemento(subjectUri);
     }
 
     private String createContainerMementoBodyContent(final String subjectUri, final String contentType)
@@ -2042,6 +1870,30 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     /**
+     * Create a versioned LDP-RS
+     *
+     * @param id the desired slug
+     * @param label label text
+     * @param isUpdate whether or not the operation is an update
+     * @throws Exception on error
+     */
+    private void putVersionedContainer(final String id, final String label, final boolean isUpdate) throws Exception {
+        final HttpPut createMethod = putObjMethod(id);
+        createMethod.addHeader("Slug", id);
+        createMethod.addHeader(CONTENT_TYPE, N3);
+        createMethod.setEntity(new StringEntity("<> <info:test#label> \"" + label + "\""));
+
+        try (final CloseableHttpResponse response = execute(createMethod)) {
+            if (isUpdate) {
+                assertEquals("Didn't get a NO_CONTENT response!", NO_CONTENT.getStatusCode(), getStatus(response));
+            } else {
+                assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+                logger.info("created object: {}", response.getFirstHeader(LOCATION).getValue());
+            }
+        }
+    }
+
+    /**
      * Create a versioned Archival Group
      *
      * @param id the desired slug
@@ -2068,7 +1920,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * @param id the desired slug
      * @param mimeType the mimeType of the content
      * @param content the actual content
-     * @param isUpdate whether or not the opertion is an update
+     * @param isUpdate whether or not the operation is an update
      * @throws Exception on error
      */
     private void putVersionedBinary(final String id, final String mimeType, final String content,

--- a/fcrepo-http-api/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-http-api/src/test/resources/spring-test/test-container.xml
@@ -6,11 +6,11 @@
   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
   http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-  <context:property-placeholder/>
+  <context:property-placeholder />
 
   <bean id="containerWrapper"
     class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"
+    init-method="start" destroy-method="stop"
     p:configLocation="classpath:web.xml"/>
 
 </beans>

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
@@ -42,8 +42,10 @@ import org.glassfish.grizzly.servlet.ServletRegistration;
 import org.glassfish.grizzly.servlet.WebappContext;
 import org.slf4j.Logger;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
 /**
  * <p>ContainerWrapper class.</p>
@@ -54,6 +56,7 @@ public class ContainerWrapper implements ApplicationContextAware {
 
     private static final Logger logger = getLogger(ContainerWrapper.class);
 
+    @Value("#{${fcrepo.dynamic.test.port} ?: 8080}")
     private int port;
 
     private HttpServer server;
@@ -146,11 +149,13 @@ public class ContainerWrapper implements ApplicationContextAware {
         }
     }
 
-    @Override
-    public void setApplicationContext(final ApplicationContext applicationContext)
-            throws BeansException {
-        // this.applicationContext = applicationContext;
+    public ApplicationContext getSpringAppContext() {
+        return WebApplicationContextUtils.findWebApplicationContext(appContext);
+    }
 
+    @Override
+    public void setApplicationContext(final ApplicationContext springAppContext)
+            throws BeansException {
     }
 
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateVersionResourceOperation.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateVersionResourceOperation.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.operations;
+
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
+
+/**
+ * An operation for creating a new version of a resource
+ */
+public interface CreateVersionResourceOperation extends ResourceOperation {
+
+    @Override
+    default ResourceOperationType getType() {
+        return UPDATE;
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateVersionResourceOperationBuilder.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateVersionResourceOperationBuilder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.operations;
+
+/**
+ * Builder for creating {@link CreateVersionResourceOperation}s
+ */
+public interface CreateVersionResourceOperationBuilder extends ResourceOperationBuilder {
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/VersionResourceOperationFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/VersionResourceOperationFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.operations;
+
+/**
+ * Factory for creating {@link CreateVersionResourceOperationBuilder}s
+ */
+public interface VersionResourceOperationFactory extends ResourceOperationFactory {
+
+    /**
+     * Create a new {@link CreateVersionResourceOperationBuilder} builder.
+     *
+     * @param rescId the resource id
+     * @return builder
+     */
+    CreateVersionResourceOperationBuilder createBuilder(String rescId);
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -19,21 +19,10 @@ package org.fcrepo.kernel.api.services;
 
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 
-import java.io.InputStream;
-import java.net.URI;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Collection;
 
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.riot.Lang;
 import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.exception.InvalidChecksumException;
-import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
-import org.fcrepo.kernel.api.models.Binary;
-import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 
 /**
  * Service for creating versions of resources
@@ -59,81 +48,9 @@ public interface VersionService {
      * Explicitly creates a version for the resource at the path provided.
      *
      * @param transaction the transaction in which the resource resides
-     * @param resource the resource to version
-     * @param idTranslator translator for producing URI of resources
-     * @param dateTime the date/time of the version
-     * @return the version
+     * @param resourceId the internal resource id
+     * @param userPrincipal the user principal
      */
-    FedoraResource createVersion(Transaction transaction, FedoraResource resource,
-            IdentifierConverter<Resource, FedoraResource> idTranslator, Instant dateTime);
+    void createVersion(Transaction transaction, String resourceId, String userPrincipal);
 
-    /**
-     * Explicitly creates a version for the resource at the path provided for the date/time provided.
-     *
-     * @param transaction the transaction in which the resource resides
-     * @param resource the resource to version
-     * @param idTranslator translator for producing URI of resources
-     * @param dateTime the date/time of the version
-     * @param rdfInputStream if provided, this stream will provide the properties of the new memento. If null, then
-     *        the state of the current resource will be used.
-     * @param rdfFormat RDF language format name
-     * @return the version
-     */
-    FedoraResource createVersion(Transaction transaction, FedoraResource resource,
-            IdentifierConverter<Resource, FedoraResource> idTranslator, Instant dateTime, InputStream rdfInputStream,
-            Lang rdfFormat);
-
-    /**
-     * Explicitly creates a version of a binary resource. If contentStream is provided, then it will be used as the
-     * content of the binary memento. Otherwise, the current state of the binary will be used.
-     *
-     * @param transaction the transaction in which the resource resides
-     * @param resource the binary resource to version
-     * @param dateTime the date/time of the version
-     * @param contentStream if provided, the content in this stream will be used as the content of the new binary
-     *        memento. If null, then the current state of the binary will be used.
-     * @param checksums Collection of checksum URIs of the content (optional)
-     * @param storagePolicyDecisionPoint optional storage policy
-     * @throws InvalidChecksumException if there are errors applying checksums
-     * @return the version
-     */
-    Binary createBinaryVersion(Transaction transaction,
-                               Binary resource,
-                               Instant dateTime,
-                               InputStream contentStream,
-                               Collection<URI> checksums,
-                               StoragePolicyDecisionPoint storagePolicyDecisionPoint)
-            throws InvalidChecksumException;
-
-    /**
-     * Explicitly creates a version of a binary resource from the current state of that binary.
-     *
-     * @param transaction the transaction in which the resource resides
-     * @param resource the binary resource to version
-     * @param dateTime the date/time of the version
-     * @param storagePolicyDecisionPoint optional storage policy
-     * @return the version
-     * @throws InvalidChecksumException on error
-     */
-    Binary createBinaryVersion(Transaction transaction, Binary resource, Instant dateTime,
-                               StoragePolicyDecisionPoint storagePolicyDecisionPoint)
-            throws InvalidChecksumException;
-
-    /**
-     * @param transaction the transaction in which the resource resides
-     * @param resource the binary resource to version
-     * @param dateTime the date/time of the version
-     * @param checksums Collection of checksum URIs of the content (optional)
-     * @param externalHandling What type of handling the external resource needs (proxy or redirect)
-     * @param externalUrl Url for the external resourcej
-     * @return the version
-     * @throws InvalidChecksumException if there are errors applying checksums
-     */
-    Binary createExternalBinaryVersion(final Transaction transaction,
-                                       final Binary resource,
-                                       final Instant dateTime,
-                                       final Collection<URI> checksums,
-                                       final String externalHandling,
-                                       final String externalUrl)
-            throws InvalidChecksumException;
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -73,7 +73,7 @@ public class TransactionImpl implements Transaction {
             return;
         }
         try {
-            log.debug("Commiting transaction {}", id);
+            log.debug("Committing transaction {}", id);
             this.getPersistentSession().commit();
             this.commited = true;
         } catch (final PersistentStorageException ex) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -246,7 +246,7 @@ public class FedoraResourceImpl implements FedoraResource {
     }
 
     protected PersistentStorageSession getSession() {
-        if (tx == null) {
+        if (tx == null || tx.isCommitted()) {
             return pSessionManager.getReadOnlySession();
         } else {
             return pSessionManager.getSession(tx.getId());

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -97,12 +97,8 @@ public class ResourceFactoryImpl implements ResourceFactory {
     public boolean doesResourceExist(final Transaction transaction, final String fedoraId, final Instant version) {
         // TODO: Check the index first.
 
-        final PersistentStorageSession psSession;
-        if (transaction == null) {
-            psSession = persistentStorageSessionManager.getReadOnlySession();
-        } else {
-            psSession = persistentStorageSessionManager.getSession(transaction.getId());
-        }
+        final PersistentStorageSession psSession = getSession(transaction);
+
         try {
             psSession.getHeaders(fedoraId, version);
             return true;
@@ -221,7 +217,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
      */
     private PersistentStorageSession getSession(final Transaction transaction) {
         final PersistentStorageSession session;
-        if (transaction == null) {
+        if (transaction == null || transaction.isCommitted()) {
             session = persistentStorageSessionManager.getReadOnlySession();
         } else {
             session = persistentStorageSessionManager.getSession(transaction.getId());

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateVersionResourceOperationBuilderImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateVersionResourceOperationBuilderImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.operations;
+
+import org.fcrepo.kernel.api.operations.CreateVersionResourceOperationBuilder;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
+
+/**
+ * Default impl of {@link CreateVersionResourceOperationBuilder}
+ */
+public class CreateVersionResourceOperationBuilderImpl implements CreateVersionResourceOperationBuilder {
+
+    private final String resourceId;
+    private String userPrincipal;
+
+    /**
+     * Create a new builder
+     *
+     * @param resourceId the resource id
+     */
+    public CreateVersionResourceOperationBuilderImpl(final String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    @Override
+    public ResourceOperationBuilder userPrincipal(final String userPrincipal) {
+        this.userPrincipal = userPrincipal;
+        return this;
+    }
+
+    @Override
+    public ResourceOperation build() {
+        final var operation = new CreateVersionResourceOperationImpl(resourceId);
+        operation.setUserPrincipal(userPrincipal);
+        return operation;
+    }
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateVersionResourceOperationImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateVersionResourceOperationImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.operations;
+
+import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
+
+/**
+ * Default impl of {@link CreateVersionResourceOperation}
+ */
+public class CreateVersionResourceOperationImpl extends AbstractResourceOperation
+        implements CreateVersionResourceOperation {
+
+    protected CreateVersionResourceOperationImpl(final String rescId) {
+        super(rescId);
+    }
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/VersionResourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/VersionResourceOperationFactoryImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.operations;
+
+import org.fcrepo.kernel.api.operations.CreateVersionResourceOperationBuilder;
+import org.fcrepo.kernel.api.operations.VersionResourceOperationFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default impl of {@link VersionResourceOperationFactory}
+ */
+@Component
+public class VersionResourceOperationFactoryImpl implements VersionResourceOperationFactory {
+
+    @Override
+    public CreateVersionResourceOperationBuilder createBuilder(final String rescId) {
+        return new CreateVersionResourceOperationBuilderImpl(rescId);
+    }
+
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/VersionServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/VersionServiceImplTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.services;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.impl.operations.VersionResourceOperationFactoryImpl;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VersionServiceImplTest {
+
+    private VersionServiceImpl service;
+
+    @Mock
+    private PersistentStorageSessionManager psManager;
+
+    @Mock
+    private PersistentStorageSession session;
+
+    @Mock
+    private Transaction transaction;
+
+    private final String TX_ID = "tx1";
+
+    @Before
+    public void setup() {
+        service = new VersionServiceImpl();
+        service.setPsManager(psManager);
+        service.setVersionOperationFactory(new VersionResourceOperationFactoryImpl());
+
+        when(transaction.getId()).thenReturn(TX_ID);
+        when(psManager.getSession(TX_ID)).thenReturn(session);
+    }
+
+    @Test
+    public void createPersistOperation() throws PersistentStorageException {
+        final var resourceId = "info:fedora/test";
+        final var user = "me";
+
+        service.createVersion(transaction, resourceId, user);
+
+        final var captor = ArgumentCaptor.forClass(ResourceOperation.class);
+        verify(session).persist(captor.capture());
+        final var captured = captor.getValue();
+
+        assertEquals(resourceId, captured.getResourceId());
+        assertEquals(user, captured.getUserPrincipal());
+    }
+
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -35,15 +35,6 @@ import java.util.stream.Stream;
 public interface OCFLObjectSession {
 
     /**
-     * The default commit option configured for the OCFL Object represented by this session.
-     * If no default commit option has been defined for the specific OCFL Object, the
-     * value returned will be the system defined global default commit option.
-     *
-     * @return The default commit option
-     */
-    CommitOption getDefaultCommitOption();
-
-    /**
      * Write the provided content to specified subpath.
      *
      * @param subpath path of the resource to write, relative to the OCFL object
@@ -89,6 +80,20 @@ public interface OCFLObjectSession {
     InputStream read(String subpath, String version) throws PersistentStorageException;
 
     /**
+     * Overrides the default {@link CommitOption} to use when the session is committed. By default, is
+     * {@link CommitOption#UNVERSIONED} when fcrepo.autoversioning.enabled is false,
+     * and {@link CommitOption#NEW_VERSION} when it is true
+     *
+     * @param commitOption the commit option
+     */
+    void setCommitOption(CommitOption commitOption);
+
+    /**
+     * @return the commit option that's configured on the session
+     */
+    CommitOption getCommitOption();
+
+    /**
      * Verify that the change set in this session can be committed. A PersistentStorageException is thrown if there
      * are any conflicts that would prevent a commit.
      */
@@ -98,11 +103,10 @@ public interface OCFLObjectSession {
      * Commit the change set from this session to the OCFL object, following the strategy suggested by commitOption.
      * Creates the OCFL object if it did not previous exist.
      *
-     * @param commitOption option indicating where changes should be committed.
      * @return identifier of the version committed
      * @throws PersistentStorageException if unable to commit
      */
-    String commit(CommitOption commitOption) throws PersistentStorageException;
+    String commit() throws PersistentStorageException;
 
     /**
      * Close this session without committing changes.

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.persistence.ocfl.impl;
+
+import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.operations.ResourceOperationType;
+import org.fcrepo.persistence.api.CommitOption;
+import org.fcrepo.persistence.api.exceptions.PersistentItemConflictException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Persister for creating a new OCFL version of a resource. The new version is not created until the session
+ * is committed.
+ */
+public class CreateVersionPersister extends AbstractPersister {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CreateVersionPersister.class);
+
+    protected CreateVersionPersister(final FedoraToOCFLObjectIndex index) {
+        super(CreateVersionResourceOperation.class, ResourceOperationType.UPDATE, index);
+    }
+
+    @Override
+    public void persist(final OCFLPersistentStorageSession session, final ResourceOperation operation)
+            throws PersistentStorageException {
+
+        final var resourceId = operation.getResourceId();
+        LOG.debug("creating new version of <{}> in session <{}>", resourceId, session);
+
+        final var archivalGroupId = findArchivalGroupInAncestry(resourceId, session);
+
+        if (archivalGroupId != null && !archivalGroupId.equals(resourceId)) {
+            throw new PersistentItemConflictException(
+                    String.format("Resource <%s> is contained in Archival Group <%s> and cannot be versioned directly."
+                            + " Version the Archival Group instead.", resourceId, archivalGroupId));
+        }
+
+        final var ocflMapping = getMapping(resourceId);
+        final var ocflObjectSession = session.findOrCreateSession(ocflMapping.getOcflObjectId());
+
+        // The version is not actually created until the session is committed
+        ocflObjectSession.setCommitOption(CommitOption.NEW_VERSION);
+    }
+
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -108,7 +108,6 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
         this.objectDeleted = false;
         this.sessionClosed = false;
         this.created = Instant.now();
-
     }
 
     /**
@@ -371,8 +370,9 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
     }
 
     private String commitUpdates(final CommitOption commitOption) {
-        // Nothing to do if there are no staged files, no deletes, and not mutable HEAD
-        if (isStagingEmpty() && deletePaths.isEmpty() && !ocflRepository.hasStagedChanges(objectIdentifier)) {
+        // Nothing to do if there are no staged files, no deletes, and not committing the mutable HEAD
+        if (isStagingEmpty() && deletePaths.isEmpty() &&
+                !(commitOption == NEW_VERSION && ocflRepository.hasStagedChanges(objectIdentifier))) {
             return ocflRepository.describeVersion(ObjectVersionId.head(objectIdentifier))
                     .getVersionId().toString();
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -19,19 +19,30 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.api.OcflObjectUpdater;
-import static edu.wisc.library.ocfl.api.OcflOption.MOVE_SOURCE;
-import static edu.wisc.library.ocfl.api.OcflOption.OVERWRITE;
 import edu.wisc.library.ocfl.api.exception.NotFoundException;
 import edu.wisc.library.ocfl.api.model.CommitInfo;
 import edu.wisc.library.ocfl.api.model.FileChangeType;
 import edu.wisc.library.ocfl.api.model.FileDetails;
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import edu.wisc.library.ocfl.api.model.VersionDetails;
+import edu.wisc.library.ocfl.api.model.VersionId;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.fcrepo.persistence.api.CommitOption;
+import org.fcrepo.persistence.api.WriteOutcome;
+import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.common.FileWriteOutcome;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.fcrepo.persistence.ocfl.api.OCFLVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import static java.lang.String.format;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -47,20 +58,10 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import edu.wisc.library.ocfl.api.model.VersionId;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.fcrepo.persistence.api.CommitOption;
+import static edu.wisc.library.ocfl.api.OcflOption.MOVE_SOURCE;
+import static edu.wisc.library.ocfl.api.OcflOption.OVERWRITE;
+import static java.lang.String.format;
 import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
-import org.fcrepo.persistence.api.WriteOutcome;
-import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
-import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
-import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
-import org.fcrepo.persistence.common.FileWriteOutcome;
-import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
-import org.fcrepo.persistence.ocfl.api.OCFLVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of an OCFL object session, which stages changes to the

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java
@@ -391,4 +391,13 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
             throw new PersistentStorageException("Session is read-only");
         }
     }
+
+    @Override
+    public String toString() {
+        return "OCFLPersistentStorageSession{" +
+                "sessionId='" + sessionId + '\'' +
+                ", state=" + state +
+                '}';
+    }
+
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -43,6 +43,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -253,8 +254,10 @@ public class OCFLPersistentStorageUtils {
     public static String resolveVersionId(final OCFLObjectSession objSession, final Instant version)
             throws PersistentStorageException {
         if (version != null) {
-            return objSession.listVersions()
-                    .stream()
+            final var versions = objSession.listVersions();
+            // reverse order so that the most recent version is matched first
+            Collections.reverse(versions);
+            return versions.stream()
                     .filter(vd -> {
                         return vd.getCreated().equals(version);
                     }).map(OCFLVersion::getOcflVersionId)

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.persistence.ocfl.impl;
+
+import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
+import org.fcrepo.kernel.api.operations.ResourceOperationType;
+import org.fcrepo.persistence.api.CommitOption;
+import org.fcrepo.persistence.api.exceptions.PersistentItemConflictException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.common.ResourceHeadersImpl;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class CreateVersionPersisterTest {
+
+    private CreateVersionPersister persister;
+
+    private FedoraToOCFLObjectIndex index;
+
+    @Mock
+    private OCFLPersistentStorageSession session;
+
+    @Before
+    public void setup() {
+        index = new TestOcflObjectIndex();
+        persister = new CreateVersionPersister(index);
+    }
+
+    @Test
+    public void setCommitToNewVersionWhenNoChildOfAg() throws PersistentStorageException {
+        final var resourceId = "info:fedora/blah";
+        final var ocflId = "blah";
+
+        final var objectSession = addMapping(resourceId, ocflId);
+        expectArchivalGroup(resourceId, false);
+        objectSession.setCommitOption(CommitOption.NEW_VERSION);
+
+        persister.persist(session, operation(resourceId));
+    }
+
+    @Test
+    public void setCommitToNewVersionWhenAg() throws PersistentStorageException {
+        final var resourceId = "info:fedora/blah";
+        final var ocflId = "blah";
+
+        final var objectSession = addMapping(resourceId, ocflId);
+        expectArchivalGroup(resourceId, true);
+        objectSession.setCommitOption(CommitOption.NEW_VERSION);
+
+        persister.persist(session, operation(resourceId));
+    }
+
+    @Test(expected = PersistentItemConflictException.class)
+    public void failVersionCreationWhenChildOfAg() throws PersistentStorageException {
+        final var resourceId = "info:fedora/ag/blah";
+
+        expectArchivalGroup(resourceId, false);
+        expectArchivalGroup("info:fedora/ag", true);
+
+        persister.persist(session, operation(resourceId));
+    }
+
+    @Test(expected = PersistentStorageException.class)
+    public void failVersionCreationWhenNoOclfMapping() throws PersistentStorageException {
+        final var resourceId = "info:fedora/bogus";
+        final var ocflId = "blah";
+
+        addMapping("info:fedora/blah", ocflId);
+        expectArchivalGroup(resourceId, false);
+
+        persister.persist(session, operation(resourceId));
+    }
+
+    private void expectArchivalGroup(final String resourceId, final boolean isAgChild)
+            throws PersistentStorageException {
+        final var headers = new ResourceHeadersImpl();
+        headers.setArchivalGroup(isAgChild);
+        when(session.getHeaders(resourceId, null)).thenReturn(headers);
+    }
+
+    private OCFLObjectSession addMapping(final String resourceId, final String ocflId) {
+        index.addMapping(resourceId, resourceId, ocflId);
+        final var objectSession = mock(OCFLObjectSession.class);
+        when(session.findOrCreateSession(ocflId)).thenReturn(objectSession);
+        return objectSession;
+    }
+
+    private CreateVersionResourceOperation operation(final String resourceId) {
+        final var operation = mock(CreateVersionResourceOperation.class);
+        when(operation.getType()).thenReturn(ResourceOperationType.UPDATE);
+        when(operation.getResourceId()).thenReturn(resourceId);
+        return operation;
+    }
+
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -571,6 +571,24 @@ public class DefaultOCFLObjectSessionTest {
         commit(session2, UNVERSIONED);
 
         final ObjectDetails objDetails = ocflRepository.describeObject(OBJ_ID);
+        assertTrue("HEAD should be mutable", objDetails.getHeadVersion().isMutable());
+        final var versionMap = objDetails.getVersionMap();
+        assertEquals("Only the mutable head and initial version exist", 2, versionMap.size());
+
+        assertFileInVersion(OBJ_ID, "v2", FILE1_SUBPATH, FILE_CONTENT1);
+        assertFileNotInVersion(OBJ_ID, "v1", FILE1_SUBPATH);
+    }
+
+    @Test
+    public void commit_MHead_CreateNewVersionWhenStagedChanges() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        commit(UNVERSIONED);
+
+        final var session2 = makeNewSession();
+        commit(session2, NEW_VERSION);
+
+        final ObjectDetails objDetails = ocflRepository.describeObject(OBJ_ID);
+        assertFalse("HEAD should not be mutable", objDetails.getHeadVersion().isMutable());
         final var versionMap = objDetails.getVersionMap();
         assertEquals("Only the mutable head and initial version exist", 2, versionMap.size());
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
 import static org.fcrepo.persistence.api.CommitOption.UNVERSIONED;
+
+import org.fcrepo.persistence.api.CommitOption;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -100,13 +102,13 @@ public class DefaultOCFLObjectSessionTest {
         if (stagingPath == null || !stagingPath.toFile().exists()) {
             stagingPath = tempFolder.newFolder("obj1-staging").toPath();
         }
-        return new DefaultOCFLObjectSession(OBJ_ID, stagingPath, ocflRepository);
+        return new DefaultOCFLObjectSession(OBJ_ID, stagingPath, ocflRepository, UNVERSIONED);
     }
 
     @Test
     public void writeNewFile_ToNewVersion_NewObject() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        final String versionId = session.commit(NEW_VERSION);
+        final String versionId = commit(NEW_VERSION);
 
         assertEquals("v1", versionId);
         assertNoMutableHead(OBJ_ID);
@@ -116,7 +118,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void writeNewFile_ToMHead_NewObject() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(UNVERSIONED);
+        commit(UNVERSIONED);
 
         assertMutableHeadPopulated(OBJ_ID);
         assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT1);
@@ -127,7 +129,7 @@ public class DefaultOCFLObjectSessionTest {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         // Change the same file again
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
-        final String versionId = session.commit(NEW_VERSION);
+        final String versionId = commit(NEW_VERSION);
 
         assertEquals("v1", versionId);
         assertNoMutableHead(OBJ_ID);
@@ -141,7 +143,7 @@ public class DefaultOCFLObjectSessionTest {
         ocflRepository.putObject(ObjectVersionId.head(OBJ_ID), preStagingPath, null);
 
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
-        final String versionId = session.commit(NEW_VERSION);
+        final String versionId = commit(NEW_VERSION);
 
         assertEquals("v2", versionId);
         assertNoMutableHead(OBJ_ID);
@@ -158,7 +160,7 @@ public class DefaultOCFLObjectSessionTest {
         });
 
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
-        final String versionId = session.commit(UNVERSIONED);
+        final String versionId = commit(UNVERSIONED);
 
         assertEquals("Multiple commits to head should stay on version", "v2", versionId);
         assertMutableHeadPopulated(OBJ_ID);
@@ -169,15 +171,15 @@ public class DefaultOCFLObjectSessionTest {
     public void writeToMHeadThenNewVersion() throws Exception {
         // Write first file to mutable head
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(UNVERSIONED);
+        commit(UNVERSIONED);
 
         assertMutableHeadPopulated(OBJ_ID);
 
-        session = new DefaultOCFLObjectSession(OBJ_ID, stagingPath, ocflRepository);
+        session = new DefaultOCFLObjectSession(OBJ_ID, stagingPath, ocflRepository, UNVERSIONED);
 
         // Commit changes to new version in second commit
         session.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
-        final String versionId = session.commit(NEW_VERSION);
+        final String versionId = commit(NEW_VERSION);
 
         assertEquals("v2", versionId);
         assertNoMutableHead(OBJ_ID);
@@ -191,7 +193,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentSessionClosedException.class)
     public void write_CommittedSession() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         session.write(FILE2_SUBPATH, fileStream(FILE_CONTENT1));
     }
@@ -219,7 +221,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void read_FromMHead() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(UNVERSIONED);
+        commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
         assertStreamMatches(FILE_CONTENT1, session2.read(FILE1_SUBPATH));
@@ -228,7 +230,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void read_FromVersion() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         assertStreamMatches(FILE_CONTENT1, session2.read(FILE1_SUBPATH));
@@ -237,7 +239,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void read_FromStagedAndVersion() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
@@ -249,7 +251,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void read_FromStagedAndMHead() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(UNVERSIONED);
+        commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
         session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
@@ -262,7 +264,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentItemNotFoundException.class)
     public void read_FromVersion_NotExist() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         // Try a path that doesn't exist
@@ -278,7 +280,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentItemNotFoundException.class)
     public void read_FromNonExistentVersion() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         // version that hasn't been created yet
@@ -288,7 +290,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void read_CommittedSession() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         assertStreamMatches(FILE_CONTENT1, session2.read(FILE1_SUBPATH));
@@ -299,7 +301,7 @@ public class DefaultOCFLObjectSessionTest {
     public void nestedPath_NewVersion_NewObject() throws Exception {
         final String nestedSubpath = "path/to/the/file.txt";
         session.write(nestedSubpath, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         assertStreamMatches(FILE_CONTENT1, session2.read(nestedSubpath));
@@ -308,7 +310,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentItemNotFoundException.class)
     public void delete_FileNotExist() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         // Try a path that doesn't exist
@@ -337,14 +339,14 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void delete_FromStaged_OtherFilesVersioned() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         session2.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
 
         // Try a path that doesn't exist
         session2.delete(FILE2_SUBPATH);
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE2_SUBPATH);
         assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT1);
@@ -353,11 +355,11 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void delete_FromMHead() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(UNVERSIONED);
+        commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
         session2.delete(FILE1_SUBPATH);
-        session2.commit(UNVERSIONED);
+        commit(session2, UNVERSIONED);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
     }
@@ -365,11 +367,11 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void delete_FromVersion() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         session2.delete(FILE1_SUBPATH);
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
         assertFileInVersion(OBJ_ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
@@ -378,12 +380,12 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void delete_FromStagedAndVersion() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
         session2.delete(FILE1_SUBPATH);
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
         assertFileInVersion(OBJ_ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
@@ -392,12 +394,12 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void delete_FromStagedAndMHead() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(UNVERSIONED);
+        commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
         session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
         session2.delete(FILE1_SUBPATH);
-        session2.commit(UNVERSIONED);
+        commit(session2, UNVERSIONED);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
         assertFileNotInVersion(OBJ_ID, "v1", FILE1_SUBPATH);
@@ -406,13 +408,13 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentItemNotFoundException.class)
     public void delete_FromDeletedObject() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         // Try to delete a file from an object that was just deleted
         session2.deleteObject();
         session2.delete(FILE1_SUBPATH);
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
         assertFileNotInVersion(OBJ_ID, "v1", FILE1_SUBPATH);
@@ -421,7 +423,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void delete_FileAddedAfterObjectDeleted() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         // Try to delete a file from an object that was just deleted
@@ -430,7 +432,7 @@ public class DefaultOCFLObjectSessionTest {
         session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
         session2.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
         session2.delete(FILE1_SUBPATH);
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
 
         assertFileNotInHeadVersion(OBJ_ID, FILE1_SUBPATH);
         assertFileInHeadVersion(OBJ_ID, FILE2_SUBPATH, FILE_CONTENT2);
@@ -441,7 +443,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentSessionClosedException.class)
     public void delete_CommittedSession() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         session.delete(FILE1_SUBPATH);
     }
@@ -449,11 +451,11 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void deleteObject_ObjectExists() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         session2.deleteObject();
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
 
         assertFalse("Deleted object must not exist",
                 ocflRepository.containsObject(OBJ_ID));
@@ -468,7 +470,7 @@ public class DefaultOCFLObjectSessionTest {
     public void deleteObject_StagedChanges_ObjectNotCreated() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         session.deleteObject();
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         assertFalse("Deleted object must not exist",
                 ocflRepository.containsObject(OBJ_ID));
@@ -479,7 +481,7 @@ public class DefaultOCFLObjectSessionTest {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         session.deleteObject();
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         // State of object should reflect post-delete object state
         assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT2);
@@ -489,17 +491,17 @@ public class DefaultOCFLObjectSessionTest {
     public void deleteObject_Recreate() throws Exception {
         // Create object
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         // Delete object
         final var session2 = makeNewSession();
         session2.deleteObject();
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
 
         // Recreate object
         final var session3 = makeNewSession();
         session3.write(FILE1_SUBPATH, fileStream(FILE_CONTENT2));
-        session3.commit(NEW_VERSION);
+        commit(session3, NEW_VERSION);
 
         assertFileInHeadVersion(OBJ_ID, FILE1_SUBPATH, FILE_CONTENT2);
 
@@ -509,7 +511,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentItemNotFoundException.class)
     public void read_FromDeletedObject() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         session2.deleteObject();
@@ -519,7 +521,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentSessionClosedException.class)
     public void deleteObject_CommittedSession() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         session.deleteObject();
     }
@@ -527,7 +529,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentItemNotFoundException.class)
     public void readVersion_FromDeletedObject() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         session2.deleteObject();
@@ -537,37 +539,36 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = IllegalArgumentException.class)
     public void commit_WithoutOption() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(null);
+        commit(null);
     }
 
     @Test(expected = PersistentStorageException.class)
     public void commit_NewObject_NoContents() throws Exception {
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
     }
 
     @Test
-    public void commit_NewVersion_NoChanges() throws Exception {
+    public void doNotCreateNewVersionWhenThereAreNoChanges() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
 
         final ObjectDetails objDetails = ocflRepository.describeObject(OBJ_ID);
         final var versionMap = objDetails.getVersionMap();
-        assertEquals("Two versions should exist", 2, versionMap.size());
+        assertEquals("One versions should exist", 1, versionMap.size());
 
         assertFileInVersion(OBJ_ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
-        assertFileInVersion(OBJ_ID, "v2", FILE1_SUBPATH, FILE_CONTENT1);
     }
 
     @Test
     public void commit_MHead_NoChanges() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(UNVERSIONED);
+        commit(UNVERSIONED);
 
         final var session2 = makeNewSession();
-        session2.commit(UNVERSIONED);
+        commit(session2, UNVERSIONED);
 
         final ObjectDetails objDetails = ocflRepository.describeObject(OBJ_ID);
         final var versionMap = objDetails.getVersionMap();
@@ -580,15 +581,15 @@ public class DefaultOCFLObjectSessionTest {
     @Test(expected = PersistentSessionClosedException.class)
     public void commit_CommittedSession() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
     }
 
     @Test
     public void close_SessionWithChanges() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         final var session2 = makeNewSession();
         session2.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
@@ -603,7 +604,7 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void close_CommittedSession() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
 
         session.close();
     }
@@ -611,16 +612,17 @@ public class DefaultOCFLObjectSessionTest {
     @Test
     public void listVersions() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
         session.close();
 
         final var session1 = makeNewSession();
-
-        session1.commit(NEW_VERSION);
+        session1.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1 + "2"));
+        commit(session1, NEW_VERSION);
         session1.close();
 
         final var session2 = makeNewSession();
-        session2.commit(UNVERSIONED);
+        session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1 + "3"));
+        commit(session2, UNVERSIONED);
         session2.close();
 
         final var session3 = makeNewSession();
@@ -634,21 +636,46 @@ public class DefaultOCFLObjectSessionTest {
     }
 
     @Test
+    public void listVersionsShouldNotIncludeEmptyVersionWhenCreatedFromMutableHead() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        commit(UNVERSIONED);
+        session.close();
+
+        final var session1 = makeNewSession();
+        session1.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1 + "2"));
+        commit(session1, NEW_VERSION);
+        session1.close();
+
+        final var session2 = makeNewSession();
+        session2.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1 + "3"));
+        commit(session2, UNVERSIONED);
+        session2.close();
+
+        final var session3 = makeNewSession();
+
+        final List<OCFLVersion> versions = session3.listVersions();
+        session3.close();
+
+        assertEquals("First version in list is not \"v1\"", "v2", versions.get(0).getOcflVersionId());
+        assertEquals("There should be exactly one version",1, versions.size());
+    }
+
+    @Test
     public void listVersionsForSubpath() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         session.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
         session.close();
 
         final var session1 = makeNewSession();
 
         session1.write(FILE2_SUBPATH, fileStream("updated"));
-        session1.commit(NEW_VERSION);
+        commit(session1, NEW_VERSION);
         session1.close();
 
         final var session2 = makeNewSession();
         session2.write("test_file3.txt", fileStream("another file"));
-        session2.commit(NEW_VERSION);
+        commit(session2, NEW_VERSION);
         session2.close();
 
         final var session3 = makeNewSession();
@@ -673,10 +700,49 @@ public class DefaultOCFLObjectSessionTest {
     }
 
     @Test
+    public void listVersionsForSubpathShouldNotIncludeChangesInMutableHead() throws Exception {
+        session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
+        session.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
+        commit(NEW_VERSION);
+        session.close();
+
+        final var session1 = makeNewSession();
+
+        session1.write(FILE2_SUBPATH, fileStream("updated"));
+        commit(session1, UNVERSIONED);
+        session1.close();
+
+        final var session2 = makeNewSession();
+        session2.write("test_file3.txt", fileStream("another file"));
+        commit(session2, UNVERSIONED);
+        session2.close();
+
+        final var session3 = makeNewSession();
+
+        final List<OCFLVersion> file1Versions = session3.listVersions(FILE1_SUBPATH);
+        final List<OCFLVersion> file2Versions = session3.listVersions(FILE2_SUBPATH);
+        final List<OCFLVersion> allVersions = session3.listVersions(null);
+
+        session3.close();
+
+        assertThat(file1Versions.stream()
+                .map(OCFLVersion::getOcflVersionId)
+                .collect(Collectors.toList()), contains("v1"));
+
+        assertThat(file2Versions.stream()
+                .map(OCFLVersion::getOcflVersionId)
+                .collect(Collectors.toList()), contains("v1"));
+
+        assertThat(allVersions.stream()
+                .map(OCFLVersion::getOcflVersionId)
+                .collect(Collectors.toList()), contains("v1"));
+    }
+
+    @Test
     public void throwExceptionWhenListingVersionsOnUnknownSubpath() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         session.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
         session.close();
 
         final var session3 = makeNewSession();
@@ -695,7 +761,7 @@ public class DefaultOCFLObjectSessionTest {
     public void listHeadSubpaths() throws Exception {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         session.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
-        session.commit(NEW_VERSION);
+        commit(NEW_VERSION);
         session.close();
 
         final var session2 = makeNewSession();
@@ -714,12 +780,12 @@ public class DefaultOCFLObjectSessionTest {
     public void ensureFilesDontStageTogether() throws Exception {
         final String obj1ID = UUID.randomUUID().toString();
         final String obj2ID = UUID.randomUUID().toString();
-        final var session1 = new DefaultOCFLObjectSession(obj1ID, stagingPath, ocflRepository);
-        final var session2 = new DefaultOCFLObjectSession(obj2ID, stagingPath, ocflRepository);
+        final var session1 = new DefaultOCFLObjectSession(obj1ID, stagingPath, ocflRepository, UNVERSIONED);
+        final var session2 = new DefaultOCFLObjectSession(obj2ID, stagingPath, ocflRepository, UNVERSIONED);
         session1.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
         session2.write(FILE2_SUBPATH, fileStream(FILE_CONTENT2));
-        session1.commit(NEW_VERSION);
-        session2.commit(NEW_VERSION);
+        commit(session1, NEW_VERSION);
+        commit(session2, NEW_VERSION);
         assertFileInVersion(obj1ID, "v1", FILE1_SUBPATH, FILE_CONTENT1);
         assertFileNotInVersion(obj1ID, "v1", FILE2_SUBPATH);
         assertFileInVersion(obj2ID, "v1", FILE2_SUBPATH, FILE_CONTENT2);
@@ -780,4 +846,15 @@ public class DefaultOCFLObjectSessionTest {
     private void assertNoMutableHead(final String objId) {
         assertFalse("No mutable head should be present for " + objId, ocflRepository.hasStagedChanges(objId));
     }
+
+    private String commit(final CommitOption option) throws PersistentStorageException {
+        return commit(session, option);
+    }
+
+    private String commit(final DefaultOCFLObjectSession session, final CommitOption option)
+            throws PersistentStorageException {
+        session.setCommitOption(option);
+        return session.commit();
+    }
+
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/TestOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/TestOcflObjectIndex.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An simple in-memory implementation of the {@link FedoraToOCFLObjectIndex} used for testing
+ */
+public class TestOcflObjectIndex implements FedoraToOCFLObjectIndex {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(TestOcflObjectIndex.class);
+
+    private Map<String, FedoraOCFLMapping> fedoraOCFLMappingMap = Collections.synchronizedMap(new HashMap<>());
+
+    @Override
+    public FedoraOCFLMapping getMapping(final String fedoraResourceIdentifier)
+            throws FedoraOCFLMappingNotFoundException {
+
+        LOGGER.debug("getting {}", fedoraResourceIdentifier);
+        final FedoraOCFLMapping m = fedoraOCFLMappingMap.get(fedoraResourceIdentifier);
+        if (m == null) {
+            throw new FedoraOCFLMappingNotFoundException(fedoraResourceIdentifier);
+        }
+
+        return m;
+    }
+
+    @Override
+    public FedoraOCFLMapping addMapping(final String fedoraResourceIdentifier,
+                                        final String fedoraRootObjectResourceId,
+                                        final String ocflObjectId) {
+        FedoraOCFLMapping mapping = fedoraOCFLMappingMap.get(fedoraRootObjectResourceId);
+
+        if (mapping == null) {
+            mapping = new FedoraOCFLMapping(fedoraRootObjectResourceId, ocflObjectId);
+            fedoraOCFLMappingMap.put(fedoraRootObjectResourceId, mapping);
+        }
+
+        if (!fedoraResourceIdentifier.equals(fedoraRootObjectResourceId)) {
+            fedoraOCFLMappingMap.put(fedoraResourceIdentifier, mapping);
+        }
+
+        LOGGER.debug("added mapping {} for {}", mapping, fedoraResourceIdentifier);
+        return mapping;
+    }
+
+    @Override
+    public void reset() {
+        fedoraOCFLMappingMap.clear();
+    }
+
+}


### PR DESCRIPTION
**JIRA Ticket**: [FCREPO-3232](https://jira.lyrasis.org/browse/FCREPO-3232)

# What does this Pull Request do?

Allows resources to be versioned on demand, and removes support for creating versions at specific timestamps.

# How should this be tested?

`mvn jetty:run`

```
# Create resource
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/version-test -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -H'Link: <http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'AG Parent'"

# Show empty timemap
curl -u fedoraAdmin:fedoraAdmin -v -H "Accept: text/turtle" http://localhost:8080/rest/version-test/fcr:versions

# Create version
curl -u fedoraAdmin:fedoraAdmin -X POST -v http://localhost:8080/rest/version-test/fcr:versions

# Show timemap with memento
curl -u fedoraAdmin:fedoraAdmin -v -H "Accept: text/turtle" http://localhost:8080/rest/version-test/fcr:versions
```

Running the above produces the following output in **F6**:

```
<info:fedora/version-test/fcr:versions>
        memento:original     <info:fedora/version-test> ;
        fedora:created       "2020-03-06T20:23:45.409097Z" ;
        fedora:lastModified  "2020-03-06T20:23:45.409097Z" ;
        rdf:type             fedora:TimeMap ;
        rdf:type             memento:TimeMap .

##########

http://localhost:8080/rest/version-test/fcr:versions/20200306203708

##########

<info:fedora/version-test/fcr:versions>
        ldp:contains         <info:fedora/version-test/fcr:versions/20200306203708> ;
        memento:original     <info:fedora/version-test> ;
        fedora:created       "2020-03-06T20:36:58.579161Z" ;
        fedora:lastModified  "2020-03-06T20:36:58.579161Z" ;
        rdf:type             fedora:TimeMap ;
        rdf:type             memento:TimeMap .
```

And the following output in **F5**:

```
<http://localhost:8080/rest/version-test/fcr:versions>
        rdf:type               fedora:TimeMap ;
        rdf:type               fedora:Resource ;
        rdf:type               memento:TimeMap ;
        fedora:lastModifiedBy  "bypassAdmin" ;
        fedora:createdBy       "bypassAdmin" ;
        fedora:created         "2020-03-06T20:41:16.101Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2020-03-06T20:41:16.101Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        memento:original       <http://localhost:8080/rest/version-test> ;
        rdf:type               ldp:RDFSource .

##########

http://localhost:8080/rest/version-test/fcr:versions/20200306204157

##########

<http://localhost:8080/rest/version-test/fcr:versions>
        rdf:type               fedora:TimeMap ;
        rdf:type               fedora:Resource ;
        rdf:type               memento:TimeMap ;
        fedora:lastModifiedBy  "bypassAdmin" ;
        fedora:createdBy       "bypassAdmin" ;
        fedora:created         "2020-03-06T20:41:16.101Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2020-03-06T20:41:57.176Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        memento:original       <http://localhost:8080/rest/version-test> ;
        rdf:type               ldp:RDFSource ;
        ldp:contains           <http://localhost:8080/rest/version-test/fcr:versions/20200306204157> .
```

# Additional Notes:

* You can no longer create mementos at a timestamp
* You cannot create a version of a resource nested in an AG
* You cannot create a version within a long-running transaction
* A version is not created if there are no changes to the resource since the most recent version

# Interested parties
@awoods 
