### PR TITLE
Adds support for PATCHing of RDF sources.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -934,12 +934,11 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
 
     protected void patchResourcewithSparql(final FedoraResource resource,
-            final String requestBody,
-            final RdfStream resourceTriples) {
+            final String requestBody) {
         updatePropertiesService.updateProperties(transaction().getId(),
                                                  getUserPrincipal(),
-                                                 resource.getId(),
-                                                 requestBody, resourceTriples);
+                                                 FedoraId.create(resource.getId()),
+                                                 requestBody);
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -97,7 +97,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -134,7 +133,6 @@ import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.TripleCategory;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
@@ -423,14 +421,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                     .build();
 
         }
-
-    private RdfStream getTriples(final FedoraResource resource, final Set<? extends TripleCategory> x) {
-        return null;
-    }
-
-    private RdfStream getTriples(final FedoraResource resource, final TripleCategory x) {
-        return null;
-    }
 
     protected URI getUri(final FedoraResource resource) {
         try {
@@ -937,7 +927,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             final String requestBody) {
         updatePropertiesService.updateProperties(transaction().getId(),
                                                  getUserPrincipal(),
-                                                 FedoraId.create(resource.getId()),
+                                                 resource.getFedoraId(),
                                                  requestBody);
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -151,8 +151,7 @@ public class FedoraAcl extends ContentExposingResource {
             final Model model = httpRdfService.bodyToInternalModel(externalPath() + "/fcr:acl",
                     requestBodyStream, requestContentType, identifierConverter());
 
-            replacePropertiesService.perform(transaction.getId(), getUserPrincipal(), aclId,
-                requestContentType.toString(), model);
+            replacePropertiesService.perform(transaction.getId(), getUserPrincipal(), aclId, model);
         } else {
             throw new BadRequestException("Content-Type (" + requestContentType + ") is invalid. Try text/turtle " +
                                           "or other RDF compatible type.");
@@ -205,12 +204,8 @@ public class FedoraAcl extends ContentExposingResource {
 
             evaluateRequestPreconditions(request, servletResponse, aclResource, transaction());
 
-            try (final RdfStream resourceTriples =
-                     aclResource.isNew() ? new DefaultRdfStream(asNode(aclResource)) :
-                     getResourceTriples(aclResource)) {
-                LOGGER.info("PATCH for '{}'", externalPath);
-                patchResourcewithSparql(aclResource, requestBody, resourceTriples);
-            }
+            LOGGER.info("PATCH for '{}'", externalPath);
+            patchResourcewithSparql(aclResource, requestBody);
             transaction().commit();
 
             addCacheControlHeaders(servletResponse, aclResource, transaction());

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -93,7 +93,6 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.http.commons.domain.PATCH;
 import org.fcrepo.kernel.api.FedoraTypes;
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
@@ -110,7 +109,6 @@ import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.ExternalContent;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
-import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.CreateResourceService;
 import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.fcrepo.kernel.api.services.FixityService;
@@ -472,7 +470,6 @@ public class FedoraLdp extends ContentExposingResource {
                 replacePropertiesService.perform(transaction.getId(),
                                                  getUserPrincipal(),
                                                  fedoraId,
-                                                 contentType.toString(),
                                                  model);
             } else {
                 createResourceService.perform(transaction.getId(), getUserPrincipal(), fedoraId, links, model);
@@ -524,11 +521,8 @@ public class FedoraLdp extends ContentExposingResource {
 
             evaluateRequestPreconditions(request, servletResponse, resource(), transaction);
 
-            try (final RdfStream resourceTriples =
-                    resource().isNew() ? new DefaultRdfStream(asNode(resource())) : getResourceTriples(resource())) {
-                LOGGER.info("PATCH for '{}'", externalPath);
-                patchResourcewithSparql(resource(), requestBody, resourceTriples);
-            }
+            LOGGER.info("PATCH for '{}'", externalPath);
+            patchResourcewithSparql(resource(), requestBody);
             transaction.commitIfShortLived();
 
             addCacheControlHeaders(servletResponse, resource(), transaction);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -62,6 +62,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -906,7 +907,7 @@ public class FedoraLdpTest {
 
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(replacePropertiesService).perform(eq(mockTransaction.getId()), anyString(), eq(fedoraID),
-                any(String.class),any(Model.class));
+                any(Model.class));
     }
 
     @Test
@@ -941,7 +942,7 @@ public class FedoraLdpTest {
 
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
         verify(replacePropertiesService).perform(eq(mockTransaction.getId()), anyString(), eq(fedoraID),
-                any(String.class), any(Model.class));
+                any(Model.class));
     }
 
     @Test(expected = ClientErrorException.class)
@@ -1034,7 +1035,7 @@ public class FedoraLdpTest {
                 MediaType.valueOf(contentTypeSPARQLUpdate), "b", toInputStream("x", UTF_8), null, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(updatePropertiesService).updateProperties(
-                anyString(), anyString(), anyString(), eq("x"), any(RdfStream.class));
+                anyString(), anyString(), isA(FedoraId.class), eq("x"));
     }
 
     @Test
@@ -1045,7 +1046,7 @@ public class FedoraLdpTest {
                 toInputStream("_:a <info:b> _:c .", UTF_8), null, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(replacePropertiesService).perform(eq(mockTransaction.getId()), anyString(), eq(fedoraID),
-                any(String.class), any(Model.class));
+               any(Model.class));
     }
 
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -995,7 +995,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testUpdateObjectGraph() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -1009,7 +1008,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteMultipleMultiValuedProperties() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -1089,7 +1087,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
      * @throws IOException in case of IOException
      */
     @Test
-@Ignore
     public void testPatchBinaryDescription() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", "some content");
@@ -1109,7 +1106,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
      * @throws IOException on error
      */
     @Test
-@Ignore
     public void testPatchBinaryDescriptionWithBinaryProperties() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", "some content");
@@ -1131,7 +1127,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPatchBinaryNameAndType() throws IOException {
         final String pid = getRandomUniqueId();
 
@@ -3023,19 +3018,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     createURI(subjectURI), createURI("info:test#date"), createLiteral("1953?",
                         getInstance().getSafeTypeByName("http://id.loc.gov/datatypes/edtf/EDTF"))));
         }
