### PR TITLE
re-enable dynamic port selection for cli ITest

### DIFF
--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.auth.integration;
 
+import com.google.common.base.Strings;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -31,6 +32,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
+import java.util.Objects;
+
+import static java.lang.Integer.parseInt;
 
 /**
  * <p>Abstract AbstractResourceIT class.</p>
@@ -48,8 +52,8 @@ public abstract class AbstractResourceIT {
         logger = LoggerFactory.getLogger(this.getClass());
     }
 
-    private static final int SERVER_PORT = Integer.parseInt(System
-            .getProperty("fcrepo.dynamic.test.port", "8080"));
+    private static final int SERVER_PORT = parseInt(Objects.requireNonNullElse(
+            Strings.emptyToNull(System.getProperty("fcrepo.dynamic.test.port")), "8080"));
 
     private static final String HOSTNAME = "localhost";
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
@@ -78,8 +78,8 @@ public class ContainerWrapper implements ApplicationContextAware {
 
     private int resolvePort() {
         /*
-         This nonsense is necessary, rather than using @Value(${fcrepo.dynamic.test.port:8080}) because Intellij is smart
-         enough to attempt to set fcrepo.dynamic.test.port based on the pom but too dumb to run the
+         This nonsense is necessary, rather than using @Value(${fcrepo.dynamic.test.port:8080}) because Intellij is
+          smart enough to attempt to set fcrepo.dynamic.test.port based on the pom but too dumb to run the
          build-helper-maven-plugin plugin that actually determines its value. As a result, it's populated with an empty
          value rather than null, and Spring will only default null property values.
          */

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
@@ -59,7 +59,7 @@ public class ContainerWrapper implements ApplicationContextAware {
 
     private static final int DEFAULT_PORT = 8080;
 
-    @Value("${fcrepo.dynamic.test.port}")
+    @Value("${fcrepo.dynamic.test.port:" + DEFAULT_PORT + "}")
     private String port;
 
     private HttpServer server;

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/ContainerWrapper.java
@@ -28,6 +28,7 @@ import javax.annotation.PreDestroy;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
 
+import com.google.common.base.Strings;
 import org.fcrepo.http.commons.webxml.WebAppConfig;
 import org.fcrepo.http.commons.webxml.bind.ContextParam;
 import org.fcrepo.http.commons.webxml.bind.Filter;
@@ -56,8 +57,10 @@ public class ContainerWrapper implements ApplicationContextAware {
 
     private static final Logger logger = getLogger(ContainerWrapper.class);
 
-    @Value("${fcrepo.dynamic.test.port:8080}")
-    private int port;
+    private static final int DEFAULT_PORT = 8080;
+
+    @Value("${fcrepo.dynamic.test.port}")
+    private String port;
 
     private HttpServer server;
 
@@ -70,7 +73,20 @@ public class ContainerWrapper implements ApplicationContextAware {
     }
 
     public void setPort(final int port) {
-        this.port = port;
+        this.port = Integer.toString(port);
+    }
+
+    private int resolvePort() {
+        /*
+         This nonsense is necessary, rather than using @Value(${fcrepo.dynamic.test.port:8080}) because Intellij is smart
+         enough to attempt to set fcrepo.dynamic.test.port based on the pom but too dumb to run the
+         build-helper-maven-plugin plugin that actually determines its value. As a result, it's populated with an empty
+         value rather than null, and Spring will only default null property values.
+         */
+        if (Strings.isNullOrEmpty(port)) {
+            return DEFAULT_PORT;
+        }
+        return Integer.parseInt(port);
     }
 
     @PostConstruct
@@ -82,7 +98,7 @@ public class ContainerWrapper implements ApplicationContextAware {
                 (WebAppConfig) u.unmarshal(getClass().getResource(
                         this.configLocation));
 
-        final URI uri = URI.create("http://localhost:" + port);
+        final URI uri = URI.create("http://localhost:" + resolvePort());
 
         server = createHttpServer(uri);
 

--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -67,7 +67,6 @@
     <jacoco.out.it.file>jacoco-it.exec</jacoco.out.it.file>
     <sonar.jacoco.reportPath>${jacoco.outputDir}/${jacoco.out.unit.file}</sonar.jacoco.reportPath>
     <sonar.jacoco.itReportPath>${jacoco.outputDir}/${jacoco.out.it.file}</sonar.jacoco.itReportPath>
-    <fcrepo.dynamic.test.port>8080</fcrepo.dynamic.test.port>
   </properties>
 
   <build>

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/AbstractResourceIT.java
@@ -21,12 +21,15 @@ import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.parseInt;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import com.google.common.base.Strings;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Before;
 import org.slf4j.Logger;
+
+import java.util.Objects;
 
 /**
  * Base class for ITs
@@ -45,8 +48,8 @@ public abstract class AbstractResourceIT {
         logger = getLogger(this.getClass());
     }
 
-    private static final int SERVER_PORT = parseInt(System.getProperty(
-            "fcrepo.dynamic.test.port", "8080"));
+    private static final int SERVER_PORT = parseInt(Objects.requireNonNullElse(
+            Strings.emptyToNull(System.getProperty("fcrepo.dynamic.test.port")), "8080"));
 
     private static final String CONTEXT_PATH = System
             .getProperty("fcrepo.test.context.path");

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
@@ -30,7 +30,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Objects;
 
+import com.google.common.base.Strings;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.client.CredentialsProvider;
@@ -63,7 +65,8 @@ public class SanityCheckIT {
      * The server port of the application, set as system property by
      * maven-failsafe-plugin.
      */
-    private static final String SERVER_PORT = System.getProperty("fcrepo.dynamic.test.port");
+    private static final String SERVER_PORT = Objects.requireNonNullElse(
+            Strings.emptyToNull(System.getProperty("fcrepo.dynamic.test.port")), "8080");
 
     /**
     * The context path of the application (including the leading "/"), set as


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3281

# What does this Pull Request do?

Re-enables dynamic port selection when the ITests are run from the CLI. ITests are still runnable using IDEs on port 8080.

# How should this be tested?

1. Run the ITests from the cli while another process has 8080 bound
1. Run the ITests from Intellij or Eclipse

# Additional Notes:

- [build-helper-maven-plugin cannot override a default port value](https://github.com/mojohaus/build-helper-maven-plugin/issues/17)
- [Intellij does not run build-helper-maven-plugin](https://youtrack.jetbrains.com/issue/IDEA-100272)

# Interested parties
@awoods @bbpennel 
