### PR TITLE
Simple attempt at including user types in getTypes

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -72,6 +72,7 @@ import org.fcrepo.kernel.api.exception.RepositoryException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.TimeMap;
+import org.fcrepo.kernel.api.models.WebacAcl;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
@@ -113,7 +114,12 @@ public class WebACRolesProvider {
 
         // Construct a list of acceptable acl:accessTo values for the target resource.
         final List<String> resourcePaths = new ArrayList<>();
-        resourcePaths.add(resource.getDescribedResource().getId());
+        if (resource instanceof WebacAcl) {
+            // ACLs don't describe their resource, but we still want the container which is the resource.
+            resourcePaths.add(resource.getContainer().getId());
+        } else {
+            resourcePaths.add(resource.getDescribedResource().getId());
+        }
 
         // Construct a list of acceptable acl:accessToClass values for the target resource.
         final List<URI> rdfTypes = resource.getDescription().getTypes();

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -351,7 +351,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(requestPatch3));
     }
 
-    @Ignore("Not getting all rdf:types back to match on accessToClass - FCREPO-3279")
     @Test
     public void scenario5() throws IOException {
         final String idPublic = "/rest/mixedCollection/publicObj";
@@ -717,7 +716,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals(HttpStatus.SC_OK, getStatus(requestGet2));
     }
 
-    @Ignore("Access to class - FCREPO-3279")
     @Test
     public void testAccessToVersionedResources() throws IOException {
         final String idVersion = "/rest/versionResource";
@@ -737,7 +735,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals("user10 can't read object", HttpStatus.SC_OK, getStatus(requestGet1));
 
         final HttpPost requestPost1 = postObjMethod(idVersion + "/fcr:versions");
-        requestPost1.addHeader("Slug", "v0");
         setAuth(requestPost1, "fedoraAdmin");
         assertEquals("Unable to create a new version", HttpStatus.SC_CREATED, getStatus(requestPost1));
 
@@ -823,7 +820,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals("testuser can't read versioned object", HttpStatus.SC_OK, getStatus(requestGet2));
     }
 
