### PR TITLE
fix NPE in event serialization

### DIFF
--- a/fcrepo-event-serialization/src/main/java/org/fcrepo/event/serialization/JsonLDEventMessage.java
+++ b/fcrepo-event-serialization/src/main/java/org/fcrepo/event/serialization/JsonLDEventMessage.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.fcrepo.kernel.api.observer.Event;
 
@@ -183,7 +184,7 @@ class JsonLDEventMessage {
 
         // build actors list
         final List<Actor> actor = new ArrayList<>();
-        actor.add(new Person(evt.getUserURI().toString(), singletonList("Person")));
+        actor.add(new Person(Objects.toString(evt.getUserURI()), singletonList("Person")));
         final String softwareAgent = evt.getUserAgent();
         if (softwareAgent != null) {
             actor.add(new Application(softwareAgent, singletonList("Application")));

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTestBase.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTestBase.java
@@ -73,7 +73,7 @@ public class EventSerializerTestBase {
 
     protected final String softwareAgent = "fcrepo-java-client";
 
-    protected void mockEvent(final String path) {
+    private void mockEventCommon(final String path) {
         final Set<EventType> typeSet = new HashSet<>();
         typeSet.add(EventType.RESOURCE_MODIFICATION);
         final Set<String> resourceTypeSet = new HashSet<>();
@@ -85,12 +85,24 @@ public class EventSerializerTestBase {
         when(mockEvent.getResourceTypes()).thenReturn(resourceTypeSet);
         when(mockEvent.getPath()).thenReturn(path);
         when(mockEvent.getUserID()).thenReturn(username);
-        when(mockEvent.getUserURI()).thenReturn(URI.create(getAgentIRI()));
+        when(mockEvent.getUserURI()).thenReturn(URI.create(getAgentURI()));
 
         when(mockEvent.getDate()).thenReturn(timestamp);
         when(mockEvent.getEventID()).thenReturn(eventResourceId);
         when(mockEvent.getUserAgent()).thenReturn(softwareAgent);
         when(mockEvent.getBaseUrl()).thenReturn(baseUrl);
+    }
+
+    protected void mockEvent(final String path) {
+        mockEventCommon(path);
+        when(mockEvent.getUserID()).thenReturn(username);
+        when(mockEvent.getUserURI()).thenReturn(URI.create(getAgentURI()));
+    }
+
+    protected void mockEventNullUser(final String path) {
+        mockEventCommon(path);
+        when(mockEvent.getUserID()).thenReturn(null);
+        when(mockEvent.getUserURI()).thenReturn(null);
     }
 
     protected void testModel(final Model model) {
@@ -117,7 +129,7 @@ public class EventSerializerTestBase {
                     final Resource r = statement.getResource();
                     if (r.hasProperty(type, createResource(ACTIVITY_STREAMS_NAMESPACE + "Person"))) {
                         assertTrue(r.hasProperty(type, createResource(ACTIVITY_STREAMS_NAMESPACE + "Person")));
-                        assertEquals(getAgentIRI(), r.toString());
+                        assertEquals(getAgentURI(), r.toString());
                     } else {
                         assertTrue(r.hasProperty(type, createResource(ACTIVITY_STREAMS_NAMESPACE + "Application")));
                         assertTrue(r.hasProperty(createProperty(ACTIVITY_STREAMS_NAMESPACE + "name"), softwareAgent));
@@ -136,7 +148,7 @@ public class EventSerializerTestBase {
         assertEquals(1, eventName.get());
     }
 
-    protected String getAgentIRI() {
+    protected String getAgentURI() {
         return userAgentBaseUri + username;
     }
 }

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
@@ -18,23 +18,23 @@
 
 package org.fcrepo.event.serialization;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
-import static org.fcrepo.kernel.api.RdfLexicon.PROV_NAMESPACE;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.jena.rdf.model.Model;
+import org.fcrepo.kernel.api.observer.EventType;
+import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.jena.rdf.model.Model;
-import org.fcrepo.kernel.api.observer.EventType;
-import org.junit.Test;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.kernel.api.RdfLexicon.PROV_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * <p>
@@ -58,11 +58,17 @@ public class JsonLDSerializerTest extends EventSerializerTestBase {
 
     @Test
     public void testJsonSerializationAsJson() throws IOException {
-        testJsonSerializationAsJson(path, path);
+        mockEvent(path);
+        testJsonSerializationAsJson(path, getAgentURI());
     }
 
-    private void testJsonSerializationAsJson(final String inputPath, final String outputPath) throws IOException {
-        mockEvent(inputPath);
+    @Test
+    public void testJsonSerializationAsJsonWithNullUser() throws IOException {
+        mockEventNullUser(path);
+        testJsonSerializationAsJson(path, "null");
+    }
+
+    private void testJsonSerializationAsJson(final String outputPath, final String user) throws IOException {
         final EventSerializer serializer = new JsonLDSerializer();
         final String json = serializer.serialize(mockEvent);
 
@@ -79,7 +85,7 @@ public class JsonLDSerializerTest extends EventSerializerTestBase {
         assertEquals(eventResourceId, node.get("id").textValue());
         assertEquals(EventType.RESOURCE_MODIFICATION.getName(), node.get("name").textValue());
         assertEquals(EventType.RESOURCE_MODIFICATION.getTypeAbbreviated(), node.get("type").get(0).asText());
-        assertEquals(getAgentIRI(), node.get("actor").get(0).get("id").asText());
+        assertEquals(user, node.get("actor").get(0).get("id").asText());
         assertEquals("Person", node.get("actor").get(0).get("type").get(0).asText());
         assertEquals(softwareAgent, node.get("actor").get(1).get("name").asText());
         assertEquals("Application", node.get("actor").get(1).get("type").get(0).asText());


### PR DESCRIPTION
# What does this Pull Request do?

Fixes an NPE serializing events with null users.

# How should this be tested?

Perform a mutating action in Fedora using an unauthenticated user and [an event should be generated](https://wiki.lyrasis.org/display/FEDORA51/How+to+Inspect+Event+Messages+Generated+by+Fedora). I do not know how preform actions in Fedora with an unauthenticated users, so I have not tried this myself, outside of a unit test.

# Interested parties

@awoods 
