### PR TITLE
FCREPO-3200 - Default Digests

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/UnsupportedAlgorithmException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/UnsupportedAlgorithmException.java
@@ -24,7 +24,7 @@ package org.fcrepo.kernel.api.exception;
  * @author harring
  * @since 2017-09-12
  */
-public class UnsupportedAlgorithmException extends Exception {
+public class UnsupportedAlgorithmException extends RepositoryRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
@@ -36,4 +36,13 @@ public class UnsupportedAlgorithmException extends Exception {
         super(message);
     }
 
+    /**
+     * Ordinary constructor.
+     *
+     * @param message the message
+     * @param rootCause the root cause
+     */
+    public UnsupportedAlgorithmException(final String message, final Throwable rootCause) {
+        super(message, rootCause);
+    }
 }

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
@@ -23,6 +23,7 @@ import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.api.utils.ContentDigest.getAlgorithm;
 import static org.junit.Assert.assertEquals;
 
+import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
 import org.junit.Test;
 
 /**
@@ -60,5 +61,16 @@ public class ContentDigestTest {
     public void testMissingAlgorithm() {
         assertEquals("Failed to produce a proper content digest URI!",
                 create("missing:fake"), asURI("SHA-819", "fake"));
+    }
+
+    @Test
+    public void testFromAlgorithm() {
+        assertEquals(DIGEST_ALGORITHM.SHA1, DIGEST_ALGORITHM.fromAlgorithm("SHA"));
+        assertEquals(DIGEST_ALGORITHM.SHA1, DIGEST_ALGORITHM.fromAlgorithm("sha-1"));
+    }
+
+    @Test
+    public void testFromAlgorithmMissing() {
+        assertEquals(DIGEST_ALGORITHM.MISSING, DIGEST_ALGORITHM.fromAlgorithm("what"));
     }
 }

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/FileWriteOutcome.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/FileWriteOutcome.java
@@ -37,7 +37,7 @@ import org.fcrepo.persistence.api.WriteOutcome;
  */
 public class FileWriteOutcome implements WriteOutcome {
 
-    private Path filePath;
+    private final Path filePath;
 
     private Collection<URI> digests;
 
@@ -71,5 +71,14 @@ public class FileWriteOutcome implements WriteOutcome {
     @Override
     public Collection<URI> getDigests() {
         return digests;
+    }
+
+    /**
+     * Set the digests for the file written
+     *
+     * @param digests
+     */
+    public void setDigests(final Collection<URI> digests) {
+        this.digests = digests;
     }
 }

--- a/fcrepo-persistence-common/src/test/java/org/fcrepo/persistence/common/MultiDigestInputStreamWrapperTest.java
+++ b/fcrepo-persistence-common/src/test/java/org/fcrepo/persistence/common/MultiDigestInputStreamWrapperTest.java
@@ -20,15 +20,16 @@ package org.fcrepo.persistence.common;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
-
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
 import org.junit.Test;
 
 /**
@@ -52,12 +53,12 @@ public class MultiDigestInputStreamWrapperTest {
     private static final String SHA512256 = "dea93ec79abc429b0065e73995a4fe0ddb7a3ec65f2b14139e75360a8ab66efc";
     private static final URI SHA512256_URI = URI.create("urn:sha-512/256:" + SHA512256);
 
-    private InputStream contentStream = new ByteArrayInputStream(CONTENT.getBytes());
+    private final InputStream contentStream = new ByteArrayInputStream(CONTENT.getBytes());
 
     @Test
     public void checkFixity_SingleDigests_Success() throws Exception {
         final var digests = asList(SHA1_URI);
-        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
 
         // Read the stream to allow digest calculation
         IOUtils.toString(wrapper.getInputStream(), UTF_8);
@@ -69,7 +70,7 @@ public class MultiDigestInputStreamWrapperTest {
     @Test
     public void checkFixity_MultiDigests_Success() throws Exception {
         final var digests = asList(MD5_URI, SHA1_URI, SHA512_URI, SHA512256_URI);
-        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
 
         // Read the stream to allow digest calculation
         IOUtils.toString(wrapper.getInputStream(), UTF_8);
@@ -81,7 +82,7 @@ public class MultiDigestInputStreamWrapperTest {
     @Test
     public void checkFixity_NoDigests() throws Exception {
         final Collection<URI> digests = emptyList();
-        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
 
         // Read the stream to allow digest calculation
         IOUtils.toString(wrapper.getInputStream(), UTF_8);
@@ -93,7 +94,7 @@ public class MultiDigestInputStreamWrapperTest {
     @Test(expected = InvalidChecksumException.class)
     public void checkFixity_InvalidDigest() throws Exception {
         final var digests = asList(MD5_URI, URI.create("urn:sha1:totallybusted"), SHA512_URI);
-        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
 
         // Read the stream to allow digest calculation
         IOUtils.toString(wrapper.getInputStream(), UTF_8);
@@ -105,17 +106,124 @@ public class MultiDigestInputStreamWrapperTest {
     @Test(expected = RepositoryRuntimeException.class)
     public void unsupportedDigestAlgorithm() throws Exception {
         final var digests = asList(URI.create("urn:yum:123456"), SHA512_URI);
-        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
 
         wrapper.getInputStream();
     }
 
-    @Test(expected = RepositoryRuntimeException.class)
+    @Test
     public void checkFixity_BeforeRead() throws Exception {
-        final Collection<URI> digests = emptyList();
-        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests);
+        final var digests = asList(MD5_URI);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
 
         // Expect no failures
         wrapper.checkFixity();
+    }
+
+    @Test
+    public void checkFixity_OnlyWantDigest() throws Exception {
+        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, null, wantDigests);
+
+        // Read the stream to allow digest calculation
+        IOUtils.toString(wrapper.getInputStream(), UTF_8);
+
+        // Expect no failures
+        wrapper.checkFixity();
+    }
+
+    @Test
+    public void checkFixity_OverlappingWantDigestAndProvided() throws Exception {
+        final var digests = asList(SHA1_URI);
+        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
+
+        // Read the stream to allow digest calculation
+        IOUtils.toString(wrapper.getInputStream(), UTF_8);
+
+        // Expect no failures
+        wrapper.checkFixity();
+    }
+
+    @Test(expected = InvalidChecksumException.class)
+    public void checkFixity_OverlappingWantDigestAndProvided_InvalidDigest() throws Exception {
+        final var digests = asList(URI.create("urn:sha1:totallybusted"));
+        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
+
+        // Read the stream to allow digest calculation
+        IOUtils.toString(wrapper.getInputStream(), UTF_8);
+
+        // Expect no failures
+        wrapper.checkFixity();
+    }
+
+    @Test
+    public void checkFixity_DifferentWantDigestAndProvided() throws Exception {
+        final var digests = asList(SHA1_URI);
+        final var wantDigests = asList(DIGEST_ALGORITHM.MD5);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
+
+        // Read the stream to allow digest calculation
+        IOUtils.toString(wrapper.getInputStream(), UTF_8);
+
+        // Expect no failures
+        wrapper.checkFixity();
+    }
+
+    @Test
+    public void getDigests_FromWantDigests() throws Exception {
+        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1, DIGEST_ALGORITHM.SHA512);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, null, wantDigests);
+
+        final var computed = wrapper.getDigests();
+        assertTrue(computed.contains(SHA1_URI));
+        assertTrue(computed.contains(SHA512_URI));
+    }
+
+    @Test
+    public void getDigests_FromProvidedDigests() throws Exception {
+        final var digests = asList(SHA1_URI, MD5_URI);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
+
+        final var computed = wrapper.getDigests();
+        assertTrue(computed.contains(SHA1_URI));
+        assertTrue(computed.contains(MD5_URI));
+    }
+
+    @Test
+    public void getDigests_FromWantDigestsAndProvided() throws Exception {
+        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1, DIGEST_ALGORITHM.SHA512);
+        final var digests = asList(SHA1_URI, MD5_URI);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
+
+        final var computed = wrapper.getDigests();
+        assertTrue(computed.contains(SHA1_URI));
+        assertTrue(computed.contains(SHA512_URI));
+        assertTrue(computed.contains(MD5_URI));
+    }
+
+    @Test
+    public void getDigests_AfterCheckFixity() throws Exception {
+        final var digests = asList(SHA1_URI);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
+
+        IOUtils.toString(wrapper.getInputStream(), UTF_8);
+
+        wrapper.checkFixity();
+
+        final var computed = wrapper.getDigests();
+        assertTrue(computed.contains(SHA1_URI));
+    }
+
+    @Test
+    public void getDigests_FromConsumedStream() throws Exception {
+        final var wantDigests = asList(DIGEST_ALGORITHM.SHA512);
+        final var wrapper = new MultiDigestInputStreamWrapper(contentStream, null, wantDigests);
+
+        IOUtils.toString(wrapper.getInputStream(), UTF_8);
+
+        final var computed = wrapper.getDigests();
+        assertTrue(computed.contains(SHA512_URI));
     }
 }

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -89,6 +89,17 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-kernel-impl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- This dependency is for compile-time: it keeps this module independent
          of any given choice of JAX-RS implementation. It must be _after_ the test

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.persistence.ocfl.api;
 
+import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
 import org.fcrepo.persistence.api.CommitOption;
 import org.fcrepo.persistence.api.WriteOutcome;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -149,4 +150,10 @@ public interface OCFLObjectSession {
      */
     Stream<String> listHeadSubpaths() throws PersistentStorageException;
 
+    /**
+     * Get the digest algorithm used by the OCFL object which is the subject of this session
+     *
+     * @return the digest algorithm used by the OCFL object
+     */
+    DIGEST_ALGORITHM getObjectDigestAlgorithm();
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
@@ -95,7 +95,8 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
             } else {
                 multiDigestWrapper = new MultiDigestInputStreamWrapper(
                         nonRdfSourceOperation.getContentStream(),
-                        nonRdfSourceOperation.getContentDigests());
+                        nonRdfSourceOperation.getContentDigests(),
+                        null);
                 contentStream = multiDigestWrapper.getInputStream();
             }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.persistence.ocfl.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.operations.DeleteResourceOperationFactory;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
