### PR TITLE
Purge resources and fix FedoraLdpTests

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -1090,14 +1090,14 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
             final FedoraResource originalResource;
             if (fedoraId.isMemento()) {
-                 originalResource = fedoraResource.getOriginalResource();
+                originalResource = fedoraResource.getOriginalResource();
             } else {
                 originalResource = fedoraResource;
             }
 
             if (originalResource instanceof Tombstone) {
                 final String tombstoneUri = identifierConverter().toExternalId(
-                            fedoraResource.getFedoraId().resolve(FCR_TOMBSTONE).getFullId()
+                            originalResource.getFedoraId().resolve(FCR_TOMBSTONE).getFullId()
                     );
                 throw new TombstoneException(fedoraResource, tombstoneUri);
             }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -1088,7 +1088,14 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         try {
             final FedoraResource fedoraResource = resourceFactory.getResource(transaction(), fedoraId);
 
-            if (fedoraResource instanceof Tombstone) {
+            final FedoraResource originalResource;
+            if (fedoraId.isMemento()) {
+                 originalResource = fedoraResource.getOriginalResource();
+            } else {
+                originalResource = fedoraResource;
+            }
+
+            if (originalResource instanceof Tombstone) {
                 final String tombstoneUri = identifierConverter().toExternalId(
                             fedoraResource.getFedoraId().resolve(FCR_TOMBSTONE).getFullId()
                     );

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -307,10 +307,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
         if (returnPreference.getValue().equals("minimal")) {
             streams.add(resource.getTriples());
-            //streams.add(getTriples(resource, MINIMAL));
             if (ldpPreferences.prefersServerManaged())  {
                 streams.add(this.managedPropertiesService.get(resource));
-                //TOOD Implement minimal return preference
+                //TODO Implement minimal return preference (https://jira.lyrasis.org/browse/FCREPO-3334)
                 //streams.add(getTriples(resource, MINIMAL));
             }
         } else {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -502,7 +502,8 @@ public class FedoraLdp extends ContentExposingResource {
         }
 
         if (resource() instanceof Binary) {
-            throw new BadRequestException(resource().getPath() + " is not a valid object to receive a PATCH");
+            throw new BadRequestException(resource().getFedoraId().getFullIdPath() +
+                    " is not a valid object to receive a PATCH");
         }
 
         try {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
@@ -28,11 +28,16 @@ import org.springframework.context.annotation.Scope;
 
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
 import static javax.ws.rs.core.Response.noContent;
+import static javax.ws.rs.core.HttpHeaders.ALLOW;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -80,12 +85,33 @@ public class FedoraTombstones extends ContentExposingResource {
         return noContent().build();
     }
 
+    /*
+     * These methods are disallowed, but need to exist here or the path gets caught by the FedoraLdp path matcher.
+     */
+    @GET
+    public Response get() {
+        return methodNotAllowed();
+    }
+
+    @POST
+    public Response post() {
+        return methodNotAllowed();
+    }
+    @PUT
+    public Response put() {
+        return methodNotAllowed();
+    }
+
+    @OPTIONS
+    public Response options() {
+        return Response.ok().header(ALLOW, "DELETE").build();
+    }
+
     @Override
     protected Tombstone resource() {
         final FedoraId resourceId = identifierConverter().pathToInternalId(externalPath);
         try {
-            final Tombstone resource = resourceFactory.getResource(transaction(), resourceId, Tombstone.class);
-            return resource;
+            return resourceFactory.getResource(transaction(), resourceId, Tombstone.class);
         } catch (final PathNotFoundException e) {
             throw new PathNotFoundRuntimeException(e);
         }
@@ -96,4 +122,7 @@ public class FedoraTombstones extends ContentExposingResource {
         return null;
     }
 
+    private Response methodNotAllowed() {
+        return Response.status(Response.Status.METHOD_NOT_ALLOWED).header(ALLOW, "DELETE").build();
+    }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -113,23 +113,24 @@ public class HttpRdfService {
 
         while (stmtIterator.hasNext()) {
             final Statement stmt = stmtIterator.nextStatement();
-            final String originalSubj = stmt.getSubject().getURI();
-            final String subj = idTranslator.inExternalDomain(originalSubj) ?
-                idTranslator.toInternalId(originalSubj) : originalSubj;
+            if (stmt.getSubject().isURIResource()) {
+                final String originalSubj = stmt.getSubject().getURI();
+                final String subj = idTranslator.inExternalDomain(originalSubj) ?
+                        idTranslator.toInternalId(originalSubj) : originalSubj;
 
-            RDFNode obj = stmt.getObject();
-            if (stmt.getObject().isResource()) {
-                final String objString = stmt.getObject().asResource().getURI();
-                if (idTranslator.inExternalDomain(objString)) {
-                    obj = model.getResource(idTranslator.toInternalId(objString));
+                RDFNode obj = stmt.getObject();
+                if (stmt.getObject().isResource()) {
+                    final String objString = stmt.getObject().asResource().getURI();
+                    if (idTranslator.inExternalDomain(objString)) {
+                        obj = model.getResource(idTranslator.toInternalId(objString));
+                    }
                 }
-            }
 
-            if (!subj.equals(originalSubj) || !obj.equals(stmt.getObject())) {
-                insertStatements.add(new StatementImpl(model.getResource(subj),
-                    stmt.getPredicate(), obj));
+                if (!subj.equals(originalSubj) || !obj.equals(stmt.getObject())) {
+                    insertStatements.add(new StatementImpl(model.getResource(subj), stmt.getPredicate(), obj));
 
-                stmtIterator.remove();
+                    stmtIterator.remove();
+                }
             }
         }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -131,6 +131,8 @@ public class HttpRdfService {
 
                     stmtIterator.remove();
                 }
+            } else {
+                log.debug("Subject is not a URI resource, skipping");
             }
         }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -132,7 +132,7 @@ public class HttpRdfService {
                     stmtIterator.remove();
                 }
             } else {
-                log.debug("Subject is not a URI resource, skipping");
+                log.debug("Subject {} is not a URI resource, skipping", stmt.getSubject());
             }
         }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -243,12 +243,7 @@ public class FedoraLdpTest {
     @Mock
     private Principal principal;
 
-    private HttpRdfService httpRdfService;
-
-    private FedoraId fedoraID;
-
     private static final Logger log = getLogger(FedoraLdpTest.class);
-
 
     @Before
     public void setUp() {
@@ -256,7 +251,7 @@ public class FedoraLdpTest {
 
         mockResponse = new MockHttpServletResponse();
 
-        httpRdfService = new HttpRdfService();
+        final HttpRdfService httpRdfService = new HttpRdfService();
 
         setField(testObj, "request", mockRequest);
         setField(testObj, "servletResponse", mockResponse);
@@ -322,7 +317,6 @@ public class FedoraLdpTest {
             return null;
         }).when(preferTag).addResponseHeaders(mockResponse);
 
-        fedoraID = FedoraId.create(mockContainer.getId());
     }
 
     private FedoraResource setResource(final Class<? extends FedoraResource> klass) {
@@ -360,7 +354,6 @@ public class FedoraLdpTest {
         when(containmentTriplesService.get(any(), eq(mockResource))).thenAnswer(containmentAnswer);
 
         doReturn(mockResource).when(testObj).resource();
-        when(mockResource.getPath()).thenReturn(path);
         when(mockResource.getFedoraId()).thenReturn(FedoraId.create(path));
         when(mockResource.getEtagValue()).thenReturn("");
         when(mockResource.getStateToken()).thenReturn("");
@@ -819,7 +812,7 @@ public class FedoraLdpTest {
         assertShouldBeAnLDPNonRDFSource();
         assertShouldNotAdvertiseAcceptPatchFlavors();
         assertShouldContainLinkToBinaryDescription();
-        assertTrue(IOUtils.toString((InputStream) actual.getEntity(), UTF_8).equals("xyz"));
+        assertEquals("xyz", IOUtils.toString((InputStream) actual.getEntity(), UTF_8));
     }
 
     private void assertShouldBeAnLDPNonRDFSource() {
@@ -876,7 +869,6 @@ public class FedoraLdpTest {
     }
 
     @Test
-    @SuppressWarnings({"resource", "unchecked"})
     public void testGetWithBinaryDescription()
             throws IOException, UnsupportedAlgorithmException {
 
@@ -1191,7 +1183,6 @@ public class FedoraLdpTest {
     public void testCreateNewBinaryWithChecksumSHA() throws MalformedRdfException,
            InvalidChecksumException, IOException, UnsupportedAlgorithmException, PathNotFoundException {
 
-        //setResource(Container.class);
         final var finalId = pathId.resolve("b");
         when(resourceFactory.getResource(any(), eq(finalId))).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {
@@ -1220,7 +1211,6 @@ public class FedoraLdpTest {
     public void testCreateNewBinaryWithChecksumSHA256() throws MalformedRdfException,
         InvalidChecksumException, IOException, UnsupportedAlgorithmException, PathNotFoundException {
 
-        //setResource(Container.class);
         final var finalId = pathId.resolve("b");
         when(resourceFactory.getResource(any(), eq(finalId))).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {
@@ -1249,7 +1239,6 @@ public class FedoraLdpTest {
     public void testCreateNewBinaryWithChecksumMD5() throws MalformedRdfException,
             InvalidChecksumException, IOException, UnsupportedAlgorithmException, PathNotFoundException {
 
-        //setResource(Container.class);
         final var finalId = pathId.resolve("b");
         when(resourceFactory.getResource(any(), eq(finalId))).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {
@@ -1278,7 +1267,6 @@ public class FedoraLdpTest {
     public void testCreateNewBinaryWithChecksumSHAandMD5() throws MalformedRdfException,
            InvalidChecksumException, IOException, UnsupportedAlgorithmException, PathNotFoundException {
 
-        //setResource(Container.class);
         final var finalId = pathId.resolve("b");
         when(resourceFactory.getResource(any(), eq(finalId))).thenReturn(mockBinary);
         try (final InputStream content = toInputStream("x", UTF_8)) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraTombstonesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraTombstonesTest.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 
 import static org.fcrepo.http.commons.test.util.TestHelpers.getUriInfoImpl;
@@ -93,7 +94,7 @@ public class FedoraTombstonesTest {
         setField(testObj, "request", mockRequest);
         setField(testObj, "context", mockServletContext);
 
-        when(resourceFactory.getResource(any(), eq(fedoraId), eq(Tombstone.class))).thenReturn(mockTombstone);
+        when(resourceFactory.getResource(any(), eq(fedoraId))).thenReturn(mockTombstone);
         when(mockTombstone.getDeletedObject()).thenReturn(mockDeletedObj);
     }
 
@@ -103,5 +104,15 @@ public class FedoraTombstonesTest {
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
         verify(purgeResourceService).perform(mockTransaction, mockDeletedObj, null);
         verify(mockTransaction).commitIfShortLived();
+    }
+
+    /**
+     * If a resource is not deleted, it doesn't return a TombstoneImpl so the fcr:tombstone URI should return 404.
+     */
+    @Test
+    public void testNotYetDeleted() throws Exception {
+        when(resourceFactory.getResource(any(), eq(fedoraId))).thenReturn(mockDeletedObj);
+        final Response actual = testObj.delete();
+        assertEquals(NOT_FOUND.getStatusCode(), actual.getStatus());
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -37,7 +37,6 @@ import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NOT_MODIFIED;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -950,47 +949,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteObjMethod(id)));
         assertDeleted(id);
         assertDeleted(id + "/foo");
-    }
-
-    @Test
-    public void testDeleteObjectAndTombstone() throws IOException {
-        final String id = getRandomUniqueId();
-        createObjectAndClose(id);
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(serverAddress + id)));
-        assertDeleted(id);
-        final HttpGet httpGet = getObjMethod(id);
-        final Link tombstone;
-        try (final CloseableHttpResponse response = execute(httpGet)) {
-            tombstone = Link.valueOf(response.getFirstHeader(LINK).getValue());
-        }
-        assertEquals("hasTombstone", tombstone.getRel());
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(tombstone.getUri())));
-        assertEquals(NOT_FOUND.getStatusCode(), getStatus(httpGet));
-    }
-
-    @Test
-    public void testTrailingSlashTombstoneLink() throws IOException {
-        final String id = getRandomUniqueId();
-        final URI expectedTombstone = URI.create(serverAddress + id + "/fcr:tombstone");
-        createObjectAndClose(id);
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(serverAddress + id)));
-        assertDeleted(id);
-        final HttpGet get1 = getObjMethod(id);
-        final Link tombstone;
-        try (final CloseableHttpResponse response = execute(get1)) {
-            tombstone = Link.valueOf(response.getFirstHeader(LINK).getValue());
-        }
-        assertEquals("hasTombstone", tombstone.getRel());
-        assertEquals(expectedTombstone, tombstone.getUri());
-        // Now with a trailing slash
-        final HttpGet get2 = getObjMethod(id + "/");
-        final Link tombstone2;
-        try (final CloseableHttpResponse response = execute(get2)) {
-            tombstone2 = Link.valueOf(response.getFirstHeader(LINK).getValue());
-        }
-        assertEquals("hasTombstone", tombstone2.getRel());
-        assertEquals(expectedTombstone, tombstone2.getUri());
-
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -943,9 +943,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteHierarchy() {
         final String id = getRandomUniqueId();
+        createObjectAndClose(id);
         createObjectAndClose(id + "/foo");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteObjMethod(id)));
         assertDeleted(id);
@@ -953,7 +953,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDeleteObjectAndTombstone() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTombstonesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTombstonesIT.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static org.junit.Assert.assertEquals;
+
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.GONE;
+import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.OK;
+
+import javax.ws.rs.core.Link;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+
+import org.apache.commons.codec.Charsets;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+
+/**
+ * Tests related to tombstone stuff.
+ */
+public class FedoraTombstonesIT extends AbstractResourceIT {
+
+    private Link getTombstoneLink(final HttpResponse res) {
+        final Collection<String> headers = getLinkHeaders(res);
+        return headers.stream().map(Link::valueOf).filter(t -> t.getRel().equals("hasTombstone")).findFirst()
+                .orElse(null);
+    }
+
+    private Link getTombstoneLink(final HttpUriRequest req) throws IOException {
+        try (final CloseableHttpResponse response = execute(req)) {
+            return getTombstoneLink(response);
+        }
+    }
+
+    @Test
+    public void testDeleteObjectAndTombstone() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(serverAddress + id)));
+        assertDeleted(id);
+        final HttpGet httpGet = getObjMethod(id);
+        final Link tombstone = getTombstoneLink(httpGet);
+        assertEquals("hasTombstone", tombstone.getRel());
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(tombstone.getUri())));
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(httpGet));
+    }
+
+    @Test
+    public void testTrailingSlashTombstoneLink() throws IOException {
+        final String id = getRandomUniqueId();
+        final URI expectedTombstone = URI.create(serverAddress + id + "/fcr:tombstone");
+        createObjectAndClose(id);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(serverAddress + id)));
+        assertDeleted(id);
+        final HttpGet get1 = getObjMethod(id);
+        final Link tombstone = getTombstoneLink(get1);
+        assertEquals("hasTombstone", tombstone.getRel());
+        assertEquals(expectedTombstone, tombstone.getUri());
+        // Now with a trailing slash
+        final HttpGet get2 = getObjMethod(id + "/");
+        final Link tombstone2 = getTombstoneLink(get2);
+        assertEquals("hasTombstone", tombstone2.getRel());
+        assertEquals(expectedTombstone, tombstone2.getUri());
+    }
+
+    @Test
+    public void testDisallowedMethods() throws Exception {
+        final String id = getRandomUniqueId();
+        final HttpPut putMethod = putObjMethod(id);
+        final HttpEntity body = new StringEntity("<> <http://example.org#title> 'a title'", Charsets.UTF_8);
+        putMethod.setEntity(body);
+        putMethod.setHeader(CONTENT_TYPE, "text/turtle");
+        assertEquals(CREATED.getStatusCode(), getStatus(putMethod));
+
+        final HttpGet getContainer = getObjMethod(id);
+        assertEquals(OK.getStatusCode(), getStatus(getContainer));
+
+        final HttpDelete deleteContainer = deleteObjMethod(id);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteContainer));
+
+        final HttpGet getContainer2 = getObjMethod(id);
+        final Link tombstoneUri;
+        try (final CloseableHttpResponse res = execute(getContainer2)) {
+            assertEquals(GONE.getStatusCode(), getStatus(res));
+            tombstoneUri = getTombstoneLink(res);
+        }
+
+        final HttpGet getTombstone = new HttpGet(tombstoneUri.getUri());
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), getStatus(getTombstone));
+
+        final HttpPut putTombstone = new HttpPut(tombstoneUri.getUri());
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), getStatus(putTombstone));
+
+        final HttpPost postTombstone = new HttpPost(tombstoneUri.getUri());
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), getStatus(postTombstone));
+
+        final HttpDelete deleteTombstone = new HttpDelete(tombstoneUri.getUri());
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteTombstone));
+    }
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api;
 
