### PR TITLE
Ensures that containment index persists between reboots.

### DIFF
--- a/fcrepo-http-api/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-http-api/src/test/resources/spring-test/fcrepo-config.xml
@@ -53,13 +53,4 @@
   <!-- Fedora's lightweight internal event bus. Currently memory-resident.-->
   <bean name="fedoraInternalEventBus" class="com.google.common.eventbus.EventBus"/>
 
-  <!-- Containment Index DB -->
-  <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-    <property name="dataSource" ref="containmentIndexDataSource" />
-  </bean>
-
-  <bean id="containmentIndexDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-    <property name="driverClassName" value="org.h2.jdbcx.JdbcDataSource" />
-    <property name="url" value="jdbc:h2:mem:index;DB_CLOSE_DELAY=-1" />
-  </bean>
 </beans>

--- a/fcrepo-jms/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-jms/src/test/resources/spring-test/fcrepo-config.xml
@@ -17,19 +17,4 @@
     
     <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager" />
 
-    <!-- Creating TransactionManager Bean -->
-    <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-        <property name="dataSource" ref="containmentIndexDataSource" />
-    </bean>
-
-    <bean id="containmentIndexDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-        <property name="driverClassName" value="org.h2.jdbcx.JdbcDataSource" />
-        <property name="url" value="jdbc:h2:mem:index;DB_CLOSE_DELAY=-1" />
-    </bean>
-
-    <!-- Containment Index to test -->
-    <bean id="containmentIndex" class="org.fcrepo.kernel.impl.ContainmentIndexImpl">
-        <property name="dataSource" ref="containmentIndexDataSource"/>
-    </bean>
-
 </beans>

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>spring-context</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+
     <!-- test gear -->
     <dependency>
       <groupId>junit</groupId>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -62,6 +62,9 @@ public class RepositoryInitializer {
     @Inject
     private IndexBuilder indexBuilder;
 
+    @Inject
+    private OCFLConstants ocflConstants;
+
     /**
      * Initializes the repository
      */
@@ -71,7 +74,7 @@ public class RepositoryInitializer {
         final PersistentStorageSession session = this.sessionManager.getSession("initializationSession" +
                                                                                  System.currentTimeMillis());
 
-        final File fedoraToOcflIndexFile = new OCFLConstants().getFedoraToOCFLIndexFile();
+        final File fedoraToOcflIndexFile = this.ocflConstants.getFedoraToOCFLIndexFile();
         if (!fedoraToOcflIndexFile.exists()) {
             LOGGER.info("The Fedora to OCFL Index not found at {}. Rebuilding...", fedoraToOcflIndexFile);
             indexBuilder.rebuild();

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistenceConfig.java
@@ -20,6 +20,12 @@ package org.fcrepo.persistence.ocfl.impl;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+import java.io.File;
 
 import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.createRepository;
 
@@ -41,5 +47,26 @@ public class OCFLPersistenceConfig {
     public MutableOcflRepository repository() {
         final OCFLConstants constants = new OCFLConstants();
         return createRepository(constants.getStorageRootDir(), constants.getWorkDir());
+    }
+
+    @Bean
+    public OCFLConstants ocflConstants(){
+        return new OCFLConstants();
+    }
+
+    @Bean
+    public DataSource dataSource(final OCFLConstants ocflConstants) {
+        final var dataSource = new DriverManagerDataSource();
+        final var workDir = ocflConstants.getWorkDir().getAbsolutePath();
+        dataSource.setUrl("jdbc:h2:" + workDir + File.separator + "containment.idx;FILE_LOCK=SOCKET");
+        dataSource.setDriverClassName("org.h2.jdbcx.JdbcDataSource");
+        return dataSource;
+    }
+
+    @Bean
+    public DataSourceTransactionManager txManager(final DataSource dataSource) {
+        final var txManager = new DataSourceTransactionManager();
+        txManager.setDataSource(dataSource);
+        return txManager;
     }
 }

--- a/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
+++ b/fcrepo-webapp/src/main/resources/spring/fcrepo-config.xml
@@ -223,14 +223,4 @@
 
     <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager" />
 
-    <!-- Containment Index DB -->
-    <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-        <property name="dataSource" ref="containmentIndexDataSource" />
-    </bean>
-
-    <bean id="containmentIndexDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-        <property name="driverClassName" value="org.h2.jdbcx.JdbcDataSource" />
-        <property name="url" value="jdbc:h2:mem:index;DB_CLOSE_DELAY=-1" />
-    </bean>
-
 </beans>


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3283

**Ensures that containment index persists between reboots.**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3283

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR changes the H2 database URL so that it persists the database to the fcrepo.ocfl.workdir.
In addition,  I moved the datasource and transaction manager configuration into the OCFLPersistenceConfig and removed the duplicate references from the spring configs.

# How should this be tested?

1. Start up Fedora.
2. Add a resource. 
3. Stop Fedora 
4. Start up Fedora
5. Verify that the repository root contains the resource.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