+import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.ocfl.impl.OCFLPersistentSessionManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/spring-test/fcrepo-config.xml")
+public class NonRdfSourcesPersistenceIT {
+    private static final String BINARY_CONTENT = "The binary content";
+    private static final URI CONTENT_SHA512 = URI.create(
+            "urn:sha-512:abc25f06e3cde4157940d4298971722eab396ebb9ba939ef978aaba3b643f317c971f7b09b2e8667f7f41339"
+            + "541da8a787e395f807cea57342f08d51a8da89a6");
+    private static final URI CONTENT_SHA1 = URI.create("urn:sha1:42c5ca63d3c0ca79a1736fbfefb8fc29e71009fd");
+    private static final URI CONTENT_MD5 = URI.create("urn:md5:519db02d3a09d960e12e6198c65e26db");
+
+    private static final String UPDATED_CONTENT = "Some updated text";
+    private static final URI UPDATED_SHA512 = URI.create(
+            "urn:sha-512:aa45bac850667712561d37fd4f334f98f6e718951388b6f7d1e968a4738b11b35c568be28e15b408826da8f6"
+            + "be89ce5246d1cb1d2f93a254cc15ff9a82809395");
+
+    @Autowired
+    private OCFLPersistentSessionManager sessionManager;
+
+    private PersistentStorageSession storageSession;
+
+    @Autowired
+    private NonRdfSourceOperationFactory nonRdfSourceOpFactory;
+    @Autowired
+    private RdfSourceOperationFactory rdfSourceOpFactory;
+    @Autowired
+    private DeleteResourceOperationFactory deleteResourceOpFactory;
+
+    private String rescId;
+
+    @Before
+    public void setup() {
+        storageSession = startWriteSession();
+
+        rescId = makeRescId();
+    }
+
+    @Test
+    public void createInternalNonRdfResource() throws Exception {
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+                .filename("test.txt")
+                .mimeType("text/plain")
+                .build();
+
+        storageSession.persist(op);
+
+        storageSession.commit();
+
+        final var readSession = sessionManager.getReadOnlySession();
+        assertContentPersisted(BINARY_CONTENT, readSession, rescId);
+
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
+        assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
+        assertEquals("test.txt", headers.getFilename());
+        assertEquals("text/plain", headers.getMimeType());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertTrue("Headers did not contain default digest",
+                headers.getDigests().contains(CONTENT_SHA512));
+    }
+
+    @Test
+    public void createInternalNonRdfResourceWithDigests() throws Exception {
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+                .contentDigests(asList(CONTENT_SHA1, CONTENT_MD5))
+                .mimeType("text/plain")
+                .build();
+
+        storageSession.persist(op);
+
+        storageSession.commit();
+
+        final var readSession = sessionManager.getReadOnlySession();
+        assertContentPersisted(BINARY_CONTENT, readSession, rescId);
+
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
+        assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
+        assertEquals("text/plain", headers.getMimeType());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertTrue("Headers did not contain md5 digest",
+                headers.getDigests().contains(CONTENT_MD5));
+        assertTrue("Headers did not contain sha1 digest",
+                headers.getDigests().contains(CONTENT_SHA1));
+        assertTrue("Headers did not contain default sha512 digest",
+                headers.getDigests().contains(CONTENT_SHA512));
+    }
+
+    @Test
+    public void createInternalNonRdfResourceUncommittedSession() throws Exception {
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+                .mimeType("text/plain")
+                .build();
+
+        storageSession.persist(op);
+
+        assertContentPersisted(BINARY_CONTENT, storageSession, rescId);
+
+        final var headers = storageSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
+        assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
+        assertEquals("text/plain", headers.getMimeType());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertTrue("Headers did not contain default digest",
+                headers.getDigests().contains(CONTENT_SHA512));
+    }
+
+    @Test(expected = InvalidChecksumException.class)
+    public void createInternalNonRdfResourceWithInvalidDigest() throws Exception {
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+                .contentDigests(asList(URI.create("urn:sha1:ohnothisisbad")))
+                .mimeType("text/plain")
+                .build();
+
+        storageSession.persist(op);
+    }
+
+    @Test(expected = InvalidChecksumException.class)
+    public void createInternalNonRdfResourceWithInvalidDefaultDigest() throws Exception {
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+                .contentDigests(asList(URI.create("urn:sha-512:ohnothisisbad"), CONTENT_SHA1))
+                .mimeType("text/plain")
+                .build();
+
+        storageSession.persist(op);
+    }
+
+    @Test
+    public void updateInternalNonRdfResource() throws Exception {
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+                .filename("test.txt")
+                .mimeType("text/plain")
+                .contentDigests(asList(CONTENT_SHA1))
+                .build();
+
+        storageSession.persist(op);
+
+        final var updateOp = nonRdfSourceOpFactory.updateInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(UPDATED_CONTENT, UTF_8))
+                .mimeType("text/plain")
+                .build();
+
+        storageSession.persist(updateOp);
+
+        storageSession.commit();
+
+        final var readSession = sessionManager.getReadOnlySession();
+        assertContentPersisted(UPDATED_CONTENT, readSession, rescId);
+
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
+        assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
+        assertNull(headers.getFilename());
+        assertEquals("text/plain", headers.getMimeType());
+        assertEquals(UPDATED_CONTENT.length(), headers.getContentSize().longValue());
+        assertEquals("Only one digest expected", 1, headers.getDigests().size());
+        assertTrue("Headers did not contain default digest",
+                headers.getDigests().contains(UPDATED_SHA512));
+    }
+
+    @Test
+    public void rollbackUpdateToInternalNonRdfResource() throws Exception {
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+            .filename("test.txt")
+            .mimeType("text/plain")
+            .build();
+
+        storageSession.persist(op);
+        storageSession.commit();
+
+        final var updateOp = nonRdfSourceOpFactory.updateInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(UPDATED_CONTENT, UTF_8))
+                .filename("test_updated.txt")
+                .mimeType("text/plain")
+                .build();
+
+        final var updateSession = startWriteSession();
+        updateSession.persist(updateOp);
+        updateSession.rollback();
+
+        final var readSession = sessionManager.getReadOnlySession();
+        assertContentPersisted(BINARY_CONTENT, readSession, rescId);
+
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
+        assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
+        assertEquals("test.txt", headers.getFilename());
+        assertEquals("text/plain", headers.getMimeType());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertTrue("Headers did not contain default digest",
+                headers.getDigests().contains(CONTENT_SHA512));
+    }
+
+    @Test
+    public void createInternalNonRdfResourceInAG() throws Exception {
+        final var agOp = rdfSourceOpFactory.createBuilder(rescId, BASIC_CONTAINER.getURI())
+                .archivalGroup(true)
+                .build();
+        storageSession.persist(agOp);
+
+        final var binId = makeRescId(rescId);
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                    binId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+                .parentId(rescId)
+                .mimeType("text/plain")
+                .build();
+
+        storageSession.persist(op);
+
+        storageSession.commit();
+
+        final var readSession = sessionManager.getReadOnlySession();
+        // Check the persisted AG details
+        final var agHeaders = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, agHeaders.getId());
+        assertNull(agHeaders.getParent());
+        assertEquals(BASIC_CONTAINER.getURI(), agHeaders.getInteractionModel());
+
+        // Check the binary details
+        assertContentPersisted(BINARY_CONTENT, readSession, binId);
+
+        final var headers = readSession.getHeaders(binId, null);
+        assertEquals(binId, headers.getId());
+        assertEquals(rescId, headers.getParent());
+        assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
+        assertEquals("text/plain", headers.getMimeType());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertTrue("Headers did not contain default digest",
+                headers.getDigests().contains(CONTENT_SHA512));
+    }
+
+    @Test
+    public void deleteInternalNonRdfResource() throws Exception {
+        final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
+                    rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
+                .filename("test.txt")
+                .mimeType("text/plain")
+                .contentDigests(asList(CONTENT_SHA1))
+                .build();
+
+        storageSession.persist(op);
+
+        storageSession.commit();
+
+        final var deleteOp = deleteResourceOpFactory.deleteBuilder(rescId).build();
+
+        final var deleteSession = startWriteSession();
+        deleteSession.persist(deleteOp);
+        deleteSession.commit();
+
+        final var readSession = sessionManager.getReadOnlySession();
+        try {
+            readSession.getBinaryContent(rescId, null);
+            fail("Binary file must no longer exist");
+        } catch (final PersistentItemNotFoundException e) {
+            // expected
+        }
+
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
+        assertTrue("Headers must indicate object deleted", headers.isDeleted());
+        assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
+    }
+
+    private void assertContentPersisted(final String expectedContent, final PersistentStorageSession session,
+            final String rescId) throws Exception {
+        final var resultContent = session.getBinaryContent(rescId, null);
+        assertEquals("Binary content did not match expectations",
+                expectedContent, IOUtils.toString(resultContent, UTF_8));
+    }
+
+    private PersistentStorageSession startWriteSession() {
+        final String sessionId = UUID.randomUUID().toString();
+        return sessionManager.getSession(sessionId);
+    }
+
+    private String makeRescId(final String... parentIds) {
+        String parents = "";
+        if (parentIds != null && parentIds.length > 0) {
+            parents = Arrays.stream(parentIds).map(p -> p.replace("info:fedora/", ""))
+                    .collect(Collectors.joining("/", "", "/"));
+        }
+        return "info:fedora/" + parents + UUID.randomUUID().toString();
+    }
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
@@ -49,8 +49,10 @@ import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
 import org.fcrepo.persistence.api.WriteOutcome;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.common.FileWriteOutcome;
 import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.junit.Before;
