### PR TITLE
Implement kernel events

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -101,7 +101,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
@@ -242,14 +241,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     protected static final Splitter.MapSplitter RFC3230_SPLITTER =
         Splitter.on(',').omitEmptyStrings().trimResults().withKeyValueSeparator(Splitter.on('=').limit(2));
-
-    /**
-     * Run these actions after initializing this resource
-     */
-    @PostConstruct
-    public void postConstruct() {
-        setUpJMSInfo(uriInfo, headers);
-    }
 
     /**
      * This method returns an HTTP response with content body appropriate to the following arguments.

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -288,7 +288,7 @@ public class FedoraAcl extends ContentExposingResource {
 
         final FedoraResource aclResource = resource().getAcl();
         if (aclResource != null) {
-            deleteResourceService.perform(transaction(), aclResource);
+            deleteResourceService.perform(transaction(), aclResource, getUserPrincipal());
         }
         transaction().commit();
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -29,17 +29,12 @@ import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.slf4j.Logger;
 
-import java.net.URI;
 import java.security.Principal;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.core.UriInfo;
 
-// import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
-// import static org.fcrepo.kernel.api.observer.OptionalValues.USER_AGENT;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -49,8 +44,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 abstract public class FedoraBaseResource extends AbstractResource {
 
     private static final Logger LOGGER = getLogger(FedoraBaseResource.class);
-
-    static final String JMS_BASEURL_PROP = "fcrepo.jms.baseUrl";
 
     @Context
     protected SecurityContext securityContext;
@@ -111,49 +104,6 @@ abstract public class FedoraBaseResource extends AbstractResource {
         return resourceFactory.doesResourceExist(transaction, fedoraId);
     }
 
-    /**
-     * Set the baseURL for JMS events.
-     * @param uriInfo the uri info
-     * @param headers HTTP headers
-     **/
-    protected void setUpJMSInfo(final UriInfo uriInfo, final HttpHeaders headers) {
-        try {
-            String baseURL = getBaseUrlProperty(uriInfo);
-            if (baseURL.length() == 0) {
-                baseURL = uriInfo.getBaseUri().toString();
-            }
-            LOGGER.debug("setting baseURL = " + baseURL);
-            // TODO determine if this data can be stored in the Transaction
-            // or if it would be necessary for the persistence layer
-
-            // session.getFedoraSession().addSessionData(BASE_URL, baseURL);
-            // if (!StringUtils.isBlank(headers.getHeaderString("user-agent"))) {
-            //     session.getFedoraSession().addSessionData(USER_AGENT, headers.getHeaderString("user-agent"));
-            // }
-        } catch (final Exception ex) {
-            LOGGER.warn("Error setting baseURL", ex);
-        }
-    }
-
-    /**
-     * Produce a baseURL for JMS events using the system property fcrepo.jms.baseUrl of the form http[s]://host[:port],
-     * if it exists.
-     *
-     * @param uriInfo used to build the base url
-     * @return String the base Url
-     */
-    private String getBaseUrlProperty(final UriInfo uriInfo) {
-        final String propBaseURL = System.getProperty(JMS_BASEURL_PROP, "");
-        if (propBaseURL.length() > 0 && propBaseURL.startsWith("http")) {
-            final URI propBaseUri = URI.create(propBaseURL);
-            if (propBaseUri.getPort() < 0) {
-                return uriInfo.getBaseUriBuilder().port(-1).uri(propBaseUri).toString();
-            }
-            return uriInfo.getBaseUriBuilder().uri(propBaseUri).toString();
-        }
-        return "";
-    }
-
     protected String getUserPrincipal() {
         final Principal p = securityContext.getUserPrincipal();
         return p == null ? null : p.getName();
@@ -161,7 +111,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
 
     protected Transaction transaction() {
         if (transaction == null) {
-            txProvider = new TransactionProvider(txManager, servletRequest);
+            txProvider = new TransactionProvider(txManager, servletRequest, uriInfo.getBaseUri());
             transaction = txProvider.provide();
         }
         return transaction;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -349,7 +349,7 @@ public class FedoraLdp extends ContentExposingResource {
 
         LOGGER.info("Delete resource '{}'", externalPath);
 
-        deleteResourceService.perform(transaction(), resource());
+        deleteResourceService.perform(transaction(), resource(), getUserPrincipal());
         transaction().commitIfShortLived();
         return noContent().build();
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
@@ -71,7 +71,7 @@ public class FedoraTombstones extends ContentExposingResource {
     @DELETE
     public Response delete() {
         LOGGER.info("Delete tombstone: {}", resource());
-        deleteResourceService.perform(transaction(), resource());
+        deleteResourceService.perform(transaction(), resource(), getUserPrincipal());
         transaction().commitIfShortLived();
         return noContent().build();
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -17,30 +17,15 @@
  */
 package org.fcrepo.http.api;
 
-import static javax.ws.rs.core.Response.ok;
-import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_LINK_FORMAT;
-import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
-import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
-import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import java.io.IOException;
-import java.net.URI;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.google.common.annotations.VisibleForTesting;
+import org.fcrepo.http.commons.responses.HtmlTemplate;
+import org.fcrepo.http.commons.responses.LinkFormatStream;
+import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Scope;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
@@ -57,17 +42,30 @@ import javax.ws.rs.core.Link.Builder;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import org.fcrepo.http.commons.responses.HtmlTemplate;
-import org.fcrepo.http.commons.responses.LinkFormatStream;
-import org.fcrepo.kernel.api.exception.InvalidChecksumException;
-import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
-import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.models.FedoraResource;
-import org.slf4j.Logger;
-import org.springframework.context.annotation.Scope;
-
-import com.google.common.annotations.VisibleForTesting;
+import static javax.ws.rs.core.Response.ok;
+import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_LINK_FORMAT;
+import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
+import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * @author cabeer
@@ -136,7 +134,7 @@ public class FedoraVersioning extends ContentExposingResource {
         try {
             LOGGER.debug("Request to create version for <{}>", externalPath);
 
-            versionService.createVersion(transaction, resource.getId(), getUserPrincipal());
+            versionService.createVersion(transaction, resource.getFedoraId(), getUserPrincipal());
 
             // need to commit the transaction before loading the memento otherwise it won't exist
             transaction.commitIfShortLived();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -18,7 +18,6 @@
 package org.fcrepo.http.api;
 
 import static com.google.common.base.Predicates.containsPattern;
-import static java.net.URI.create;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
@@ -39,7 +38,6 @@ import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
 import static org.fcrepo.http.api.ContentExposingResource.buildLink;
 import static org.fcrepo.http.api.ContentExposingResource.getSimpleContentType;
-import static org.fcrepo.http.api.FedoraBaseResource.JMS_BASEURL_PROP;
 import static org.fcrepo.http.api.FedoraLdp.HTTP_HEADER_ACCEPT_PATCH;
 import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES_TYPE;
 import static org.fcrepo.http.commons.test.util.TestHelpers.getUriInfoImpl;
@@ -56,7 +54,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
-// import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -99,7 +96,6 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.graph.Triple;
@@ -131,8 +127,6 @@ import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.kernel.api.services.TimeMapService;
 import org.fcrepo.kernel.api.services.UpdatePropertiesService;
-import org.glassfish.jersey.internal.PropertiesDelegate;
-import org.glassfish.jersey.server.ContainerRequest;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -872,7 +866,7 @@ public class FedoraLdpTest {
         when(mockRequest.getMethod()).thenReturn("PATCH");
         final Response actual = testObj.deleteObject();
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
-        verify(deleteResourceService).perform(mockTransaction, fedoraResource);
+        verify(deleteResourceService).perform(eq(mockTransaction), eq(fedoraResource), anyString());
     }
 
     @Test
@@ -1215,157 +1209,6 @@ public class FedoraLdpTest {
         final MediaType mediaType = new MediaType("text", "plain", ImmutableMap.of("charset", "UTF-8"));
         final MediaType sanitizedMediaType = MediaType.valueOf(getSimpleContentType(mediaType));
         assertEquals("text/plain", sanitizedMediaType.toString());
-    }
-
-    /**
-     * Demonstrates that when the {@link FedoraBaseResource#JMS_BASEURL_PROP fcrepo.jms.baseUrl} system property is not
-     * set, the url used for JMS messages is the same as the base url found in the {@code UriInfo}.
-     * <p>
-     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
-     * {@code javax.ws.rs.core.UriBuilder} and {@code FedoraBaseResource} that is being tested.
-     * </p>
-     */
-    @Test
-    public void testJmsBaseUrlDefault() {
-        // Obtain a concrete instance of UriInfo
-        final URI baseUri = create("http://localhost/fcrepo");
-        final URI requestUri = create("http://localhost/fcrepo/foo");
-        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
-                mock(PropertiesDelegate.class));
-        final UriInfo info = spy(req.getUriInfo());
-
-        final String expectedBaseUrl = baseUri.toString();
-
-        testObj.setUpJMSInfo(info, mockHeaders);
-
-        // verify(mockTransaction).addSessionData(BASE_URL, expectedBaseUrl);
-        verify(info, times(0)).getBaseUriBuilder();
-        verify(info).getBaseUri();
-    }
-
-    /**
-     * Demonstrates that the host supplied by the {@link FedoraBaseResource#JMS_BASEURL_PROP fcrepo.jms.baseUrl} system
-     * property is used as the as the base url for JMS messages, and not the base url found in {@code UriInfo}.
-     * <p>
-     * Note: the path from the request is preserved, the host from the fcrepo.jms.baseUrl is used
-     * </p>
-     * <p>
-     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
-     * {@code javax.ws.rs.core.UriBuilder} and {@code FedoraBaseResource} that is being tested.
-     * </p>
-     */
-    @Test
-    public void testJmsBaseUrlOverrideHost() {
-        // Obtain a concrete implementation of UriInfo
-        final URI baseUri = create("http://localhost/fcrepo");
-        final URI requestUri = create("http://localhost/fcrepo/foo");
-        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
-                mock(PropertiesDelegate.class));
-        final UriInfo info = spy(req.getUriInfo());
-
-        final String baseUrl = "http://example.org";
-        final String expectedBaseUrl = baseUrl + baseUri.getPath();
-        System.setProperty(JMS_BASEURL_PROP, baseUrl);
-
-        testObj.setUpJMSInfo(info, mockHeaders);
-
-        // verify(mockTransaction).addSessionData(BASE_URL, expectedBaseUrl);
-        verify(info).getBaseUriBuilder();
-        System.clearProperty(JMS_BASEURL_PROP);
-    }
-
-    /**
-     * Demonstrates that the host and port supplied by the {@link FedoraBaseResource#JMS_BASEURL_PROP
-     * fcrepo.jms.baseUrl} system property is used as the as the base url for JMS messages, and not the base url found
-     * in {@code UriInfo}.
-     * <p>
-     * Note: the path from the request is preserved, but the host and port from the request is overridden by the values
-     * from fcrepo.jms.baseUrl
-     * </p>
-     * <p>
-     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
-     * {@code javax.ws.rs.core.UriBuilder} and {@code FedoraBaseResource} that is being tested.
-     * </p>
-     */
-    @Test
-    public void testJmsBaseUrlOverrideHostAndPort() {
-        // Obtain a concrete implementation of UriInfo
-        final URI baseUri = create("http://localhost/fcrepo");
-        final URI requestUri = create("http://localhost/fcrepo/foo");
-        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
-                mock(PropertiesDelegate.class));
-        final UriInfo info = spy(req.getUriInfo());
-
-        final String baseUrl = "http://example.org:9090";
-        final String expectedBaseUrl = baseUrl + baseUri.getPath();
-        System.setProperty(JMS_BASEURL_PROP, baseUrl);
-
-        testObj.setUpJMSInfo(info, mockHeaders);
-
-        // verify(mockTransaction).addSessionData(BASE_URL, expectedBaseUrl);
-        verify(info).getBaseUriBuilder();
-        System.clearProperty(JMS_BASEURL_PROP);
-    }
-
-    /**
-     * Demonstrates that the url supplied by the {@link FedoraBaseResource#JMS_BASEURL_PROP fcrepo.jms.baseUrl} system
-     * property is used as the as the base url for JMS messages, and not the base url found in {@code UriInfo}.
-     * <p>
-     * Note: the host and path from the request is overridden by the values from fcrepo.jms.baseUrl
-     * </p>
-     * <p>
-     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
-     * {@code javax.ws.rs.core.UriBuilder} and {@code FedoraBaseResource} that is being tested.
-     * </p>
-     */
-    @Test
-    public void testJmsBaseUrlOverrideUrl() {
-        // Obtain a concrete implementation of UriInfo
-        final URI baseUri = create("http://localhost/fcrepo");
-        final URI requestUri = create("http://localhost/fcrepo/foo");
-        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
-                mock(PropertiesDelegate.class));
-        final UriInfo info = spy(req.getUriInfo());
-
-        final String expectedBaseUrl = "http://example.org/fcrepo/rest";
-        System.setProperty(JMS_BASEURL_PROP, expectedBaseUrl);
-
-        testObj.setUpJMSInfo(info, mockHeaders);
-
-        // verify(mockTransaction).addSessionData(BASE_URL, expectedBaseUrl);
-        verify(info).getBaseUriBuilder();
-        System.clearProperty(JMS_BASEURL_PROP);
-    }
-
-    /**
-     * Demonstrates that when the the base url in {@code UriInfo} contains a port number, and the base url defined by
-     * {@link FedoraBaseResource#JMS_BASEURL_PROP fcrepo.jms.baseUrl} does <em>not</em> contain a port number, that the
-     * base url for JMS messages does not contain a port number.
-     * <p>
-     * Note: the host, port, and path from the request is overridden by values from fcrepo.jms.baseUrl
-     * </p>
-     * <p>
-     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
-     * {@code javax.ws.rs.core.UriBuilder} and {@code FedoraBaseResource} that is being tested.
-     * </p>
-     */
-    @Test
-    public void testJmsBaseUrlOverrideRequestUrlWithPort8080() {
-        // Obtain a concrete implementation of UriInfo
-        final URI baseUri = create("http://localhost:8080/fcrepo/rest");
-        final URI reqUri = create("http://localhost:8080/fcrepo/rest/foo");
-        final ContainerRequest req = new ContainerRequest(baseUri, reqUri, "GET", mock(SecurityContext.class),
-                mock(PropertiesDelegate.class));
-        final UriInfo info = spy(req.getUriInfo());
-
-        final String expectedBaseUrl = "http://example.org/fcrepo/rest/";
-        System.setProperty(JMS_BASEURL_PROP, expectedBaseUrl);
-
-        testObj.setUpJMSInfo(info, mockHeaders);
-
-        // verify(mockTransaction).addSessionData(BASE_URL, expectedBaseUrl);
-        verify(info).getBaseUriBuilder();
-        System.clearProperty(JMS_BASEURL_PROP);
     }
 
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraTombstonesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraTombstonesTest.java
@@ -72,7 +72,7 @@ public class FedoraTombstonesTest {
         doReturn(mockResource).when(testObj).resource();
         final Response actual = testObj.delete();
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
-        verify(deleteResourceService).perform(mockTransaction, mockResource);
+        verify(deleteResourceService).perform(mockTransaction, mockResource, null);
         verify(mockTransaction).commitIfShortLived();
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/TransactionsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/TransactionsTest.java
@@ -28,12 +28,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.Principal;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.kernel.api.Transaction;
@@ -70,6 +72,9 @@ public class TransactionsTest {
     private TransactionManager mockTxManager;
 
     @Mock
+    private UriInfo mockUriInfo;
+
+    @Mock
     private HttpIdentifierConverter mockIdConverter;
 
     @Mock
@@ -82,7 +87,7 @@ public class TransactionsTest {
     private SecurityContext mockSecurityContext;
 
     @Before
-    public void setUp() {
+    public void setUp() throws URISyntaxException {
         testObj = new Transactions();
         mockTransaction.setShortLived(false);
         when(mockTxManager.create()).thenReturn(mockTransaction);
@@ -91,7 +96,11 @@ public class TransactionsTest {
             .thenThrow(new TransactionNotFoundException("No Transaction found with transactionId"));
         when(mockTransaction.getId()).thenReturn("123");
         when(mockTransaction.getExpires()).thenReturn(now().plusSeconds(100));
+
+        when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://localhost/rest"));
+
         setField(testObj, "txManager", mockTxManager);
+        setField(testObj, "uriInfo", mockUriInfo);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/TransactionsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/TransactionsTest.java
@@ -87,7 +87,7 @@ public class TransactionsTest {
     private SecurityContext mockSecurityContext;
 
     @Before
-    public void setUp() throws URISyntaxException {
+    public void setUp() {
         testObj = new Transactions();
         mockTransaction.setShortLived(false);
         when(mockTxManager.create()).thenReturn(mockTransaction);
@@ -97,7 +97,7 @@ public class TransactionsTest {
         when(mockTransaction.getId()).thenReturn("123");
         when(mockTransaction.getExpires()).thenReturn(now().plusSeconds(100));
 
-        when(mockUriInfo.getBaseUri()).thenReturn(new URI("http://localhost/rest"));
+        when(mockUriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/rest"));
 
         setField(testObj, "txManager", mockTxManager);
         setField(testObj, "uriInfo", mockUriInfo);

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/session/TransactionProviderTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/session/TransactionProviderTest.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.http.commons.session;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.TransactionManager;
+import org.glassfish.jersey.internal.PropertiesDelegate;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+
+import static java.net.URI.create;
+import static org.fcrepo.http.commons.session.TransactionProvider.JMS_BASEURL_PROP;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class TransactionProviderTest {
+
+    @Mock
+    private TransactionManager transactionManager;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private Transaction transaction;
+
+    @Before
+    public void setup() {
+        when(transactionManager.create()).thenReturn(transaction);
+    }
+
+    private TransactionProvider createProvider(final UriInfo uriInfo) {
+        return new TransactionProvider(transactionManager, request, uriInfo.getBaseUri());
+    }
+
+    @Test
+    public void testSetUserAgent() {
+        // Obtain a concrete instance of UriInfo
+        final URI baseUri = create("http://localhost/fcrepo");
+        final URI requestUri = create("http://localhost/fcrepo/foo");
+        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
+                mock(PropertiesDelegate.class));
+        final UriInfo info = spy(req.getUriInfo());
+
+        final String expectedBaseUrl = baseUri.toString();
+        final String expectedUserAgent = "fedoraAdmin";
+
+        when(request.getHeader("user-agent")).thenReturn(expectedUserAgent);
+
+        createProvider(info).provide();
+
+        verify(transaction).setBaseUri(expectedBaseUrl);
+        verify(transaction).setUserAgent(expectedUserAgent);
+        verify(info).getBaseUri();
+    }
+
+    /**
+     * Demonstrates that when the {@link TransactionProvider#JMS_BASEURL_PROP fcrepo.jms.baseUrl} system property is not
+     * set, the url used for JMS messages is the same as the base url found in the {@code UriInfo}.
+     * <p>
+     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
+     * {@code javax.ws.rs.core.UriBuilder} and {@code TransactionProvider} that is being tested.
+     * </p>
+     */
+    @Test
+    public void testJmsBaseUrlDefault() {
+        // Obtain a concrete instance of UriInfo
+        final URI baseUri = create("http://localhost/fcrepo");
+        final URI requestUri = create("http://localhost/fcrepo/foo");
+        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
+                mock(PropertiesDelegate.class));
+        final UriInfo info = spy(req.getUriInfo());
+
+        final String expectedBaseUrl = baseUri.toString();
+
+        createProvider(info).provide();
+
+        verify(transaction).setBaseUri(expectedBaseUrl);
+        verify(info).getBaseUri();
+    }
+
+    /**
+     * Demonstrates that the host supplied by the {@link TransactionProvider#JMS_BASEURL_PROP fcrepo.jms.baseUrl} system
+     * property is used as the as the base url for JMS messages, and not the base url found in {@code UriInfo}.
+     * <p>
+     * Note: the path from the request is preserved, the host from the fcrepo.jms.baseUrl is used
+     * </p>
+     * <p>
+     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
+     * {@code javax.ws.rs.core.UriBuilder} and {@code TransactionProvider} that is being tested.
+     * </p>
+     */
+    @Test
+    public void testJmsBaseUrlOverrideHost() {
+        // Obtain a concrete implementation of UriInfo
+        final URI baseUri = create("http://localhost/fcrepo");
+        final URI requestUri = create("http://localhost/fcrepo/foo");
+        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
+                mock(PropertiesDelegate.class));
+        final UriInfo info = spy(req.getUriInfo());
+
+        final String baseUrl = "http://example.org";
+        final String expectedBaseUrl = baseUrl + baseUri.getPath();
+        System.setProperty(JMS_BASEURL_PROP, baseUrl);
+
+        createProvider(info).provide();
+
+        verify(transaction).setBaseUri(expectedBaseUrl);
+        System.clearProperty(JMS_BASEURL_PROP);
+    }
+
+    /**
+     * Demonstrates that the host and port supplied by the {@link TransactionProvider#JMS_BASEURL_PROP
+     * fcrepo.jms.baseUrl} system property is used as the as the base url for JMS messages, and not the base url found
+     * in {@code UriInfo}.
+     * <p>
+     * Note: the path from the request is preserved, but the host and port from the request is overridden by the values
+     * from fcrepo.jms.baseUrl
+     * </p>
+     * <p>
+     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
+     * {@code javax.ws.rs.core.UriBuilder} and {@code TransactionProvider} that is being tested.
+     * </p>
+     */
+    @Test
+    public void testJmsBaseUrlOverrideHostAndPort() {
+        // Obtain a concrete implementation of UriInfo
+        final URI baseUri = create("http://localhost/fcrepo");
+        final URI requestUri = create("http://localhost/fcrepo/foo");
+        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
+                mock(PropertiesDelegate.class));
+        final UriInfo info = spy(req.getUriInfo());
+
+        final String baseUrl = "http://example.org:9090";
+        final String expectedBaseUrl = baseUrl + baseUri.getPath();
+        System.setProperty(JMS_BASEURL_PROP, baseUrl);
+
+        createProvider(info).provide();
+
+        verify(transaction).setBaseUri(expectedBaseUrl);
+        System.clearProperty(JMS_BASEURL_PROP);
+    }
+
+    /**
+     * Demonstrates that the url supplied by the {@link TransactionProvider#JMS_BASEURL_PROP fcrepo.jms.baseUrl} system
+     * property is used as the as the base url for JMS messages, and not the base url found in {@code UriInfo}.
+     * <p>
+     * Note: the host and path from the request is overridden by the values from fcrepo.jms.baseUrl
+     * </p>
+     * <p>
+     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
+     * {@code javax.ws.rs.core.UriBuilder} and {@code TransactionProvider} that is being tested.
+     * </p>
+     */
+    @Test
+    public void testJmsBaseUrlOverrideUrl() {
+        // Obtain a concrete implementation of UriInfo
+        final URI baseUri = create("http://localhost/fcrepo");
+        final URI requestUri = create("http://localhost/fcrepo/foo");
+        final ContainerRequest req = new ContainerRequest(baseUri, requestUri, "GET", mock(SecurityContext.class),
+                mock(PropertiesDelegate.class));
+        final UriInfo info = spy(req.getUriInfo());
+
+        final String expectedBaseUrl = "http://example.org/fcrepo/rest";
+        System.setProperty(JMS_BASEURL_PROP, expectedBaseUrl);
+
+        createProvider(info).provide();
+
+        verify(transaction).setBaseUri(expectedBaseUrl);
+        System.clearProperty(JMS_BASEURL_PROP);
+    }
+
+    /**
+     * Demonstrates that when the the base url in {@code UriInfo} contains a port number, and the base url defined by
+     * {@link TransactionProvider#JMS_BASEURL_PROP fcrepo.jms.baseUrl} does <em>not</em> contain a port number, that the
+     * base url for JMS messages does not contain a port number.
+     * <p>
+     * Note: the host, port, and path from the request is overridden by values from fcrepo.jms.baseUrl
+     * </p>
+     * <p>
+     * Implementation note: this test requires a concrete instance of {@link UriInfo}, because it is the interaction of
+     * {@code javax.ws.rs.core.UriBuilder} and {@code TransactionProvider} that is being tested.
+     * </p>
+     */
+    @Test
+    public void testJmsBaseUrlOverrideRequestUrlWithPort8080() {
+        // Obtain a concrete implementation of UriInfo
+        final URI baseUri = create("http://localhost:8080/fcrepo/rest");
+        final URI reqUri = create("http://localhost:8080/fcrepo/rest/foo");
+        final ContainerRequest req = new ContainerRequest(baseUri, reqUri, "GET", mock(SecurityContext.class),
+                mock(PropertiesDelegate.class));
+        final UriInfo info = spy(req.getUriInfo());
+
+        final String expectedBaseUrl = "http://example.org/fcrepo/rest/";
+        System.setProperty(JMS_BASEURL_PROP, expectedBaseUrl);
+
+        createProvider(info).provide();
+
+        verify(transaction).setBaseUri(expectedBaseUrl);
+        System.clearProperty(JMS_BASEURL_PROP);
+    }
+
+}

--- a/fcrepo-jms/pom.xml
+++ b/fcrepo-jms/pom.xml
@@ -37,6 +37,18 @@
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-kernel-impl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-persistence-ocfl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-event-serialization</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -105,6 +117,11 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -17,6 +17,44 @@
  */
 package org.fcrepo.integration.jms.observer;
 
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.TransactionManager;
+import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.services.CreateResourceService;
+import org.fcrepo.kernel.api.services.DeleteResourceService;
+import org.fcrepo.kernel.api.services.ReplaceBinariesService;
+import org.fcrepo.kernel.api.services.ReplacePropertiesService;
+import org.fcrepo.kernel.api.services.UpdatePropertiesService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.Session;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
+
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.jayway.awaitility.Awaitility.await;
 import static com.jayway.awaitility.Duration.ONE_HUNDRED_MILLISECONDS;
@@ -27,44 +65,16 @@ import static org.fcrepo.jms.DefaultMessageFactory.EVENT_TYPE_HEADER_NAME;
 import static org.fcrepo.jms.DefaultMessageFactory.IDENTIFIER_HEADER_NAME;
 import static org.fcrepo.jms.DefaultMessageFactory.RESOURCE_TYPE_HEADER_NAME;
 import static org.fcrepo.jms.DefaultMessageFactory.TIMESTAMP_HEADER_NAME;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.observer.EventType.INBOUND_REFERENCE;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
-// import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
-// import static org.fcrepo.kernel.api.observer.OptionalValues.USER_AGENT;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-import javax.inject.Inject;
-import javax.jms.Connection;
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageListener;
-import javax.jms.Session;
-
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.jena.rdf.model.Resource;
-
-import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.TransactionManager;
-import org.fcrepo.kernel.api.exception.InvalidChecksumException;
-import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
-import org.fcrepo.kernel.api.models.Container;
-import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.services.DeleteResourceService;
-import org.fcrepo.kernel.api.services.ReplacePropertiesService;
-import org.fcrepo.kernel.api.services.UpdatePropertiesService;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.slf4j.Logger;
+// import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
+// import static org.fcrepo.kernel.api.observer.OptionalValues.USER_AGENT;
 
 /**
  * <p>
@@ -80,23 +90,29 @@ abstract class AbstractJmsIT implements MessageListener {
      */
     private static final long TIMEOUT = 20000;
 
-    private static final String testIngested = "/testMessageFromIngestion-" + randomUUID();
+    private String testIngested = "/testMessageFromIngestion-" + randomUUID();
 
-    private static final String testRemoved = "/testMessageFromRemoval-" + randomUUID();
+    private String testRemoved = "/testMessageFromRemoval-" + randomUUID();
 
-    private static final String testFile = "/testMessageFromFile-" + randomUUID() + "/file1";
+    private String testFile = "/testMessageFromFile-" + randomUUID() + "/file1";
 
-    private static final String testMeta = "/testMessageFromMetadata-" + randomUUID();
+    private String testMeta = "/testMessageFromMetadata-" + randomUUID();
 
+    private static final String USER = "fedoraAdmin";
     private static final String TEST_USER_AGENT = "FedoraClient/1.0";
     private static final String TEST_BASE_URL = "http://localhost:8080/rest";
 
     @Inject
+    private ResourceFactory resourceFactory;
+
+    @Inject
     private TransactionManager txMananger;
 
-    // @Inject
-    // TODO: Replace with some other service/factory
-    // private ContainerService containerService;
+    @Inject
+    private CreateResourceService createResourceService;
+
+    @Inject
+    private ReplaceBinariesService replaceBinariesService;
 
     @Inject
     private UpdatePropertiesService updatePropertiesService;
@@ -123,141 +139,112 @@ abstract class AbstractJmsIT implements MessageListener {
     protected abstract Destination createDestination() throws JMSException;
 
     @Test(timeout = TIMEOUT)
-    @Ignore
     public void testIngestion() {
 
         LOGGER.debug("Expecting a {} event", RESOURCE_CREATION.getType());
 
-        final Transaction tx = txMananger.create();
-        // session.addSessionData(BASE_URL, TEST_BASE_URL);
-        // session.addSessionData(USER_AGENT, TEST_USER_AGENT);
-
-        try {
-            // containerService.findOrCreate(session, testIngested);
+        doInTx(tx -> {
+            createResourceService.perform(tx.getId(), USER, FedoraId.create(testIngested),
+                    null, ModelFactory.createDefaultModel());
             tx.commit();
             awaitMessageOrFail(testIngested, RESOURCE_CREATION.getType(), null);
-        } finally {
-            tx.expire();
-        }
+        });
     }
 
     @Test(timeout = TIMEOUT)
-    @Ignore
     public void testFileEvents() throws InvalidChecksumException {
+        final var fedoraId = FedoraId.create(testFile);
 
-        final Transaction tx = txMananger.create();
-        // session.addSessionData(BASE_URL, TEST_BASE_URL);
-        // session.addSessionData(USER_AGENT, TEST_USER_AGENT);
-
-        try {
-            // binaryService.findOrCreate(tx, testFile)
-            // .setContent(new ByteArrayInputStream("foo".getBytes()), "text/plain", null, null, null);
+        doInTx(tx -> {
+            createResourceService.perform(tx.getId(), USER, fedoraId,
+                    "text/plain", "file.txt", 3L,
+                    List.of(), null, stream("foo"), null);
             tx.commit();
-            awaitMessageOrFail(testFile, RESOURCE_CREATION.getType(), REPOSITORY_NAMESPACE + "Binary");
+            awaitMessageOrFail(testFile, RESOURCE_CREATION.getType(), NON_RDF_SOURCE.toString());
+        });
 
-            // binaryService.find(tx, testFile)
-            // .setContent(new ByteArrayInputStream("barney".getBytes()), "text/plain", null, null, null);
+        doInTx(tx -> {
+            replaceBinariesService.perform(tx.getId(), USER, fedoraId,
+                    "file.txt", "text/plain", null,
+                    stream("barney"), 6L, null);
             tx.commit();
-            awaitMessageOrFail(testFile, RESOURCE_MODIFICATION.getType(), REPOSITORY_NAMESPACE + "Binary");
+            awaitMessageOrFail(testFile, RESOURCE_MODIFICATION.getType(), NON_RDF_SOURCE.toString());
+        });
 
-            final FedoraResource binaryResource = null;
-            //TODO update previous line to support new binary resource location
-            // approach that will replace binaryService.find(session, testFile)
-            deleteResourceService.perform(tx, binaryResource);
+        doInTx(tx -> {
+            final FedoraResource binaryResource = getResource(fedoraId);
+            deleteResourceService.perform(tx, binaryResource, USER);
             tx.commit();
             awaitMessageOrFail(testFile, RESOURCE_DELETION.getType(), null);
-        } finally {
-            tx.expire();
-        }
+        });
     }
 
     @Test(timeout = TIMEOUT)
-    @Ignore
+    @Ignore("updatePropertiesService is not implemented")
     public void testMetadataEvents() {
+        final IdentifierConverter<Resource,FedoraResource> subjects = null;
 
-        final Transaction tx = txMananger.create();
-        // session.addSessionData(BASE_URL, TEST_BASE_URL);
-        // session.addSessionData(USER_AGENT, TEST_USER_AGENT);
-        final IdentifierConverter<Resource,FedoraResource>
-            subjects = null;
-
-        try {
+        doInTx(tx -> {
             // final FedoraResource resource1 = containerService.findOrCreate(tx, testMeta);
             final String sparql1 = "insert data { <> <http://foo.com/prop> \"foo\" . }";
             // updatePropertiesService.updateProperties(resource1, sparql1, resource1.getTriples(subjects,
             // PROPERTIES));
             tx.commit();
             awaitMessageOrFail(testMeta, RESOURCE_MODIFICATION.getType(), REPOSITORY_NAMESPACE + "Container");
+        });
 
+        doInTx(tx -> {
             // final FedoraResource resource2 = containerService.findOrCreate(tx, testMeta);
             final String sparql2 = " delete { <> <http://foo.com/prop> \"foo\" . } "
-                + "insert { <> <http://foo.com/prop> \"bar\" . } where {}";
+                    + "insert { <> <http://foo.com/prop> \"bar\" . } where {}";
             // updatePropertiesService.updateProperties(resource2, sparql2, resource2.getTriples(subjects,
             // PROPERTIES));
             tx.commit();
             awaitMessageOrFail(testMeta, RESOURCE_MODIFICATION.getType(), REPOSITORY_NAMESPACE + "Resource");
-        } finally {
-            tx.expire();
-        }
-    }
-
-    private void awaitMessageOrFail(final String id, final String eventType, final String type) {
-        await().pollInterval(ONE_HUNDRED_MILLISECONDS).until(() -> messages.stream().anyMatch(msg -> {
-            try {
-                return getPath(msg).equals(id) && getEventTypes(msg).contains(eventType)
-                        && getResourceTypes(msg).contains(nullToEmpty(type));
-            } catch (final JMSException e) {
-                throw new RuntimeException(e);
-            }
-        }));
+        });
     }
 
     @Test(timeout = TIMEOUT)
-    @Ignore
-    public void testRemoval() {
+    public void testRemoval() throws PathNotFoundException {
+        final var fedoraId = FedoraId.create(testRemoved);
 
         LOGGER.debug("Expecting a {} event", RESOURCE_DELETION.getType());
-        final Transaction tx = txMananger.create();
-        // session.addSessionData(BASE_URL, TEST_BASE_URL);
-        // session.addSessionData(USER_AGENT, TEST_USER_AGENT);
 
-        try {
-            // final Container resource = containerService.findOrCreate(tx, testRemoved);
+        doInTx(tx -> {
+            createResourceService.perform(tx.getId(), USER, fedoraId,
+                    null, ModelFactory.createDefaultModel());
             tx.commit();
-            //TODO connect the next line with the new resource creation mechanism
-            // that will replace containerService.findOrCreate(session, testRemoved);
-            final Container resource = null;
-            deleteResourceService.perform(tx, resource);
+        });
+
+        doInTx(tx -> {
+            final var resource = getResource(fedoraId);
+            deleteResourceService.perform(tx, resource, USER);
             tx.commit();
             awaitMessageOrFail(testRemoved, RESOURCE_DELETION.getType(), null);
-        } finally {
-            tx.expire();
-        }
+        });
     }
 
     @Test(timeout = TIMEOUT)
-    @Ignore
+    @Ignore("updatePropertiesService is not implemented")
     public void testInboundReference() {
         final String uri1 = "/testInboundReference-" + randomUUID().toString();
         final String uri2 = "/testInboundReference-" + randomUUID().toString();
 
-        final Transaction tx = txMananger.create();
-        final IdentifierConverter<Resource,FedoraResource>
-            subjects = null;
-        // session.addSessionData(BASE_URL, TEST_BASE_URL);
-        // session.addSessionData(USER_AGENT, TEST_USER_AGENT);
-        try {
+        final IdentifierConverter<Resource,FedoraResource> subjects = null;
+
+        doInTx(tx -> {
             // final Container resource = containerService.findOrCreate(tx, uri1);
             // final Container resource2 = containerService.findOrCreate(tx, uri2);
             tx.commit();
+        });
+
+        doInTx(tx -> {
             // final Resource subject2 = subjects.reverse().convert(resource2);
             // final String sparql = "insert { <> <http://foo.com/prop> <" + subject2 + "> . } where {}";
             // updatePropertiesService.updateProperties(resource, sparql, resource.getTriples(subjects, PROPERTIES));
             tx.commit();
             awaitMessageOrFail(uri2, INBOUND_REFERENCE.getType(), null);
-        } finally {
-            tx.expire();
-        }
+        });
     }
 
     @Override
@@ -295,6 +282,18 @@ abstract class AbstractJmsIT implements MessageListener {
         connection.close();
     }
 
+    private void awaitMessageOrFail(final String id, final String eventType, final String type) {
+        await().pollInterval(ONE_HUNDRED_MILLISECONDS).until(() -> messages.stream().anyMatch(msg -> {
+            try {
+                LOGGER.debug("Received msg: {}", msg);
+                return getPath(msg).equals(id) && getEventTypes(msg).contains(eventType)
+                        && getResourceTypes(msg).contains(nullToEmpty(type));
+            } catch (final JMSException e) {
+                throw new RuntimeException(e);
+            }
+        }));
+    }
+
     private static String getPath(final Message msg) throws JMSException {
         final String id = msg.getStringProperty(IDENTIFIER_HEADER_NAME);
         LOGGER.debug("Processing an event with identifier: {}", id);
@@ -317,6 +316,34 @@ abstract class AbstractJmsIT implements MessageListener {
 
     private static String getResourceTypes(final Message msg) throws JMSException {
         return msg.getStringProperty(RESOURCE_TYPE_HEADER_NAME);
+    }
+
+    private void doInTx(final Consumer<Transaction> consumer) {
+        final var tx = newTransaction();
+        try {
+            consumer.accept(tx);
+        } finally {
+            tx.expire();
+        }
+    }
+
+    private Transaction newTransaction() {
+        final var tx = txMananger.create();
+        tx.setBaseUri(TEST_BASE_URL);
+        tx.setUserAgent(TEST_USER_AGENT);
+        return tx;
+    }
+
+    private InputStream stream(final String value) {
+        return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private FedoraResource getResource(final FedoraId fedoraId) {
+        try {
+            return resourceFactory.getResource(fedoraId);
+        } catch (PathNotFoundException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -73,9 +73,6 @@ import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
 import static org.slf4j.LoggerFactory.getLogger;
 
-// import static org.fcrepo.kernel.api.observer.OptionalValues.BASE_URL;
-// import static org.fcrepo.kernel.api.observer.OptionalValues.USER_AGENT;
-
 /**
  * <p>
  * AbstractJmsIT class.

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/JmsQueueIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/JmsQueueIT.java
@@ -17,14 +17,13 @@
  */
 package org.fcrepo.integration.jms.observer;
 
-import javax.jms.Destination;
-import javax.jms.JMSException;
-
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.jms.Destination;
+import javax.jms.JMSException;
 
 /**
  * <p>
@@ -33,7 +32,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  *
  * @author acoburn
  */
-@Ignore //TODO Fix these tests
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({ "/spring-test/jms-queue.xml", "/spring-test/fcrepo-config.xml",
     "/spring-test/eventing.xml" })

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/JmsTopicIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/JmsTopicIT.java
@@ -20,7 +20,6 @@ package org.fcrepo.integration.jms.observer;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -33,7 +32,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  *
  * @author acoburn
  */
-@Ignore //TODO Fix these tests
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({ "/spring-test/jms-topic.xml", "/spring-test/fcrepo-config.xml",
     "/spring-test/eventing.xml" })

--- a/fcrepo-jms/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-jms/src/test/resources/spring-test/fcrepo-config.xml
@@ -17,4 +17,19 @@
     
     <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager" />
 
+    <!-- Creating TransactionManager Bean -->
+    <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+        <property name="dataSource" ref="containmentIndexDataSource" />
+    </bean>
+
+    <bean id="containmentIndexDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+        <property name="driverClassName" value="org.h2.jdbcx.JdbcDataSource" />
+        <property name="url" value="jdbc:h2:mem:index;DB_CLOSE_DELAY=-1" />
+    </bean>
+
+    <!-- Containment Index to test -->
+    <bean id="containmentIndex" class="org.fcrepo.kernel.impl.ContainmentIndexImpl">
+        <property name="dataSource" ref="containmentIndexDataSource"/>
+    </bean>
+
 </beans>

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
@@ -96,4 +96,16 @@ public interface Transaction {
      */
     void refresh();
 
+    /**
+     * Sets the baseUri on the transaction
+     * @param baseUri the baseUri of the requests
+     */
+    void setBaseUri(String baseUri);
+
+    /**
+     * Sets the user-agent on the transaction
+     * @param userAgent the request's user-agent
+     */
+    void setUserAgent(String userAgent);
+
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
@@ -165,6 +165,14 @@ public class FedoraId {
     }
 
     /**
+     * Return the original full ID without the info:fedora prefix.
+     * @return the full id path part
+     */
+    public String getFullIdPath() {
+        return pathOnly;
+    }
+
+    /**
      * Return the Memento datetime as Instant.
      * @return The datetime or null if not a memento.
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/observer/Event.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/observer/Event.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.observer;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 import java.net.URI;
 import java.time.Instant;
 import java.util.Map;
@@ -30,6 +32,11 @@ import java.util.Set;
  * @since Feb 19, 2013
  */
 public interface Event {
+
+    /**
+     * @return the FedoraId of the resource associated with this event.
+     */
+    FedoraId getFedoraId();
 
     /**
      * @return the event types associated with this event.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/observer/EventAccumulator.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/observer/EventAccumulator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.observer;
+
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+
+/**
+ * Accumulates events for changes made to resources, grouped by transaction. The events are not emitted until after the
+ * transaction has been committed. If a transaction is rolled back, {@link #clearEvents} MUST be called to release the
+ * stored events.
+ */
+public interface EventAccumulator {
+
+    /**
+     * Registers a new event to a transaction.
+     *
+     * @param transactionId the id of the transaction
+     * @param fedoraId the id of the affected resource
+     * @param operation the operation affecting the resource
+     */
+    void recordEventForOperation(String transactionId, FedoraId fedoraId, ResourceOperation operation);
+
+    /**
+     * Emits all of the events that were accumulated within the transaction. Multiple events affecting the same resource
+     * are combined into a single event.
+     *
+     * <p>This method SHOULD NOT throw an exception if an event fails to be emitted. It should always attempt to emit
+     * all events accumulated within a transaction.
+     *
+     * @param transactionId the id of the transaction
+     * @param baseUrl the baseUrl of the requests
+     * @param userAgent the user-agent of the user making the requests
+     */
+    void emitEvents(String transactionId, String baseUrl, String userAgent);
+
+    /**
+     * Removes all of a transaction's accumulated events without emitting them. This must be called when a transaction
+     * is rolled back.
+     *
+     * @param transactionId the id of the transaction
+     */
+    void clearEvents(String transactionId);
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/DeleteResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/DeleteResourceService.java
@@ -31,6 +31,7 @@ public interface DeleteResourceService {
    *
    * @param tx the transaction associated with the operation
    * @param fedoraResource The Fedora resource to delete
+   * @param userPrincipal the principal of the user performing the operation
    */
-  void perform(final Transaction tx, final FedoraResource fedoraResource);
+  void perform(final Transaction tx, final FedoraResource fedoraResource, final String userPrincipal);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -23,6 +23,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 
 /**
  * Service for creating versions of resources
@@ -48,9 +49,9 @@ public interface VersionService {
      * Explicitly creates a version for the resource at the path provided.
      *
      * @param transaction the transaction in which the resource resides
-     * @param resourceId the internal resource id
+     * @param fedoraId the internal resource id
      * @param userPrincipal the user principal
      */
-    void createVersion(Transaction transaction, String resourceId, String userPrincipal);
+    void createVersion(Transaction transaction, FedoraId fedoraId, String userPrincipal);
 
 }

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -85,6 +85,11 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- This dependency is for compile-time: it keeps this module independent 
       of any given choice of JAX-RS implementation. It must be _after_ the test 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -28,9 +28,9 @@ import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
 import org.fcrepo.kernel.api.exception.TransactionExpiredException;
 import org.fcrepo.kernel.api.exception.TransactionNotFoundException;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.springframework.stereotype.Component;
-
 
 /**
  * The Fedora Transaction Manager implementation
@@ -48,11 +48,14 @@ public class TransactionManagerImpl implements TransactionManager {
     @Inject
     private PersistentStorageSessionManager pSessionManager;
 
+    @Inject
+    private EventAccumulator eventAccumulator;
+
     TransactionManagerImpl() {
         transactions = new HashMap<>();
     }
 
-    // TODO Add a timer to periadically rollback and cleanup expired transaction?
+    // TODO Add a timer to periodically rollback and cleanup expired transaction?
 
     @Override
     public synchronized Transaction create() {
@@ -92,6 +95,10 @@ public class TransactionManagerImpl implements TransactionManager {
 
     protected ContainmentIndex getContainmentIndex() {
         return containmentIndex;
+    }
+
+    protected EventAccumulator getEventAccumulator() {
+        return eventAccumulator;
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.observer;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.eventbus.EventBus;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.emptyToNull;
+
+@Component
+public class EventAccumulatorImpl implements EventAccumulator {
+
+    private final static Logger LOG = LoggerFactory.getLogger(EventAccumulatorImpl.class);
+
+    private final Map<String, Multimap<FedoraId, EventBuilder>> transactionEventMap;
+
+    @Inject
+    private ResourceFactory resourceFactory;
+
+    @Inject
+    private EventBus eventBus;
+
+    public EventAccumulatorImpl() {
+        this.transactionEventMap = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void recordEventForOperation(final String transactionId, final FedoraId fedoraId,
+                                        final ResourceOperation operation) {
+        checkNotNull(emptyToNull(transactionId), "transactionId cannot be blank");
+        checkNotNull(fedoraId, "fedoraId cannot be null");
+
+        final var events = transactionEventMap.computeIfAbsent(transactionId, key ->
+                MultimapBuilder.hashKeys().arrayListValues().build());
+        final var eventBuilder = ResourceOperationEventBuilder.fromResourceOperation(fedoraId, operation);
+        events.put(fedoraId, eventBuilder);
+    }
+
+    @Override
+    public void emitEvents(final String transactionId, final String baseUrl, final String userAgent) {
+        LOG.info("Emitting events for transaction {}", transactionId);
+
+        final var eventMap = transactionEventMap.remove(transactionId);
+
+        if (eventMap != null) {
+            eventMap.keySet().forEach(fedoraId -> {
+                final var events = eventMap.get(fedoraId);
+
+                try {
+                    final var mergedBuilder = events.stream()
+                            .reduce(EventBuilder::merge).get();
+
+                    final var event = mergedBuilder
+                            .withResourceTypes(loadResourceTypes(fedoraId))
+                            .withBaseUrl(baseUrl)
+                            .withUserAgent(userAgent)
+                            .build();
+
+                    LOG.debug("Emitting event: {}", event);
+                    eventBus.post(event);
+                } catch (Exception e) {
+                    LOG.error("Failed to emit events: {}", events, e);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void clearEvents(final String transactionId) {
+        LOG.info("Clearing events for transaction {}", transactionId);
+        transactionEventMap.remove(transactionId);
+    }
+
+    private Set<String> loadResourceTypes(final FedoraId fedoraId) {
+        try {
+            return resourceFactory.getResource(fedoraId).getTypes().stream()
+                    .map(URI::toString)
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            LOG.debug("Could not load resource types for {}", fedoraId, e);
+            // This can happen if the resource no longer exists
+            return Collections.emptySet();
+        }
+    }
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.observer;
+
+import org.fcrepo.kernel.api.observer.Event;
+
+import java.util.Set;
+
+/**
+ * Stores details about an Event.
+ */
+public interface EventBuilder {
+
+    /**
+     * Merges another EventBuilder into this EventBuilder. This should be used to combine multiple events on the same
+     * resource.
+     *
+     * @param other another EventBuilder
+     * @return this builder
+     */
+    EventBuilder merge(EventBuilder other);
+
+    /**
+     * Sets the resource's RDF Types on the event
+     *
+     * @param resourceTypes RDF Types
+     * @return this builder
+     */
+    EventBuilder withResourceTypes(Set<String> resourceTypes);
+
+    /**
+     * Sets the baseUrl of the requests
+     *
+     * @param baseUrl the base url
+     * @return this builder
+     */
+    EventBuilder withBaseUrl(String baseUrl);
+
+    /**
+     * Sets the user's user-agent
+     *
+     * @param userAgent the user's user-agent
+     * @return this builder
+     */
+    EventBuilder withUserAgent(String userAgent);
+
+    /**
+     * Constructs a new Event object from the details in the builder.
+     *
+     * @return new event
+     */
+    Event build();
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventImpl.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.observer;
+
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.observer.Event;
+import org.fcrepo.kernel.api.observer.EventType;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.UUID.randomUUID;
+
+/**
+ * An event that describes one or more actions that a user preformed on a resource.
+ */
+public class EventImpl implements Event {
+
+    private final String eventId;
+    private final FedoraId fedoraId;
+    private final Set<EventType> types;
+    private final Set<String> resourceTypes;
+    private final String userID;
+    private final URI userURI;
+    private final Instant date;
+    // TODO I think this should go away and baseUrl and userAgent should be proper fields
+    private final Map<String, String> info;
+
+    /**
+     * Create a new FedoraEvent
+     *
+     * @param fedoraId the FedoraId of the resource the event is on
+     * @param types a collection of Fedora EventTypes
+     * @param resourceTypes the rdf types of the corresponding resource
+     * @param userID the acting user for this event
+     * @param userURI the uri of the acting user for this event
+     * @param date the timestamp for this event
+     * @param info supplementary information
+     */
+    public EventImpl(final FedoraId fedoraId, final Set<EventType> types,
+                     final Set<String> resourceTypes, final String userID,
+                     final URI userURI, final Instant date,
+                     final Map<String, String> info) {
+        this.eventId = "urn:uuid:" + randomUUID().toString();
+        this.fedoraId = checkNotNull(fedoraId, "fedoraId cannot be null");
+        this.types = Set.copyOf(checkNotNull(types, "types cannot be null"));
+        this.resourceTypes = Set.copyOf(checkNotNull(resourceTypes, "resourceTypes cannot be null"));
+        this.userID = userID;
+        this.userURI = userURI;
+        this.date = checkNotNull(date, "date cannot be null");
+        this.info = Map.copyOf(checkNotNull(info, "info cannot be null"));
+    }
+
+    @Override
+    public FedoraId getFedoraId() {
+        return fedoraId;
+    }
+
+    @Override
+    public Set<EventType> getTypes() {
+        return types;
+    }
+
+    @Override
+    public Set<String> getResourceTypes() {
+        return resourceTypes;
+    }
+
+    @Override
+    public String getPath() {
+        return fedoraId.getFullIdPath();
+    }
+
+    @Override
+    public String getUserID() {
+        return userID;
+    }
+
+    @Override
+    public Instant getDate() {
+        return date;
+    }
+
+    @Override
+    public String getEventID() {
+        return eventId;
+    }
+
+    @Override
+    public Map<String, String> getInfo() {
+        return info;
+    }
+
+    @Override
+    public URI getUserURI() {
+        return userURI;
+    }
+
+    @Override
+    public String toString() {
+        return "EventImpl{" +
+                "eventId='" + eventId + '\'' +
+                ", fedoraId=" + fedoraId +
+                ", types=" + types +
+                ", resourceTypes=" + resourceTypes +
+                ", userID='" + userID + '\'' +
+                ", userURI=" + userURI +
+                ", date=" + date +
+                ", info=" + info +
+                '}';
+    }
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.observer;
+
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.observer.Event;
+import org.fcrepo.kernel.api.observer.EventType;
+import org.fcrepo.kernel.api.observer.OptionalValues;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.impl.util.UserUtil;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Converts a ResourceOperation into an Event.
+ */
+public class ResourceOperationEventBuilder implements EventBuilder {
+
+    private FedoraId fedoraId;
+    private Set<EventType> types;
+    private Set<String> resourceTypes;
+    private String userID;
+    private Instant date;
+    private Map<String, String> info;
+
+    /**
+     * Creates a new EventBuilder based on an ResourceOperation
+     *
+     * @param fedoraId the FedoraId the operation is on
+     * @param operation the ResourceOperation to create an event for
+     * @return new builder
+     */
+    public static ResourceOperationEventBuilder fromResourceOperation(final FedoraId fedoraId,
+                                                                      final ResourceOperation operation) {
+        final var builder = new ResourceOperationEventBuilder();
+        builder.fedoraId = fedoraId;
+        builder.date = Instant.now();
+        builder.resourceTypes = new HashSet<>();
+        builder.userID = operation.getUserPrincipal();
+        builder.types = new HashSet<>();
+        builder.types.add(mapOperationToEventType(operation));
+        builder.info = new HashMap<>();
+        return builder;
+    }
+
+    private static EventType mapOperationToEventType(final ResourceOperation operation) {
+        switch (operation.getType()) {
+            case CREATE:
+                return EventType.RESOURCE_CREATION;
+            case UPDATE:
+                return EventType.RESOURCE_MODIFICATION;
+            case DELETE:
+                return EventType.RESOURCE_DELETION;
+            default:
+                throw new IllegalStateException(
+                        String.format("There is no EventType mapping for ResourceOperation type %s on operation %s",
+                                operation.getType(), operation));
+        }
+    }
+
+    private ResourceOperationEventBuilder() {
+        // Intentionally left blank
+    }
+
+    @Override
+    public EventBuilder merge(final EventBuilder other) {
+        if (other == null) {
+            return this;
+        }
+
+        if (!(other instanceof ResourceOperationEventBuilder)) {
+            throw new IllegalStateException(
+                    String.format("Cannot merge EventBuilders because they are different types <%s> and <%s>",
+                            this.getClass(), other.getClass()));
+        }
+
+        final var otherCast = (ResourceOperationEventBuilder) other;
+
+        if (!this.fedoraId.equals(otherCast.fedoraId)) {
+            throw new IllegalStateException(
+                    String.format("Cannot merge events because they are for different resources: <%s> and <%s>",
+                            this, otherCast));
+        }
+
+        this.types.addAll(otherCast.types);
+        this.resourceTypes.addAll(otherCast.resourceTypes);
+        this.info.putAll(otherCast.info);
+
+        if (this.date.isBefore(otherCast.date)) {
+            this.date = otherCast.date;
+        }
+
+        return this;
+    }
+
+    @Override
+    public EventBuilder withResourceTypes(final Set<String> resourceTypes) {
+        this.resourceTypes = Objects.requireNonNullElse(resourceTypes, new HashSet<>());
+        return this;
+    }
+
+    @Override
+    public EventBuilder withBaseUrl(final String baseUrl) {
+        if (baseUrl == null) {
+            this.info.remove(OptionalValues.BASE_URL);
+        } else {
+            // baseUrl is expected to not have a trailing slash
+            this.info.put(OptionalValues.BASE_URL,
+                    baseUrl.replaceAll("/+$", ""));
+        }
+        return this;
+    }
+
+    @Override
+    public EventBuilder withUserAgent(final String userAgent) {
+        if (userAgent == null) {
+            this.info.remove(OptionalValues.USER_AGENT);
+        } else {
+            this.info.put(OptionalValues.USER_AGENT, userAgent);
+        }
+        return this;
+    }
+
+    @Override
+    public Event build() {
+        URI userUri = null;
+        if (userID != null) {
+            userUri = UserUtil.getUserURI(userID);
+        }
+        return new EventImpl(fedoraId, types, resourceTypes, userID, userUri, date, info);
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceOperationEventBuilder{" +
+                "fedoraId=" + fedoraId +
+                ", types=" + types +
+                ", resourceTypes=" + resourceTypes +
+                ", userID='" + userID + '\'' +
+                ", date=" + date +
+                ", info=" + info +
+                '}';
+    }
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -84,7 +84,7 @@ public abstract class AbstractService {
     protected ContainmentIndex containmentIndex;
 
     @Inject
-    protected EventAccumulator eventAccumulator;
+    private EventAccumulator eventAccumulator;
 
     /**
      * Utility to determine the correct interaction model from elements of a request.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -58,6 +58,8 @@ import org.fcrepo.kernel.api.exception.RequestWithAclLinkHeaderException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.slf4j.Logger;
 
 
@@ -80,6 +82,9 @@ public abstract class AbstractService {
 
     @Inject
     protected ContainmentIndex containmentIndex;
+
+    @Inject
+    protected EventAccumulator eventAccumulator;
 
     /**
      * Utility to determine the correct interaction model from elements of a request.
@@ -243,6 +248,10 @@ public abstract class AbstractService {
                 inputModel.add(createDefaultAccessToStatement(subject.toString()));
             }
         });
+    }
+
+    protected void recordEvent(final String transactionId, final FedoraId fedoraId, final ResourceOperation operation) {
+        this.eventAccumulator.recordEventForOperation(transactionId, fedoraId, operation);
     }
 
     /**

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -110,6 +110,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
         try {
             pSession.persist(createOp);
             addToContainmentIndex(txId, parentId, fedoraId);
+            recordEvent(txId, fedoraId, createOp);
         } catch (final PersistentStorageException exc) {
             throw new RepositoryRuntimeException(String.format("failed to create resource %s", fedoraId), exc);
         }
@@ -151,11 +152,13 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
                 .triples(stream)
                 .relaxedProperties(model)
                 .archivalGroup(rdfTypes.contains(ARCHIVAL_GROUP.getURI()))
+                .userPrincipal(userPrincipal)
                 .build();
 
         try {
             pSession.persist(createOp);
             addToContainmentIndex(txId, parentId, fedoraId);
+            recordEvent(txId, fedoraId, createOp);
         } catch (final PersistentStorageException exc) {
             throw new RepositoryRuntimeException(String.format("failed to create resource %s", fedoraId), exc);
         }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -17,14 +17,6 @@
  */
 package org.fcrepo.kernel.impl.services;
 
-import static java.lang.String.format;
-
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Collection;
-
-import javax.inject.Inject;
-
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ExternalContent;
@@ -35,6 +27,13 @@ import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
+import static java.lang.String.format;
 
 /**
  * Implementation of a service for replacing/updating binary resources
@@ -87,6 +86,7 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
             final var replaceOp = builder.build();
 
             pSession.persist(replaceOp);
+            recordEvent(txId, fedoraId, replaceOp);
         } catch (final PersistentStorageException ex) {
             throw new RepositoryRuntimeException(format("failed to replace binary %s",
                   fedoraId), ex);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -18,9 +18,6 @@
  */
 package org.fcrepo.kernel.impl.services;
 
-import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
-
-import javax.inject.Inject;
 import org.apache.jena.rdf.model.Model;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -32,6 +29,10 @@ import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
 
 /**
  * This class mediates update operations between the kernel and persistent storage layers
@@ -70,6 +71,7 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
                 .build();
 
             pSession.persist(updateOp);
+            recordEvent(txId, fedoraId, updateOp);
         } catch (final PersistentStorageException ex) {
             throw new RepositoryRuntimeException(String.format("failed to replace resource %s",
                   fedoraId), ex);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/VersionServiceImpl.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.impl.services;
 import com.google.common.annotations.VisibleForTesting;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.VersionResourceOperationFactory;
 import org.fcrepo.kernel.api.services.VersionService;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
@@ -43,17 +44,18 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     private VersionResourceOperationFactory versionOperationFactory;
 
     @Override
-    public void createVersion(final Transaction transaction, final String resourceId, final String userPrincipal) {
+    public void createVersion(final Transaction transaction, final FedoraId fedoraId, final String userPrincipal) {
         final var session = psManager.getSession(transaction.getId());
-        final var operation = versionOperationFactory.createBuilder(resourceId)
+        final var operation = versionOperationFactory.createBuilder(fedoraId.getResourceId())
                 .userPrincipal(userPrincipal)
                 .build();
 
         try {
             session.persist(operation);
+            recordEvent(transaction.getId(), fedoraId, operation);
         } catch (PersistentStorageException e) {
             throw new RepositoryRuntimeException(String.format("Failed to create new version of %s",
-                    resourceId), e);
+                    fedoraId.getResourceId()), e);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/util/UserUtil.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/util/UserUtil.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+
+import java.net.URI;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author Daniel Bernstein
+ * @since Sep 25, 2017
+ */
+public class UserUtil {
+
+    private static final Logger LOGGER = getLogger(UserUtil.class);
+
+    @VisibleForTesting
+    public static final String USER_AGENT_BASE_URI_PROPERTY = "fcrepo.auth.webac.userAgent.baseUri";
+    @VisibleForTesting
+    public static final String DEFAULT_USER_AGENT_BASE_URI = "info:fedora/local-user#";
+
+    private UserUtil() {
+    }
+
+    /**
+     * Returns the user agent based on the session user id.
+     * @param sessionUserId the acting user's id for this session
+     * @return the uri of the user agent
+     */
+    public static URI getUserURI(final String sessionUserId) {
+        // user id could be in format <anonymous>, remove < at the beginning and the > at the end in this case.
+        final String userId = (sessionUserId == null ? "anonymous" : sessionUserId).replaceAll("^<|>$", "");
+        try {
+            final URI uri = URI.create(userId);
+            // return useId if it's an absolute URI or an opaque URI
+            if (uri.isAbsolute() || uri.isOpaque()) {
+                return uri;
+            } else {
+                return buildDefaultURI(userId);
+            }
+        } catch (final IllegalArgumentException e) {
+            return buildDefaultURI(userId);
+        }
+    }
+
+    /**
+     * Build default URI with the configured base uri for agent
+     * @param userId of which a URI will be created
+     * @return URI
+     */
+    private static URI buildDefaultURI(final String userId) {
+        // Construct the default URI for the user ID that is not a URI.
+        String userAgentBaseUri = System.getProperty(USER_AGENT_BASE_URI_PROPERTY);
+        if (isNullOrEmpty(userAgentBaseUri)) {
+            // use the default local user agent base uri
+            userAgentBaseUri = DEFAULT_USER_AGENT_BASE_URI;
+        }
+
+        final String userAgentUri = userAgentBaseUri + userId;
+
+        LOGGER.trace("Default URI is created for user {}: {}", userId, userAgentUri);
+        return URI.create(userAgentUri);
+    }
+
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.TransactionRuntimeException;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -64,11 +65,15 @@ public class TransactionImplTest {
     @Mock
     private ContainmentIndex containmentIndex;
 
+    @Mock
+    private EventAccumulator eventAccumulator;
+
     @Before
     public void setUp() {
         when(pssManager.getSession("123")).thenReturn(psSession);
         when(txManager.getPersistentStorageSessionManager()).thenReturn(pssManager);
         when(txManager.getContainmentIndex()).thenReturn(containmentIndex);
+        when(txManager.getEventAccumulator()).thenReturn(eventAccumulator);
         testTx = new TransactionImpl("123", txManager);
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
@@ -26,6 +26,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.TransactionManager;
 import org.fcrepo.kernel.api.exception.TransactionRuntimeException;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.junit.Before;
@@ -55,12 +56,16 @@ public class TransactionManagerImplTest {
     @Mock
     private ContainmentIndex containmentIndex;
 
+    @Mock
+    private EventAccumulator eventAccumulator;
+
     @Before
     public void setUp() {
         testTxManager = new TransactionManagerImpl();
         when(pssManager.getSession(any())).thenReturn(psSession);
         setField(testTxManager, "pSessionManager", pssManager);
         setField(testTxManager, "containmentIndex", containmentIndex);
+        setField(testTxManager, "eventAccumulator", eventAccumulator);
         testTx = (TransactionImpl) testTxManager.create();
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImplTest.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.observer;
+
+import com.google.common.eventbus.EventBus;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.observer.Event;
+import org.fcrepo.kernel.api.observer.EventType;
+import org.fcrepo.kernel.api.observer.OptionalValues;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.impl.operations.DeleteResourceOperationFactoryImpl;
+import org.fcrepo.kernel.impl.operations.RdfSourceOperationFactoryImpl;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EventAccumulatorImplTest {
+
+    private static final String TX_ID = "tx1";
+    private static final String BASE_URL = "http://localhost/rest";
+    private static final String USER_AGENT = "user-agent";
+    private static final String USER = "user";
+
+    private static final URI CONTAINER_TYPE = uri("http://www.w3.org/ns/ldp#Container");
+    private static final URI RESOURCE_TYPE = uri("http://fedora.info/definitions/v4/repository#Resource");
+    private static final URI RDF_TYPE = uri("http://www.w3.org/ns/ldp#RDFSource");
+
+    private EventAccumulatorImpl accumulator;
+
+    @Mock
+    private ResourceFactory resourceFactory;
+
+    @Mock
+    private EventBus eventBus;
+
+    private ArgumentCaptor<Event> eventCaptor;
+
+    @Before
+    public void setup() {
+        accumulator = new EventAccumulatorImpl();
+        setField(accumulator, "resourceFactory", resourceFactory);
+        setField(accumulator, "eventBus", eventBus);
+        eventCaptor = ArgumentCaptor.forClass(Event.class);
+    }
+
+    @Test
+    public void emitEventsWhenEventsOnTransactionNoMerge() throws PathNotFoundException {
+        final var fId1 = FedoraId.create("/test/1");
+        final var fId2 = FedoraId.create("/test/2");
+
+        final var op1 = createOp(fId1);
+        final var op2 = updateOp(fId2);
+
+        accumulator.recordEventForOperation(TX_ID, fId1, op1);
+        accumulator.recordEventForOperation(TX_ID, fId2, op2);
+
+        expectResource(fId1, CONTAINER_TYPE);
+        expectResource(fId2, CONTAINER_TYPE, RESOURCE_TYPE);
+
+        accumulator.emitEvents(TX_ID, BASE_URL, USER_AGENT);
+
+        verify(eventBus, times(2)).post(eventCaptor.capture());
+
+        final var events = eventCaptor.getAllValues();
+
+        assertThat(events, containsInAnyOrder(
+                defaultEvent(fId1, Set.of(EventType.RESOURCE_CREATION), Set.of(CONTAINER_TYPE.toString())),
+                defaultEvent(fId2, Set.of(EventType.RESOURCE_MODIFICATION),
+                        Set.of(CONTAINER_TYPE.toString(), RESOURCE_TYPE.toString()))
+        ));
+    }
+
+    @Test
+    public void emitEventsWhenEventsOnTransactionWithMerge() throws PathNotFoundException {
+        final var fId1 = FedoraId.create("/test/1");
+        final var fId2 = FedoraId.create("/test/2");
+
+        final var op1 = createOp(fId1);
+        final var op2 = updateOp(fId2);
+        final var op3 = updateOp(fId1);
+
+        accumulator.recordEventForOperation(TX_ID, fId1, op1);
+        accumulator.recordEventForOperation(TX_ID, fId2, op2);
+        accumulator.recordEventForOperation(TX_ID, fId1, op3);
+
+        expectResource(fId1, CONTAINER_TYPE, RDF_TYPE);
+        expectResource(fId2, CONTAINER_TYPE, RESOURCE_TYPE);
+
+        accumulator.emitEvents(TX_ID, BASE_URL, USER_AGENT);
+
+        verify(eventBus, times(2)).post(eventCaptor.capture());
+
+        final var events = eventCaptor.getAllValues();
+
+        assertThat(events, containsInAnyOrder(
+                defaultEvent(fId1, Set.of(EventType.RESOURCE_CREATION, EventType.RESOURCE_MODIFICATION),
+                        Set.of(CONTAINER_TYPE.toString(), RDF_TYPE.toString())),
+                defaultEvent(fId2, Set.of(EventType.RESOURCE_MODIFICATION),
+                        Set.of(CONTAINER_TYPE.toString(), RESOURCE_TYPE.toString()))
+        ));
+    }
+
+    @Test
+    public void onlyEmitEventsForSameSpecifiedTransaction() throws PathNotFoundException {
+        final var fId1 = FedoraId.create("/test/1");
+        final var fId2 = FedoraId.create("/test/2");
+
+        final var op1 = createOp(fId1);
+        final var op2 = updateOp(fId2);
+
+        accumulator.recordEventForOperation(TX_ID, fId1, op1);
+        accumulator.recordEventForOperation("tx2", fId2, op2);
+
+        expectResource(fId2, CONTAINER_TYPE);
+
+        accumulator.emitEvents("tx2", BASE_URL, USER_AGENT);
+
+        verify(eventBus, times(1)).post(eventCaptor.capture());
+
+        final var events = eventCaptor.getAllValues();
+
+        assertThat(events, contains(
+                defaultEvent(fId2, Set.of(EventType.RESOURCE_MODIFICATION),
+                        Set.of(CONTAINER_TYPE.toString()))
+        ));
+    }
+
+    @Test
+    public void doNothingWhenTransactionHasNoEvents() throws PathNotFoundException {
+        final var fId1 = FedoraId.create("/test/1");
+        final var fId2 = FedoraId.create("/test/2");
+
+        final var op1 = createOp(fId1);
+        final var op2 = updateOp(fId2);
+
+        accumulator.recordEventForOperation(TX_ID, fId1, op1);
+        accumulator.recordEventForOperation("tx2", fId2, op2);
+
+        expectResource(fId2, CONTAINER_TYPE);
+
+        accumulator.emitEvents("tx3", BASE_URL, USER_AGENT);
+
+        verify(eventBus, times(0)).post(eventCaptor.capture());
+
+        final var events = eventCaptor.getAllValues();
+
+        assertEquals(0, events.size());
+    }
+
+    @Test
+    public void clearTransactionEventsWhenCleared() throws PathNotFoundException {
+        final var fId1 = FedoraId.create("/test/1");
+        final var fId2 = FedoraId.create("/test/2");
+
+        final var op1 = createOp(fId1);
+        final var op2 = updateOp(fId2);
+        final var op3 = updateOp(fId1);
+
+        accumulator.recordEventForOperation(TX_ID, fId1, op1);
+        accumulator.recordEventForOperation(TX_ID, fId2, op2);
+        accumulator.recordEventForOperation(TX_ID, fId1, op3);
+
+        expectResource(fId1, CONTAINER_TYPE, RDF_TYPE);
+        expectResource(fId2, CONTAINER_TYPE, RESOURCE_TYPE);
+
+        accumulator.clearEvents(TX_ID);
+
+        accumulator.emitEvents(TX_ID, BASE_URL, USER_AGENT);
+
+        verify(eventBus, times(0)).post(eventCaptor.capture());
+
+        final var events = eventCaptor.getAllValues();
+        assertEquals(0, events.size());
+    }
+
+    @Test
+    public void nonDefaultValues() throws PathNotFoundException {
+        final var tx = "tx4";
+        final var url = "http://example.com/rest";
+        final var agent = "me";
+
+        final var fId1 = FedoraId.create("/example/1");
+        final var fId2 = FedoraId.create("/example/2");
+
+        final var op1 = createOp(fId1);
+        final var op2 = updateOp(fId2);
+        final var op3 = deleteOp(fId1);
+
+        accumulator.recordEventForOperation(tx, fId1, op1);
+        accumulator.recordEventForOperation(tx, fId2, op2);
+        accumulator.recordEventForOperation(tx, fId1, op3);
+
+        expectResource(fId1, RDF_TYPE);
+        expectResource(fId2, RESOURCE_TYPE);
+
+        accumulator.emitEvents(tx, url, agent);
+
+        verify(eventBus, times(2)).post(eventCaptor.capture());
+
+        final var events = eventCaptor.getAllValues();
+
+        assertThat(events, containsInAnyOrder(
+                event(fId1, Set.of(EventType.RESOURCE_CREATION, EventType.RESOURCE_DELETION),
+                        Set.of(RDF_TYPE.toString()), url, agent),
+                event(fId2, Set.of(EventType.RESOURCE_MODIFICATION),
+                        Set.of(RESOURCE_TYPE.toString()), url, agent)
+        ));
+    }
+
+    @Test
+    public void doNotSetResourceTypesWhenCannotLoad() throws PathNotFoundException {
+        final var fId1 = FedoraId.create("/test/1");
+        final var fId2 = FedoraId.create("/test/2");
+        final var fId3 = FedoraId.create("/test/3");
+
+        final var op1 = createOp(fId1);
+        final var op2 = deleteOp(fId2);
+        final var op3 = updateOp(fId3);
+
+        accumulator.recordEventForOperation(TX_ID, fId1, op1);
+        accumulator.recordEventForOperation(TX_ID, fId2, op2);
+        accumulator.recordEventForOperation(TX_ID, fId3, op3);
+
+        expectResource(fId1, CONTAINER_TYPE);
+        when(resourceFactory.getResource(fId2)).thenThrow(new PathNotFoundException("not found"));
+        expectResource(fId3, RESOURCE_TYPE);
+
+        accumulator.emitEvents(TX_ID, BASE_URL, USER_AGENT);
+
+        verify(eventBus, times(3)).post(eventCaptor.capture());
+
+        final var events = eventCaptor.getAllValues();
+
+        assertThat(events, containsInAnyOrder(
+                defaultEvent(fId1, Set.of(EventType.RESOURCE_CREATION),
+                        Set.of(CONTAINER_TYPE.toString())),
+                defaultEvent(fId2, Set.of(EventType.RESOURCE_DELETION),
+                        Set.of()),
+                defaultEvent(fId3, Set.of(EventType.RESOURCE_MODIFICATION),
+                        Set.of(RESOURCE_TYPE.toString()))
+        ));
+    }
+
+    private ResourceOperation createOp(final FedoraId fedoraId) {
+        return new RdfSourceOperationFactoryImpl().createBuilder(fedoraId.getResourceId(), RDF_SOURCE.toString())
+                .userPrincipal(USER)
+                .build();
+    }
+
+    private ResourceOperation updateOp(final FedoraId fedoraId) {
+        return new RdfSourceOperationFactoryImpl().updateBuilder(fedoraId.getResourceId())
+                .userPrincipal(USER)
+                .build();
+    }
+
+    private ResourceOperation deleteOp(final FedoraId fedoraId) {
+        return new DeleteResourceOperationFactoryImpl().deleteBuilder(fedoraId.getResourceId())
+                .userPrincipal(USER)
+                .build();
+    }
+
+    private void expectResource(final FedoraId fedoraId, final URI... types) throws PathNotFoundException {
+        final var resource = mockResource(types);
+        when(resourceFactory.getResource(fedoraId)).thenReturn(resource);
+    }
+
+    private FedoraResource mockResource(final URI... types) {
+        final var resource = Mockito.mock(FedoraResource.class);
+        when(resource.getTypes()).thenReturn(Arrays.asList(types));
+        return resource;
+    }
+
+    private static URI uri(final String uri) {
+        try {
+            return new URI(uri);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Matcher<Event> defaultEvent(final FedoraId fedoraId,
+                                               final Set<EventType> eventTypes,
+                                               final Set<String> resourceTypes) {
+        return event(fedoraId, eventTypes, resourceTypes, BASE_URL, USER_AGENT);
+    }
+
+    private static Matcher<Event> event(final FedoraId fedoraId,
+                                        final Set<EventType> eventTypes,
+                                        final Set<String> resourceTypes,
+                                        final String baseUrl,
+                                        final String userAgent) {
+        return new TypeSafeMatcher<>() {
+            @Override
+            protected boolean matchesSafely(final Event item) {
+                if (! Objects.equals(item.getFedoraId(), fedoraId)) {
+                    return false;
+                } else if (! Objects.equals(item.getTypes(), eventTypes)) {
+                    return false;
+                } else if (! Objects.equals(item.getResourceTypes(), resourceTypes)) {
+                    return false;
+                } else if (! Objects.equals(item.getInfo().get(OptionalValues.BASE_URL), baseUrl)) {
+                    return false;
+                } else if (! Objects.equals(item.getInfo().get(OptionalValues.USER_AGENT), userAgent)) {
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public void describeTo(final Description description) {
+                description.appendText("fedoraId=").appendValue(fedoraId)
+                        .appendText(", eventTypes=").appendValue(eventTypes)
+                        .appendText(", resourceTyps=").appendValue(resourceTypes)
+                        .appendText(", baseUrl=").appendValue(baseUrl)
+                        .appendText(", userAgent=").appendValue(userAgent);
+            }
+        };
+    }
+
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilderTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.observer;
+
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.observer.Event;
+import org.fcrepo.kernel.api.observer.EventType;
+import org.fcrepo.kernel.api.observer.OptionalValues;
+import org.fcrepo.kernel.impl.operations.DeleteResourceOperationFactoryImpl;
+import org.fcrepo.kernel.impl.operations.NonRdfSourceOperationFactoryImpl;
+import org.fcrepo.kernel.impl.operations.RdfSourceOperationFactoryImpl;
+import org.fcrepo.kernel.impl.operations.VersionResourceOperationFactoryImpl;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.Set;
+
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ResourceOperationEventBuilderTest {
+
+    private static final FedoraId FEDORA_ID = FedoraId.create("/test");
+    private static final String USER = "user1";
+
+    @Test
+    public void buildCreateEventFromCreateRdfOperation() {
+        final var operation = new RdfSourceOperationFactoryImpl()
+                .createBuilder(FEDORA_ID.getResourceId(), RDF_SOURCE.toString())
+                .userPrincipal(USER)
+                .build();
+
+        final var event = ResourceOperationEventBuilder.fromResourceOperation(FEDORA_ID, operation).build();
+
+        assertDefaultEvent(event, EventType.RESOURCE_CREATION);
+    }
+
+    @Test
+    public void buildCreateEventFromCreateNonRdfOperation() {
+        final var fedoraId = FedoraId.create("/test/ab/c");
+        final var user = "user2";
+        final var operation = new NonRdfSourceOperationFactoryImpl()
+                .createInternalBinaryBuilder(fedoraId.getResourceId(), new ByteArrayInputStream(new byte[]{}))
+                .userPrincipal(user)
+                .build();
+
+        final var event = ResourceOperationEventBuilder.fromResourceOperation(fedoraId, operation).build();
+
+        assertEquals(fedoraId, event.getFedoraId());
+        assertEquals(fedoraId.getFullIdPath(), event.getPath());
+        assertEquals(user, event.getUserID());
+        assertThat(event.getTypes(), contains(EventType.RESOURCE_CREATION));
+        assertNotNull(event.getEventID());
+        assertNotNull(event.getDate());
+    }
+
+    @Test
+    public void buildCreateEventFromVersionOperation() {
+        final var operation = new VersionResourceOperationFactoryImpl().createBuilder(FEDORA_ID.getResourceId())
+                .userPrincipal(USER)
+                .build();
+
+        final var event = ResourceOperationEventBuilder.fromResourceOperation(FEDORA_ID, operation).build();
+
+        assertDefaultEvent(event, EventType.RESOURCE_MODIFICATION);
+    }
+
+    @Test
+    public void buildDeleteEventFromDeleteOperation() {
+        final var operation = new DeleteResourceOperationFactoryImpl().deleteBuilder(FEDORA_ID.getResourceId())
+                .userPrincipal(USER)
+                .build();
+
+        final var event = ResourceOperationEventBuilder.fromResourceOperation(FEDORA_ID, operation).build();
+
+        assertDefaultEvent(event, EventType.RESOURCE_DELETION);
+    }
+
+    @Test
+    public void buildUpdateEventFromUpdateRdfOperation() {
+        final var operation = new RdfSourceOperationFactoryImpl().updateBuilder(FEDORA_ID.getResourceId())
+                .userPrincipal(USER)
+                .build();
+
+        final var event = ResourceOperationEventBuilder.fromResourceOperation(FEDORA_ID, operation).build();
+
+        assertDefaultEvent(event, EventType.RESOURCE_MODIFICATION);
+    }
+
+    @Test
+    public void buildUpdateEventFromUpdateNonRdfOperation() {
+        final var operation = new NonRdfSourceOperationFactoryImpl()
+                .updateInternalBinaryBuilder(FEDORA_ID.getResourceId(), new ByteArrayInputStream(new byte[]{}))
+                .userPrincipal(USER)
+                .build();
+
+        final var event = ResourceOperationEventBuilder.fromResourceOperation(FEDORA_ID, operation).build();
+
+        assertDefaultEvent(event, EventType.RESOURCE_MODIFICATION);
+    }
+
+    @Test
+    public void mergeValidObjects() {
+        final var createOperation = new RdfSourceOperationFactoryImpl()
+                .createBuilder(FEDORA_ID.getResourceId(), RDF_SOURCE.toString())
+                .userPrincipal(USER)
+                .build();
+
+        final var createEventBuilder = ResourceOperationEventBuilder.fromResourceOperation(FEDORA_ID, createOperation);
+
+        final var updateOperation = new NonRdfSourceOperationFactoryImpl()
+                .updateInternalBinaryBuilder(FEDORA_ID.getResourceId(), new ByteArrayInputStream(new byte[]{}))
+                .userPrincipal(USER)
+                .build();
+
+        final var updateEventBuilder = ResourceOperationEventBuilder.fromResourceOperation(FEDORA_ID, updateOperation);
+        final var updateEvent = updateEventBuilder.build();
+
+        final var merged = createEventBuilder.merge(updateEventBuilder).build();
+
+        assertEquals(FEDORA_ID, merged.getFedoraId());
+        assertEquals(FEDORA_ID.getFullIdPath(), merged.getPath());
+        assertEquals(USER, merged.getUserID());
+        assertThat(merged.getTypes(), containsInAnyOrder(EventType.RESOURCE_CREATION, EventType.RESOURCE_MODIFICATION));
+        assertEquals(updateEvent.getDate(), merged.getDate());
+    }
+
+    @Test
+    public void populateOtherEventFields() {
+        final var operation = new NonRdfSourceOperationFactoryImpl()
+                .updateInternalBinaryBuilder(FEDORA_ID.getResourceId(), new ByteArrayInputStream(new byte[]{}))
+                .userPrincipal(USER)
+                .build();
+
+        final var baseUrl = "http://localhost/rest";
+        final var userAgent = "user-agent";
+        final var resourceTypes = Set.of("resource-type");
+
+        final var event = ResourceOperationEventBuilder.fromResourceOperation(FEDORA_ID, operation)
+                .withBaseUrl(baseUrl)
+                .withUserAgent(userAgent)
+                .withResourceTypes(resourceTypes)
+                .build();
+
+        assertEquals(baseUrl, event.getInfo().get(OptionalValues.BASE_URL));
+        assertEquals(userAgent, event.getInfo().get(OptionalValues.USER_AGENT));
+        assertEquals(resourceTypes, event.getResourceTypes());
+    }
+
+    private void assertDefaultEvent(final Event event, final EventType type) {
+        assertEquals(FEDORA_ID, event.getFedoraId());
+        assertEquals(FEDORA_ID.getFullIdPath(), event.getPath());
+        assertEquals(USER, event.getUserID());
+        assertThat(event.getTypes(), contains(type));
+        assertNotNull(event.getEventID());
+        assertNotNull(event.getDate());
+    }
+
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -170,7 +170,7 @@ public class CreateResourceServiceImplTest {
         nonRdfSourceOperationFactory = new NonRdfSourceOperationFactoryImpl();
         setField(createResourceService, "nonRdfSourceOperationFactory", nonRdfSourceOperationFactory);
         setField(createResourceService, "containmentIndex", containmentIndex);
-        createResourceService.eventAccumulator = eventAccumulator;
+        setField(createResourceService, "eventAccumulator", eventAccumulator);
         when(psManager.getSession(ArgumentMatchers.any())).thenReturn(psSession);
         when(extContent.getURL()).thenReturn(EXTERNAL_URL);
         when(extContent.getHandling()).thenReturn(ExternalContent.PROXY);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -68,6 +68,7 @@ import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ExternalContent;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
@@ -133,6 +134,9 @@ public class CreateResourceServiceImplTest {
     @Captor
     private ArgumentCaptor<ResourceOperation> operationCaptor;
 
+    @Mock
+    private EventAccumulator eventAccumulator;
+
     @InjectMocks
     private CreateResourceServiceImpl createResourceService;
 
@@ -166,6 +170,7 @@ public class CreateResourceServiceImplTest {
         nonRdfSourceOperationFactory = new NonRdfSourceOperationFactoryImpl();
         setField(createResourceService, "nonRdfSourceOperationFactory", nonRdfSourceOperationFactory);
         setField(createResourceService, "containmentIndex", containmentIndex);
+        createResourceService.eventAccumulator = eventAccumulator;
         when(psManager.getSession(ArgumentMatchers.any())).thenReturn(psSession);
         when(extContent.getURL()).thenReturn(EXTERNAL_URL);
         when(extContent.getHandling()).thenReturn(ExternalContent.PROXY);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -26,6 +26,7 @@ import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.models.WebacAcl;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.impl.operations.DeleteResourceOperation;
 import org.fcrepo.kernel.impl.operations.DeleteResourceOperationFactoryImpl;
 import org.fcrepo.persistence.api.PersistentStorageSession;
@@ -42,6 +43,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import javax.inject.Inject;
 import java.util.List;
 
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
@@ -52,8 +54,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-import javax.inject.Inject;
-
 /**
  * DeleteResourceServiceTest
  *
@@ -63,8 +63,13 @@ import javax.inject.Inject;
 @ContextConfiguration("/containmentIndexTest.xml")
 public class DeleteResourceServiceImplTest {
 
+    private static final String USER = "fedoraAdmin";
+
     @Mock
     private Transaction tx;
+
+    @Mock
+    private EventAccumulator eventAccumulator;
 
     @Mock
     private PersistentStorageSession pSession;
@@ -117,6 +122,7 @@ public class DeleteResourceServiceImplTest {
         final DeleteResourceOperationFactoryImpl factoryImpl = new DeleteResourceOperationFactoryImpl();
         setField(service, "deleteResourceFactory", factoryImpl);
         setField(service, "containmentIndex", containmentIndex);
+        service.eventAccumulator = eventAccumulator;
         when(container.getFedoraId()).thenReturn(RESOURCE_FEDORA_ID);
     }
 
@@ -132,7 +138,7 @@ public class DeleteResourceServiceImplTest {
         when(container.isAcl()).thenReturn(false);
         when(container.getAcl()).thenReturn(null);
 
-        service.perform(tx, container);
+        service.perform(tx, container, USER);
         verifyResourceOperation(RESOURCE_FEDORA_ID, operationCaptor, pSession);
     }
 
@@ -151,7 +157,7 @@ public class DeleteResourceServiceImplTest {
         when(container.getAcl()).thenReturn(null);
 
         assertEquals(1, containmentIndex.getContains(tx, container).count());
-        service.perform(tx, container);
+        service.perform(tx, container, USER);
 
         verify(pSession, times(2)).persist(operationCaptor.capture());
         final List<DeleteResourceOperation> operations = operationCaptor.getAllValues();
@@ -175,14 +181,14 @@ public class DeleteResourceServiceImplTest {
     public void testAclDelete() throws Exception {
         when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_FEDORA_ID);
         when(acl.isAcl()).thenReturn(true);
-        service.perform(tx, acl);
+        service.perform(tx, acl, USER);
         verifyResourceOperation(RESOURCE_ACL_FEDORA_ID, operationCaptor, pSession);
     }
 
     @Test(expected = RepositoryRuntimeException.class)
     public void testBinaryDescriptionDelete() throws Exception {
         when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_FEDORA_ID);
-        service.perform(tx, binaryDesc);
+        service.perform(tx, binaryDesc, USER);
     }
 
     @Test
@@ -194,7 +200,7 @@ public class DeleteResourceServiceImplTest {
         when(binary.getAcl()).thenReturn(acl);
         when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_FEDORA_ID);
 
-        service.perform(tx, binary);
+        service.perform(tx, binary, USER);
 
         verify(pSession, times(3)).persist(operationCaptor.capture());
         final List<DeleteResourceOperation> operations = operationCaptor.getAllValues();

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -122,7 +122,7 @@ public class DeleteResourceServiceImplTest {
         final DeleteResourceOperationFactoryImpl factoryImpl = new DeleteResourceOperationFactoryImpl();
         setField(service, "deleteResourceFactory", factoryImpl);
         setField(service, "containmentIndex", containmentIndex);
-        service.eventAccumulator = eventAccumulator;
+        setField(service, "eventAccumulator", eventAccumulator);
         when(container.getFedoraId()).thenReturn(RESOURCE_FEDORA_ID);
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
@@ -38,6 +38,7 @@ import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ExternalContent;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
@@ -76,6 +77,9 @@ public class ReplaceBinariesServiceImplTest {
     private final Collection<URI> DIGESTS = asList(URI.create("urn:sha1:1234abcd"), URI.create("urn:md5:zyxw9876"));
 
     @Mock
+    private EventAccumulator eventAccumulator;
+
+    @Mock
     private Transaction tx;
 
     @Mock
@@ -101,6 +105,7 @@ public class ReplaceBinariesServiceImplTest {
     public void setup() {
         factory = new NonRdfSourceOperationFactoryImpl();
         setField(service, "factory", factory);
+        service.eventAccumulator = eventAccumulator;
         when(psManager.getSession(anyString())).thenReturn(pSession);
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
@@ -105,7 +105,7 @@ public class ReplaceBinariesServiceImplTest {
     public void setup() {
         factory = new NonRdfSourceOperationFactoryImpl();
         setField(service, "factory", factory);
-        service.eventAccumulator = eventAccumulator;
+        setField(service, "eventAccumulator", eventAccumulator);
         when(psManager.getSession(anyString())).thenReturn(pSession);
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
@@ -36,6 +36,7 @@ import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.kernel.impl.operations.RdfSourceOperationFactoryImpl;
 import org.fcrepo.kernel.impl.operations.UpdateRdfSourceOperation;
@@ -72,6 +73,9 @@ public class ReplacePropertiesServiceImplTest {
     @Mock
     private FedoraResource resource;
 
+    @Mock
+    private EventAccumulator eventAccumulator;
+
     @InjectMocks
     private UpdateRdfSourceOperation operation;
 
@@ -95,6 +99,7 @@ public class ReplacePropertiesServiceImplTest {
     public void setup() {
         factory = new RdfSourceOperationFactoryImpl();
         setField(service, "factory", factory);
+        service.eventAccumulator = eventAccumulator;
         when(tx.getId()).thenReturn(TX_ID);
         when(psManager.getSession(anyString())).thenReturn(pSession);
         when(resource.getId()).thenReturn(FEDORA_ID);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
@@ -99,7 +99,7 @@ public class ReplacePropertiesServiceImplTest {
     public void setup() {
         factory = new RdfSourceOperationFactoryImpl();
         setField(service, "factory", factory);
-        service.eventAccumulator = eventAccumulator;
+        setField(service, "eventAccumulator", eventAccumulator);
         when(tx.getId()).thenReturn(TX_ID);
         when(psManager.getSession(anyString())).thenReturn(pSession);
         when(resource.getId()).thenReturn(FEDORA_ID);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/VersionServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/VersionServiceImplTest.java
@@ -36,6 +36,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VersionServiceImplTest {
@@ -59,7 +60,7 @@ public class VersionServiceImplTest {
     @Before
     public void setup() {
         service = new VersionServiceImpl();
-        service.eventAccumulator = eventAccumulator;
+        setField(service, "eventAccumulator", eventAccumulator);
         service.setPsManager(psManager);
         service.setVersionOperationFactory(new VersionResourceOperationFactoryImpl());
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/VersionServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/VersionServiceImplTest.java
@@ -19,6 +19,8 @@
 package org.fcrepo.kernel.impl.services;
 
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.kernel.impl.operations.VersionResourceOperationFactoryImpl;
 import org.fcrepo.persistence.api.PersistentStorageSession;
@@ -41,6 +43,9 @@ public class VersionServiceImplTest {
     private VersionServiceImpl service;
 
     @Mock
+    private EventAccumulator eventAccumulator;
+
+    @Mock
     private PersistentStorageSessionManager psManager;
 
     @Mock
@@ -54,6 +59,7 @@ public class VersionServiceImplTest {
     @Before
     public void setup() {
         service = new VersionServiceImpl();
+        service.eventAccumulator = eventAccumulator;
         service.setPsManager(psManager);
         service.setVersionOperationFactory(new VersionResourceOperationFactoryImpl());
 
@@ -63,16 +69,16 @@ public class VersionServiceImplTest {
 
     @Test
     public void createPersistOperation() throws PersistentStorageException {
-        final var resourceId = "info:fedora/test";
+        final var fedoraId = FedoraId.create("info:fedora/test");
         final var user = "me";
 
-        service.createVersion(transaction, resourceId, user);
+        service.createVersion(transaction, fedoraId, user);
 
         final var captor = ArgumentCaptor.forClass(ResourceOperation.class);
         verify(session).persist(captor.capture());
         final var captured = captor.getValue();
 
-        assertEquals(resourceId, captured.getResourceId());
+        assertEquals(fedoraId.getResourceId(), captured.getResourceId());
         assertEquals(user, captured.getUserPrincipal());
     }
 


### PR DESCRIPTION
**JIRA Ticket**: [FCREPO-3249](https://jira.lyrasis.org/browse/FCREPO-3249) & [FCREPO-3250](https://jira.lyrasis.org/browse/FCREPO-3250)

# What does this Pull Request do?

ResourceOperations are turned into Events that are emitted to the JMS code when a transaction is successfully completed.

# How should this be tested?

1. Start Fedora
1. [Start an event listener](https://wiki.lyrasis.org/display/FEDORA51/How+to+Inspect+Event+Messages+Generated+by+Fedora)
1. Perform a mutating action on a resource
1. See a JMS event logged by the listener

# Additional Notes:

* Events are only emitted if a transaction is entirely successful
* I don't think that `FedoraResource` is correctly loading all of a resources types at this point

# Interested parties

@fcrepo4/committers