### PR TITLE
Resolve transaction correctly and allow binary descriptions to share …

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -23,6 +23,7 @@ import static org.fcrepo.auth.webac.URIConstants.FOAF_AGENT_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_AUTHENTICATED_AGENT_VALUE;
 import static org.fcrepo.auth.common.HttpHeaderPrincipalProvider.HttpHeaderPrincipal;
 import static org.fcrepo.auth.common.DelegateHeaderPrincipalProvider.DelegatedHeaderPrincipal;
+import static org.fcrepo.auth.webac.WebACFilter.getBaseUri;
 import static org.fcrepo.auth.webac.WebACFilter.identifierConverter;
 import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_ID_HEADER;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -47,13 +48,12 @@ import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.fcrepo.auth.common.ContainerRolesPrincipalProvider.ContainerRolesPrincipal;
+import org.fcrepo.http.commons.session.TransactionProvider;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.RepositoryConfigurationException;
-import org.fcrepo.kernel.api.exception.TransactionClosedException;
-import org.fcrepo.kernel.api.exception.TransactionNotFoundException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
@@ -95,11 +95,8 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
         if (txId == null) {
             return null;
         }
-        try {
-            return transactionManager.get(txId);
-        } catch (final TransactionClosedException | TransactionNotFoundException e) {
-            return null;
-        }
+        final var txProvider = new TransactionProvider(transactionManager, request, getBaseUri(request));
+        return txProvider.provide();
     }
 
     @Override

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
@@ -75,9 +75,11 @@ import org.springframework.mock.web.MockHttpServletResponse;
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class WebACFilterTest {
 
-    private static final String transactionId = "tx-id";
-
     private static final String baseURL = "http://localhost";
+
+    private static final String transactionId = "abc-def";
+
+    private static final String transactionUri = baseURL + "/fcr:tx/" + transactionId;
 
     private static final String testPath = "/testUri";
 
@@ -161,7 +163,7 @@ public class WebACFilterTest {
         request.setPathInfo(testPath);
         request.setRequestURI(testPath);
         request.setContentType(null);
-        request.addHeader(ATOMIC_ID_HEADER, transactionId);
+        request.addHeader(ATOMIC_ID_HEADER, transactionUri);
 
         setField(webacFilter, "transactionManager", mockTransactionManager);
 


### PR DESCRIPTION
…the binaries ACL.

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3323 and https://jira.lyrasis.org/browse/FCREPO-3324

# What does this Pull Request do?
Use the TransactionProvider to get the transaction from the Atomic-ID URI and handle NonRdfSourceDescription and TimeMap containment specially to properly resolve the resource with the ACL.

# How should this be tested?

There are tests to show both scenarios, but essentially.

Before the PR
1. Create a resource and make it read/write able by testuser (but don't use acl:default)
1. Create a transaction (you'll have to do this as fedoraAdmin)
1. Using the transaction ID from above but with testuser POST a new child (this is allowed)
1. Using the transaction ID from above but with testuser POST to the child you made above, this should not be allowed.

After the PR, you'll get a 403 on step 4

Before the PR
1. Create a resource and make it read/writeable by testuser
1. Create a binary as testuser
1. PUT/PATCH the binary's description as testuser (you'll fail)

After the PR, step 3 will succeed. 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
