### PR TITLE
added support for retrieving mementos

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -289,8 +289,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (returnPreference.getValue().equals("minimal")) {
             streams.add(resource.getTriples());
             //streams.add(getTriples(resource, MINIMAL));
-            // Mementos already have the server managed properties in the PROPERTIES category
-            // since mementos are immutable and these triples are no longer managed
             if (ldpPreferences.prefersServerManaged())  {
                 streams.add(this.managedPropertiesService.get(resource));
                 //TOOD Implement minimal return preference
@@ -300,8 +298,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             streams.add(resource.getTriples());
 
             // Additional server-managed triples about this resource
-            // Mementos already have the server managed properties in the PROPERTIES category
-            // since mementos are immutable and these triples are no longer managed
             if (ldpPreferences.prefersServerManaged()) {
                 streams.add(this.managedPropertiesService.get(resource));
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -291,7 +291,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             //streams.add(getTriples(resource, MINIMAL));
             // Mementos already have the server managed properties in the PROPERTIES category
             // since mementos are immutable and these triples are no longer managed
-            if (ldpPreferences.prefersServerManaged() && !resource.isMemento())  {
+            if (ldpPreferences.prefersServerManaged())  {
                 streams.add(this.managedPropertiesService.get(resource));
                 //TOOD Implement minimal return preference
                 //streams.add(getTriples(resource, MINIMAL));
@@ -302,7 +302,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             // Additional server-managed triples about this resource
             // Mementos already have the server managed properties in the PROPERTIES category
             // since mementos are immutable and these triples are no longer managed
-            if (ldpPreferences.prefersServerManaged() && !resource.isMemento()) {
+            if (ldpPreferences.prefersServerManaged()) {
                 streams.add(this.managedPropertiesService.get(resource));
             }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -24,6 +24,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.http.commons.api.rdf.HttpResourceConverter;
+import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.InvalidMementoPathException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
@@ -63,7 +64,8 @@ abstract public class FedoraBaseResource extends AbstractResource {
 
     private static final Pattern TRAILING_SLASH_REGEX = Pattern.compile("/+$");
 
-    private static final Pattern MEMENTO_PATH_PATTERN = Pattern.compile(".*/fcr:versions/(.*)$");
+    // Note: This pattern is intentionally loose, matching invalid memento strings, for error handling purposes
+    private static final Pattern MEMENTO_PATH_PATTERN = Pattern.compile(".*/" + FedoraTypes.FCR_VERSIONS + "/(.*)$");
 
     @Inject
     protected Transaction transaction;

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InvalidMementoPathException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InvalidMementoPathException.java
@@ -36,4 +36,14 @@ public class InvalidMementoPathException extends ConstraintViolationException {
         super(msg);
     }
 
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     * @param rootCause the root cause
+     */
+    public InvalidMementoPathException(final String msg, final Throwable rootCause) {
+        super(msg, rootCause);
+    }
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -32,6 +32,7 @@ import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -112,6 +113,13 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public FedoraResource getOriginalResource() {
+        if (isMemento()) {
+            try {
+                return resourceFactory.getResource(tx, getId());
+            } catch (PathNotFoundException e) {
+                throw new PathNotFoundRuntimeException(e);
+            }
+        }
         return this;
     }
 
@@ -138,11 +146,22 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public FedoraResource findMementoByDatetime(final Instant mementoDatetime) {
-        try {
-            return resourceFactory.getResource(tx, getId(), mementoDatetime);
-        } catch (PathNotFoundException e) {
-            throw new PathNotFoundRuntimeException(e);
+        FedoraResource match = null;
+        long matchDiff = 0;
+
+        for (var it = getTimeMap().getChildren().iterator(); it.hasNext();) {
+            final var current = it.next();
+            final var diff = Duration.between(current.getMementoDatetime(), mementoDatetime).toSeconds();
+
+            if (match == null
+                    || (matchDiff < 0 && diff >= matchDiff)
+                    || (diff >= 0 && diff <= matchDiff)) {
+                match = current;
+                matchDiff = diff;
+            }
         }
+
+        return match;
     }
 
     @Override
@@ -231,8 +250,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public boolean isOriginalResource() {
-        // TODO Auto-generated method stub
-        return false;
+        return !isMemento();
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -151,11 +151,13 @@ public class FedoraResourceImpl implements FedoraResource {
 
         for (var it = getTimeMap().getChildren().iterator(); it.hasNext();) {
             final var current = it.next();
+            // Negative if the memento is AFTER the requested datetime
+            // Positive if the memento is BEFORE the requested datetime
             final var diff = Duration.between(current.getMementoDatetime(), mementoDatetime).toSeconds();
 
-            if (match == null
-                    || (matchDiff < 0 && diff >= matchDiff)
-                    || (diff >= 0 && diff <= matchDiff)) {
+            if (match == null                               // Save the first memento examined
+                    || (matchDiff < 0 && diff >= matchDiff) // Match is AFTER requested && current is closer
+                    || (diff >= 0 && diff <= matchDiff)) {  // Current memento EQUAL/BEFORE request && closer than match
                 match = current;
                 matchDiff = diff;
             }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -100,6 +100,11 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
     }
 
     @Override
+    public boolean isOriginalResource() {
+        return false;
+    }
+
+    @Override
     public FedoraResource getTimeMap() {
         return this;
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -18,10 +18,11 @@
 package org.fcrepo.kernel.impl.services;
 
 import org.apache.jena.graph.Triple;
+import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.TimeMap;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.ManagedPropertiesService;
-import org.fcrepo.kernel.api.utils.FedoraResourceIdConverter;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
     @Override
     public Stream<Triple> get(final FedoraResource resource) {
         final List<Triple> triples = new ArrayList<>();
-        final var subject = createURI(FedoraResourceIdConverter.resolveFedoraId(resource.getDescribedResource()));
+        final var subject = createURI(resolveId(resource.getDescribedResource()));
         triples.add(Triple.create(subject, CREATED_DATE.asNode(),
                 createLiteral(resource.getCreatedDate().toString())));
         triples.add(Triple.create(subject, LAST_MODIFIED_DATE.asNode(),
@@ -58,4 +59,12 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
 
         return new DefaultRdfStream(subject, triples.stream());
     }
+
+    private String resolveId(final FedoraResource resource) {
+        if (resource instanceof TimeMap) {
+            return resource.getId() + "/" + FedoraTypes.FCR_VERSIONS;
+        }
+        return resource.getId();
+    }
+
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.models;
+
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.TimeMap;
+import org.fcrepo.kernel.api.services.VersionService;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.Instant;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class FedoraResourceImplTest {
+
+    @Mock
+    private TimeMap timeMap;
+
+    @Mock
+    private PersistentStorageSessionManager sessionManager;
+
+    @Mock
+    private ResourceFactory resourceFactory;
+
+    private static final String ID = "info:fedora/test";
+
+    @Test
+    public void findMementoWhenOnlyOneAndBeforeSearch() {
+        final var resource = resourceWithMockedTimeMap(ID);
+        expectMementos("20200309172117");
+        final var match = resource.findMementoByDatetime(instant("20200309172118"));
+        assertEquals("0", match.getId());
+    }
+
+    @Test
+    public void findClosestMementoWhenMultiple() {
+        final var resource = resourceWithMockedTimeMap(ID);
+        expectMementos("20200309172117", "20200309172118", "20200309172119");
+        final var match = resource.findMementoByDatetime(instant("20200309172118"));
+        assertEquals("1", match.getId());
+    }
+
+    @Test
+    public void findClosestMementoWhenMultipleNoneExact() {
+        final var resource = resourceWithMockedTimeMap(ID);
+        expectMementos("20200309172116", "20200309172117", "20200309172119");
+        final var match = resource.findMementoByDatetime(instant("20200309172118"));
+        assertEquals("1", match.getId());
+    }
+
+    @Test
+    public void findClosestMementoMultipleSameSecond() {
+        final var resource = resourceWithMockedTimeMap(ID);
+        expectMementos("20200309172117", "20200309172117", "20200309172117");
+        final var match = resource.findMementoByDatetime(instant("20200309172118"));
+        assertEquals("2", match.getId());
+    }
+
+    @Test
+    public void findMementoWhenNonBeforeSearch() {
+        final var resource = resourceWithMockedTimeMap(ID);
+        expectMementos("20200309172119", "20200309172120", "20200309172121");
+        final var match = resource.findMementoByDatetime(instant("20200309172118"));
+        assertEquals("0", match.getId());
+    }
+
+    @Test
+    public void findNoMementoWhenThereAreNone() {
+        final var resource = resourceWithMockedTimeMap(ID);
+        expectMementos();
+        final var match = resource.findMementoByDatetime(instant("20200309172118"));
+        assertNull("Should not find a memento", match);
+    }
+
+    private void expectMementos(final String... instants) {
+        final var mementos = new ArrayList<FedoraResource>(instants.length);
+        for (int i = 0; i < instants.length; i++) {
+            mementos.add(memento(String.valueOf(i), instant(instants[i])));
+        }
+        when(timeMap.getChildren()).thenReturn(mementos.stream());
+    }
+
+    private FedoraResource resourceWithMockedTimeMap(final String id) {
+        final var resource = spy(new FedoraResourceImpl(id, null, sessionManager, resourceFactory));
+        doReturn(timeMap).when(resource).getTimeMap();
+        return resource;
+    }
+
+    private FedoraResource memento(final String id, final Instant instant) {
+        final var memento = new FedoraResourceImpl(id, null, sessionManager, resourceFactory);
+        memento.setIsMemento(true);
+        memento.setMementoDatetime(instant);
+        return memento;
+    }
+
+    private Instant instant(final String timestamp) {
+        return Instant.from(VersionService.MEMENTO_LABEL_FORMATTER.parse(timestamp));
+    }
+
+}


### PR DESCRIPTION
**JIRA Ticket**: [FCREPO-3245](https://jira.lyrasis.org/projects/FCREPO/issues/FCREPO-3245)

# What does this Pull Request do?

Adds the ability to retrieve mementos.

# How should this be tested?

Test script:

```
# Create an AG
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/version-test-3 -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -H'Link: <http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'AG Parent'"

# Create a child of the AG
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/version-test-3/child1 -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "testing"

# Attempt to find a memento
curl -u fedoraAdmin:fedoraAdmin -H "Accept: text/turtle" -H "Accept-Datetime: Mon, 09 Mar 2020 17:00:00 GMT" -v http://localhost:8080/rest/version-test-3

< HTTP/1.1 406 Not Acceptable
< Set-Cookie: JSESSIONID=node01k7b201ep5d6r153a2qwcopxcy2.node0; Path=/
< Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Mon, 09-Mar-2020 14:56:57 GMT
< Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
< Link: <http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel="type"
< Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
< Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
< Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
< Link: <http://localhost:8080/rest/version-test-3>; rel="timegate"
< Link: <http://localhost:8080/rest/version-test-3>; rel="original"
< Link: <http://localhost:8080/rest/version-test-3/fcr:versions>; rel="timemap"
< Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
< Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
< Accept-External-Content-Handling: copy,redirect,proxy
< Accept-Patch: application/sparql-update
< Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json
< Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
< Link: <http://localhost:8080/rest/version-test-3/fcr:acl>; rel="acl"
< Preference-Applied: return=representation
< Cache-Control: must-revalidate,no-cache,no-store
< Content-Length: 0
< Server: Jetty(9.4.24.v20191120)

# Create a memento
curl -u fedoraAdmin:fedoraAdmin -X POST -v http://localhost:8080/rest/version-test-3/fcr:versions

# Find a memento
curl -u fedoraAdmin:fedoraAdmin -H "Accept: text/turtle" -H "Accept-Datetime: Mon, 09 Mar 2020 17:00:00 GMT" -v http://localhost:8080/rest/version-test-3

< HTTP/1.1 302 Found
< Date: Tue, 10 Mar 2020 14:59:48 GMT
< Set-Cookie: JSESSIONID=node07umaoh56bopz184qx3zggro8f5.node0; Path=/
< Expires: Thu, 01 Jan 1970 00:00:00 GMT
< Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Mon, 09-Mar-2020 14:59:48 GMT
< Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
< Link: <http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel="type"
< Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
< Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
< Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
< Link: <http://localhost:8080/rest/version-test-3>; rel="timegate"
< Link: <http://localhost:8080/rest/version-test-3>; rel="original"
< Link: <http://localhost:8080/rest/version-test-3/fcr:versions>; rel="timemap"
< Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
< Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
< Accept-External-Content-Handling: copy,redirect,proxy
< Accept-Patch: application/sparql-update
< Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json
< Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
< Link: <http://localhost:8080/rest/version-test-3/fcr:acl>; rel="acl"
< Preference-Applied: return=representation
< Vary: Prefer
< Vary: Accept
< Vary: Range
< Vary: Accept-Encoding
< Vary: Accept-Language
< Vary: Accept-Datetime
< Location: http://localhost:8080/rest/version-test-3/fcr:versions/20200310145927
< Content-Length: 0
< Server: Jetty(9.4.24.v20191120)

# Retrieve AG memento
curl -u fedoraAdmin:fedoraAdmin -H "Accept: text/turtle" -v http://localhost:8080/rest/version-test-3/fcr:versions/20200310145927

<info:fedora/version-test-3>
        dc:title             "AG Parent" ;
        rdf:type             ldp:RDFSource ;
        fedora:created       "2020-03-10T14:56:24.560756Z" ;
        fedora:lastModified  "2020-03-10T14:56:24.560756Z" ;
        rdf:type             ldp:BasicContainer ;
        rdf:type             fedora:ArchivalGroup .
		
# Retrieve child memento
curl -u fedoraAdmin:fedoraAdmin -v http://localhost:8080/rest/version-test-3/child1/fcr:versions/20200310145927

< HTTP/1.1 200 OK
< Date: Tue, 10 Mar 2020 15:24:49 GMT
< Set-Cookie: JSESSIONID=node0zapulvibku6wfrke08ex49wv1.node0; Path=/
< Expires: Thu, 01 Jan 1970 00:00:00 GMT
< Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Mon, 09-Mar-2020 15:24:49 GMT
< ETag: "7494DAE3016C368D7773144D0CCC929F"
< X-State-Token: 7494DAE3016C368D7773144D0CCC929F
< Last-Modified: Tue, 10 Mar 2020 14:56:43 GMT
< Content-Type: text/plain
< Accept-Ranges: bytes
< Content-Disposition: attachment; filename=""; creation-date="Tue, 10 Mar 2020 14:56:43 GMT"; modification-date="Tue, 10 Mar 2020 14:56:43 GMT"; size=7
< Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
< Link: <http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"
< Link: <http://localhost:8080/rest/version-test-3/child1/fcr:metadata>; rel="describedby"
< Link: <http://localhost:8080/rest/version-test-3/child1>; rel="timegate"
< Link: <http://localhost:8080/rest/version-test-3/child1>; rel="original"
< Link: <http://localhost:8080/rest/version-test-3/child1/fcr:versions>; rel="timemap"
< Accept-External-Content-Handling: copy,redirect,proxy
< Allow: GET,HEAD,OPTIONS,DELETE
< Memento-Datetime: Tue, 10 Mar 2020 14:59:27 GMT
< Link: <http://mementoweb.org/ns#Memento>; rel="type"
< Cache-Control: no-transform, must-revalidate, max-age=0
< Content-Length: 7
< Server: Jetty(9.4.24.v20191120)
< 
* Connection #0 to host localhost left intact
testing

# Update the child
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/version-test-3/child1 -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "updated"

# Create a new memento
curl -u fedoraAdmin:fedoraAdmin -X POST -v http://localhost:8080/rest/version-test-3/fcr:versions

# Retrieve the original memento
curl -u fedoraAdmin:fedoraAdmin -v http://localhost:8080/rest/version-test-3/child1/fcr:versions/20200310145927

testing

# Retrieve the new memento
curl -u fedoraAdmin:fedoraAdmin -v http://localhost:8080/rest/version-test-3/child1/fcr:versions/20200310153910

updated
```

Same outputs from F5:

```
curl -u fedoraAdmin:fedoraAdmin -H "Accept: text/turtle" -H "Accept-Datetime: Mon, 09 Mar 2020 17:00:00 GMT" -v http://localhost:8080/rest/version-test-3

< HTTP/1.1 406 Not Acceptable
< Date: Tue, 10 Mar 2020 15:28:44 GMT
< Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
< Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
< Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
< Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
< Link: <http://localhost:8080/rest/version-test-3>; rel="timegate"
< Link: <http://localhost:8080/rest/version-test-3>; rel="original"
< Link: <http://localhost:8080/rest/version-test-3/fcr:versions>; rel="timemap"
< Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
< Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
< Accept-External-Content-Handling: copy,redirect,proxy
< Accept-Patch: application/sparql-update
< Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json
< Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
< Link: <http://localhost:8080/rest/version-test-3/fcr:acl>; rel="acl"
< Preference-Applied: return=representation
< Vary: Prefer
< Vary: Accept
< Vary: Range
< Vary: Accept-Encoding
< Vary: Accept-Language
< Vary: Accept-Datetime
< Cache-Control: must-revalidate,no-cache,no-store
< Content-Length: 0
< Server: Jetty(9.3.25.v20180904)


curl -u fedoraAdmin:fedoraAdmin -H "Accept: text/turtle" -H "Accept-Datetime: Mon, 09 Mar 2020 17:00:00 GMT" -v http://localhost:8080/rest/version-test-3

< HTTP/1.1 302 Found
< Date: Tue, 10 Mar 2020 15:30:14 GMT
< Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
< Link: <http://www.w3.org/ns/ldp#Container>;rel="type"
< Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
< Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"
< Link: <http://localhost:8080/rest/version-test-3>; rel="timegate"
< Link: <http://localhost:8080/rest/version-test-3>; rel="original"
< Link: <http://localhost:8080/rest/version-test-3/fcr:versions>; rel="timemap"
< Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
< Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
< Accept-External-Content-Handling: copy,redirect,proxy
< Accept-Patch: application/sparql-update
< Accept-Post: text/turtle,text/rdf+n3,text/n3,application/rdf+xml,application/n-triples,application/ld+json
< Allow: MOVE,COPY,DELETE,POST,HEAD,GET,PUT,PATCH,OPTIONS
< Link: <http://localhost:8080/rest/version-test-3/fcr:acl>; rel="acl"
< Preference-Applied: return=representation
< Vary: Prefer
< Vary: Accept
< Vary: Range
< Vary: Accept-Encoding
< Vary: Accept-Language
< Vary: Accept-Datetime
< Location: http://localhost:8080/rest/version-test-3/fcr:versions/20200310152937
< Content-Length: 0
< Server: Jetty(9.3.25.v20180904)


curl -u fedoraAdmin:fedoraAdmin -H "Accept: text/turtle" -v http://localhost:8080/rest/version-test-3/fcr:versions/20200310152937

<http://localhost:8080/rest/version-test-3>
        rdf:type               fedora:Container ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        rdf:type               fedora:Resource ;
        rdf:type               ldp:BasicContainer ;
        fedora:created         "2020-03-10T15:27:24.684Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        ldp:contains           <http://localhost:8080/rest/version-test-3/child1> ;
        dc:title               "AG Parent" ;
        fedora:lastModified    "2020-03-10T15:27:40.661Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModifiedBy  "bypassAdmin" ;
        fedora:createdBy       "bypassAdmin" .
```

# Interested parties
@awoods 