+import javax.annotation.Nonnull;
+
 import java.util.stream.Stream;
 
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -40,6 +42,16 @@ public interface ContainmentIndex {
     Stream<String> getContains(Transaction tx, FedoraResource fedoraResource);
 
     /**
+     * Return a stream of fedora identifiers contained by the specified fedora resource that have deleted
+     * relationships.
+     *
+     * @param tx The transaction.  If no transaction, null is okay.
+     * @param fedoraResource The containing fedora resource
+     * @return A stream of contained identifiers
+     */
+    Stream<String> getContainsDeleted(Transaction tx, FedoraResource fedoraResource);
+
+    /**
      * Return the ID of the containing resource for resourceID.
      * @param txID The transaction. If no transaction, null is okay.
      * @param resource The FedoraId of the resource to find the containing resource for.
@@ -48,29 +60,47 @@ public interface ContainmentIndex {
     String getContainedBy(String txID, final FedoraId resource);
 
     /**
-     * Remove a contained by relation between the child resource and its parent.
+     * Mark a contained by relation between the child resource and its parent as deleted.
      *
-     * @param txID The transaction ID.  If no transaction, null is okay.
+     * @param txID The transaction ID.
      * @param parent The containing resource fedoraID.
      * @param child The contained resource fedoraID.
      */
-    void removeContainedBy(final String txID, final FedoraId parent, final FedoraId child);
+    void removeContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child);
 
     /**
-     * Remove all relationships to the specified resource.
-     * @param txID The transaction ID. If no transaction, null is okay.
+     * Mark all relationships to the specified resource as deleted.
+     *
+     * @param txID The transaction ID.
      * @param resource The FedoraId of resource to remove.
      */
