### PR TITLE
Implement adding ACLs

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -154,6 +154,8 @@ import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.kernel.api.models.WebacAcl;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
+import org.fcrepo.kernel.api.services.CreateResourceService;
+import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.fcrepo.kernel.api.services.ManagedPropertiesService;
 import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.kernel.api.services.UpdatePropertiesService;
@@ -221,6 +223,12 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     @Inject
     protected RdfNamespaceRegistry namespaceRegistry;
+
+    @Inject
+    protected CreateResourceService createResourceService;
+
+    @Inject
+    protected DeleteResourceService deleteResourceService;
 
     @Inject
     protected ReplacePropertiesService replacePropertiesService;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -148,7 +148,7 @@ public class FedoraAcl extends ContentExposingResource {
             throw new BadRequestException("Content-Type (" + requestContentType + ") is invalid. Try text/turtle " +
                                           "or other RDF compatible type.");
         }
-        transaction().commit();
+        transaction().commitIfShortLived();
 
         final FedoraResource aclResource = getFedoraResource(transaction(), aclId);
         addCacheControlHeaders(servletResponse, aclResource, transaction());
@@ -201,7 +201,7 @@ public class FedoraAcl extends ContentExposingResource {
 
             LOGGER.info("PATCH for '{}'", externalPath);
             patchResourcewithSparql(aclResource, requestBody);
-            transaction().commit();
+            transaction().commitIfShortLived();
 
             addCacheControlHeaders(servletResponse, aclResource, transaction());
 
@@ -293,7 +293,7 @@ public class FedoraAcl extends ContentExposingResource {
             }
             throw new PathNotFoundRuntimeException(exc);
         } finally {
-            transaction().commit();
+            transaction().commitIfShortLived();
         }
         return noContent().build();
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -38,7 +38,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_REPOSITORY_ROOT;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -46,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
@@ -74,11 +74,12 @@ import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.WebacAcl;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
-import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.fcrepo.kernel.api.services.WebacAclService;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -105,9 +106,6 @@ public class FedoraAcl extends ContentExposingResource {
     @PathParam("path") protected String externalPath;
 
     @Inject
-    private DeleteResourceService deleteResourceService;
-
-    @Inject
     private WebacAclService webacAclService;
 
     /**
@@ -130,37 +128,32 @@ public class FedoraAcl extends ContentExposingResource {
         if (resource().isAcl() || resource().isMemento()) {
             throw new BadRequestException("ACL resource creation is not allowed for resource " + resource().getId());
         }
+        LOGGER.info("PUT acl resource '{}'", externalPath());
 
-        final boolean created;
-        final FedoraResource aclResource;
-
-        final String path = toPath(translator(), externalPath);
-        LOGGER.info("PUT acl resource '{}'", externalPath);
-
-        final var transaction = transaction();
-
-        aclResource = webacAclService.findOrCreate(transaction, path);
-        created = aclResource.isNew();
-        final FedoraId aclId = aclResource.getFedoraId();
+        final FedoraId aclId = identifierConverter().pathToInternalId(externalPath()).resolve(FCR_ACL);
+        final boolean exists = resourceFactory.doesResourceExist(transaction(), aclId);
 
         final MediaType contentType =
             requestContentType == null ? RDFMediaType.TURTLE_TYPE : valueOf(getSimpleContentType(requestContentType));
         if (isRdfContentType(contentType.toString())) {
 
-            // TODO: confirm this is correct logic for ACL's
-            final Model model = httpRdfService.bodyToInternalModel(externalPath() + "/fcr:acl",
-                    requestBodyStream, requestContentType, identifierConverter());
-
-            replacePropertiesService.perform(transaction.getId(), getUserPrincipal(), aclId, model);
+            final Model model = httpRdfService.bodyToInternalModel(aclId.getFullId(),
+                    requestBodyStream, contentType, identifierConverter());
+            if (exists) {
+                replacePropertiesService.perform(transaction().getId(), getUserPrincipal(), aclId, model);
+            } else {
+                webacAclService.create(transaction(), aclId, getUserPrincipal(), model);
+            }
         } else {
             throw new BadRequestException("Content-Type (" + requestContentType + ") is invalid. Try text/turtle " +
                                           "or other RDF compatible type.");
         }
-        transaction.commit();
+        transaction().commit();
 
-        addCacheControlHeaders(servletResponse, aclResource, transaction);
+        final FedoraResource aclResource = getFedoraResource(transaction(), aclId);
+        addCacheControlHeaders(servletResponse, aclResource, transaction());
         final URI location = getUri(aclResource);
-        if (created) {
+        if (!exists) {
             return created(location).build();
         } else {
             return noContent().location(location).build();
@@ -184,15 +177,17 @@ public class FedoraAcl extends ContentExposingResource {
             throw new BadRequestException("SPARQL-UPDATE requests must have content!");
         }
 
-        final FedoraResource aclResource = resource().getAcl();
-
-        if (aclResource == null) {
-            if (resource().hasType(FEDORA_REPOSITORY_ROOT)) {
+        final FedoraId originalId = identifierConverter().pathToInternalId(externalPath());
+        final FedoraId aclId = originalId.resolve(FCR_ACL);
+        final FedoraResource aclResource;
+        try {
+             aclResource = resourceFactory.getResource(transaction(), aclId);
+        } catch (final PathNotFoundException exc) {
+            if (originalId.isRepositoryRoot()) {
                 throw new ClientErrorException("The default root ACL is system generated and cannot be modified. " +
                         "To override the default root ACL you must PUT a user-defined ACL to this endpoint.",
                         CONFLICT);
             }
-
             throw new ItemNotFoundException("not found");
         }
 
@@ -243,25 +238,29 @@ public class FedoraAcl extends ContentExposingResource {
     public Response getResource()
             throws IOException, ItemNotFoundException {
 
-        LOGGER.info("GET resource '{}'", externalPath);
+        LOGGER.info("GET resource '{}'", externalPath());
 
-        final FedoraResource aclResource = resource().getAcl();
+        final FedoraId originalId = identifierConverter().pathToInternalId(externalPath());
+        final FedoraId aclId = originalId.resolve(FCR_ACL);
+        final boolean exists = resourceFactory.doesResourceExist(transaction(), aclId);
 
-        if (aclResource == null) {
-            if (resource().hasType(FEDORA_REPOSITORY_ROOT)) {
-                final String resourceUri = getUri(resource()).toString();
-                final String aclUri = resourceUri + (resourceUri.endsWith("/") ? "" : "/") + FCR_ACL;
+        if (!exists) {
+            if (originalId.isRepositoryRoot()) {
+                final String aclUri = identifierConverter().toExternalId(aclId.getFullId());
 
                 final RdfStream defaultRdfStream = DefaultRdfStream.fromModel(createResource(aclUri).asNode(),
                     getDefaultAcl(aclUri));
-                final RdfNamespacedStream output = new RdfNamespacedStream(defaultRdfStream,
-                    namespaceRegistry.getNamespaces());
+                final RdfStream rdfStream = httpRdfService.bodyToExternalStream(aclUri,
+                        defaultRdfStream, identifierConverter());
+                final var output = new RdfNamespacedStream(
+                        rdfStream, namespaceRegistry.getNamespaces());
                 return ok(output).build();
             }
 
             throw new ItemNotFoundException(String.format("No ACL found at %s", externalPath));
         }
 
+        final WebacAcl aclResource = webacAclService.find(transaction(), aclId);
         checkCacheControlHeaders(request, servletResponse, aclResource, transaction());
 
         LOGGER.info("GET resource '{}'", externalPath);
@@ -281,24 +280,22 @@ public class FedoraAcl extends ContentExposingResource {
         hasRestrictedPath(externalPath);
         LOGGER.info("Delete resource '{}'", externalPath);
 
-        final FedoraResource aclResource = resource().getAcl();
-        if (aclResource != null) {
+        final FedoraId originalId = identifierConverter().pathToInternalId(externalPath());
+        final FedoraId aclId = originalId.resolve(FCR_ACL);
+        try {
+            final var aclResource = resourceFactory.getResource(transaction(), aclId);
             deleteResourceService.perform(transaction(), aclResource, getUserPrincipal());
-        }
-        transaction().commit();
-
-        if (aclResource == null) {
-            if (resource().hasType(FEDORA_REPOSITORY_ROOT)) {
+        } catch (final PathNotFoundException exc) {
+            if (originalId.isRepositoryRoot()) {
                 throw new ClientErrorException("The default root ACL is system generated and cannot be deleted. " +
                         "To override the default root ACL you must PUT a user-defined ACL to this endpoint.",
                         CONFLICT);
             }
-
-            throw new ItemNotFoundException("not found");
+            throw new PathNotFoundRuntimeException(exc);
+        } finally {
+            transaction().commit();
         }
-
         return noContent().build();
-
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -109,8 +109,6 @@ import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.ExternalContent;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
-import org.fcrepo.kernel.api.services.CreateResourceService;
-import org.fcrepo.kernel.api.services.DeleteResourceService;
 import org.fcrepo.kernel.api.services.FixityService;
 import org.fcrepo.kernel.api.services.ReplaceBinariesService;
 import org.fcrepo.kernel.api.utils.ContentDigest;
@@ -148,12 +146,6 @@ public class FedoraLdp extends ContentExposingResource {
 
     @Inject
     private FedoraHttpConfiguration httpConfiguration;
-
-    @Inject
-    private CreateResourceService createResourceService;
-
-    @Inject
-    private DeleteResourceService deleteResourceService;
 
     @Inject
     protected ReplaceBinariesService replaceBinariesService;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -53,7 +53,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -76,7 +75,6 @@ public class FedoraAclIT extends AbstractResourceIT {
         subjectUri = serverAddress + id;
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithoutBody() throws Exception {
         createObjectAndClose(id);
@@ -91,7 +89,6 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclOnAclResource() throws Exception {
         createObjectAndClose(id);
@@ -111,7 +108,6 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclOnBinary() throws Exception {
         createDatastream(id, "x", "some content");
@@ -134,7 +130,6 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testPatchAcl() throws Exception {
         createObjectAndClose(id);
@@ -156,7 +151,6 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAndRetrieveAcl() throws Exception {
         createObjectAndClose(id);
@@ -175,7 +169,6 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testPutACLBadRdf() throws IOException {
         createObjectAndClose(id);
@@ -186,7 +179,6 @@ public class FedoraAclIT extends AbstractResourceIT {
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(put));
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testDeleteAcl() throws Exception {
         createObjectAndClose(id);
@@ -219,11 +211,10 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetDefaultRootAcl() throws Exception {
         final String rootAclUri = serverAddress + FCR_ACL;
-        final String rootFedoraUri = "info:fedora/";
+        final String rootFedoraUri = serverAddress;
         final String authzUri = rootFedoraUri + FCR_ACL + "#authz";
         try (final CloseableDataset dataset = getDataset(new HttpGet(rootAclUri))) {
             final DatasetGraph graph = dataset.asDatasetGraph();
@@ -249,7 +240,6 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testDeleteDefaultRootAcl() {
         final String rootAclUri = serverAddress + FCR_ACL;
@@ -257,7 +247,6 @@ public class FedoraAclIT extends AbstractResourceIT {
                 CONFLICT.getStatusCode(), getStatus(new HttpDelete(rootAclUri)));
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testPatchDefaultRootAcl() {
         final String rootAclUri = serverAddress + FCR_ACL;
@@ -265,7 +254,6 @@ public class FedoraAclIT extends AbstractResourceIT {
                 CONFLICT.getStatusCode(), getStatus(new HttpPatch(rootAclUri)));
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testGetUserDefinedDefaultRootAcl() throws Exception {
         System.setProperty(ROOT_AUTHORIZATION_PROPERTY, "./target/test-classes/test-root-authorization.ttl");
@@ -284,7 +272,6 @@ public class FedoraAclIT extends AbstractResourceIT {
             }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testAddModifyDeleteUserDefinedDefaultRootAcl() throws Exception {
         final String rootAclUri = serverAddress + FCR_ACL;
@@ -316,7 +303,6 @@ public class FedoraAclIT extends AbstractResourceIT {
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(rootAclUri)));
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithBody() throws Exception {
         createObjectAndClose(id);
@@ -352,7 +338,6 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithoutAccessToSetsDefaultTarget() throws Exception {
         createObjectAndClose(id);
@@ -387,7 +372,6 @@ public class FedoraAclIT extends AbstractResourceIT {
 
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithAccessTo() throws Exception {
         createObjectAndClose(id);
@@ -433,7 +417,6 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithAccessToClass() throws Exception {
         createObjectAndClose(id);
@@ -479,7 +462,6 @@ public class FedoraAclIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateAclWithBothAccessToandAccessToClassIsNotAllowed() throws Exception {
         createObjectAndClose(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -721,7 +721,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testCheckGetAclResourceHeaders() throws IOException {
         final String aclUri = createAcl();
 
@@ -4434,7 +4433,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPostCreateNonRDFSourceWithAcl() throws IOException {
         final String aclURI = createAcl();
         final String subjectURI = getRandomUniqueId();
@@ -4447,8 +4445,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         checkResponseForMethodWithAcl(createMethod);
     }
 
-@Test
-@Ignore
+    @Test
     public void testPostCreateRDFSourceWithAcl() throws IOException {
         final String aclURI = createAcl();
         final String subjectURI = getRandomUniqueId();
@@ -4462,7 +4459,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
 }
 
     @Test
-@Ignore
     public void testPutCreateNonRDFSourceWithAcl() throws IOException {
         final String aclURI = createAcl();
         final String subjectURI = serverAddress + getRandomUniqueId();
@@ -4475,7 +4471,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testPutCreateRDFSourceWithAcl() throws IOException {
         final String aclURI = createAcl();
         final String subjectURI = serverAddress + getRandomUniqueId();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StateTokensIT.java
@@ -63,7 +63,6 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testAclGetHasStateTokenRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -83,7 +82,6 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testAclHeadHasStateTokenRDFSource() throws IOException {
         final String id = getRandomUniqueId();
@@ -225,7 +223,6 @@ public class StateTokensIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testPatchWithStateTokenOnAcl() throws IOException {
         final String id = getRandomUniqueId();

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -116,9 +116,15 @@ public class HttpIdentifierConverter {
             // If it starts with our prefix, strip the prefix and any leading slashes and use it as the path
             // part of the URI.
             final String path = fedoraId.substring(FEDORA_ID_PREFIX.length()).replaceFirst("\\/", "");
-            final String[] values = { path };
-            // Need to pass as Array or second arg is ignored. Second arg is DON'T encode slashes
-            return uriBuilder().build(values, false).toString();
+            final UriBuilder uri = uriBuilder();
+            if (path.contains("#")) {
+                final String[] split = path.split("#", 2);
+                uri.resolveTemplate("path", split[0], false);
+                uri.fragment(split[1]);
+            } else {
+                uri.resolveTemplate("path", path, false);
+            }
+            return uri.build().toString();
         }
         throw new IllegalArgumentException("Cannot translate IDs without our prefix");
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -42,6 +42,8 @@ public final class RdfLexicon {
     **/
     public static final String REPOSITORY_NAMESPACE = "http://fedora.info/definitions/v4/repository#";
 
+    public static final String REPOSITORY_WEBAC_NAMESPACE = "http://fedora.info/definitions/v4/webac#";
+
     public static final String FCREPO_API_NAMESPACE = "http://fedora.info/definitions/fcrepo#";
 
     public static final String ACTIVITY_STREAMS_NAMESPACE = "https://www.w3.org/ns/activitystreams#";
@@ -217,6 +219,8 @@ public final class RdfLexicon {
     public static final String WEBAC_ACCESS_TO_CLASS = WEBAC_NAMESPACE_VALUE + "accessToClass";
 
     public static final Property WEBAC_ACCESS_TO_PROPERTY = createProperty(WEBAC_ACCESS_TO);
+
+    public static final String FEDORA_WEBAC_ACL_URI = REPOSITORY_WEBAC_NAMESPACE + "Acl";
 
     // Properties which are managed by the server but are not from managed namespaces
     private static final Set<Property> serverManagedProperties;

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.api.identifiers;
 
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
@@ -26,7 +27,10 @@ import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMAT
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -48,8 +52,9 @@ import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
  */
 public class FedoraId {
 
-    private String id;
+    private String resourceId;
     private String fullId;
+    private String parentId;
     private String hashUri;
     private boolean isRepositoryRoot = false;
     private boolean isNonRdfSourceDescription = false;
@@ -59,6 +64,14 @@ public class FedoraId {
     private Instant mementoDatetime;
     private String mementoDatetimeStr;
     private String pathOnly;
+
+    private final static Set<String> extensions = new HashSet<>();
+    static {
+        extensions.add(FCR_TOMBSTONE);
+        extensions.add(FCR_METADATA);
+        extensions.add(FCR_ACL);
+        extensions.add(FCR_VERSIONS);
+    }
 
     /**
      * Basic constructor.
@@ -70,7 +83,7 @@ public class FedoraId {
         this.fullId = this.fullId.replaceAll("/+$", "");
         // Carry the path of the request for any exceptions.
         this.pathOnly = this.fullId.substring(FEDORA_ID_PREFIX.length());
-
+        checkForInvalidPath();
         processIdentifier();
     }
 
@@ -149,11 +162,25 @@ public class FedoraId {
     }
 
     /**
-     * Return the ID of the base resource for this request.
+     * Return the ID of the base resource that exists as a separate resource.
      * @return the shorten id.
      */
     public String getResourceId() {
-        return id;
+        if (isNonRdfSourceDescription) {
+            return resourceId + "/" + FCR_METADATA;
+        } else if (isAcl) {
+            return resourceId + "/" + FCR_ACL;
+        }
+        return resourceId;
+    }
+
+    /**
+     * For elements that exist as separate resources but also are lifecycle tied to a resource (fcr:acl and
+     * fcr:metadata), return the ID of the "containing" resource.
+     * @return the containing resource id.
+     */
+    public String getContainingId() {
+        return resourceId;
     }
 
     /**
@@ -189,17 +216,6 @@ public class FedoraId {
     }
 
     /**
-     * Descriptions are needed to retrieve from the persistence, but otherwise is just an addendum to the binary.
-     * @return The description ID or null if not a description.
-     */
-    public String getDescriptionId() {
-        if (isDescription()) {
-            return getResourceId() + "/" + FCR_METADATA;
-        }
-        return null;
-    }
-
-    /**
      * Resolve the string or strings against this ID to create a new one.
      *
      * A string starting with a slash (/) will resolve from the resource ID, a string not starting with a slash
@@ -219,7 +235,8 @@ public class FedoraId {
         }
         final String[] parts;
         if (addition[0].startsWith("/")) {
-            parts = Stream.of(new String[]{this.getResourceId()}, addition).flatMap(Stream::of).toArray(String[]::new);
+            parts = Stream.of(new String[]{this.getContainingId()}, addition).flatMap(Stream::of)
+                    .toArray(String[]::new);
             return FedoraId.create(parts);
         }
         parts = Stream.of(new String[]{this.getFullId()}, addition).flatMap(Stream::of).toArray(String[]::new);
@@ -295,7 +312,7 @@ public class FedoraId {
         String processID = this.fullId;
         if (processID.equals(FEDORA_ID_PREFIX)) {
             this.isRepositoryRoot = true;
-            this.id = this.fullId;
+            this.resourceId = this.fullId;
             // Root has no other possible endpoints, so short circuit out.
             return;
         }
@@ -347,6 +364,31 @@ public class FedoraId {
         if (processID.endsWith("/")) {
             processID = processID.replaceAll("/+$", "");
         }
-        this.id = processID;
+        this.resourceId = processID;
+    }
+
+    /**
+     * Check for obvious path errors.
+     */
+    private void checkForInvalidPath() {
+        // Check for combinations of endpoints not allowed.
+        if (
+            // ID contains fcr:acl or fcr:tombstone AND fcr:metadata or fcr:versions
+            ((this.fullId.contains(FCR_ACL) || this.fullId.contains(FCR_TOMBSTONE)) &&
+                (this.fullId.contains(FCR_METADATA) || this.fullId.contains(FCR_VERSIONS))) ||
+            // or ID contains fcr:acl AND fcr:tombstone
+            (this.fullId.contains(FCR_TOMBSTONE) && this.fullId.contains(FCR_ACL))
+        ) {
+            throw new InvalidResourceIdentifierException(String.format("Path is invalid: %s", pathOnly));
+        }
+        // Ensure we don't have 2 of any of the extensions, ie. info:fedora/object/fcr:acl/fcr:acl, etc.
+        for (final String extension : extensions) {
+            if (this.fullId.contains(extension)) {
+                final Pattern extPattern = Pattern.compile(extension);
+                if (extPattern.matcher(this.fullId).results().count() > 1) {
+                    throw new InvalidResourceIdentifierException(String.format("Path is invalid: %s", pathOnly));
+                }
+            }
+        }
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/WebacAclService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/WebacAclService.java
@@ -18,13 +18,37 @@
 
 package org.fcrepo.kernel.api.services;
 
+import org.apache.jena.rdf.model.Model;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.WebacAcl;
 
 /**
  * Service for creating and retrieving {@link WebacAcl}
  *
  * @author peichman
+ * @author whikloj
  * @since 6.0.0
  */
-public interface WebacAclService extends Service<WebacAcl> {
+public interface WebacAclService {
+
+    /**
+     * Retrieve an existing WebACL by transaction and path
+     *
+     * @param fedoraId the fedoraID to the resource the ACL is part of
+     * @param transaction the transaction
+     * @return retrieved ACL
+     */
+    WebacAcl find(final Transaction transaction, final FedoraId fedoraId);
+
+    /**
+     * Retrieve or create a new WebACL by transaction and path
+     *
+     * @param transaction the transaction
+     * @param fedoraId the fedoraID to the resource the ACL is part of
+     * @param userPrincipal the user creating the ACL.
+     * @param model the contents of the ACL RDF.
+     */
+    void create(final Transaction transaction, final FedoraId fedoraId, final String userPrincipal,
+                    final Model model);
 }

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
@@ -121,11 +121,10 @@ public class FedoraIdTest {
         final FedoraId fedoraID = FedoraId.create(testID);
     }
 
-    @Test
+    @Test(expected = InvalidResourceIdentifierException.class)
     public void testMetadataAcl() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_ACL;
         final FedoraId fedoraID = FedoraId.create(testID);
-        assertResource(fedoraID, Arrays.asList("ACL", "METADATA"), testID, FEDORA_ID_PREFIX + "/first-object");
     }
 
 
@@ -188,7 +187,7 @@ public class FedoraIdTest {
         assertEquals("hashURI", fedoraID.getHashUri());
     }
 
-    @Test
+    @Test(expected = InvalidResourceIdentifierException.class)
     public void testMetadataAclWithHash() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_ACL + "#hashURI";
         final FedoraId fedoraID = FedoraId.create(testID);
@@ -338,6 +337,11 @@ public class FedoraIdTest {
         fedoraId.resolve("");
     }
 
+    @Test(expected = InvalidResourceIdentifierException.class)
+    public void testDoubleAcl() {
+        final FedoraId fedoraId = FedoraId.create("core-object/" + FCR_ACL).resolve(FCR_ACL);
+    }
+
 
     /**
      * Utility to test a FedoraId against expectations.
@@ -390,6 +394,6 @@ public class FedoraIdTest {
             assertFalse(fedoraID.isTimemap());
         }
         assertEquals(fullID, fedoraID.getFullId());
-        assertEquals(shortID, fedoraID.getResourceId());
+        assertEquals(shortID, fedoraID.getContainingId());
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -385,7 +385,8 @@ public class ContainmentIndexImpl implements ContainmentIndex {
 
     @Override
     public boolean resourceExists(final String txID, final FedoraId fedoraID) {
-        final String resourceID = fedoraID.getResourceId();
+        // Get the containing ID because fcr:metadata will not exist here but MUST exist if the containing resource does
+        final String resourceID = fedoraID.getContainingId();
         LOGGER.debug("Checking if {} exists in transaction {}", resourceID, txID);
         if (fedoraID.isRepositoryRoot()) {
             // Root always exists.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -58,13 +58,13 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
 
     @Override
     public String getId() {
-        return getFedoraId().getDescriptionId();
+        return getFedoraId().getResourceId();
     }
 
     @Override
     public FedoraResource getDescribedResource() {
         // Get a FedoraId for the binary
-        final FedoraId describedId = FedoraId.create(this.getFedoraId().getResourceId());
+        final FedoraId describedId = FedoraId.create(this.getFedoraId().getContainingId());
         try {
             return this.resourceFactory.getResource(tx, describedId);
         } catch (final PathNotFoundException e) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.kernel.impl.models;
 
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
@@ -46,17 +45,12 @@ public class WebacAclImpl extends ContainerImpl implements WebacAcl {
 
     @Override
     public FedoraResource getDescribedResource() {
-        final var originalId = FedoraId.create(getFedoraId().getResourceId());
+        final var originalId = FedoraId.create(getFedoraId().getContainingId());
         try {
             return resourceFactory.getResource(tx, originalId);
         } catch (final PathNotFoundException exc) {
             throw new PathNotFoundRuntimeException(exc);
         }
-    }
-
-    @Override
-    public RdfStream getTriples() {
-        return super.getTriples();
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.models;
+
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.WebacAcl;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+
+/**
+ * Webac Acl class
+ */
+public class WebacAclImpl extends ContainerImpl implements WebacAcl {
+
+    /**
+     * Constructor
+     * @param fedoraID the internal identifier
+     * @param tx the current transaction
+     * @param pSessionManager a session manager
+     * @param resourceFactory a resource factory instance.
+     */
+    public WebacAclImpl(final FedoraId fedoraID, final Transaction tx,
+                        final PersistentStorageSessionManager pSessionManager, final ResourceFactory resourceFactory) {
+        super(fedoraID, tx, pSessionManager, resourceFactory);
+    }
+
+    @Override
+    public FedoraResource getDescribedResource() {
+        final var originalId = FedoraId.create(getFedoraId().getResourceId());
+        try {
+            return resourceFactory.getResource(tx, originalId);
+        } catch (final PathNotFoundException exc) {
+            throw new PathNotFoundRuntimeException(exc);
+        }
+    }
+
+    @Override
+    public RdfStream getTriples() {
+        return super.getTriples();
+    }
+
+    @Override
+    public boolean isOriginalResource() {
+        return false;
+    }
+
+    @Override
+    public boolean isAcl() {
+        return true;
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -218,10 +218,9 @@ public abstract class AbstractService {
      * - Throws an exception if an authorization has both accessTo and accessToClass
      * - Adds a default accessTo target if an authorization has neither accessTo nor accessToClass
      *
-     * @param fedoraId the fedora Id
      * @param inputModel to be checked and updated
      */
-    protected void ensureValidACLAuthorization(final String fedoraId, final Model inputModel) {
+    protected void ensureValidACLAuthorization(final Model inputModel) {
 
         // TODO -- check ACL first
 
@@ -241,7 +240,7 @@ public abstract class AbstractService {
                 throw new ACLAuthorizationConstraintViolationException(
                     String.format(
                             "Using both accessTo and accessToClass within " +
-                                    "a single Authorization is not allowed: {0}.",
+                                    "a single Authorization is not allowed: %s.",
                             subject.toString().substring(subject.toString().lastIndexOf("#"))));
             } else if (!(graph.contains(subject, WEBAC_ACCESS_TO_URI, Node.ANY) ||
                     graph.contains(subject, WEBAC_ACCESS_TO_CLASS_URI, Node.ANY))) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -59,7 +59,7 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
 
             ensureValidMemberRelation(inputModel);
 
-            ensureValidACLAuthorization(fedoraId.getFullId(), inputModel);
+            ensureValidACLAuthorization(inputModel);
 
             checkForSmtsLdpTypes(inputModel);
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3134

# What does this Pull Request do?
Allows you to PUT/GET/DELETE and PATCH ACLs.

This does not ensure ACLs are enforced, that is next up.

# What's new?
I finally determined the issue with the FedoraId `resourceId` versus `fullId`. I need the resourceId to be the path as stored on disk. So for pretend things like fcr:tombstone and fcr:versions which don't exist it is the resource they hang off of, but for things that have an actual representation on disk (fcr:metadata and fcr:acl) we need their id (ie. info:fedora/object/fcr:metadata)

# How should this be tested?

Try PUTting an ACL
Try GETting the ACL
Try PATCHing an ACL
Try DELETEing the ACL

# Interested parties
@fcrepo4/committers
