### PR TITLE
Fixes windows build issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
  - "echo $PATH"
  - "export JAVA_OPTS=-Xmx512m"
  - "mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=${MAVEN_VERSION}"
- - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
- - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
+ - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z "$GPG_SECRET_KEYS" ] [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
+ - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
 
 # Default installation command is 
 # mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
@@ -57,7 +57,8 @@ deploy:
    skip_cleanup: true
    on:
      repo: fcrepo4/fcrepo4
-     branch: master
+     branch: master 
+     condition: $TRAVIS_OS_NAME = linux
 
 notifications:
   irc: "irc.freenode.org#fcrepo"

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,13 +1,7 @@
-# only deploy on linux
-if  [ "$TRAVIS_OS_NAME" = "linux" ]
+if [ ! -z "$TRAVIS_TAG" ]
 then
-  if [ ! -z "$TRAVIS_TAG" ]
-  then
-      echo "on a tag -> $TRAVIS_TAG and therefore we will do nothing. Tagged releases are deployed to sonatype manually."
-  else
-      echo "not on a tag -> deploying to sonatype snapshot repo..."
-      ./mvnw clean deploy --settings .travis/settings.xml -DskipTests=true -B -U
-  fi
+    echo "on a tag -> $TRAVIS_TAG and therefore we will do nothing. Tagged releases are deployed to sonatype manually."
 else
-   echo "Ignoring deploy step since we are not on linux. (TRAVIS_OS_NAME=${TRAVIS_OS_NAME})"
+    echo "not on a tag -> deploying to sonatype snapshot repo..."
+    ./mvnw clean deploy --settings .travis/settings.xml -DskipTests=true -B -U
 fi


### PR DESCRIPTION
Reverts some of the changes from the previous commit.
Uses `condition`  directive in the .travis.yml to ensure build does not happen on windows. 
I tested it successfully against the following branch:  https://github.com/fcrepo4/fcrepo4/tree/fix-broken-windows-build.  It succeeded here: https://travis-ci.com/github/fcrepo4/fcrepo4/jobs/329674431

I then simply changed the branch to `master`.