-    void removeResource(final String txID, final FedoraId resource);
+    void removeResource(@Nonnull final String txID, final FedoraId resource);
+
+    /**
+     * Remove a contained by relation between the child resource and its parent.
+     *
+     * @param txID The transaction ID.
+     * @param parent The containing resource fedoraID.
+     * @param child The contained resource fedoraID.
+     */
+    void purgeContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child);
+
+    /**
+     * Remove all relationships to the specified resource as deleted.
+     *
+     * @param txID The transaction ID.
+     * @param resource The FedoraId of resource to remove.
+     */
+    void purgeResource(@Nonnull final String txID, final FedoraId resource);
 
     /**
      * Add a contained by relation between the child resource and its parent.
      *
-     * @param txID The transaction ID.  If no transaction, null is okay.
+     * @param txID The transaction ID.
      * @param parent The containing resource fedoraID.
      * @param child The contained resource fedoraID.
      */
-    void addContainedBy(final String txID, final FedoraId parent, final FedoraId child);
+    void addContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child);
 
     /**
      * Commit the changes made in the transaction.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -86,14 +86,6 @@ public interface ContainmentIndex {
     void purgeContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child);
 
     /**
-     * Remove all relationships to the specified resource as deleted.
-     *
-     * @param txID The transaction ID.
-     * @param resource The FedoraId of resource to remove.
-     */
-    void purgeResource(@Nonnull final String txID, final FedoraId resource);
-
-    /**
      * Add a contained by relation between the child resource and its parent.
      *
      * @param txID The transaction ID.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -77,13 +77,12 @@ public interface ContainmentIndex {
     void removeResource(@Nonnull final String txID, final FedoraId resource);
 
     /**
-     * Remove a contained by relation between the child resource and its parent.
+     * Remove all relationships to the specified resource.
      *
      * @param txID The transaction ID.
-     * @param parent The containing resource fedoraID.
-     * @param child The contained resource fedoraID.
+     * @param resource The FedoraId of resource to remove.
      */
