### PR TITLE
Ensure charset Content-Type parameter not included when mapping to RDF lang

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -177,7 +177,13 @@ public class HttpRdfService {
             return null;
         }
 
-        final Lang format = contentTypeToLang(contentType.toString());
+        // The 'contentTypeToLang()' method will not accept 'charset' parameters
+        String contentTypeWithoutCharset = contentType.toString();
+        if (contentType.getParameters().containsKey("charset")) {
+            contentTypeWithoutCharset = contentType.getType() + "/" + contentType.getSubtype();
+        }
+
+        final Lang format = contentTypeToLang(contentTypeWithoutCharset);
         try {
             final Model inputModel = createDefaultModel();
             inputModel.read(requestBodyStream, extResourceId, format.getName().toUpperCase());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -35,6 +35,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
@@ -113,6 +114,7 @@ public abstract class AbstractResourceIT {
     protected static Logger logger;
 
     protected static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
+    protected static final String BASIC_CONTAINER_LINK_HEADER = "<" + BASIC_CONTAINER.getURI() + ">;rel=\"type\"";
 
     @Inject
     private ContainerWrapper containerWrapper;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -705,6 +705,18 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testCreateContainerWithCharset() throws IOException {
+        final String id = getRandomUniqueId();
+
+        final HttpPut put = putObjMethod(id, "text/turtle; charset=ISO-8859-1", "<> <http://test.org/title> 'hello'");
+        put.setHeader(LINK, BASIC_CONTAINER_LINK_HEADER);
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(CREATED.getStatusCode(), response.getStatusLine().getStatusCode());
+
+        }
+    }
+
+    @Test
     public void testGetRDFSourceWithPreferMinimal() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3297

# What does this Pull Request do?
Ensures that charset Content-Type parameter not included when mapping to RDF lang.
This bug was revealed when executing the Fedora API Test Suite.

# How should this be tested?
Perform the test described in: https://jira.lyrasis.org/browse/FCREPO-3297

# Interested parties
@fcrepo4/committers