-    }
-
-    @Test
-    // TODO there is no actual use of the JCR namespace in this test-- what is it testing?
-            public
-            void testUpdateWithSparqlQueryJcrNS() throws IOException {
-        final String subjectURI = getLocation(postObjMethod());
-        final HttpPatch updateObjectGraphMethod = new HttpPatch(subjectURI);
-        updateObjectGraphMethod.addHeader(CONTENT_TYPE, "application/sparql-update");
-        updateObjectGraphMethod.setEntity(new StringEntity("PREFIX fcr: <http://xmlns.com/my-fcr/> "
-                + "INSERT { <" + subjectURI + "> <info:test#label> \"asdfg\" } WHERE {}"));
-        assertNotEquals("Got updated response with jcr namspace prefix!\n",
-                NO_CONTENT.getStatusCode(), getStatus(updateObjectGraphMethod));
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
@@ -103,7 +103,6 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testLdpcvGetHasStateTokenRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -114,7 +113,6 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testLdpcvHeadHasStateTokenRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -189,7 +187,6 @@ public class StateTokensIT extends AbstractResourceIT {
 
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testPatchWithStateTokenOnRDFSource() throws IOException {
         final String id = getRandomUniqueId();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplacePropertiesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplacePropertiesService.java
@@ -34,13 +34,11 @@ public interface ReplacePropertiesService {
      * @param txId the Transaction Id
      * @param userPrincipal the user performing the service
      * @param fedoraId the internal Id of the fedora resource to update
-     * @param contentType the original triples
      * @param inputModel the model built from the body of the request
      * @throws MalformedRdfException if malformed rdf exception occurred
      */
     void perform(String txId,
                 String userPrincipal,
                 FedoraId fedoraId,
-                String contentType,
                 Model inputModel) throws MalformedRdfException;
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdatePropertiesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdatePropertiesService.java
@@ -17,9 +17,9 @@
  */
 package org.fcrepo.kernel.api.services;
 
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 
 /**
  * @author peichman
@@ -34,13 +34,11 @@ public interface UpdatePropertiesService {
    * @param userPrincipal the user performing the service
    * @param fedoraId the internal Id of the fedora resource to update
    * @param sparqlUpdateStatement sparql update statement
-   * @param originalTriples original triples
    * @throws MalformedRdfException if malformed rdf exception occurred
    * @throws AccessDeniedException if access denied in updating properties
    */
   void updateProperties(final String txId,
                         final String userPrincipal,
-                        final String fedoraId,
-                        final String sparqlUpdateStatement,
-                        final RdfStream originalTriples) throws MalformedRdfException, AccessDeniedException;
+                        final FedoraId fedoraId,
+                        final String sparqlUpdateStatement) throws MalformedRdfException, AccessDeniedException;
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -51,7 +51,6 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
     public void perform(final String txId,
                         final String userPrincipal,
                         final FedoraId fedoraId,
-                        final String contentType,
                         final Model inputModel) throws MalformedRdfException {
         try {
             final PersistentStorageSession pSession = this.psManager.getSession(txId);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
@@ -89,8 +89,6 @@ public class ReplacePropertiesServiceImplTest {
 
     private static final String FEDORA_ID = "info:fedora/resource1";
     private static final String TX_ID = "tx-1234";
-    private static final String CONTENT_TYPE = "text/turtle";
-
     private static final String RDF =
             "<" + FEDORA_ID + "> <" + DC.getURI() + "title> 'fancy title' .\n" +
             "<" + FEDORA_ID + "> <" + DC.getURI() + "title> 'another fancy title' .";
@@ -112,7 +110,7 @@ public class ReplacePropertiesServiceImplTest {
 
         final FedoraId fedoraID = FedoraId.create(resource.getId());
 
-        service.perform(tx.getId(), USER_PRINCIPAL, fedoraID, CONTENT_TYPE, model);
+        service.perform(tx.getId(), USER_PRINCIPAL, fedoraID, model);
         verify(pSession).persist(operationCaptor.capture());
         assertEquals(FEDORA_ID, operationCaptor.getValue().getResourceId());
         final RdfStream stream = operationCaptor.getValue().getTriples();


### PR DESCRIPTION
**Implement PATCH for RDF**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3078

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Adds support for PATCH and enables the following integration tests: 

- FedoraLdpIT.testUpdateObjectGraph()
- FedoraLdpIT.testDeleteMultipleMultiValuedProperties
- FedoraLdpIT.testPatchBinary()
- FedoraLdpIT.testPatchBinaryDescriptionWithBinaryProperties()
- FedoraLdpIT.testPatchBinaryNameAndType()

# What's new?
Basic PATCH support with 5 old integration tests brought online.  One vestigial integration test was removed.

# How should this be tested?

```
#  create an RDF resource
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test1 -X PUT -H "Content-Type: text/turtle"

# modify  it by adding triples via SPARQL
curl -i -XPATCH -H"Content-type:application/sparql-update" -ufedoraAdmin:fedoraAdmin -d "INSERT DATA {<> <http://purl.org/dc/elements/1.1/title> 'MY TITLE'}" http://localhost:8080/rest/test1 -u fedoraAdmin:fedoraAdmin 

# verify that the change took
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test1

# modify it again by removing triples
curl -i -XPATCH -H"Content-type:application/sparql-update" -ufedoraAdmin:secret3 -d "DELETE {<> <http://purl.org/dc/elements/1.1/title> 'MY TITLE'} WHERE {}" http://localhost:8080/rest/test1 -u fedoraAdmin:fedoraAdmin
# verify that the removed triples are gone.
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test1
```

# Additional Notes:
This PR does not attempt to deal with all the potential corner cases around PATCH.  The object is to get PATCH working enough in order to unblock other work (WebACs) that depends on this functionality.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
