### PR TITLE
Ensure that <> in RDF bodies uses 'this' resource URI

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -489,7 +489,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadDatastream() throws IOException, ParseException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", "123");
@@ -578,7 +577,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadNonRdfHeaders() throws IOException {
         final String id = getRandomUniqueId();
         final HttpPut put = putObjMethod(id, "text/plain", "<> a <http://example.com/Foo> .");
@@ -605,7 +603,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testOptionsBinary() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", id);
@@ -755,7 +752,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetNonRDFSource() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", "some content");
@@ -1080,7 +1076,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPatchBinary() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", "some content");
@@ -1226,7 +1221,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCreateGraph() throws IOException {
         final String subjectURI = serverAddress + getRandomUniqueId();
         final HttpPut createMethod = new HttpPut(subjectURI);
@@ -1242,13 +1236,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCreateVersionedRDFResource() throws IOException {
         createVersionedRDFResource();
     }
 
     @Test
-@Ignore
     public void testGetVersionedResourceHeaders() throws IOException {
         final String subjectURI = createVersionedRDFResource();
         try (final CloseableHttpResponse response = execute(new HttpGet(subjectURI))) {
@@ -1258,7 +1250,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadVersionedResourceHeaders() throws IOException {
         final String subjectURI = createVersionedRDFResource();
         try (final CloseableHttpResponse response = execute(new HttpHead(subjectURI))) {
@@ -1303,7 +1294,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCreateVersionedBinaryResource() throws IOException {
         final HttpPost method = postObjMethod();
         final String id = getRandomUniqueId();
@@ -1541,7 +1531,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutBinaryRdfChanges() throws Exception {
         final String id = getRandomUniqueId();
         final Model model = createDefaultModel();
@@ -1788,7 +1777,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testIngestWithSparqlQueryBadNS() throws IOException {
         final HttpPost method = postObjMethod();
         method.addHeader(CONTENT_TYPE, "application/sparql-update");
@@ -1799,7 +1787,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testIngestWithNewAndGraph() throws IOException {
         final HttpPost method = postObjMethod();
         method.addHeader(CONTENT_TYPE, "text/n3");
@@ -2085,7 +2072,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testIngestWithRDFLang() throws IOException {
         final HttpPost method = postObjMethod();
         method.addHeader(CONTENT_TYPE, "text/n3");
@@ -3270,7 +3256,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testValidHTMLForDS() throws IOException, SAXException {
         final String id = getRandomUniqueId();
         createDatastream(id, "ds", "content");
@@ -3347,7 +3332,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCreatedAndModifiedDates() throws IOException {
         final String location = getLocation(postObjMethod());
         final HttpGet getObjMethod = new HttpGet(location);
@@ -3700,7 +3684,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
 
     @Test
-@Ignore
     public void testJsonLdProfileCompacted() throws IOException {
         // Create a resource
         final HttpPost method = postObjMethod();
@@ -4054,7 +4037,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testConcurrentPuts() throws InterruptedException, IOException {
         final String parent = getRandomUniqueId();
         executeAndClose(putObjMethod(parent));
@@ -4088,7 +4070,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testConcurrentPutsWithPairtrees() throws InterruptedException, IOException {
         final String parent = getRandomUniqueId();
         executeAndClose(putObjMethod(parent));
@@ -4751,7 +4732,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutGetRdfSourceWithUndefinedPrefix() throws Exception {
         final String id = "some_prefix:" + getRandomUniqueId();
         final HttpPut putMethod = putObjMethod(id);
@@ -4763,7 +4743,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutGetNonRdfSourceWithUndefinedPrefix() throws Exception {
         final String id = "some_prefix:" + getRandomUniqueId();
         final String dsid = "anotherPrefix:" + getRandomUniqueId();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
@@ -37,9 +37,7 @@ public interface CreateResourceService {
      *
      * @param txId The transaction ID for the request.
      * @param userPrincipal the principal of the user performing the service
-     * @param fedoraId The internal identifier of the parent.
-     * @param slug The Slug header or null if none.
-     * @param isContained The new resource is contained by fedoraId (ie. POST).
+     * @param fedoraId The internal identifier of the resource.
      * @param contentType The content-type header or null if none.
      * @param filename The original filename of the binary
      * @param contentSize The size of the content stream
@@ -47,10 +45,8 @@ public interface CreateResourceService {
      * @param digest The binary digest or null if none.
      * @param requestBody The request body or null if none.
      * @param externalContent The external content handler or null if none.
-     *
-     * @return The identifier of the created resource.
      */
-    String perform(String txId, String userPrincipal, String fedoraId, String slug, boolean isContained,
+    void perform(String txId, String userPrincipal, String fedoraId,
             String contentType, String filename, Long contentSize, List<String> linkHeaders,
             Collection<URI> digest, InputStream requestBody, ExternalContent externalContent);
 
@@ -59,15 +55,11 @@ public interface CreateResourceService {
      *
      * @param txId The transaction ID for the request.
      * @param userPrincipal the principal of the user performing the service
-     * @param fedoraId The internal identifier of the parent.
-     * @param slug The Slug header or null if none.
-     * @param isContained The new resource is contained by fedoraId (ie. POST).
+     * @param fedoraId The internal identifier of the resource
      * @param linkHeaders The original LINK headers or null if none.
      * @param model The request body RDF as a Model
-     *
-     * @return The identifier of the created resource.
      */
-    String perform(String txId, String userPrincipal, String fedoraId, String slug, boolean isContained,
+    void perform(String txId, String userPrincipal, String fedoraId,
             List<String> linkHeaders, Model model);
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/functions/FedoraIdUtils.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/functions/FedoraIdUtils.java
@@ -28,17 +28,6 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 public final class FedoraIdUtils {
 
     /**
-     * Add a subpath to an existing identifier.
-     *
-     * @param oldId the old identifier
-     * @param newIdPart the new identifier part
-     * @return A combination of old and new.
-     */
-    public static String addToIdentifier(final String oldId, final String newIdPart) {
-        return oldId + (oldId.endsWith("/") ? "" : "/") + newIdPart;
-    }
-
-    /**
      * Ensure the ID has the info:fedora/ prefix.
      * @param id the identifier, if null assume repository root (info:fedora/)
      * @return the identifier with the info:fedora/ prefix.


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3259
Incremental resolution for: https://jira.lyrasis.org/browse/FCREPO-3223

# What does this Pull Request do?
Establishes resource URI in FedoraLDP for all creation requests
Fixes more FedoraLdpIT tests

# How should this be tested?
1. PUT and POST of containers and binaries should work as before
1. PUT and POST of containers with RDF bodies should create the correct RDF subjects
1. POST with a slug of an existing resource should work as before

The following `curl` examples can be helpful in manually testing this pull-request
```
# Create and inspect empty PUT resource
curl -XPUT localhost:8080/rest/put0
curl  localhost:8080/rest/put0

# Create and inspect empty POST resource
curl -XPOST localhost:8080/rest/ -H"slug: post0"
curl  localhost:8080/rest/post0

# Create and inspect empty POST resource, with compound slug
curl -XPOST localhost:8080/rest/ -H"slug: post0/1"
curl  localhost:8080/rest/post0/1

# Create and inspect PUT non-RDF resource with body
# ..where binary.txt is:
# "Hello World"
curl -i -XPUT --data-binary @binary.txt -H"Content-Type: text/plain"  localhost:8080/rest/put1
curl  localhost:8080/rest/put1
curl  localhost:8080/rest/put1/fcr:metadata

# Create and inspect POST non-RDF resource with body
# ..where binary.txt is:
# "Hello World"
curl -i -XPOST --data-binary @binary.txt -H"Content-Type: text/plain"  localhost:8080/rest/ -H"slug: post1"
curl  localhost:8080/rest/post1/fcr:metadata
curl  localhost:8080/rest/post1

# re-POST with an existing slug
curl -i -XPOST --data-binary @binary.txt -H"Content-Type: text/plain"  localhost:8080/rest/ -H"slug: post1"
curl http://localhost:8080/rest/c49a58b1-d71f-4fe5-8501-b92a6f65f98a
curl http://localhost:8080/rest/c49a58b1-d71f-4fe5-8501-b92a6f65f98a/fcr:metadata

# Create and inspect PUT RDF resource with body
# ..where body.ttl is:
# "<> <http://purl.org/dc/elements/1.1/title> "Some title""
curl -XPUT --data-binary @body.ttl -H"Content-Type: text/turtle" http://localhost:8080/rest/put2
curl http://localhost:8080/rest/put2

# Create and inspect POST RDF resource with body
# ..where body.ttl is:
# "<> <http://purl.org/dc/elements/1.1/title> "Some title""
curl -XPOST --data-binary @body.ttl -H"Content-Type: text/turtle" http://localhost:8080/rest/ -H"slug: post2"
curl http://localhost:8080/rest/post2

# re-POST with an existing slug
curl -XPOST --data-binary @body.ttl -H"Content-Type: text/turtle" http://localhost:8080/rest/ -H"slug: post2"
```

# Interested parties
@whikloj and @fcrepo4/committers 
