### PR TITLE
Add datetime type to created/lastmodified date, add additional contai…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -421,10 +421,10 @@ public class FedoraLdp extends ContentExposingResource {
         boolean created = false;
 
         if ((resourceExists && resource() instanceof Binary) ||
-                isBinary(interactionModel,
+                (!resourceExists && isBinary(interactionModel,
                         providedContentType,
                         requestBodyStream != null && providedContentType != null,
-                        extContent != null)) {
+                        extContent != null))) {
             ensureArchivalGroupHeaderNotPresentForBinaries(links);
 
             final Collection<URI> checksums = parseDigestHeader(digest);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -69,7 +69,6 @@ import static org.apache.jena.vocabulary.DC_11.title;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_VARIANTS;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
@@ -1729,13 +1728,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals(
                 "Expected UNSUPPORTED MEDIA TYPE response when PUTing content to an object (as opposed to datastream)",
                 UNSUPPORTED_MEDIA_TYPE.getStatusCode(), getStatus(put));
-    }
-
-    @Test
-@Ignore
-    public void testInvalidNamespaceOnHeadReturnsCorrectContentType() throws IOException {
-        assertEquals("Expected " + TEXT_PLAIN_WITH_CHARSET,
-                TEXT_PLAIN_WITH_CHARSET, getContentType(headObjMethod("/fcr:accessroles"), Status.BAD_REQUEST));
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1405,9 +1405,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutBinaryChildViolation() throws IOException {
         final String id = getRandomUniqueId();
+        createObject(id);
         createDatastream(id, "binary", "some-content");
 
         final String location = serverAddress + id + "/binary/xx";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2274,7 +2274,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetObjectGraph() throws IOException {
         logger.trace("Entering testGetObjectGraph()...");
         final String location = getLocation(postObjMethod());
@@ -2295,7 +2294,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void verifyFullSetOfRdfTypes() throws IOException {
         logger.trace("Entering verifyFullSetOfRdfTypes()...");
         final String id = getRandomUniqueId();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1747,7 +1747,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpPut put = putObjMethod(id);
         put.setEntity(new StringEntity(content));
         put.setHeader(CONTENT_TYPE, "text/plain");
-        put.setHeader("Link", RDF_SOURCE_LINK_HEADER);
         assertEquals("Expected BAD REQUEST response code when PUTing malformed RDF on an object",
                 BAD_REQUEST.getStatusCode(), getStatus(put));
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -85,6 +85,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.IS_MEMBER_OF_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
@@ -3496,6 +3497,75 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final DatasetGraph graph = dataset.asDatasetGraph();
             assertFalse("Expected NOT to have resource: " + graph, graph.contains(ANY,
                     createURI(container), createURI("info:some/relation"), createURI(resource)));
+        }
+    }
+
+    @Test
+@Ignore
+    public void testIndirectContainerInteractionMemberOf() throws IOException {
+        // Create resource (object)
+        final String resourceId = getRandomUniqueId();
+        final String resource;
+        try (final CloseableHttpResponse createResponse = createObject(resourceId)) {
+            resource = getLocation(createResponse);
+        }
+        // Create container (c0)
+        final String containerId = getRandomUniqueId();
+        final String container;
+        try (final CloseableHttpResponse createResponse = createObject(containerId)) {
+            container = getLocation(createResponse);
+        }
+        // Create indirect container (c0/members)
+        final String indirectContainerId = containerId + "/t";
+        final HttpPut putIndirect = putObjMethod(indirectContainerId);
+        putIndirect.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        final String indirectContainer;
+        try (final CloseableHttpResponse createResponse = execute(putIndirect)) {
+            indirectContainer = getLocation(createResponse);
+        }
+
+        // Add LDP properties to indirect container
+        final HttpPatch patch = patchObjMethod(indirectContainerId);
+        patch.addHeader("Content-Type", "application/sparql-update");
+        final String sparql = "INSERT DATA { "
+                + "<> <" + MEMBERSHIP_RESOURCE + "> <" + container + "> .\n"
+                + "<> <" + IS_MEMBER_OF_RELATION + "> <info:some/relation> .\n"
+                + "<> <" + LDP_NAMESPACE + "insertedContentRelation> <info:proxy/for> .\n"
+                + " }";
+        patch.setEntity(new StringEntity(sparql));
+        assertEquals("Expected patch to succeed", NO_CONTENT.getStatusCode(), getStatus(patch));
+
+        // Add indirect resource to indirect container
+        final HttpPost postIndirectResource = postObjMethod(indirectContainerId);
+        final String irRdf =
+                "<> <info:proxy/in>  <" + container + "> ;\n" +
+                        "   <info:proxy/for> <" + resource + "> .";
+        postIndirectResource.setEntity(new StringEntity(irRdf));
+        postIndirectResource.setHeader("Content-Type", "text/turtle");
+
+        final String indirectResource;
+        try (final CloseableHttpResponse postResponse = execute(postIndirectResource)) {
+            indirectResource = getLocation(postResponse);
+            assertEquals("Expected post to succeed", CREATED.getStatusCode(), getStatus(postResponse));
+        }
+        // Ensure resource has been updated with relationship... indirectly
+        try (final CloseableHttpResponse getResponse = execute(new HttpGet(resource));
+             final CloseableDataset dataset = getDataset(getResponse)) {
+                final DatasetGraph graph = dataset.asDatasetGraph();
+                assertTrue("Expected to have triple on resource: " + createURI("info:some/relation") + " <"
+                                + createURI(container) + ">, graph: " + graph.toString(),
+                    graph.contains(ANY, createURI(resource), createURI("info:some/relation"), createURI(container)));
+        }
+        // Remove indirect resource
+        assertEquals("Expected delete to succeed",
+                NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(indirectResource)));
+
+        // Ensure resource has been updated with relationship... indirectly
+        try (final CloseableHttpResponse getResponse1 = execute(new HttpGet(resource));
+             final CloseableDataset dataset = getDataset(getResponse1)) {
+            final DatasetGraph graph1 = dataset.asDatasetGraph();
+            assertFalse("Expected NOT to have resource: " + graph1, graph1.contains(ANY,
+                    createURI(resource), createURI("info:some/relation"), createURI(container)));
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -442,7 +442,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadDefaultNonRDF() throws IOException {
         final String id = getRandomUniqueId();
         final HttpPut put = putObjMethod(id, "text/plain", "<> a <http://example.com/Foo> .");
@@ -1748,6 +1747,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpPut put = putObjMethod(id);
         put.setEntity(new StringEntity(content));
         put.setHeader(CONTENT_TYPE, "text/plain");
+        put.setHeader("Link", RDF_SOURCE_LINK_HEADER);
         assertEquals("Expected BAD REQUEST response code when PUTing malformed RDF on an object",
                 BAD_REQUEST.getStatusCode(), getStatus(put));
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -153,6 +153,8 @@ public final class RdfLexicon {
             createProperty(LDP_NAMESPACE + "hasMemberRelation");
     public static final Property INSERTED_CONTENT_RELATION =
             createProperty(LDP_NAMESPACE + "insertedContentRelation");
+    public static final Property IS_MEMBER_OF_RELATION =
+            createProperty(LDP_NAMESPACE + "isMemberOfRelation");
     public static final Property CONTAINS =
         createProperty(LDP_NAMESPACE + "contains");
     public static final Property LDP_MEMBER =

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -18,12 +18,16 @@
 package org.fcrepo.kernel.impl.models;
 
 import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.apache.jena.vocabulary.RDF.type;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 
 import java.util.stream.Stream;
 
+import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.models.Container;
@@ -60,8 +64,12 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
 
     @Override
     public RdfStream getTriples() {
+        final Node subject = createURI(getId());
         final Stream<Triple> extra_triples = Stream.of(
-                new Triple(createURI(getId()), RDF.Init.type().asNode(), RDF_SOURCE.asNode())
+                Triple.create(subject, type.asNode(), RDF_SOURCE.asNode()),
+                Triple.create(subject, type.asNode(), CONTAINER.asNode()),
+                Triple.create(subject, type.asNode(), FEDORA_CONTAINER.asNode()),
+                Triple.create(subject, type.asNode(), FEDORA_RESOURCE.asNode())
         );
         return new DefaultRdfStream(createURI(getId()), Stream.concat(super.getTriples(), extra_triples));
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -41,6 +41,7 @@ import javax.ws.rs.core.Link;
 import org.apache.jena.rdf.model.Model;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
+import org.fcrepo.kernel.api.exception.InteractionModelViolationException;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.ExternalContent;
@@ -194,8 +195,8 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             final ResourceHeaders parent;
             try {
                 // Make sure the parent exists.
+                // TODO: object existence can be from the index, but we don't have interaction model. Should we add it?
                 final boolean parentExists = containmentIndex.resourceExists(txId, fedoraId);
-                // TODO: object existence check could be from an index. Review later.
                 parent = pSession.getHeaders(fedoraId, null);
             } catch (final PersistentItemNotFoundException exc) {
                 throw new ItemNotFoundException(String.format("Item %s was not found", fedoraId), exc);
@@ -207,7 +208,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             final boolean isParentBinary = NON_RDF_SOURCE.toString().equals(parent.getInteractionModel());
             if (isParentBinary) {
                 // Binary is not a container, can't have children.
-                throw new CannotCreateResourceException("NonRdfSource resources cannot contain other resources");
+                throw new InteractionModelViolationException("NonRdfSource resources cannot contain other resources");
             }
             // TODO: Will this type still be needed?
             final boolean isPairTree = FEDORA_PAIR_TREE.toString().equals(parent.getInteractionModel());

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -17,6 +17,17 @@
  */
 package org.fcrepo.kernel.impl.services;
 
+import static org.apache.jena.datatypes.xsd.impl.XSDDateTimeType.XSDdateTime;
+import static org.apache.jena.graph.NodeFactory.createLiteral;
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.apache.jena.vocabulary.RDF.type;
+import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.apache.jena.graph.Triple;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -24,16 +35,6 @@ import org.fcrepo.kernel.api.models.TimeMap;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.ManagedPropertiesService;
 import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.apache.jena.graph.NodeFactory.createLiteral;
-import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.apache.jena.vocabulary.RDF.type;
-import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
-import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 
 /**
  * Retrieve the managed properties as triples
@@ -49,9 +50,9 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
         final List<Triple> triples = new ArrayList<>();
         final var subject = createURI(resolveId(resource.getDescribedResource()));
         triples.add(Triple.create(subject, CREATED_DATE.asNode(),
-                createLiteral(resource.getCreatedDate().toString())));
+                createLiteral(resource.getCreatedDate().toString(), XSDdateTime)));
         triples.add(Triple.create(subject, LAST_MODIFIED_DATE.asNode(),
-                createLiteral(resource.getLastModifiedDate().toString())));
+                createLiteral(resource.getLastModifiedDate().toString(), XSDdateTime)));
 
         resource.getDescribedResource().getTypes().forEach(triple -> {
             triples.add(Triple.create(subject, type.asNode(), createURI(triple.toString())));

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -64,7 +64,7 @@ import org.apache.jena.vocabulary.DC_11;
 import org.apache.jena.vocabulary.XSD;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
+import org.fcrepo.kernel.api.exception.InteractionModelViolationException;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RequestWithAclLinkHeaderException;
@@ -243,17 +243,15 @@ public class CreateResourceServiceImplTest {
         assertEquals(1, containmentIndex.getContains(transaction, fedoraResource).count());
     }
 
-    @Test(expected = CannotCreateResourceException.class)
+    @Test(expected = InteractionModelViolationException.class)
     public void testParentIsBinaryRdf() throws Exception {
         final String fedoraId = ensurePrefix(UUID.randomUUID().toString());
         when(resourceHeaders.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         createResourceService.perform(TX_ID, USER_PRINCIPAL, fedoraId, null, true, null, model);
-        when(fedoraResource.getId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction, fedoraResource).count());
     }
 
-    @Test(expected = CannotCreateResourceException.class)
+    @Test(expected = InteractionModelViolationException.class)
     public void testParentIsBinaryBinary() throws Exception {
         final String fedoraId = ensurePrefix(UUID.randomUUID().toString());
         when(resourceHeaders.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
@@ -483,7 +481,7 @@ public class CreateResourceServiceImplTest {
                 DIGESTS, null, extContent);
     }
 
-    @Test(expected = CannotCreateResourceException.class)
+    @Test(expected = InteractionModelViolationException.class)
     public void testParentIsExternal() throws Exception {
         final String fedoraId = ensurePrefix(UUID.randomUUID().toString());
         when(resourceHeaders.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -253,20 +253,6 @@
       e.preventDefault();
   }
 
-  function updateAccessRoles(e)
-  {
-      const update_json = document.getElementById('rbacl_json').value;
-      const url = window.location + '/fcr:accessroles';
-      http('POST', url, [['Content-Type', 'application/json']], update_json, function(res) {
-          if (res.status == 204 || res.status == 201) {
-              window.location.reload(true);
-          } else {
-              ajaxErrorHandler(res, 'Error');
-          }
-      });
-      e.preventDefault();
-  }
-
   function ajaxErrorHandler(xhr, errorThrown) {
       document.getElementById('errorLabel').textContent = errorThrown || xhr.statusText;
       document.getElementById('errorText').textContent = xhr.responseText;
@@ -336,7 +322,6 @@
       listen('action_create_version', 'submit', createVersionSnapshot);
       listen('action_enable_version', 'submit', enableVersioning);
       listen('action_update_file', 'submit', updateFile);
-      listen('update_rbacl', 'submit', updateAccessRoles);
 
       const links = document.querySelectorAll('a[property][href*="' + location.host + '"],#childList a,.breadcrumb a,.version_link');
       for (var i = 0; i < links.length; ++i) {


### PR DESCRIPTION
…ner types

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3223

This PR does not fulfill all of the above ticket.

# What does this Pull Request do?
Adds a bunch of other `rdf:type` to a Container. Also adds the appropriate xsd:datetime type to the created date and last modified date server managed triples.

# How should this be tested?

Build and create a RDF source, then GET it.
Before you will get the interaction model (ie. `ldp:DirectContainer`) and `ldp:RdfSource` types
Now you will also `ldp:Container`, `fedora:Container` and `fedora:Resource` types.
Also the `fedora:created` and `fedora:lastmodified` will now have the `xsd:dateTime` type 

# Interested parties
@fcrepo4/committers
