### PR TITLE
Don't fail with stacktrace on empty path segment in WebAC Filter

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -208,13 +208,15 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
             for (final URI uri : rolesForURI.keySet()) {
                 log.debug("Adding permissions gathered for URI {}", uri);
                 final Map<String, Collection<String>> roles = rolesForURI.get(uri);
-                final Collection<String> modesForUser = roles.get(agentName);
-                if (modesForUser != null) {
-                    // add WebACPermission instance for each mode in the Authorization
-                    for (final String mode : modesForUser) {
-                        final WebACPermission perm = new WebACPermission(URI.create(mode), uri);
-                        authzInfo.addObjectPermission(perm);
-                        log.debug("Added permission {}", perm);
+                if (roles != null) {
+                    final Collection<String> modesForUser = roles.get(agentName);
+                    if (modesForUser != null) {
+                        // add WebACPermission instance for each mode in the Authorization
+                        for (final String mode : modesForUser) {
+                            final WebACPermission perm = new WebACPermission(URI.create(mode), uri);
+                            authzInfo.addObjectPermission(perm);
+                            log.debug("Added permission {}", perm);
+                        }
                     }
                 }
             }

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACFilterTest.java
@@ -18,6 +18,8 @@
 package org.fcrepo.auth.webac;
 
 import static java.util.stream.Stream.of;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
@@ -796,6 +798,37 @@ public class WebACFilterTest {
         request.setMethod("DELETE");
         webacFilter.doFilter(request, response, filterChain);
         assertEquals(SC_FORBIDDEN, response.getStatus());
+    }
+
+
+    @Test
+    public void testUserEmptyPath1() throws ServletException, IOException {
+        setupAuthUserReadOnly();
+        request.setMethod("GET");
+        request.setContextPath("/");
+        request.setRequestURI("testUri//testChild");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_BAD_REQUEST, response.getStatus());
+    }
+
+    @Test
+    public void testUserEmptyPath2() throws ServletException, IOException {
+        setupAuthUserReadOnly();
+        request.setMethod("GET");
+        request.setContextPath("/");
+        request.setRequestURI("/testUri/testChild");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_BAD_REQUEST, response.getStatus());
+    }
+
+    @Test
+    public void testUserEmptyPath3() throws ServletException, IOException {
+        setupAuthUserReadOnly();
+        request.setMethod("GET");
+        request.setContextPath("/");
+        request.setRequestURI("testUri/testChild//");
+        webacFilter.doFilter(request, response, filterChain);
+        assertEquals(SC_BAD_REQUEST, response.getStatus());
     }
 
     @After

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -1951,10 +1951,15 @@ public class WebACRecipesIT extends AbstractResourceIT {
         final HttpGet getAdminRequest = getObjMethod(parent + "//" + child);
         setAuth(getAdminRequest, "fedoraAdmin");
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(getAdminRequest));
-        // User can't access the URL (because the path is not correct).
+        // Bad request, empty path in the middle.
         final HttpGet getUserRequest = getObjMethod(parent + "//" + child);
         setAuth(getUserRequest, username);
-        assertEquals(FORBIDDEN.getStatusCode(), getStatus(getUserRequest));
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(getUserRequest));
+        // Bad request, empty path at the end.
+        final HttpGet getUserRequest2 = getObjMethod(parent + "/" + child + "//");
+        setAuth(getUserRequest2, username);
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(getUserRequest2));
+        // On the front side extra slashes seem to get stripped off, so no testing here.
     }
 
     /**

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -18,7 +18,12 @@
 package org.fcrepo.integration.auth.webac;
 
 import static java.util.Arrays.stream;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.OK;
+
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
@@ -1886,6 +1891,70 @@ public class WebACRecipesIT extends AbstractResourceIT {
 
         // Ensure we can write to the writeable resource.
         testCanWrite(writeableResource, username);
+    }
+
+    @Test
+    public void testRequestWithEmptyPath() throws Exception {
+        final String username = "testUser92";
+        final String parent = getRandomUniqueId();
+        final HttpPost postParent = postObjMethod();
+        postParent.setHeader("Slug", parent);
+        setAuth(postParent, "fedoraAdmin");
+        final String parentUri;
+        try (final CloseableHttpResponse response = execute(postParent)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            parentUri = getLocation(response);
+        }
+        // Make parent only accessible to fedoraAdmin
+        final String parentAcl = "@prefix acl: <http://www.w3.org/ns/auth/acl#> .\n" +
+                "<#readauthz> a acl:Authorization ;\n" +
+                "   acl:agent \"fedoraAdmin\" ;\n" +
+                "   acl:mode acl:Read, acl:Write ;\n" +
+                "   acl:accessTo <" + parentUri + "> .";
+        ingestAclString(parentUri, parentAcl, "fedoraAdmin");
+        // Admin can see parent
+        final HttpGet getAdminParent = getObjMethod(parent);
+        setAuth(getAdminParent, "fedoraAdmin");
+        assertEquals(OK.getStatusCode(), getStatus(getAdminParent));
+        final HttpGet getParent = getObjMethod(parent);
+        setAuth(getParent, username);
+        // testUser92 cannot see parent.
+        assertEquals(FORBIDDEN.getStatusCode(), getStatus(getParent));
+
+        final String child = getRandomUniqueId();
+        final HttpPost postChild = postObjMethod(parent);
+        postChild.setHeader("Slug", child);
+        setAuth(postChild, "fedoraAdmin");
+        final String childUri;
+        try (final CloseableHttpResponse response = execute(postChild)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            childUri = getLocation(response);
+        }
+        // Make child accessible to testUser92
+        final String childAcl = "@prefix acl: <http://www.w3.org/ns/auth/acl#> .\n" +
+                "<#readauthz> a acl:Authorization ;\n" +
+                "   acl:agent \"" + username + "\" ;\n" +
+                "   acl:mode acl:Read, acl:Write ;\n" +
+                "   acl:accessTo <" + childUri + "> .";
+        ingestAclString(childUri, childAcl, "fedoraAdmin");
+        // Admin can see child.
+        final HttpGet getAdminChild = getObjMethod(parent + "/" + child);
+        setAuth(getAdminChild, "fedoraAdmin");
+        assertEquals(OK.getStatusCode(), getStatus(getAdminChild));
+
+        // testUser92 can see child.
+        final HttpGet getChild = getObjMethod(parent + "/" + child);
+        setAuth(getChild, username);
+        assertEquals(OK.getStatusCode(), getStatus(getChild));
+
+        // Admin bypasses ACL resolution gets 409.
+        final HttpGet getAdminRequest = getObjMethod(parent + "//" + child);
+        setAuth(getAdminRequest, "fedoraAdmin");
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(getAdminRequest));
+        // User can't access the URL (because the path is not correct).
+        final HttpGet getUserRequest = getObjMethod(parent + "//" + child);
+        setAuth(getUserRequest, username);
+        assertEquals(FORBIDDEN.getStatusCode(), getStatus(getUserRequest));
     }
 
     /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3339

# What does this Pull Request do?
When passing a URI with an empty path segment into the WebAC Filter it ends up without roles, but we don't account for that so it does a stacktrace.
This now checks that it isn't null before proceeding, resulting in a 403 for the path with empty path segments.

# How should this be tested?

Before this PR

1. Start a Fedora 5
1. Execute `curl -utestuser:testpass http://localhost:8080/rest/bob//bob`
1. See stacktrace.

# Interested parties
@fcrepo4/committers