-    @Ignore("Not getting all rdf:types back to match on accessToClass - FCREPO-3279")
     @Test
     public void testAgentAsUri() throws IOException {
         final String id = "/rest/" + getRandomUniqueId();
@@ -1302,7 +1298,6 @@ public class WebACRecipesIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore("Not getting all rdf:types back to match on accessToClass - FCREPO-3279")
     @Test
     public void testCreateAclWithAccessToClassForBinary() throws Exception {
         final String id = getRandomUniqueId();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -199,7 +199,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final Node DC_IDENTIFIER = DC_11.identifier.asNode();
 
-    private static final String LDP_RESOURCE_LINK_HEADER = "<" + LDP_NAMESPACE + "Resource>;rel=\"type\"";
+    private static final String LDP_RESOURCE_LINK_HEADER = "<" + LDP_NAMESPACE + "Resource>; rel=\"type\"";
 
     private static final Node rdfType = type.asNode();
 
@@ -207,16 +207,16 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final Resource PCDM_FILE_TYPE = createResource("http://pcdm.org/models#File");
 
-    private static final String CONTAINER_LINK_HEADER = "<" + CONTAINER.getURI() + ">;rel=\"type\"";
+    private static final String CONTAINER_LINK_HEADER = "<" + CONTAINER.getURI() + ">; rel=\"type\"";
 
-    private static final String BASIC_CONTAINER_LINK_HEADER = "<" + BASIC_CONTAINER.getURI() + ">;rel=\"type\"";
-    private static final String DIRECT_CONTAINER_LINK_HEADER = "<" + DIRECT_CONTAINER.getURI() + ">;rel=\"type\"";
-    private static final String INDIRECT_CONTAINER_LINK_HEADER = "<" + INDIRECT_CONTAINER.getURI() + ">;rel=\"type\"";
-    private static final String ARCHIVAL_GROUP_LINK_HEADER = "<" + ARCHIVAL_GROUP.getURI() + ">;rel=\"type\"";
+    private static final String BASIC_CONTAINER_LINK_HEADER = "<" + BASIC_CONTAINER.getURI() + ">; rel=\"type\"";
+    private static final String DIRECT_CONTAINER_LINK_HEADER = "<" + DIRECT_CONTAINER.getURI() + ">; rel=\"type\"";
+    private static final String INDIRECT_CONTAINER_LINK_HEADER = "<" + INDIRECT_CONTAINER.getURI() + ">; rel=\"type\"";
+    private static final String ARCHIVAL_GROUP_LINK_HEADER = "<" + ARCHIVAL_GROUP.getURI() + ">; rel=\"type\"";
 
-    private static final String RESOURCE_LINK_HEADER = "<" + RESOURCE.getURI() + ">;rel=\"type\"";
-    private static final String RDF_SOURCE_LINK_HEADER = "<" + RDF_SOURCE.getURI() + ">;rel=\"type\"";
-    private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
+    private static final String RESOURCE_LINK_HEADER = "<" + RESOURCE.getURI() + ">; rel=\"type\"";
+    private static final String RDF_SOURCE_LINK_HEADER = "<" + RDF_SOURCE.getURI() + ">; rel=\"type\"";
+    private static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">; rel=\"type\"";
     private static final String VERSIONED_RESOURCE_LINK_HEADER = "<" + VERSIONED_RESOURCE.getURI() + ">; rel=\"type\"";
 
     private static final String TEST_ACTIVATION_PROPERTY = "RUN_TEST_CREATE_MANY";
@@ -629,7 +629,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testOptionsBinaryMetadata() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", null);
@@ -642,7 +641,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testOptionsBinaryMetadataWithUriEncoding() throws Exception {
         final String id = getRandomUniqueId();
         createDatastream(id, "x", null);
@@ -870,7 +868,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetRDFSourceWithUserTypes() throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -879,7 +876,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetNonRDFSourceAndDescriptionWithUserTypes() throws IOException {
         final String id = getRandomUniqueId();
         createDatastream(id, "ds", "sample-content");

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -185,7 +185,21 @@ public interface FedoraResource {
     boolean hasType(final String type);
 
     /**
-     * Get the RDF:type values for this resource
+     * Get only the user provided types from their RDF.
+     * @return a list of types from the user provided RDF.
+     */
+    List<URI> getUserTypes();
+
+    /**
+     * Get only the system defined types from their RDF.
+     * @param forRdf whether we only want types for displaying in a RDF body.
+     * @return a list of types from the user provided RDF.
+     */
+    List<URI> getSystemTypes(final boolean forRdf);
+
+    /**
+     * Get the RDF:type values for this resource, this is usually the combination of getUserTypes and
+     * getSystemTypes(false) to get ALL the types.
      * @return a list of types for this resource
      */
     List<URI> getTypes();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -17,24 +17,19 @@
  */
 package org.fcrepo.kernel.impl.models;
 
-import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 
-import java.util.stream.Stream;
+import java.net.URI;
+import java.util.List;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.Triple;
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
-import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 
 
@@ -64,14 +59,11 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
     }
 
     @Override
-    public RdfStream getTriples() {
-        final Node subject = createURI(getId());
-        final Stream<Triple> extra_triples = Stream.of(
-                Triple.create(subject, type.asNode(), RDF_SOURCE.asNode()),
-                Triple.create(subject, type.asNode(), CONTAINER.asNode()),
-                Triple.create(subject, type.asNode(), FEDORA_CONTAINER.asNode()),
-                Triple.create(subject, type.asNode(), FEDORA_RESOURCE.asNode())
-        );
-        return new DefaultRdfStream(createURI(getId()), Stream.concat(super.getTriples(), extra_triples));
+    public List<URI> getSystemTypes(final boolean forRdf) {
+        final var types = super.getSystemTypes(forRdf);
+        types.addAll(List.of(URI.create(RDF_SOURCE.toString()), URI.create(CONTAINER.toString()),
+                URI.create(FEDORA_CONTAINER.toString()), URI.create(FEDORA_RESOURCE.toString())));
+        return types;
     }
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -18,7 +18,10 @@
 package org.fcrepo.kernel.impl.models;
 
 import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 
+import java.net.URI;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.jena.graph.Node;
@@ -70,6 +73,14 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
         } catch (final PathNotFoundException e) {
             throw new PathNotFoundRuntimeException(e);
         }
+    }
+
+    @Override
+    public List<URI> getSystemTypes(final boolean forRdf) {
+        final var types = super.getSystemTypes(forRdf);
+        // NonRdfSource gets the ldp:Resource and adds ldp:RDFSource types.
+        types.add(URI.create(RDF_SOURCE.getURI()));
+        return types;
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
@@ -44,7 +44,7 @@ public class WebacAclImpl extends ContainerImpl implements WebacAcl {
     }
 
     @Override
-    public FedoraResource getDescribedResource() {
+    public FedoraResource getContainer() {
         final var originalId = FedoraId.create(getFedoraId().getContainingId());
         try {
             return resourceFactory.getResource(tx, originalId);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.jena.graph.Triple;
-import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.TimeMap;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
@@ -54,7 +53,7 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
         triples.add(Triple.create(subject, LAST_MODIFIED_DATE.asNode(),
                 createLiteral(resource.getLastModifiedDate().toString(), XSDdateTime)));
 
-        resource.getDescribedResource().getTypes().forEach(triple -> {
+        resource.getDescribedResource().getSystemTypes(true).forEach(triple -> {
             triples.add(Triple.create(subject, type.asNode(), createURI(triple.toString())));
         });
 
@@ -63,7 +62,7 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
 
     private String resolveId(final FedoraResource resource) {
         if (resource instanceof TimeMap) {
-            return resource.getId() + "/" + FedoraTypes.FCR_VERSIONS;
+            return resource.getFedoraId().getFullId();
         }
         return resource.getId();
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -92,9 +93,12 @@ public class TimeMapImplTest {
 
     @Test
     public void shouldHaveTimeMapTypes() {
-        assertThat(timeMap.getTypes(), contains(
+        assertTrue(timeMap.getTypes().containsAll(
+                List.of(
                 URI.create(RdfLexicon.TIME_MAP.getURI()),
-                URI.create(RdfLexicon.VERSIONING_TIMEMAP.getURI())));
+                URI.create(RdfLexicon.VERSIONING_TIMEMAP.getURI())
+                ))
+        );
     }
 
     @Test
@@ -106,8 +110,8 @@ public class TimeMapImplTest {
 
         final var children = timeMap.getChildren();
 
-        assertThat(children.map(FedoraResource::getMementoDatetime)
-                .collect(Collectors.toList()), contains(version1, version2));
+        assertTrue(children.map(FedoraResource::getMementoDatetime)
+                .collect(Collectors.toList()).containsAll(List.of(version1, version2)));
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3279

# What does this Pull Request do?
Separates the inclusion of user defined types from system defined types. When getting types we now have to read the user's RDF and filter for types. 

Perhaps this information should be included in the header file and eventually be cached for quick access?

As a user could add or remove a `rdf:type` at any time it seems like we might need to do this at POST/PUT/PATCH? Perhaps in the persistence layer?

# How should this be tested?

Not sure how this would expose itself through common use other than now the WebAC `acl:accessToClass` directives work because we get the user defined types back when we `getTypes()`

# Interested parties
@fcrepo4/committers
