### PR TITLE
Change default versioning policy to autoversioning = true

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -81,8 +81,8 @@ public interface OCFLObjectSession {
 
     /**
      * Overrides the default {@link CommitOption} to use when the session is committed. By default, is
-     * {@link CommitOption#UNVERSIONED} when fcrepo.autoversioning.enabled is false,
-     * and {@link CommitOption#NEW_VERSION} when it is true
+     * {@link CommitOption#NEW_VERSION} when fcrepo.autoversioning.enabled is true,
+     * and {@link CommitOption#UNVERSIONED} when it is false
      *
      * @param commitOption the commit option
      */

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionFactory.java
@@ -47,9 +47,9 @@ public class DefaultOCFLObjectSessionFactory implements OCFLObjectSessionFactory
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultOCFLObjectSessionFactory.class);
 
     /**
-     * Controls whether or changes are committed to new OCFL versions or to a mutable HEAD
+     * Controls whether changes are committed to new OCFL versions or to a mutable HEAD
      */
-    @Value("${fcrepo.autoversioning.enabled:false}")
+    @Value("${fcrepo.autoversioning.enabled:true}")
     private boolean autoVersioningEnabled;
 
     private File ocflStagingDir;

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -496,7 +496,6 @@ public class OCFLPersistentStorageSessionTest {
     public void rollbackFailsWhenAlreadyCommitted() throws Exception {
         mockMappingAndIndex(mintOCFLObjectId(RESOURCE_ID), RESOURCE_ID, ROOT_OBJECT_ID, mapping);
         mockResourceOperation(rdfSourceOperation, RESOURCE_ID);
-        objectSessionFactory.setAutoVersioningEnabled(true);
 
         final PersistentStorageSession session1 = createSession(index, objectSessionFactory);
         //persist the operation


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3302

# What does this Pull Request do?
Changes the default versioning policy from autoversioning = `false`, to `true`.

# How should this be tested?
1. Start Fedora with no versioning configuration
   ```
   java -jar fcrepo-webapp/target/fcrepo-webapp-6.0.0-SNAPSHOT-jetty-console.jar --headless 
   ```
1. Create a resource
   ```
   curl -i -XPUT localhost:8080/rest/test0
   ```
1. Inspect OCFL storage (/tmp/fcrepo.ocfl.storage.root.dir), looking for full OCFL version for the 'test0' resource
1. Stop Fedora
1. Start Fedora with autoversioning disabled:
   ```
   java -Dfcrepo.autoversioning.enabled=false -jar fcrepo-webapp/target/fcrepo-webapp-6.0.0-SNAPSHOT-jetty-console.jar --headless 
   ```
1. Create a resource
   ```
   curl -i -XPUT localhost:8080/rest/test1
   ```
1. Inspect OCFL storage (/tmp/fcrepo.ocfl.storage.root.dir), looking for a mutable-head for the 'test1' resource

# Interested parties
@fcrepo4/committers
