### PR TITLE
Change delete to remove data files and set headers to deleted.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -60,6 +60,7 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_ID_HEADER;
 import static org.fcrepo.http.commons.session.TransactionConstants.TX_ENDPOINT_REL;
 import static org.fcrepo.http.commons.session.TransactionConstants.TX_PREFIX;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
 import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
@@ -1098,8 +1099,10 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             final FedoraResource fedoraResource = resourceFactory.getResource(transaction(), fedoraId);
 
             if (fedoraResource instanceof Tombstone) {
-                final String resourceURI = TRAILING_SLASH_REGEX.matcher(externalPath).replaceAll("");
-                throw new TombstoneException(fedoraResource, resourceURI + "/fcr:tombstone");
+                final String tombstoneUri = identifierConverter().toExternalId(
+                            fedoraResource.getFedoraId().resolve(FCR_TOMBSTONE).getFullId()
+                    );
+                throw new TombstoneException(fedoraResource, tombstoneUri);
             }
 
             return fedoraResource;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -69,6 +69,7 @@ import static org.apache.jena.vocabulary.DC_11.title;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_VARIANTS;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
 import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
@@ -902,7 +903,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteObject() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -911,7 +911,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteContainerWithDepthHeaderSet() {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -959,7 +958,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testTrailingSlashTombstoneLink() throws IOException {
         final String id = getRandomUniqueId();
         final URI expectedTombstone = URI.create(serverAddress + id + "/fcr:tombstone");
@@ -2153,7 +2151,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteDatastream() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -2163,7 +2160,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteBinaryDescription() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id, NON_RDF_SOURCE_LINK_HEADER);
@@ -2220,13 +2216,20 @@ public class FedoraLdpIT extends AbstractResourceIT {
      */
     private void binaryStatus(final String id, final Status status) throws IOException {
         final HttpHead headBinary = headObjMethod(id);
+        final var tombstoneUri = serverAddress + id + "/" + FCR_TOMBSTONE;
         try (final CloseableHttpResponse response = execute(headBinary)) {
             assertEquals(status.getStatusCode(), getStatus(response));
+            if (status.equals(GONE)) {
+                checkForLinkHeader(response, tombstoneUri, "hasTombstone");
+            }
         }
 
         final HttpHead headBinaryDesc = headObjMethod(id + "/" + FCR_METADATA);
         try (final CloseableHttpResponse response = execute(headBinaryDesc)) {
             assertEquals(status.getStatusCode(), getStatus(response));
+            if (status.equals(GONE)) {
+                checkForLinkHeader(response, tombstoneUri, "hasTombstone");
+            }
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/OcflPersistenceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/OcflPersistenceIT.java
@@ -19,7 +19,7 @@ package org.fcrepo.integration.http.api;
 
 import static org.slf4j.LoggerFactory.getLogger;
 import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 
@@ -64,8 +64,7 @@ public class OcflPersistenceIT extends AbstractResourceIT {
         final HttpDelete deleteChild = new HttpDelete(childLocation);
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteChild));
 
-        // TODO: Should be GONE once FCREPO-3033 is resolved
         final HttpGet getChildAgain = new HttpGet(childLocation);
-        assertEquals(NOT_FOUND.getStatusCode(), getStatus(getChildAgain));
+        assertEquals(GONE.getStatusCode(), getStatus(getChildAgain));
     }
 }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapperTest.java
@@ -17,51 +17,84 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import org.fcrepo.kernel.api.exception.TombstoneException;
-import org.fcrepo.kernel.api.models.Tombstone;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.Response.Status.GONE;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.MockitoAnnotations.initMocks;
+
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import java.time.Instant;
+
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.exception.TombstoneException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * @author cabeer
  */
 public class TombstoneExceptionMapperTest {
 
+    @Mock
+    private FedoraResource mockResource;
+
+    private final FedoraId fedoraId = FedoraId.create("/some:uri");
+
+    private final Instant deleteTime = Instant.now();
+
     private ExceptionMapper<TombstoneException> testObj;
 
-    @Mock
-    public Tombstone mockTombstone;
+    private static final String SERVER_URI = "http://localhost:8080/rest(.*)";
+
+    private final HttpIdentifierConverter idConverter = new HttpIdentifierConverter(UriBuilder.fromUri(SERVER_URI));
 
     @Before
     public void setUp() {
         initMocks(this);
-
+        when(mockResource.getFedoraId()).thenReturn(fedoraId);
+        when(mockResource.getLastModifiedDate()).thenReturn(deleteTime);
         testObj = new TombstoneExceptionMapper();
     }
 
     @Test
     public void testUrilessException() {
-        final Response response = testObj.toResponse(new TombstoneException(mockTombstone));
+        final Response response = testObj.toResponse(new TombstoneException(mockResource));
         assertEquals(GONE.getStatusCode(), response.getStatus());
+        assertTombstone(response, fedoraId.getFullIdPath(), null);
     }
 
     @Test
     public void testExceptionWithUri() {
-        final Response response = testObj.toResponse(new TombstoneException(mockTombstone, "some:uri"));
+        final String tombstone = idConverter.toExternalId(fedoraId.resolve(FCR_TOMBSTONE).getFullId());
+        final Response response = testObj.toResponse(new TombstoneException(mockResource, tombstone));
         assertEquals(GONE.getStatusCode(), response.getStatus());
-        final Link link = Link.valueOf(response.getHeaderString(LINK));
-        assertEquals("some:uri", link.getUri().toString());
-        assertEquals("hasTombstone", link.getRel());
+        assertTombstone(response, fedoraId.getFullIdPath(), tombstone);
     }
 
+    private void assertTombstone(final Response response, final String tombstoneAt, final String tombstoneUri) {
+        if (tombstoneUri == null) {
+            assertNull(response.getHeaderString(LINK));
+        } else {
+            final Link link = Link.valueOf(response.getHeaderString(LINK));
+            assertEquals(tombstoneUri, link.getUri().toString());
+            assertEquals("hasTombstone", link.getRel());
+        }
+        final String expectedString = "Discovered tombstone resource at " + tombstoneAt + ", departed at: " +
+                ISO_INSTANT.withZone(UTC).format(deleteTime);
+        assertEquals(expectedString, response.getEntity().toString());
+    }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/FedoraTypes.java
@@ -97,6 +97,8 @@ public interface FedoraTypes {
 
     String FCR_FIXITY = "fcr:fixity";
 
+    String FCR_TOMBSTONE = "fcr:tombstone";
+
     String LDP_HAS_MEMBER_RELATION = "ldp:hasMemberRelation";
 
     String LDP_IS_MEMBER_OF_RELATION = "ldp:isMemberOfRelation";

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TombstoneException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TombstoneException.java
@@ -17,9 +17,9 @@
  */
 package org.fcrepo.kernel.api.exception;
 
+import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
@@ -38,7 +38,7 @@ public class TombstoneException extends RepositoryRuntimeException {
 
     private final String uri;
 
-    private static DateTimeFormatter isoFormatter = ISO_INSTANT.withZone(ZoneId.of("UTC"));
+    private static DateTimeFormatter isoFormatter = ISO_INSTANT.withZone(UTC);
 
     /**
      * Construct a new tombstone exception for a resource

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TombstoneException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TombstoneException.java
@@ -17,6 +17,12 @@
  */
 package org.fcrepo.kernel.api.exception;
 
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
 import org.fcrepo.kernel.api.models.FedoraResource;
 
 /**
@@ -32,22 +38,26 @@ public class TombstoneException extends RepositoryRuntimeException {
 
     private final String uri;
 
+    private static DateTimeFormatter isoFormatter = ISO_INSTANT.withZone(ZoneId.of("UTC"));
+
     /**
      * Construct a new tombstone exception for a resource
-     * @param fedoraResource the fedora resource
+     * @param resource the fedora resource
      */
-    public TombstoneException(final FedoraResource fedoraResource) {
-        this(fedoraResource, null);
+    public TombstoneException(final FedoraResource resource) {
+        this(resource, null);
     }
 
     /**
      * Create a new tombstone exception with a URI to the tombstone resource
-     * @param fedoraResource the fedora resource
-     * @param uri the uri to the tombstone resource
+     * @param resource the fedora resource
+     * @param tombstoneUri the uri to the tombstone resource for the Link header.
      */
-    public TombstoneException(final FedoraResource fedoraResource, final String uri) {
-        super("Discovered tombstone resource at " + fedoraResource);
-        this.uri = uri;
+    public TombstoneException(final FedoraResource resource, final String tombstoneUri) {
+        super("Discovered tombstone resource at " + resource.getFedoraId().getFullIdPath() +
+                (Objects.nonNull(resource.getLastModifiedDate()) ? ", departed at: " +
+                isoFormatter.format(resource.getLastModifiedDate()) : ""));
+        this.uri = tombstoneUri;
     }
 
     /**

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHeaders.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHeaders.java
@@ -137,4 +137,11 @@ public interface ResourceHeaders {
      * @return
      */
     boolean isObjectRoot();
+
+    /**
+     * Determine if the resource is now a tombstone.
+     * @return Deleted status.
+     */
+    boolean isDeleted();
+
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -17,9 +17,9 @@
  */
 package org.fcrepo.kernel.api.services;
 
+import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import org.fcrepo.kernel.api.Transaction;
@@ -38,12 +38,12 @@ public interface VersionService {
      * To format a datetime for use as a Memento path.
      */
     DateTimeFormatter MEMENTO_LABEL_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
-            .withZone(ZoneId.of("UTC"));
+            .withZone(UTC);
 
     /**
      * To format a datetime as RFC-1123 with correct timezone.
      */
-    DateTimeFormatter MEMENTO_RFC_1123_FORMATTER = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
+    DateTimeFormatter MEMENTO_RFC_1123_FORMATTER = RFC_1123_DATE_TIME.withZone(UTC);
 
     /**
      * Explicitly creates a version for the resource at the path provided.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -167,6 +167,14 @@ public class ResourceFactoryImpl implements ResourceFactory {
             final Instant versionDateTime = identifier.isMemento() ? identifier.getMementoInstant() : null;
             final var headers = psSession.getHeaders(id, versionDateTime);
 
+            if (headers.isDeleted()) {
+                final var rootId = FedoraId.create(identifier.getResourceId());
+                final var tombstone = new TombstoneImpl(rootId, transaction, persistentStorageSessionManager,
+                        this);
+                tombstone.setLastModifiedDate(headers.getLastModifiedDate());
+                return tombstone;
+            }
+
             // Determine the appropriate class from headers
             final var createClass = getClassForTypes(headers);
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.models;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.Tombstone;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+
+/**
+ * Tombstone class
+ */
+public class TombstoneImpl extends FedoraResourceImpl implements Tombstone {
+
+
+    protected TombstoneImpl(final FedoraId fedoraID, final Transaction tx,
+                            final PersistentStorageSessionManager pSessionManager,
+                            final ResourceFactory resourceFactory) {
+        super(fedoraID, tx, pSessionManager, resourceFactory);
+    }
+}

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentStorageException.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentStorageException.java
@@ -48,4 +48,12 @@ public class PersistentStorageException extends Exception {
     public PersistentStorageException(final String msg, final Throwable e) {
         super(msg, e);
     }
+
+    /**
+     * Constructor
+     * @param e cause
+     */
+    public PersistentStorageException(final Throwable e) {
+        super(e);
+    }
 }

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentStorageRuntimeException.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentStorageRuntimeException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.api.exceptions;
+
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+
+/**
+ * Wrapper class to allow using things that throw PersistentStorageExceptions in lambda functions.
+ */
+public class PersistentStorageRuntimeException extends RepositoryRuntimeException {
+    public PersistentStorageRuntimeException(final String msg) {
+        super(msg);
+    }
+
+    public PersistentStorageRuntimeException(final Throwable rootCause) {
+        super(rootCause);
+    }
+
+    public PersistentStorageRuntimeException(final String msg, final Throwable rootCause) {
+        super(msg, rootCause);
+    }
+}

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeadersImpl.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeadersImpl.java
@@ -62,6 +62,8 @@ public class ResourceHeadersImpl implements ResourceHeaders {
 
     private boolean objectRoot;
 
+    private boolean deleted;
+
     @Override
     public String getId() {
         return id;
@@ -257,5 +259,18 @@ public class ResourceHeadersImpl implements ResourceHeaders {
         } else {
             return objectRoot;
         }
+    }
+
+    /**
+     * Set deleted status flag.
+     * @param deleted true if deleted (a tombstone).
+     */
+    public void setDeleted(final boolean deleted) {
+        this.deleted = deleted;
+    }
+
+    @Override
+    public boolean isDeleted() {
+        return deleted;
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -75,6 +75,7 @@ class DeleteResourcePersister extends AbstractPersister {
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             final var filePath = resolveExtensions(ocflSubPath, isRdf);
             deletePath(filePath, objectSession, headers, user, deleteTime);
+            // TODO: Delete the ACL at some point - https://jira.lyrasis.org/browse/FCREPO-3288
             if (!isRdf) {
                 // Delete the description too.
                 final var descPath = resolveExtensions(ocflSubPath + "-description", true);
@@ -91,6 +92,7 @@ class DeleteResourcePersister extends AbstractPersister {
     private void deletePath(final String path, final OCFLObjectSession session, final String user,
                             final Instant deleteTime) throws PersistentStorageException {
         // readHeaders and writeHeaders need the subpath where as delete needs the file name. So remove any extensions.
+        // TODO: See https://jira.lyrasis.org/browse/FCREPO-3287
         final var no_extension = (path.contains(".") ? path.substring(0, path.indexOf(".")) : path);
         final var headers = (ResourceHeadersImpl) readHeaders(session, no_extension);
         deletePath(path, session, headers, user, deleteTime);
@@ -110,6 +112,7 @@ class DeleteResourcePersister extends AbstractPersister {
         headers.setDeleted(true);
         ResourceHeaderUtils.touchModificationHeaders(headers, user, deleteTime);
         // readHeaders and writeHeaders need the subpath where as delete needs the file name. So remove any extensions.
+        // TODO: See https://jira.lyrasis.org/browse/FCREPO-3287
         final var no_extension = (path.contains(".") ? path.substring(0, path.indexOf(".")) : path);
         writeHeaders(session, headers, no_extension);
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -63,7 +63,7 @@ class DeleteResourcePersister extends AbstractPersister {
                         p -> deletePathWrapped(p, objectSession));
             } catch (final PersistentStorageRuntimeException exc) {
                 // Rethrow the exception as a checked exception
-                throw new PersistentStorageException(exc.getCause().getMessage());
+                throw new PersistentStorageException(exc);
             }
         } else {
             final var relativeSubPath = relativizeSubpath(fedoraResourceRoot, operation.getResourceId());


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3033

# What does this Pull Request do?
Changes how deletes work from an immediate purge to just removing the data files and setting the resources as deleted in their header files. This allows the ResourceFactory to determine if the requested resource was deleted and provide a tombstone link.

# How should this be tested?

Before the PR all deleted objects would return a 404, now they should return a 410 GONE and include a Link header to a tombstone location. For NonRdfSourceDescription, TimeMaps and Mementos the link header refers to the original resource + `fcr:tombstone`

# Interested parties
@fcrepo4/committers
