### PR TITLE
Make NonRdfSourceDescription implement the interface

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -76,7 +76,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
-import static org.fcrepo.kernel.api.RdfLexicon.DESCRIBED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
@@ -767,7 +766,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetNonRDFSourceDescription() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", "some content");
@@ -775,6 +773,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String location = serverAddress + id + "/x";
         try (final CloseableHttpResponse response = execute(getDSDescMethod(id, "x"));
                 final CloseableDataset dataset = getDataset(response)) {
+            checkForLinkHeader(response, location, "describes");
             checkForLinkHeader(response, location + "/" + FCR_ACL, "acl");
             final DatasetGraph graph = dataset.asDatasetGraph();
             final Node correctDSSubject = createURI(serverAddress + id + "/x");
@@ -785,8 +784,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
             graph.find().forEachRemaining(quad -> {
                 assertEquals("Found a triple with incorrect subject!", correctDSSubject, quad.getSubject());
             });
-            assertTrue(graph.contains(ANY, ANY, DESCRIBED_BY.asNode(),
-                    createURI(serverAddress + id + "/x/fcr:metadata")));
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -29,6 +29,7 @@ import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
@@ -38,7 +39,7 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
  *
  * @author bbpennel
  */
-public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl {
+public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements NonRdfSourceDescription {
 
     /**
      * Construct a description resource


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3263

# What does this Pull Request do?
Fixes some headers on NonRDFSource descriptions

# What's new?
Makes the NonRdfSourceDescriptionImpl implement the NonRdfSourceDescription interface so it adds appropriate headers.

Also fixes an integration test to check for this link header and stop looking for a `describedby` triple in the body (its now only a Link header).

# How should this be tested?

1. Make a binary
    ```
     > curl -ufedoraAdmin:fedoraAdmin -XPOST -H"Slug: binary1" -H"Content-type: text/plain" --data-binary "This is some text" http://localhost:8080/rest

     http://localhost:8080/rest/binary1
     ```
1. Get the `fcr:metadata` of the binary
     ````
     > curl -ufedoraAdmin:fedoraAdmin -i http://localhost:8080/rest/binary1/fcr:metadata
     HTTP/1.1 200 OK
     Date: Wed, 01 Apr 2020 20:50:35 GMT
     Set-Cookie: JSESSIONID=node0tr00iiw8q00t16wjxnovd3q4j1.node0; Path=/
     Expires: Thu, 01 Jan 1970 00:00:00 GMT
     Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Tue, 31-Mar-2020 20:50:35 GMT
     ETag: W/"1BF56C4C5F0C280D6FB4DB20C7C183A7"
     X-State-Token: 1BF56C4C5F0C280D6FB4DB20C7C183A7
     Last-Modified: Wed, 01 Apr 2020 20:50:09 GMT
     Link: <http://www.w3.org/ns/ldp#Resource>;rel="type"
     Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
     Link: <http://localhost:8080/rest/binary1/fcr:metadata>; rel="timegate"
     Link: <http://localhost:8080/rest/binary1/fcr:metadata>; rel="original"
     Link: <http://localhost:8080/rest/binary1/fcr:metadata/fcr:versions>; rel="timemap"
     Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
     Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
     Accept-External-Content-Handling: copy,redirect,proxy
     Allow:
     Link: <http://localhost:8080/rest/binary1/fcr:acl>; rel="acl"
     Preference-Applied: return=representation
     Vary: Prefer
     Vary: Accept
     Vary: Range
     Vary: Accept-Encoding
     Vary: Accept-Language
     Vary: Accept-Datetime
     Content-Type: text/turtle;charset=utf-8
     Content-Length: 471
     Server: Jetty(9.4.24.v20191120)

     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
     @prefix fedora: <http://fedora.info/definitions/v4/repository#> .
     @prefix ldp: <http://www.w3.org/ns/ldp#> .

     <http://localhost:8080/rest/binary1>
            fedora:created "2020-04-01T20:50:09.916295Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
            fedora:lastModified "2020-04-01T20:50:09.916295Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
            rdf:type ldp:NonRDFSource .
     ```
3. Notice there is no `Link: <http://localhost:8080/rest/binary1>; rel="describes"` and only `Allow:`
4. Pull in this PR, build, restart steps and see the missing Headers.

# Additional Notes:

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@fcrepo4/committers
