### PR TITLE
FCREPO-3330 - Implement Want-Digest

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -101,11 +101,14 @@ public class FedoraFixity extends ContentExposingResource {
         final Link.Builder rdfSourceLink = Link.fromUri(LDP_NAMESPACE + "RDFSource").rel("type");
         servletResponse.addHeader(LINK, rdfSourceLink.build().toString());
 
+        // TODO implement fixity check and generate response
+        fixityService.checkFixity((Binary)resource(), null);
+
         LOGGER.info("Get fixity for '{}'", externalPath);
         return new RdfNamespacedStream(
             new DefaultRdfStream(
                 asNode(resource()),
-                fixityService.getFixity((Binary)resource())
+                null
             ),
             namespaceRegistry.getNamespaces()
         );

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -704,7 +704,7 @@ public class FedoraLdp extends ContentExposingResource {
                     "Unsupported digest algorithm provided in 'Want-Digest' header: " + wantDigest);
         }
 
-        final Collection<URI> checksumResults = fixityService.checkFixity(binary, preferredDigests);
+        final Collection<URI> checksumResults = fixityService.getFixity(binary, preferredDigests);
         return checksumResults.stream().map(uri -> uri.toString().replaceFirst("urn:", "")
                 .replaceFirst(":", "=").replaceFirst("sha1=", "sha=")).collect(Collectors.joining(","));
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -507,7 +507,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadDatastreamWithWantDigest() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", TEST_BINARY_CONTENT);
@@ -525,7 +524,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testHeadDatastreamWithWantDigestMultiple() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", TEST_BINARY_CONTENT);
@@ -546,7 +544,22 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
+    public void testHeadDatastreamWithWantDigestMultipleOneUnsupported() throws IOException {
+        final String id = getRandomUniqueId();
+        createDatastream(id, "x", TEST_BINARY_CONTENT);
+
+        final HttpHead headObjMethod = headObjMethod(id + "/x");
+        headObjMethod.addHeader(WANT_DIGEST, "md5, Indigestion");
+        try (final CloseableHttpResponse response = execute(headObjMethod)) {
+            assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
+            assertEquals(1, response.getHeaders(DIGEST).length);
+            final String digesterHeaderValue = response.getHeaders(DIGEST)[0].getValue();
+            assertTrue("MD5 fixity checksum doesn't match",
+                    digesterHeaderValue.contains(TEST_MD5_DIGEST_HEADER_VALUE));
+        }
+    }
+
+    @Test
     public void testHeadDatastreamWithWantDigestSha256() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", TEST_BINARY_CONTENT);
@@ -801,7 +814,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetNonRDFSourceWithWantDigest() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", TEST_BINARY_CONTENT);
@@ -821,7 +833,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetNonRDFSourceWithWantDigestMultiple() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", TEST_BINARY_CONTENT);
@@ -4377,7 +4388,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testDigestConsistency() throws IOException {
         final String id = getRandomUniqueId();
         executeAndClose(putDSMethod(id, "binary1", "some test content"));

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/FixityService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/FixityService.java
@@ -17,31 +17,24 @@
  */
 package org.fcrepo.kernel.api.services;
 
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.Binary;
 
 import java.net.URI;
 import java.util.Collection;
 
+/**
+ * Service which calculates and compares digests for binary objects
+ */
 public interface FixityService {
-
   /**
-   * Get the fixity of this binary compared to metadata stored in the repository
-   * @param binary the binary resource to get fixity for
-   * @return the fixity of this binary compared to metadata stored in the repository
+   * Calculate the requested set of digests for the provided binary
+   * @param binary the binary resource to
+   * @param algorithms set of digest algorithms to calculate
+   * @return list of calculated digests
+   * @throws UnsupportedAlgorithmException if unsupported digest algorithms were provided
    */
-  RdfStream getFixity(Binary binary);
-
-  /**
-   * Get the fixity of this binary in a given repository's binary store.
-   * @param binary the binary resource to compare
-   * @param contentDigest the checksum to compare against
-   * @param size the expected size of the binary
-   * @return the fixity of the binary
-   */
-  RdfStream getFixity(Binary binary, URI contentDigest, long size);
-
+  Collection<URI> getFixity(Binary binary, Collection<String> algorithms) throws UnsupportedAlgorithmException;
 
   /**
    * Digest this binary with the digest algorithms provided

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/FixityServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/FixityServiceImpl.java
@@ -17,14 +17,16 @@
  */
 package org.fcrepo.kernel.impl.services;
 
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.services.FixityService;
+import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
+import org.fcrepo.persistence.common.MultiDigestInputStreamWrapper;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of {@link org.fcrepo.kernel.api.services.FixityService}
@@ -34,13 +36,16 @@ import java.util.Collection;
 @Component
 public class FixityServiceImpl extends AbstractService implements FixityService {
     @Override
-    public RdfStream getFixity(final Binary binary) {
-        return null;
-    }
+    public Collection<URI> getFixity(final Binary binary, final Collection<String> algorithms)
+            throws UnsupportedAlgorithmException {
+        final var digestAlgs = algorithms.stream()
+                .map(DIGEST_ALGORITHM::fromAlgorithm)
+                .collect(Collectors.toList());
 
-    @Override
-    public RdfStream getFixity(final Binary binary, final URI contentDigest, final long size) {
-        return null;
+        final MultiDigestInputStreamWrapper digestWrapper = new MultiDigestInputStreamWrapper(
+                binary.getContent(), null, digestAlgs);
+
+        return digestWrapper.getDigests();
     }
 
     @Override


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3330

# What does this Pull Request do?
* Implements Want-Digest functionality
* Updates to the FixityService interface, removing some unused methods and adding the currently needed signature for getFixity

# How should this be tested?

Fedora API Test Suite should now be passing for the 3.2.3 tests.

# Interested parties
@fcrepo4/committers
