### PR TITLE
Use RDF extension when looking for files

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/OcflPersistenceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/OcflPersistenceIT.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static org.slf4j.LoggerFactory.getLogger;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.OK;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+/**
+ * Test of OCFL specific issues from the HTTP layer.
+ */
+public class OcflPersistenceIT extends AbstractResourceIT {
+
+    private static final Logger LOGGER = getLogger(OcflPersistenceIT.class);
+
+    @Test
+    public void testDeleteAgChild() throws Exception {
+        final String id = getRandomUniqueId();
+        final HttpPost postAg = postObjMethod();
+        postAg.setHeader("Link", "<http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel=\"type\"");
+        postAg.setHeader("Slug", id);
+        assertEquals(CREATED.getStatusCode(), getStatus(postAg));
+
+        assertEquals(OK.getStatusCode(), getStatus(getObjMethod(id)));
+
+        final String childId = getRandomUniqueId();
+        final HttpPost postChild = postObjMethod(id);
+        postAg.setHeader("Slug", childId);
+        final String childLocation;
+        try (final CloseableHttpResponse response = execute(postChild)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            childLocation = getLocation(response);
+        }
+
+        final HttpGet getChild = new HttpGet(childLocation);
+        assertEquals(OK.getStatusCode(), getStatus(getChild));
+
+        final HttpDelete deleteChild = new HttpDelete(childLocation);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteChild));
+
+        // TODO: Should be GONE once FCREPO-3033 is resolved
+        final HttpGet getChildAgain = new HttpGet(childLocation);
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(getChildAgain));
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -17,9 +17,13 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.DELETE;
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.relativizeSubpath;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.resolveExtensions;
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.resolveOCFLSubpath;
+
+import java.util.Objects;
 
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -53,7 +57,11 @@ class DeleteResourcePersister extends AbstractPersister {
         } else {
             final var relativeSubPath = relativizeSubpath(fedoraResourceRoot, operation.getResourceId());
             final var ocflSubPath = resolveOCFLSubpath(fedoraResourceRoot, relativeSubPath);
-            objectSession.delete(ocflSubPath);
+            final var headers = readHeaders(objectSession, ocflSubPath);
+            final var filePath = resolveExtensions(ocflSubPath,
+                    !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel())
+            );
+            objectSession.delete(filePath);
         }
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -155,6 +155,16 @@ public class OCFLPersistentStorageUtils {
     }
 
     /**
+     * Simple function to centralize adding (or not adding the RDF extension).
+     * @param subPath the current subpath
+     * @param isRdf whether the subpath is for a RDF resource.
+     * @return The subpath with the correct file extension (if applicable).
+     */
+    public static String resolveExtensions(final String subPath, final boolean isRdf) {
+        return subPath + (isRdf ? getRDFFileExtension() : "");
+    }
+
+    /**
      * Returns the RDF topic to be returned for a given resource identifier
      * For example:  passing info:fedora/resource1/fcr:metadata would return
      *  info:fedora/resource1 since  info:fedora/resource1 would be the expected
@@ -190,7 +200,7 @@ public class OCFLPersistentStorageUtils {
             streamRDF.finish();
 
             final var is = new ByteArrayInputStream(os.toByteArray());
-            final var outcome = session.write(subpath + getRDFFileExtension(), is);
+            final var outcome = session.write(resolveExtensions(subpath, true), is);
             log.debug("wrote {} to {}", subpath, session);
             return outcome;
         } catch (final IOException ex) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/projects/FCREPO/issues/FCREPO-3278

# What does this Pull Request do?

When we write RDF we append the `.nt` extension to the id, but when we delete we just look for a file with the id name.

When trying to delete a child in an AG I got a 500 because it was trying to find a file called `test2`, but the actual file was `test2.nt`. 

This refactors the Delete operations to track whether we are deleting a RDFSource or NonRDFSource object.

# How should this be tested?

Before the PR:
1. Create an Archival Group
     ```
     curl -i -ufedoraAdmin:fedoraAdmin -H"Slug: parent" -H'Link: <http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel="type"' -H"Content-type: text/turtle" -XPOST http://localhost:8080/rest
     ```
1. Create a child resource in the AG.
     ```
     curl -i -ufedoraAdmin:fedoraAdmin -H"Slug: child" -H"Content-type: text/turtle" -XPOST http://localhost:8080/rest/parent
     ```
1. Delete the child resource
    ```
     curl -i -ufedoraAdmin:fedoraAdmin -XDELETE http://localhost:8080/rest/parent/child
    ```
1. See 500 and explosion
1. Pull in this PR 
1. Repeat steps
1. Joy.

# Interested parties
@fcrepo4/committers
