### PR TITLE
change itests to use inmemory h2

### DIFF
--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -357,6 +357,11 @@
             <configuration>
               <properties>
                 <property>
+                  <name>fcrepo.db.url</name>
+                  <value>jdbc:h2:mem:fcrepo</value>
+                </property>
+
+                <property>
                   <name>fcrepo.dynamic.jms.port</name>
                   <value>${fcrepo.dynamic.jms.port}</value>
                 </property>

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/config/DatabaseConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/config/DatabaseConfig.java
@@ -56,6 +56,7 @@ public class DatabaseConfig {
     public DataSource dataSource() throws PropertyVetoException {
         final var driver = identifyDbDriver();
 
+        LOGGER.debug("JDBC URL: {}", dbUrl);
         LOGGER.debug("Using database driver: {}", driver);
 
         final var dataSource = new ComboPooledDataSource();


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3347

# What does this Pull Request do?

The ITests in `fcrepo-webapp` now use an in memory H2.

# How should this be tested?

1. Start the one-click Fedora with default settings
1. Build `fcrepo-webapp`
1. The ITests should not hang

# Interested parties
@fcrepo4/committers
