### PR TITLE
Remove '/commit' suffix from Transaction commit API

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/Transactions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/Transactions.java
@@ -24,7 +24,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSE
 import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_EXPIRES_HEADER;
 import static org.fcrepo.http.commons.session.TransactionConstants.EXPIRES_RFC_1123_FORMATTER;
 import static org.fcrepo.http.commons.session.TransactionConstants.TX_COMMIT_REL;
-import static org.fcrepo.http.commons.session.TransactionConstants.TX_COMMIT_SUFFIX;
 import static org.fcrepo.http.commons.session.TransactionConstants.TX_PREFIX;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -138,7 +137,7 @@ public class Transactions extends FedoraBaseResource {
         final var res = created(new URI(externalId));
         res.expires(from(tx.getExpires()));
 
-        final var commitUri = URI.create(externalId + TX_COMMIT_SUFFIX);
+        final var commitUri = URI.create(externalId);
         final var commitLink = Link.fromUri(commitUri).rel(TX_COMMIT_REL).build();
         res.links(commitLink);
 
@@ -152,7 +151,7 @@ public class Transactions extends FedoraBaseResource {
      * @return 204
      */
     @PUT
-    @Path("{transactionId}/commit")
+    @Path("{transactionId}")
     public Response commit(@PathParam("transactionId") final String txId) {
         try {
             final Transaction transaction = txManager.get(txId);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
@@ -37,7 +37,6 @@ import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_EXPIRE
 import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_ID_HEADER;
 import static org.fcrepo.http.commons.session.TransactionConstants.EXPIRES_RFC_1123_FORMATTER;
 import static org.fcrepo.http.commons.session.TransactionConstants.TX_COMMIT_REL;
-import static org.fcrepo.http.commons.session.TransactionConstants.TX_COMMIT_SUFFIX;
 import static org.fcrepo.http.commons.session.TransactionConstants.TX_ENDPOINT_REL;
 import static org.fcrepo.http.commons.session.TransactionConstants.TX_PREFIX;
 import static org.fcrepo.kernel.impl.TransactionImpl.TIMEOUT_SYSTEM_PROPERTY;
@@ -107,7 +106,7 @@ public class TransactionsIT extends AbstractResourceIT {
             assertNotNull("Expected Location header to send us to root node path within the transaction",
                     txId);
 
-            final String commitUri = serverAddress + TX_PREFIX + txId + TX_COMMIT_SUFFIX;
+            final String commitUri = serverAddress + TX_PREFIX + txId;
             checkForLinkHeader(response, commitUri, TX_COMMIT_REL);
 
             assertHeaderIsRfc1123Date(response, "Expires");
@@ -223,7 +222,7 @@ public class TransactionsIT extends AbstractResourceIT {
         assertEquals("Expected to not find our object within the scope of the transaction",
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(datasetLoc)));
         /* and commit */
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation + TX_COMMIT_SUFFIX)));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation)));
 
         /* fetch the object-in-tx outside of the tx after it has been committed */
         try (CloseableDataset dataset = getDataset(new HttpGet(datasetLoc))) {
@@ -285,7 +284,7 @@ public class TransactionsIT extends AbstractResourceIT {
         }
 
         /* commit */
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation + TX_COMMIT_SUFFIX)));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation)));
 
         /* it must exist after commit */
         try (final CloseableDataset dataset = getDataset(new HttpGet(serverAddress + objectInTxCommit))) {
@@ -428,7 +427,7 @@ public class TransactionsIT extends AbstractResourceIT {
         }
 
         // Commit the transaction containing deletion
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation + TX_COMMIT_SUFFIX)));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation)));
     }
 
     /**
@@ -483,7 +482,7 @@ public class TransactionsIT extends AbstractResourceIT {
         final String txLocation = createTransaction();
 
         // Commit tx
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation + TX_COMMIT_SUFFIX)));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation)));
 
         // Attempt to create object inside completed tx
         final HttpPost postNew = new HttpPost(serverAddress);
@@ -508,7 +507,7 @@ public class TransactionsIT extends AbstractResourceIT {
         assertEquals(OK.getStatusCode(), getStatus(addTxTo(new HttpGet(newLocation), uuid)));
 
         // Commit tx
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation + TX_COMMIT_SUFFIX)));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation)));
 
         // Retrieve outside of tx
         assertEquals(OK.getStatusCode(), getStatus(new HttpGet(newLocation)));

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/TransactionConstants.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/TransactionConstants.java
@@ -47,7 +47,5 @@ public class TransactionConstants {
 
     public static final String TX_COMMIT_REL = TX_NS + "commitEndpoint";
 
-    public static final String TX_COMMIT_SUFFIX = "/commit";
-
     public static final DateTimeFormatter EXPIRES_RFC_1123_FORMATTER = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 }


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3301

# What does this Pull Request do?
Removes the '/commit' suffix from the Transaction commit API.
The rationale for this is to be aligned with the rest of the transaction API:
- refresh transaction: POST tx-URI
- rollback transaction: DELETE tx-URI
- status of transaction: GET tx-URI

# How should this be tested?
- Integration tests have been updated
- A manual test would be to verify the updated API by performing the following actions
```
# Start transaction
curl -i -XPOST http://localhost:8080/rest/fcr:tx

# Verify "Link" header in response has a "commitEndpoint" without the '/commit' suffix

# Using value found in 'Location' header at ${txURI}, create a resource
curl -H"Atomic-ID: ${txURI}" -XPUT http://localhost:8080/rest/test

# Commit transaction
curl -XPUT ${txURI}
```

# Interested parties
@fcrepo4/committers
