### PR TITLE
Set default dynamic test port value with spring defaults

### DIFF
--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
@@ -56,7 +56,7 @@ public class ContainerWrapper implements ApplicationContextAware {
 
     private static final Logger logger = getLogger(ContainerWrapper.class);
 
-    @Value("#{${fcrepo.dynamic.test.port} ?: 8080}")
+    @Value("${fcrepo.dynamic.test.port:8080}")
     private int port;
 
     private HttpServer server;

--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -67,6 +67,7 @@
     <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
     <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.unit.file}</sonar.jacoco.reportPath>
     <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
+    <fcrepo.dynamic.test.port>8080</fcrepo.dynamic.test.port>
   </properties>
 
   <build>


### PR DESCRIPTION
**JIRA Ticket**: none

# What does this Pull Request do?
Updates to the way the `fcrepo.dynamic.test.port` is set for tests so that it works across intellij, eclipse, and maven.

# What's new?
* Changes syntax for setting property in ContainerWrapper
* Sets a default value for `fcrepo.dynamic.test.port`

# How should this be tested?

Running `mvn clean install`
Running integration tests which use ContainerWrapper, such as FedoraLdpIT

You can also change the dynamic test port via commandline to verify that it still overrides the default:
`mvn verify -Dfcrepo.dynamic.test.port=8081 -pl fcrepo-http-api`

Similarly, you can set a custom value in your IDE by following the instructions for how to set environment variables during test runs for your IDE.

# Interested parties
@pwinckles 