@@ -82,7 +84,7 @@ public class CreateNonRdfSourcePersisterTest {
     private FedoraToOCFLObjectIndex index;
 
     @Mock
-    private WriteOutcome writeOutcome;
+    private FileWriteOutcome writeOutcome;
 
     @Captor
     private ArgumentCaptor<InputStream> userContentCaptor;
@@ -124,6 +126,7 @@ public class CreateNonRdfSourcePersisterTest {
         when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
 
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
+        when(session.getObjectDigestAlgorithm()).thenReturn(DIGEST_ALGORITHM.SHA1);
 
         nonRdfSourceOperation = mock(NonRdfSourceOperation.class, withSettings().extraInterfaces(
                 CreateResourceOperation.class));

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
@@ -45,7 +45,8 @@ import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
-import org.fcrepo.persistence.api.WriteOutcome;
+import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
+import org.fcrepo.persistence.common.FileWriteOutcome;
 import org.fcrepo.persistence.ocfl.api.FedoraToOCFLObjectIndex;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.junit.Before;
@@ -75,7 +76,7 @@ public class UpdateNonRdfSourcePersisterTest {
     @Mock
     private FedoraToOCFLObjectIndex index;
     @Mock
-    private WriteOutcome writeOutcome;
+    private FileWriteOutcome writeOutcome;
 
     @Captor
     private ArgumentCaptor<InputStream> userContentCaptor;
@@ -104,6 +105,7 @@ public class UpdateNonRdfSourcePersisterTest {
         when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
 
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
+        when(session.getObjectDigestAlgorithm()).thenReturn(DIGEST_ALGORITHM.SHA1);
 
         nonRdfSourceOperation = mock(NonRdfSourceOperation.class, withSettings().extraInterfaces(
                 CreateResourceOperation.class));

--- a/fcrepo-persistence-ocfl/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-persistence-ocfl/src/test/resources/spring-test/fcrepo-config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:task="http://www.springframework.org/schema/task"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+    http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+  <context:annotation-config/>
+  <context:property-placeholder />
+  <context:component-scan base-package="org.fcrepo.persistence.ocfl.impl"/>
+  <context:component-scan base-package="org.fcrepo.kernel.impl.operations"/>
+  
+  <bean id="containmentIndex" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.fcrepo.kernel.api.ContainmentIndex" />
+  </bean>
+  
+  <bean id="transactionManager" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.fcrepo.kernel.api.TransactionManager" />
+  </bean>
+
+</beans>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3200

# What does this Pull Request do?
* Internal fedora binaries will always record a default digest
* Adds a repository wide default digest algorithm from a system property.
   * Can only be SHA512 or SHA256 due to OCFL restrictions
* New OCFL objects are configured to use this default digest algorithm
* Added aliases for digest algorithms to help with matching across domains
* Adds integration tests for binary persistence in OCFL


# How should this be tested?

Digests are not currently visible in http responses unfortunately, so you would need to look at the OCFL persistence to verify results:

```
curl -XPOST http://localhost:8080/rest/ -H"Slug: binary_default_digest" --data-binary @README.md -H"Content-type: text/plain" -ufedoraAdmin:fedoraAdmin

# verify that the sha512 is set (adjust for your OCFL storage root)
less /var/folders/v6/r6tq3p3n2h165cw93s39rl25cv0v_w/T/fcrepo.ocfl.storage.root.dir/84/43/86/binary_default_digest/v1/content/.fcrepo/binary_default_digest.json 

{
  "parent": "info:fedora",
  "id": "info:fedora/binary_default_digest",
  "lastModifiedDate": "2020-06-03T18:14:13.987960Z",
  "interactionModel": "http://www.w3.org/ns/ldp#NonRDFSource",
  "createdBy": "fedoraAdmin",
  "createdDate": "2020-06-03T18:14:13.987960Z",
  "lastModifiedBy": "fedoraAdmin",
  "stateToken": "4BE570CA6FBA4D7ECD6D94DB8878B3C2",
  "contentSize": 5770,
  "digests": [
    "urn:sha-512:7003d24ed80964957eb59d590f8d63961a8db755bc5760b9d55c21d97d3b011497bce353e1ceaa9374efbe9f05f4b277010468b92a55c543b0dca787300f8681"
  ],
  "filename": "",
  "deleted": false,
  "mimeType": "text/plain",
  "archivalGroup": false,
  "objectRoot": true
}
```
```
# With bad digest
curl -XPOST http://localhost:8080/rest/ -H"Slug: binary_sha1_digest" --data-binary @LICENSE -H"Content-type: text/plain" -H"digest: sha=checksumdoesntmatch" -ufedoraAdmin:fedoraAdmin
# Checksum mismatch, computed SHA digest f5c0f25223b84f167e917701f91e90c49525def0 did not match expected value checksumdoesntmatch

# With sha1 digest
curl -XPOST http://localhost:8080/rest/ -H"Slug: binary_sha1_digest" --data-binary @LICENSE -H"Content-type: text/plain" -H"digest: sha=f5c0f25223b84f167e917701f91e90c49525def0" -ufedoraAdmin:fedoraAdmin

# Verify that the sha512 and provided sha1 are present
less /var/folders/v6/r6tq3p3n2h165cw93s39rl25cv0v_w/T/fcrepo.ocfl.storage.root.dir/82/70/bb/binary_sha1_digest/v1/content/.fcrepo/binary_sha1_digest.json 

{
  "parent": "info:fedora",
  "id": "info:fedora/binary_sha1_digest",
  "lastModifiedDate": "2020-06-03T18:24:03.656085Z",
  "interactionModel": "http://www.w3.org/ns/ldp#NonRDFSource",
  "createdBy": "fedoraAdmin",
  "createdDate": "2020-06-03T18:24:03.656085Z",
  "lastModifiedBy": "fedoraAdmin",
  "stateToken": "9C8C83F606DBDA2BCB78A431E45AD3EC",
  "contentSize": 10831,
  "digests": [
    "urn:sha1:f5c0f25223b84f167e917701f91e90c49525def0",
    "urn:sha-512:05de5e29e68a7e33c86d494cf88da0c3c8c7c10ce5d3d678a548c2538991f806728d6e44495d3b59da13d279533c29952f6467b61a57415e9239d76e23201b22"
  ],
  "filename": "",
  "deleted": false,
  "mimeType": "text/plain",
  "archivalGroup": false,
  "objectRoot": true
}
```

# Notes
The SHA512 is generated both when the file is written to staging, and the OCFL client also generates and verifies it. Some efficiency should be gained later in FCREPO-3201 by passing the digest along with the OCFL client in terms of transmission fixity checking.

# Interested parties
@awoods @pwinckles 
