### PR TITLE
Clean up content-types to remove charset.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -29,7 +29,6 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_LOCATION;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
-import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.created;
@@ -909,7 +908,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected static String getSimpleContentType(final MediaType requestContentType) {
         return requestContentType != null ?
                 requestContentType.getType() + "/" + requestContentType.getSubtype()
-                : APPLICATION_OCTET_STREAM_TYPE.toString();
+                : null;
     }
 
     protected static boolean isRdfContentType(final String contentTypeString) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -408,7 +408,7 @@ public class FedoraLdp extends ContentExposingResource {
         // TODO: Refactor to check preconditions
         //evaluateRequestPreconditions(request, servletResponse, resource, transaction);
 
-        final var providedContentType = requestContentType != null ? requestContentType.toString() : null;
+        final var providedContentType = getSimpleContentType(requestContentType);
 
         boolean created = false;
 
@@ -584,7 +584,7 @@ public class FedoraLdp extends ContentExposingResource {
 
         final FedoraId fedoraId = identifierConverter().pathToInternalId(externalPath());
         final FedoraId newFedoraId = mintNewPid(fedoraId, slug);
-        final var providedContentType = requestContentType != null ? requestContentType.toString() : null;
+        final var providedContentType = getSimpleContentType(requestContentType);
 
         if (isBinary(interactionModel,
                      providedContentType,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3312

# What does this Pull Request do?
Properly removes any charset parts of Content-type header do make comparisons cleaner.

# How should this be tested?

There is an integrated test, but essentially do a POST like
```
curl -ufedoraAdmin:fedoraAdmin -XPOST -H"Slug: object1" --data "<> a <http://example.org/Thing>" -H"Content-type: text/turtle" http://localhost:8080/rest
```
And one like
```
curl -ufedoraAdmin:fedoraAdmin -XPOST -H"Slug: object2" --data "<> a <http://example.org/Thing>" -H"Content-type: text/turtle;charset=utf-8" http://localhost:8080/rest
```
Then `GET` both the resources and notice that the second one (object2) is a NonRdfSource instead of a BasicContainer.

This PR should fix that.

# Interested parties
@fcrepo4/committers