-    void purgeContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child);
+    void purgeResource(@Nonnull final String txID, final FedoraId resource);
 
     /**
      * Add a contained by relation between the child resource and its parent.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Tombstone.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Tombstone.java
@@ -22,4 +22,10 @@ package org.fcrepo.kernel.api.models;
  * @since 10/16/14
  */
 public interface Tombstone extends FedoraResource {
+
+    /**
+     * Return the object this tombstone is for.
+     * @return the original deleted resource.
+     */
+    public FedoraResource getDeletedObject();
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/observer/EventType.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/observer/EventType.java
@@ -31,7 +31,8 @@ public enum EventType {
     RESOURCE_DELETION("delete resource", "Delete"),
     RESOURCE_MODIFICATION("update resource", "Update"),
     RESOURCE_RELOCATION("move resource", "Move"),
-    INBOUND_REFERENCE("refer to resource", "Follow");
+    INBOUND_REFERENCE("refer to resource", "Follow"),
+    RESOURCE_PURGE("remove resource tombstone", "Purge");
 
     private final String eventName;
     private final String eventType;

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/DeleteResourceOperationFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/DeleteResourceOperationFactory.java
@@ -32,4 +32,12 @@ public interface DeleteResourceOperationFactory extends ResourceOperationFactory
      * @return new builder
      */
     ResourceOperationBuilder deleteBuilder(String rescId);
+
+    /**
+     * Get a builder for an operation to purge a deleted resource.
+     *
+     * @param rescId id of the resource to purge
+     * @return new builder
+     */
+    ResourceOperationBuilder purgeBuilder(String rescId);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/PurgeResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/PurgeResourceService.java
@@ -15,14 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.operations;
+package org.fcrepo.kernel.api.services;
 
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.models.FedoraResource;
 
 /**
- * Specifies the type of modification action represented by a resource operation.
+ * Service to permanently remove a resource from the repository.
  *
- * @author bbpennel
+ * @author whikloj
  */
-public enum ResourceOperationType {
-    UPDATE, CREATE, DELETE, PURGE
+public interface PurgeResourceService {
+    /**
+     * Purges the specified resource
+     *
+     * @param tx the transaction associated with the operation
+     * @param fedoraResource The Fedora resource to delete
+     * @param userPrincipal the principal of the user performing the operation
+     */
+    void perform(final Transaction tx, final FedoraResource fedoraResource, final String userPrincipal);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/PurgeResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/PurgeResourceService.java
@@ -29,9 +29,9 @@ public interface PurgeResourceService {
     /**
      * Purges the specified resource
      *
-     * @param tx the transaction associated with the operation
-     * @param fedoraResource The Fedora resource to delete
-     * @param userPrincipal the principal of the user performing the operation
+     * @param tx the transaction associated with the operation.
+     * @param fedoraResource The Fedora resource to purge.
+     * @param userPrincipal the principal of the user performing the operation.
      */
     void perform(final Transaction tx, final FedoraResource fedoraResource, final String userPrincipal);
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -34,6 +34,7 @@ import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.sql.DataSource;
@@ -73,9 +74,18 @@ public class ContainmentIndexImpl implements ContainmentIndex {
 
     private static final String OPERATION_COLUMN = "operation";
 
-    private static final String SELECT_CHILDREN = "SELECT " + FEDORA_ID_COLUMN +
-            " FROM " + RESOURCES_TABLE + " WHERE " + PARENT_COLUMN + " = :parent";
+    private static final String IS_DELETED_COLUMN = "is_deleted";
 
+    /*
+     * Select children of a resource that are not marked as deleted.
+     */
+    private static final String SELECT_CHILDREN = "SELECT " + FEDORA_ID_COLUMN +
+            " FROM " + RESOURCES_TABLE + " WHERE " + PARENT_COLUMN + " = :parent AND " + IS_DELETED_COLUMN + " = FALSE";
+
+    /*
+     * Select children of a parent from resources table and from the transaction table with an 'add' operation,
+     * but exclude any records that also exist in the transaction table with a 'delete' operation.
+     */
     private static final String SELECT_CHILDREN_IN_TRANSACTION = "SELECT x." + FEDORA_ID_COLUMN + " FROM" +
             " (SELECT " + FEDORA_ID_COLUMN + " FROM " + RESOURCES_TABLE + " WHERE " + PARENT_COLUMN + " = :parent" +
             " UNION SELECT " + FEDORA_ID_COLUMN + " FROM " + TRANSACTION_OPERATIONS_TABLE +
@@ -86,57 +96,142 @@ public class ContainmentIndexImpl implements ContainmentIndex {
             " WHERE " + PARENT_COLUMN + " = :parent AND " + FEDORA_ID_COLUMN + " = x." + FEDORA_ID_COLUMN +
             " AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'delete')";
 
-    private static final String INSERT_CHILD = "INSERT INTO " + RESOURCES_TABLE +
-            " (" + FEDORA_ID_COLUMN + ", " + PARENT_COLUMN + ") VALUES (:child, :parent)";
+    /*
+     * Select all children of a resource that are marked for deletion.
+     */
+    private static final String SELECT_DELETED_CHILDREN = "SELECT " + FEDORA_ID_COLUMN +
+            " FROM " + RESOURCES_TABLE + " WHERE " + PARENT_COLUMN + " = :parent AND " + IS_DELETED_COLUMN + " = TRUE";
 
-    private static final String DELETE_CHILD = "DELETE FROM " + RESOURCES_TABLE +
-            " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + PARENT_COLUMN + " = :parent";
+    /*
+     * Select children of a resource plus children 'add'ed in the non-committed transaction, but excluding any
+     * 'delete'd in the non-committed transaction.
+     */
+    private static final String SELECT_DELETED_CHILDREN_IN_TRANSACTION = "SELECT x." + FEDORA_ID_COLUMN +
+            " FROM " + TRANSACTION_OPERATIONS_TABLE + "(SELECT " + FEDORA_ID_COLUMN + " FROM " + RESOURCES_TABLE +
+            " WHERE " + PARENT_COLUMN + " = :parent UNION SELECT " + FEDORA_ID_COLUMN + " FROM " +
+            TRANSACTION_OPERATIONS_TABLE + " WHERE " + PARENT_COLUMN + " = :parent AND " + TRANSACTION_ID_COLUMN +
+            " = :transactionId AND " + OPERATION_COLUMN + " = 'add') x" +
+            " WHERE NOT EXISTS " +
+            "(SELECT 1 FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " + PARENT_COLUMN + " = :parent AND " +
+            FEDORA_ID_COLUMN + " = x." + FEDORA_ID_COLUMN + " AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " +
+            OPERATION_COLUMN + " = 'delete')";
 
+    /*
+     * Select children of a resource purged in a non-committed transaction.
+     */
+    private static final String SELECT_PURGED_CHILDREN = "SELECT " + FEDORA_ID_COLUMN +
+            " FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + PARENT_COLUMN + " = :parent AND " +
+            TRANSACTION_ID_COLUMN + " = :transactionId AND " +
+            OPERATION_COLUMN + " = 'purge'";
+
+    /*
+     * Insert a parent child relationship to the transaction operation table.
+     */
     private static final String INSERT_CHILD_IN_TRANSACTION = "INSERT INTO " + TRANSACTION_OPERATIONS_TABLE +
             " ( " + PARENT_COLUMN + ", " + FEDORA_ID_COLUMN + ", " + TRANSACTION_ID_COLUMN + ", " + OPERATION_COLUMN +
             " ) VALUES (:parent, :child, :transactionId, 'add')";
 
+    /*
+     * Remove an insert row from the transaction operation table for this parent child relationship.
+     */
     private static final String UNDO_INSERT_CHILD_IN_TRANSACTION = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE +
             " WHERE " + PARENT_COLUMN + " = :parent AND " + FEDORA_ID_COLUMN + " = :child AND " + TRANSACTION_ID_COLUMN
             + " = :transactionId AND " + OPERATION_COLUMN + " = 'add'";
 
+    /*
+     * Add a parent child relationship deletion to the transaction operation table.
+     */
     private static final String DELETE_CHILD_IN_TRANSACTION = "INSERT INTO " + TRANSACTION_OPERATIONS_TABLE +
             " ( " + PARENT_COLUMN + ", " + FEDORA_ID_COLUMN + ", " + TRANSACTION_ID_COLUMN + ", " + OPERATION_COLUMN +
             " ) VALUES (:parent, :child, :transactionId, 'delete')";
 
+    /*
+     * Add a parent child relationship purge to the transaction operation table.
+     */
+    private static final String PURGE_CHILD_IN_TRANSACTION = "INSERT INTO " + TRANSACTION_OPERATIONS_TABLE +
+            " ( " + PARENT_COLUMN + ", " + FEDORA_ID_COLUMN + ", " + TRANSACTION_ID_COLUMN + ", " + OPERATION_COLUMN +
+            " ) VALUES (:parent, :child, :transactionId, 'purge')";
+
+    /*
+     * Remove a mark as deleted row from the transaction operation table for this parent child relationship.
+     */
     private static final String UNDO_DELETE_CHILD_IN_TRANSACTION = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE +
             " WHERE " + PARENT_COLUMN + " = :parent AND " + FEDORA_ID_COLUMN + " = :child AND " + TRANSACTION_ID_COLUMN
             + " = :transactionId AND " + OPERATION_COLUMN + " = 'delete'";
 
+    /*
+     * Remove a purge row from the transaction operation table for this parent child relationship.
+     */
+    private static final String UNDO_PURGE_CHILD_IN_TRANSACTION = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + PARENT_COLUMN + " = :parent AND " + FEDORA_ID_COLUMN + " = :child AND " + TRANSACTION_ID_COLUMN
+            + " = :transactionId AND " + OPERATION_COLUMN + " = 'purge'";
+
+    /*
+     * Is this parent child relationship being added in this transaction?
+     */
     private static final String IS_CHILD_ADDED_IN_TRANSACTION = "SELECT TRUE FROM " + TRANSACTION_OPERATIONS_TABLE +
             " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + PARENT_COLUMN + " = :parent" +
             " AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'add'";
 
+    /*
+     * Is this parent child relationship being marked for deletion in this transaction?
+     */
     private static final String IS_CHILD_DELETED_IN_TRANSACTION = "SELECT TRUE FROM " + TRANSACTION_OPERATIONS_TABLE +
             " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + PARENT_COLUMN + " = :parent" +
             " AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'delete'";
 
-    private static final String ROLLBACK_TRANSACTION = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " +
+    /*
+     * Is this parent child relationship being purged in this transaction?
+     */
+    private static final String IS_CHILD_PURGED_IN_TRANSACTION = "SELECT TRUE FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + PARENT_COLUMN + " = :parent" +
+            " AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'purge'";
+
+   /*
+    * Delete all rows from the transaction operation table for this transaction.
+    */
+    private static final String DELETE_ENTIRE_TRANSACTION = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " +
             TRANSACTION_ID_COLUMN + " = :transactionId";
 
+    /*
+     * Add to the main table all rows from the transaction operation table marked 'add' for this transaction.
+     */
     private static final String COMMIT_ADD_RECORDS = "INSERT INTO " + RESOURCES_TABLE + " ( " + FEDORA_ID_COLUMN + ", "
             + PARENT_COLUMN + " ) SELECT " + FEDORA_ID_COLUMN + ", " + PARENT_COLUMN + " FROM " +
             TRANSACTION_OPERATIONS_TABLE + " WHERE " + TRANSACTION_ID_COLUMN + " = :transactionId AND " +
             OPERATION_COLUMN + " = 'add'";
 
-    private static final String COMMIT_DELETE_RECORDS = "DELETE FROM " + RESOURCES_TABLE + " WHERE " +
+    /*
+     * Mark deleted in the main table all rows from transaction operation table marked 'delete' for this transaction.
+     */
+    private static final String COMMIT_DELETE_RECORDS = "UPDATE " + RESOURCES_TABLE + " r " +
+            "SET r." + IS_DELETED_COLUMN + " = TRUE WHERE EXISTS " +
+            "(SELECT * from " + TRANSACTION_OPERATIONS_TABLE + " t WHERE " +
+            "r." + FEDORA_ID_COLUMN + " = " + "t." + FEDORA_ID_COLUMN + " AND " +
+            "t." + TRANSACTION_ID_COLUMN + " = :transactionId AND t." +  OPERATION_COLUMN + " = 'delete' AND " +
+            "r." + PARENT_COLUMN + " = t." + PARENT_COLUMN + ")";
+
+    /*
+     * Remove from the main table all rows from transaction operation table marked 'purge' for this transaction.
+     */
+    private static final String COMMIT_PURGE_RECORDS = "DELETE FROM " + RESOURCES_TABLE + " WHERE " +
             "EXISTS (SELECT * FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " +
-            TRANSACTION_ID_COLUMN + " = :transactionId AND " +  OPERATION_COLUMN + " = 'delete' AND " +
+            TRANSACTION_ID_COLUMN + " = :transactionId AND " +  OPERATION_COLUMN + " = 'purge' AND " +
             RESOURCES_TABLE + "." + FEDORA_ID_COLUMN + " = " + TRANSACTION_OPERATIONS_TABLE + "." + FEDORA_ID_COLUMN +
             " AND " + RESOURCES_TABLE + "." + PARENT_COLUMN + " = " + TRANSACTION_OPERATIONS_TABLE + "." +
             PARENT_COLUMN + ")";
 
-    private static final String COMMIT_CLEANUP = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " +
-            TRANSACTION_ID_COLUMN + " = :transactionId";
-
+    /*
+     * Query if a resource exists in the main table and is not deleted.
+     */
     private static final String RESOURCE_EXISTS = "SELECT " + FEDORA_ID_COLUMN + " FROM " + RESOURCES_TABLE +
-            " WHERE " + FEDORA_ID_COLUMN + " = :child";
+            " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + IS_DELETED_COLUMN + " = FALSE";
 
+    /*
+     * Resource exists as a record in the transaction operations table with an 'add' operation and not also
+     * exists as a 'delete' operation.
+     */
     private static final String RESOURCE_EXISTS_IN_TRANSACTION = "SELECT " + FEDORA_ID_COLUMN + " FROM" +
             " (SELECT " + FEDORA_ID_COLUMN + " FROM " + RESOURCES_TABLE + " WHERE " + FEDORA_ID_COLUMN + " = :child" +
             " UNION SELECT " + FEDORA_ID_COLUMN + " FROM " + TRANSACTION_OPERATIONS_TABLE +
@@ -147,9 +242,16 @@ public class ContainmentIndexImpl implements ContainmentIndex {
             " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + TRANSACTION_ID_COLUMN + " = :transactionId" +
             " AND " + OPERATION_COLUMN + " = 'delete')";
 
+    /*
+     * Get the parent ID for this resource from the main table if not deleted.
+     */
     private static final String PARENT_EXISTS = "SELECT " + PARENT_COLUMN + " FROM " + RESOURCES_TABLE +
-            " WHERE " + FEDORA_ID_COLUMN + " = :child";
+            " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + IS_DELETED_COLUMN + " = FALSE";
 
+    /*
+     * Get the parent ID for this resource from the operations table for an 'add' operation in this transaction, but
+     * exclude any 'delete' operations for this resource in this transaction.
+     */
     private static final String PARENT_EXISTS_IN_TRANSACTION= "SELECT x." + PARENT_COLUMN + " FROM" +
             " (SELECT " + PARENT_COLUMN + " FROM " + RESOURCES_TABLE + " WHERE " + FEDORA_ID_COLUMN + " = :child" +
             " UNION SELECT " + PARENT_COLUMN + " FROM " + TRANSACTION_OPERATIONS_TABLE +
@@ -160,13 +262,16 @@ public class ContainmentIndexImpl implements ContainmentIndex {
             " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + TRANSACTION_ID_COLUMN + " = :transactionId" +
             " AND " + OPERATION_COLUMN + " = 'delete')";
 
-    private static final String DELETE_ALL_RESOURCE = "DELETE FROM " + RESOURCES_TABLE + " WHERE " + FEDORA_ID_COLUMN +
-            " = :child";
-
+    /*
+     * Does this resource exist in the transaction operation table for an 'add' record.
+     */
     private static final String IS_CHILD_ADDED_IN_TRANSACTION_NO_PARENT = "SELECT TRUE FROM " +
             TRANSACTION_OPERATIONS_TABLE + " WHERE " + FEDORA_ID_COLUMN + " = :child AND " +
             TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'add'";
 
+    /*
+     * Delete a row from the transaction operation table with this resource and 'add' operation, no parent required.
+     */
     private static final String UNDO_INSERT_CHILD_IN_TRANSACTION_NO_PARENT = "DELETE FROM " +
             TRANSACTION_OPERATIONS_TABLE + " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + TRANSACTION_ID_COLUMN
             + " = :transactionId AND " + OPERATION_COLUMN + " = 'add'";
@@ -193,7 +298,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     private String lookupDdl() {
-        try (var connection = dataSource.getConnection()) {
+        try (final var connection = dataSource.getConnection()) {
             final var productName = connection.getMetaData().getDatabaseProductName();
             LOGGER.debug("Identified database as: {}", productName);
             final var ddl = DDL_MAP.get(productName);
@@ -201,7 +306,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
                 throw new IllegalStateException("Unknown database platform: " + productName);
             }
             return ddl;
-        } catch (SQLException e) {
+        } catch (final SQLException e) {
             throw new RuntimeException(e);
         }
     }
@@ -210,15 +315,10 @@ public class ContainmentIndexImpl implements ContainmentIndex {
         return new NamedParameterJdbcTemplate(getDataSource());
     }
 
-    /**
-     * Do the actual database query to get the contained IDs.
-     *
-     * @param resource Containing resource
-     * @param transactionId ID of the current transaction (if any)
-     * @return A stream of contained identifiers
-     */
-    private Stream<String> getChildren(final FedoraResource resource, final String transactionId) {
-        final String resourceId = resource.getFedoraId().getFullId();
+    @Override
+    public Stream<String> getContains(final Transaction tx, final FedoraResource fedoraResource) {
+        final String transactionId = (tx != null) ? tx.getId() : null;
+        final String resourceId = fedoraResource.getFedoraId().getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("parent", resourceId);
 
@@ -231,15 +331,30 @@ public class ContainmentIndexImpl implements ContainmentIndex {
             // not in a transaction
             children = jdbcTemplate.queryForList(SELECT_CHILDREN, parameterSource, String.class);
         }
-        LOGGER.debug("getChildren for {} in transaction {} found {} children", resourceId, transactionId,
+        LOGGER.debug("getContains for {} in transaction {} found {} children", resourceId, transactionId,
                 children.size());
         return children.stream();
     }
 
     @Override
-    public Stream<String> getContains(final Transaction tx, final FedoraResource fedoraResource) {
-        final String txId = (tx != null) ? tx.getId() : null;
-        return getChildren(fedoraResource, txId);
+    public Stream<String> getContainsDeleted(final Transaction tx, final FedoraResource fedoraResource) {
+        final String transactionId = (tx != null) ? tx.getId() : null;
+        final String resourceId = fedoraResource.getFedoraId().getFullId();
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+        parameterSource.addValue("parent", resourceId);
+
+        final List<String> children;
+        if (transactionId != null) {
+            // we are in a transaction
+            parameterSource.addValue("transactionId", transactionId);
+            children = jdbcTemplate.queryForList(SELECT_DELETED_CHILDREN_IN_TRANSACTION, parameterSource, String.class);
+        } else {
+            // not in a transaction
+            children = jdbcTemplate.queryForList(SELECT_DELETED_CHILDREN, parameterSource, String.class);
+        }
+        LOGGER.debug("getContainsDeleted for {} in transaction {} found {} children", resourceId, transactionId,
+                children.size());
+        return children.stream();
     }
 
     @Override
@@ -258,69 +373,95 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public void addContainedBy(final String txID, final FedoraId parent, final FedoraId child) {
+    public void addContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child) {
         final String parentID = parent.getFullId();
         final String childID = child.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("parent", parentID);
         parameterSource.addValue("child", childID);
-        if (txID != null) {
-            parameterSource.addValue("transactionId", txID);
-            final boolean removedInTxn = !jdbcTemplate.queryForList(IS_CHILD_DELETED_IN_TRANSACTION, parameterSource)
-                    .isEmpty();
-            if (removedInTxn) {
-                jdbcTemplate.update(UNDO_DELETE_CHILD_IN_TRANSACTION, parameterSource);
-            } else {
-                jdbcTemplate.update(INSERT_CHILD_IN_TRANSACTION, parameterSource);
-            }
+        parameterSource.addValue("transactionId", txID);
+        final boolean purgedInTxn = !jdbcTemplate.queryForList(IS_CHILD_PURGED_IN_TRANSACTION, parameterSource)
+                .isEmpty();
+        if (purgedInTxn) {
+            // We purged it, but are re-adding it so remove the purge operation.
+            jdbcTemplate.update(UNDO_PURGE_CHILD_IN_TRANSACTION, parameterSource);
         } else {
-            jdbcTemplate.update(INSERT_CHILD, parameterSource);
+            jdbcTemplate.update(INSERT_CHILD_IN_TRANSACTION, parameterSource);
         }
     }
 
     @Override
-    public void removeContainedBy(final String txID, final FedoraId parent, final FedoraId child) {
+    public void removeContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child) {
         final String parentID = parent.getFullId();
         final String childID = child.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("parent", parentID);
         parameterSource.addValue("child", childID);
-        if (txID != null) {
-            parameterSource.addValue("transactionId", txID);
-            final boolean addedInTxn = !jdbcTemplate.queryForList(IS_CHILD_ADDED_IN_TRANSACTION, parameterSource)
-                    .isEmpty();
-            if (addedInTxn) {
-                jdbcTemplate.update(UNDO_INSERT_CHILD_IN_TRANSACTION, parameterSource);
-            } else {
-                jdbcTemplate.update(DELETE_CHILD_IN_TRANSACTION, parameterSource);
-            }
+        parameterSource.addValue("transactionId", txID);
+        final boolean addedInTxn = !jdbcTemplate.queryForList(IS_CHILD_ADDED_IN_TRANSACTION, parameterSource)
+                .isEmpty();
+        if (addedInTxn) {
+            jdbcTemplate.update(UNDO_INSERT_CHILD_IN_TRANSACTION, parameterSource);
         } else {
-            jdbcTemplate.update(DELETE_CHILD, parameterSource);
+            jdbcTemplate.update(DELETE_CHILD_IN_TRANSACTION, parameterSource);
         }
     }
 
     @Override
-    public void removeResource(final String txID, final FedoraId resource) {
+    public void purgeContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child) {
+        final String parentID = parent.getFullId();
+        final String childID = child.getFullId();
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+        parameterSource.addValue("parent", parentID);
+        parameterSource.addValue("child", childID);
+        parameterSource.addValue("transactionId", txID);
+        final boolean deletedInTxn = !jdbcTemplate.queryForList(IS_CHILD_DELETED_IN_TRANSACTION, parameterSource)
+                .isEmpty();
+        if (deletedInTxn) {
+            jdbcTemplate.update(UNDO_DELETE_CHILD_IN_TRANSACTION, parameterSource);
+        }
+        // We don't need to do both the delete and the purge, so just do the purge.
+        jdbcTemplate.update(PURGE_CHILD_IN_TRANSACTION, parameterSource);
+    }
+
+    @Override
+    public void removeResource(@Nonnull final String txID, final FedoraId resource) {
         final String resourceID = resource.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("child", resourceID);
-        if (txID != null) {
-            parameterSource.addValue("transactionId", txID);
-            final boolean addedInTxn = !jdbcTemplate.queryForList(IS_CHILD_ADDED_IN_TRANSACTION_NO_PARENT,
-                    parameterSource).isEmpty();
-            if (addedInTxn) {
-                jdbcTemplate.update(UNDO_INSERT_CHILD_IN_TRANSACTION_NO_PARENT, parameterSource);
-            } else {
-                final String parent = getContainedBy(txID, resource);
-                if (parent != null) {
-                    LOGGER.debug("Removing containment relationship between parent ({}) and child ({})", parent,
-                            resourceID);
-                    parameterSource.addValue("parent", parent);
-                    jdbcTemplate.update(DELETE_CHILD_IN_TRANSACTION, parameterSource);
-                }
-            }
+        parameterSource.addValue("transactionId", txID);
+        final boolean addedInTxn = !jdbcTemplate.queryForList(IS_CHILD_ADDED_IN_TRANSACTION_NO_PARENT,
+                parameterSource).isEmpty();
+        if (addedInTxn) {
+            jdbcTemplate.update(UNDO_INSERT_CHILD_IN_TRANSACTION_NO_PARENT, parameterSource);
         } else {
-            jdbcTemplate.update(DELETE_ALL_RESOURCE, parameterSource);
+            final String parent = getContainedBy(txID, resource);
+            if (parent != null) {
+                LOGGER.debug("Marking containment relationship between parent ({}) and child ({}) deleted", parent,
+                        resourceID);
+                parameterSource.addValue("parent", parent);
+                jdbcTemplate.update(DELETE_CHILD_IN_TRANSACTION, parameterSource);
+            }
+        }
+    }
+
+    @Override
+    public void purgeResource(@Nonnull final String txID, final FedoraId resource) {
+        final String resourceID = resource.getFullId();
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+        parameterSource.addValue("child", resourceID);
+        parameterSource.addValue("transactionId", txID);
+        final String parent = getContainedBy(txID, resource);
+        final boolean deletedInTxn = !jdbcTemplate.queryForList(IS_CHILD_DELETED_IN_TRANSACTION, parameterSource)
+                .isEmpty();
+        if (deletedInTxn) {
+            jdbcTemplate.update(UNDO_DELETE_CHILD_IN_TRANSACTION, parameterSource);
+        }
+        if (parent != null) {
+            LOGGER.debug("Removing containment relationship between parent ({}) and child ({})", parent,
+                    resourceID);
+            parameterSource.addValue("parent", parent);
+            jdbcTemplate.update(PURGE_CHILD_IN_TRANSACTION, parameterSource);
         }
     }
 
@@ -338,9 +479,10 @@ public class ContainmentIndexImpl implements ContainmentIndex {
                 new TransactionCallbackWithoutResult() {
                     protected void doInTransactionWithoutResult(final TransactionStatus status) {
                         try {
+                            jdbcTemplate.update(COMMIT_PURGE_RECORDS, parameterSource);
                             jdbcTemplate.update(COMMIT_DELETE_RECORDS, parameterSource);
                             jdbcTemplate.update(COMMIT_ADD_RECORDS, parameterSource);
-                            jdbcTemplate.update(COMMIT_CLEANUP, parameterSource);
+                            jdbcTemplate.update(DELETE_ENTIRE_TRANSACTION, parameterSource);
                         } catch (final Exception e) {
                             status.setRollbackOnly();
                             LOGGER.warn("Unable to commit containment index transaction {}: {}", txId, e.getMessage());
@@ -358,7 +500,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
             final String txId = tx.getId();
             final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
             parameterSource.addValue("transactionId", txId);
-            jdbcTemplate.update(ROLLBACK_TRANSACTION, parameterSource);
+            jdbcTemplate.update(DELETE_ENTIRE_TRANSACTION, parameterSource);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -247,7 +247,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
      */
     private static final String PARENT_EXISTS = "SELECT " + PARENT_COLUMN + " FROM " + RESOURCES_TABLE +
             " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + IS_DELETED_COLUMN + " = FALSE";
-
+    
     /*
      * Get the parent ID for this resource from the operations table for an 'add' operation in this transaction, but
      * exclude any 'delete' operations for this resource in this transaction.
@@ -442,26 +442,6 @@ public class ContainmentIndexImpl implements ContainmentIndex {
                 parameterSource.addValue("parent", parent);
                 jdbcTemplate.update(DELETE_CHILD_IN_TRANSACTION, parameterSource);
             }
-        }
-    }
-
-    @Override
-    public void purgeResource(@Nonnull final String txID, final FedoraId resource) {
-        final String resourceID = resource.getFullId();
-        final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-        parameterSource.addValue("child", resourceID);
-        parameterSource.addValue("transactionId", txID);
-        final String parent = getContainedBy(txID, resource);
-        final boolean deletedInTxn = !jdbcTemplate.queryForList(IS_CHILD_DELETED_IN_TRANSACTION, parameterSource)
-                .isEmpty();
-        if (deletedInTxn) {
-            jdbcTemplate.update(UNDO_DELETE_CHILD_IN_TRANSACTION, parameterSource);
-        }
-        if (parent != null) {
-            LOGGER.debug("Removing containment relationship between parent ({}) and child ({})", parent,
-                    resourceID);
-            parameterSource.addValue("parent", parent);
-            jdbcTemplate.update(PURGE_CHILD_IN_TRANSACTION, parameterSource);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.impl.models;
 
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
@@ -28,10 +29,17 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
  */
 public class TombstoneImpl extends FedoraResourceImpl implements Tombstone {
 
+    private FedoraResource originalResource;
 
     protected TombstoneImpl(final FedoraId fedoraID, final Transaction tx,
                             final PersistentStorageSessionManager pSessionManager,
-                            final ResourceFactory resourceFactory) {
+                            final ResourceFactory resourceFactory, final FedoraResource original) {
         super(fedoraID, tx, pSessionManager, resourceFactory);
+        this.originalResource = original;
+    }
+
+    @Override
+    public FedoraResource getDeletedObject() {
+        return originalResource;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
@@ -70,6 +70,8 @@ public class ResourceOperationEventBuilder implements EventBuilder {
                 return EventType.RESOURCE_MODIFICATION;
             case DELETE:
                 return EventType.RESOURCE_DELETION;
+            case PURGE:
+                return EventType.RESOURCE_PURGE;
             default:
                 throw new IllegalStateException(
                         String.format("There is no EventType mapping for ResourceOperation type %s on operation %s",

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractResourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractResourceOperationBuilder.java
@@ -15,14 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.operations;
+package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
 
 /**
- * Specifies the type of modification action represented by a resource operation.
- *
- * @author bbpennel
+ * Base resource operation builder to share class fields and userPrincipal method.
+ * @author whikloj
  */
-public enum ResourceOperationType {
-    UPDATE, CREATE, DELETE, PURGE
+abstract public class AbstractResourceOperationBuilder implements ResourceOperationBuilder {
+
+    protected String rescId;
+
+    protected String userPrincipal;
+
+    /**
+     * Constructor.
+     * @param rescId the resource identifier.
+     */
+    public AbstractResourceOperationBuilder(final String rescId) {
+        this.rescId = rescId;
+    }
+
+    @Override
+    public ResourceOperationBuilder userPrincipal(final String userPrincipal) {
+        this.userPrincipal = userPrincipal;
+        return this;
+    }
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperationBuilder.java
@@ -25,11 +25,8 @@ import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
  *
  * @author bbpennel
  */
-public class DeleteResourceOperationBuilder implements ResourceOperationBuilder {
-
-    private String rescId;
-
-    private String userPrincipal;
+public class DeleteResourceOperationBuilder extends AbstractResourceOperationBuilder
+        implements ResourceOperationBuilder {
 
     /**
      * Construct the builder
@@ -37,13 +34,7 @@ public class DeleteResourceOperationBuilder implements ResourceOperationBuilder 
      * @param rescId identifier of the resource to delete
      */
     public DeleteResourceOperationBuilder(final String rescId) {
-        this.rescId = rescId;
-    }
-
-    @Override
-    public DeleteResourceOperationBuilder userPrincipal(final String userPrincipal) {
-        this.userPrincipal = userPrincipal;
-        return this;
+        super(rescId);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperationFactoryImpl.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.impl.operations;
 
 import org.fcrepo.kernel.api.operations.DeleteResourceOperationFactory;
+import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -31,6 +32,11 @@ public class DeleteResourceOperationFactoryImpl implements DeleteResourceOperati
     @Override
     public DeleteResourceOperationBuilder deleteBuilder(final String rescId) {
         return new DeleteResourceOperationBuilder(rescId);
+    }
+
+    @Override
+    public ResourceOperationBuilder purgeBuilder(final String rescId) {
+        return new PurgeResourceOperationBuilder(rescId);
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/PurgeResourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/PurgeResourceOperation.java
@@ -15,14 +15,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.operations;
+package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 /**
- * Specifies the type of modification action represented by a resource operation.
+ * Purge resource operation
  *
- * @author bbpennel
+ * @author whikloj
+ * @since 6.0.0
  */
-public enum ResourceOperationType {
-    UPDATE, CREATE, DELETE, PURGE
+public class PurgeResourceOperation extends AbstractResourceOperation {
+
+    protected PurgeResourceOperation(final String rescId) {
+        super(rescId);
+    }
+
+    @Override
+    public ResourceOperationType getType() {
+        return ResourceOperationType.PURGE;
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/PurgeResourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/PurgeResourceOperationBuilder.java
@@ -15,14 +15,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.operations;
+package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
 
 /**
- * Specifies the type of modification action represented by a resource operation.
+ * Builder for operations to purge a resource
  *
- * @author bbpennel
+ * @author whikloj
  */
-public enum ResourceOperationType {
-    UPDATE, CREATE, DELETE, PURGE
+public class PurgeResourceOperationBuilder extends AbstractResourceOperationBuilder
+        implements ResourceOperationBuilder {
+
+    /**
+     * Construct the builder
+     *
+     * @param rescId identifier of the resource to delete
+     */
+    public PurgeResourceOperationBuilder(final String rescId) {
+        super(rescId);
+    }
+
+    @Override
+    public PurgeResourceOperation build() {
+        final var operation = new PurgeResourceOperation(rescId);
+        operation.setUserPrincipal(userPrincipal);
+        return operation;
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static java.lang.String.format;
+
+import javax.inject.Inject;
+
+import java.util.stream.Stream;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.Binary;
+import org.fcrepo.kernel.api.models.Container;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared delete/purge code.
+ * @author whikloj
+ */
+abstract public class AbstractDeleteResourceService extends AbstractService {
+
+    private final static Logger log = LoggerFactory.getLogger(AbstractDeleteResourceService.class);
+
+    @Inject
+    protected ResourceFactory resourceFactory;
+
+    @Inject
+    protected PersistentStorageSessionManager psManager;
+
+    /**
+     * The starts the service, does initial checks and setups for processing.
+     * @param tx the transaction.
+     * @param fedoraResource the resource to start delete/purging.
+     * @param userPrincipal the user performing the action.
+     */
+    public void perform(final Transaction tx, final FedoraResource fedoraResource, final String userPrincipal) {
+        final String fedoraResourceId = fedoraResource.getId();
+
+        if (fedoraResource instanceof NonRdfSourceDescription) {
+            throw new RepositoryRuntimeException(
+            format("A NonRdfSourceDescription cannot be deleted independently of the NonRDFSource:  %s",
+            fedoraResourceId));
+        }
+
+        try {
+            log.debug("operating on {}", fedoraResourceId);
+            final PersistentStorageSession pSession = this.psManager.getSession(tx.getId());
+            deleteDepthFirst(tx, pSession, fedoraResource, userPrincipal);
+        } catch (final PersistentStorageException ex) {
+            throw new RepositoryRuntimeException(format("failed to delete/purge resource %s", fedoraResourceId), ex);
+        }
+    }
+
+    /**
+     * Code to perform the recursion of containers.
+     * @param tx the transaction
+     * @param pSession the persistent storage session
+     * @param fedoraResource the current resource to check for any children.
+     * @param userPrincipal the user performing the action.
+     * @throws PersistentStorageException any problems accessing the underlying storage.
+     */
+    protected void deleteDepthFirst(final Transaction tx, final PersistentStorageSession pSession,
+                                  final FedoraResource fedoraResource, final String userPrincipal)
+            throws PersistentStorageException {
+
+        final FedoraId fedoraId = fedoraResource.getFedoraId();
+
+        if (fedoraResource instanceof Container) {
+            final Stream<String> children = getContained(tx, fedoraResource);
+            children.forEach(childResourceId -> {
+                try {
+                    final FedoraResource res = resourceFactory.getResource(tx, FedoraId.create(childResourceId));
+                    deleteDepthFirst(tx, pSession, res, userPrincipal);
+                } catch (final PathNotFoundException ex) {
+                    log.error("Path not found for {}: {}", fedoraId.getFullId(), ex.getMessage());
+                    throw new PathNotFoundRuntimeException(ex);
+                } catch (final PersistentStorageException ex) {
+                    throw new RepositoryRuntimeException(format("failed to delete resource %s", fedoraId.getFullId()),
+                            ex);
+                }
+            });
+        } else if (fedoraResource instanceof Binary) {
+            //delete/purge described resource if binary
+            doAction(tx, pSession, fedoraResource.getDescribedResource().getFedoraId(), userPrincipal);
+        }
+
+        //delete/purge the acl if this is not the acl
+        if (!fedoraResource.isAcl()) {
+            final FedoraResource acl = fedoraResource.getAcl();
+            if (acl != null) {
+                doAction(tx, pSession, acl.getFedoraId(), userPrincipal);
+            }
+        }
+
+        //delete/purge the resource itself
+        doAction(tx, pSession, fedoraId, userPrincipal);
+    }
+
+    /**
+     * Get the contained resources to act upon.
+     * @param tx the transaction this occurs in.
+     * @param resource the parent resource to find contained resources for.
+     * @return stream of child ids.
+     */
+    abstract protected Stream<String> getContained(final Transaction tx, final FedoraResource resource);
+
+    /**
+     * Perform the actual delete or purge action
+     * @param tx the transaction this occurs in.
+     * @param pSession the persistent storage session.
+     * @param resourceId the resource to perform the action on.
+     * @param userPrincipal the user performing the action
+     * @throws PersistentStorageException if problem performing the action.
+     */
+    abstract protected void doAction(final Transaction tx, final PersistentStorageSession pSession,
+                                     final FedoraId resourceId, final String userPrincipal)
+            throws PersistentStorageException;
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -85,7 +85,7 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
      * @param userPrincipal the user performing the action.
      * @throws PersistentStorageException any problems accessing the underlying storage.
      */
-    protected void deleteDepthFirst(final Transaction tx, final PersistentStorageSession pSession,
+    private void deleteDepthFirst(final Transaction tx, final PersistentStorageSession pSession,
                                   final FedoraResource fedoraResource, final String userPrincipal)
             throws PersistentStorageException {
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
@@ -59,6 +59,7 @@ public class PurgeResourceServiceImpl extends AbstractDeleteResourceService impl
                 .userPrincipal(userPrincipal)
                 .build();
         pSession.persist(purgeOp);
+        containmentIndex.purgeResource(tx.getId(), resourceId);
         recordEvent(tx.getId(), resourceId, purgeOp);
         log.debug("purged {}", resourceId.getFullId());
     }

--- a/fcrepo-kernel-impl/src/main/resources/sql/default-containment.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/default-containment.sql
@@ -4,12 +4,13 @@
 -- Holds the ID and its parent.
 CREATE TABLE IF NOT EXISTS resources (
     fedora_id varchar(503) NOT NULL PRIMARY KEY,
-    parent varchar(503) NOT NULL
+    parent varchar(503) NOT NULL,
+    is_deleted boolean NOT NULL DEFAULT(FALSE)
 );
 
 -- Create an index to speed searches for children of a parent.
 CREATE INDEX IF NOT EXISTS resources_idx
-    ON resources (parent);
+    ON resources (parent, is_deleted);
 
 -- Holds operations to add or delete records from the RESOURCES_TABLE.
 CREATE TABLE IF NOT EXISTS transaction_operations (

--- a/fcrepo-kernel-impl/src/main/resources/sql/mysql-containment.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/mysql-containment.sql
@@ -4,14 +4,15 @@
 -- Holds the ID and its parent.
 CREATE TABLE IF NOT EXISTS resources (
     fedora_id  varchar(503) NOT NULL PRIMARY KEY,
-    parent varchar(503) NOT NULL
+    parent varchar(503) NOT NULL,
+    is_deleted boolean NOT NULL DEFAULT(FALSE)
 );
 
 -- Create an index to speed searches for children of a parent.
 SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
     WHERE table_name = 'resources' AND index_name = 'resources_idx' AND table_schema = database());
 SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
-    'CREATE INDEX resources_idx ON resources (parent)');
+    'CREATE INDEX resources_idx ON resources (parent, is_deleted)');
 PREPARE stmt FROM @sqlstmt;
 EXECUTE stmt;
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -190,7 +190,7 @@ public class ContainmentIndexImplTest {
         assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(transaction1, parent1).count());
-        containmentIndex.purgeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
+        containmentIndex.purgeResource(transaction1.getId(), child1.getFedoraId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
@@ -216,7 +216,7 @@ public class ContainmentIndexImplTest {
         assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
         assertEquals(1, containmentIndex.getContainsDeleted(null, parent1).count());
         assertEquals(1, containmentIndex.getContainsDeleted(transaction1, parent1).count());
-        containmentIndex.purgeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
+        containmentIndex.purgeResource(transaction1.getId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1);
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
@@ -160,7 +160,8 @@ public class ResourceFactoryImplTest {
         when(mockResource.getFedoraId()).thenReturn(rootId);
         containmentIndex.rollbackTransaction(mockTx);
         containmentIndex.getContains(null, mockResource).forEach(c ->
-                containmentIndex.removeContainedBy(null, rootId, FedoraId.create(c)));
+                containmentIndex.removeContainedBy(mockTx.getId(), rootId, FedoraId.create(c)));
+        containmentIndex.commitTransaction(mockTx);
     }
 
     @Test(expected = PathNotFoundException.class)
@@ -360,14 +361,16 @@ public class ResourceFactoryImplTest {
 
     @Test
     public void doesResourceExist_Exists_WithoutSession() throws Exception {
-        containmentIndex.addContainedBy(null, rootId, fedoraId);
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
+        containmentIndex.commitTransaction(mockTx);
         final boolean answer = factory.doesResourceExist(null, fedoraId);
         assertTrue(answer);
     }
 
     @Test
     public void doesResourceExist_Exists_Description_WithoutSession() {
-        containmentIndex.addContainedBy(null, rootId, fedoraId);
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
+        containmentIndex.commitTransaction(mockTx);
         final FedoraId descId = fedoraId.resolve("/" + FCR_METADATA);
         final boolean answer = factory.doesResourceExist(null, descId);
         assertTrue(answer);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -346,7 +346,8 @@ public class CreateResourceServiceImplTest {
     public void testWithBinary() throws Exception {
         final FedoraId fedoraId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraId childId = fedoraId.resolve("testSlug");
-        containmentIndex.addContainedBy(null, fedoraId, childId);
+        containmentIndex.addContainedBy(TX_ID, fedoraId, childId);
+        containmentIndex.commitTransaction(transaction);
         when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
         when(psSession.getHeaders(childId.getFullId(), null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -75,7 +75,6 @@ class DeleteResourcePersister extends AbstractPersister {
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             final var filePath = resolveExtensions(ocflSubPath, isRdf);
             deletePath(filePath, objectSession, headers, user, deleteTime);
-            // TODO: Delete the ACL at some point - https://jira.lyrasis.org/browse/FCREPO-3288
             if (!isRdf) {
                 // Delete the description too.
                 final var descPath = resolveExtensions(ocflSubPath + "-description", true);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java
@@ -125,6 +125,7 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
         persisterList.add(new UpdateNonRdfSourcePersister(this.fedoraOcflIndex));
         persisterList.add(new DeleteResourcePersister(this.fedoraOcflIndex));
         persisterList.add(new CreateVersionPersister(this.fedoraOcflIndex));
+        persisterList.add(new PurgeResourcePersister(this.fedoraOcflIndex));
 
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.PURGE;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.getSidecarSubpath;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.relativizeSubpath;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.resolveOCFLSubpath;
+
+import java.util.Objects;
+
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.common.ResourceHeadersImpl;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Purge Resource Persister
+ * @author whikloj
+ */
+class PurgeResourcePersister extends AbstractPersister {
+
+    private static final Logger log = LoggerFactory.getLogger(PurgeResourcePersister.class);
+
+    protected PurgeResourcePersister(final FedoraToOCFLObjectIndex fedoraOcflIndex) {
+        super(ResourceOperation.class, PURGE, fedoraOcflIndex);
+    }
+
+    @Override
+    public void persist(final OCFLPersistentStorageSession session, final ResourceOperation operation)
+            throws PersistentStorageException {
+        final var mapping = getMapping(operation.getResourceId());
+        final var fedoraResourceRoot = mapping.getRootObjectIdentifier();
+        final var resourceId = operation.getResourceId();
+        final var objectSession = session.findOrCreateSession(mapping.getOcflObjectId());
+        log.debug("Deleting {} from {}", resourceId, mapping.getOcflObjectId());
+        if (fedoraResourceRoot.equals(resourceId)) {
+            // We are at the root of the object, so remove the entire OCFL object.
+            objectSession.deleteObject();
+        } else {
+            final var relativeSubPath = relativizeSubpath(fedoraResourceRoot, operation.getResourceId());
+            final var ocflSubPath = resolveOCFLSubpath(fedoraResourceRoot, relativeSubPath);
+            final var headers = (ResourceHeadersImpl) readHeaders(objectSession, ocflSubPath);
+            final var sidecar = getSidecarSubpath(ocflSubPath);
+            final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
+            purgePath(sidecar, objectSession);
+            if (!isRdf) {
+                // Delete the description sidecar file too.
+                final var descSidecar = getSidecarSubpath(ocflSubPath + "-description");
+                purgePath(descSidecar, objectSession);
+            }
+        }
+    }
+
+    /**
+     * Simple utility to delete a path's sidecar files.
+     * @param path Path to purge.
+     * @param session Session to delete the path in.
+     * @throws PersistentStorageException if can't read, write or delete a file.
+     */
+    private void purgePath(final String path, final OCFLObjectSession session) throws PersistentStorageException {
+        session.delete(path);
+    }
+
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
+import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Purge Persister tests.
+ * @author whikloj
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class PurgeResourcePersisterTest {
+
+    @Mock
+    private FedoraOCFLMapping mapping;
+
+    @Mock
+    private PersistentStorageSession storageSession;
+
+    @Mock
+    private OCFLObjectSession session;
+
+    @Mock
+    private ResourceOperation operation;
+
+    @Mock
+    private FedoraToOCFLObjectIndex index;
+
+    @Mock
+    private OCFLPersistentStorageSession psSession;
+
+    private PurgeResourcePersister persister;
+
+    @Before
+    public void setup() throws Exception {
+        operation = mock(ResourceOperation.class);
+        persister = new PurgeResourcePersister(this.index);
+
+        when(psSession.findOrCreateSession(anyString())).thenReturn(session);
+    }
+
+    @Test
+    public void testPurgeSubPathBinary() throws Exception {
+        final String header_string1 = "{\"parent\":\"info:fedora/an-ocfl-object\",\"id\":" +
+            "\"info:fedora/an-ocfl-object/some-subpath\",\"lastModifiedDate\":\"2020-04-14T03:42:00.765231Z\"," +
+            "\"interactionModel\":\"http://www.w3.org/ns/ldp#NonRDFSource\",\"createdDate\":" +
+            "\"2020-04-14T03:42:00.765231Z\",\"stateToken\":\"6763672ED325A4B632B450545518B34B\"," +
+            "\"archivalGroup\":false,\"objectRoot\":false}";
+        final InputStream header_stream1 = new ByteArrayInputStream(header_string1.getBytes());
+        when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream1);
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(index.getMapping(anyString())).thenReturn(mapping);
+        persister.persist(psSession, operation);
+        verify(session).read(".fcrepo/some-subpath.json");
+        verify(session).delete(".fcrepo/some-subpath.json");
+        verify(session).delete(".fcrepo/some-subpath-description.json");
+    }
+
+    @Test
+    public void testPurgeSubPathRdf() throws Exception {
+        final String header_string = "{\"parent\":\"info:fedora/an-ocfl-object\",\"id\":" +
+            "\"info:fedora/an-ocfl-object/some-subpath\",\"lastModifiedDate\":\"2020-04-14T03:42:00.765231Z\"," +
+            "\"interactionModel\":\"http://www.w3.org/ns/ldp#BasicContainer\",\"createdDate\":" +
+            "\"2020-04-14T03:42:00.765231Z\",\"stateToken\":\"6763672ED325A4B632B450545518B34B\"," +
+            "\"archivalGroup\":false,\"objectRoot\":false}";
+        final InputStream header_stream = new ByteArrayInputStream(header_string.getBytes());
+        when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream);
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(index.getMapping(anyString())).thenReturn(mapping);
+        persister.persist(psSession, operation);
+        verify(session).delete(".fcrepo/some-subpath.json");
+    }
+
+    @Test(expected = PersistentStorageException.class)
+    public void testPurgeSubPathDoesNotExist() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(session.read(".fcrepo/some-subpath.json")).thenThrow(
+                new PersistentStorageException("error")
+        );
+        persister.persist(psSession, operation);
+    }
+
+    @Test(expected = PersistentStorageException.class)
+    public void testPurgeFullObjectDoesNotExist() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(index.getMapping(anyString())).thenThrow(new FedoraOCFLMappingNotFoundException("error"));
+
+        persister.persist(psSession, operation);
+        verify(session).delete("some-subpath");
+    }
+
+    @Test
+    public void testPurgeFullObjectRdf() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(index.getMapping(anyString())).thenReturn(mapping);
+
+        persister.persist(psSession, operation);
+        verify(session).deleteObject();
+    }
+
+    @Test
+    public void testPurgeFullObjectBinary() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(index.getMapping(anyString())).thenReturn(mapping);
+
+        persister.persist(psSession, operation);
+        verify(session).deleteObject();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNotPartOfObject() throws Exception {
+        when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
+        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/some-wrong-object");
+        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(index.getMapping(anyString())).thenReturn(mapping);
+        persister.persist(psSession, operation);
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3034

# What does this Pull Request do?
Allows you to DELETE a `fcr:tombstone` to remove the sidecar files (if part of an Archival Group) or delete the entire object.

Also re-enables the FedoraLdpTests unit test class and fixes all the tests.

# How should this be tested?

Build the PR.
Create an object.
Find the object in your storage root.
Delete the object, see that the object still exists but the sidecar file has the `deleted: true` property.
Delete the tombstone, see the entire OCFL object is removed.

# Interested parties
@fcrepo4/committers
