### PR TITLE
Account for no fedora path in filter

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -199,15 +199,18 @@ public class WebACFilter extends RequestContextFilter {
             httpRequest = new CachedHttpRequest(httpRequest);
         }
 
+        final String requestUrl = httpRequest.getRequestURL().toString();
         try {
-            FedoraId.create(identifierConverter(httpRequest).toInternalId(httpRequest.getRequestURL().toString()));
+            FedoraId.create(identifierConverter(httpRequest).toInternalId(requestUrl));
         } catch (final InvalidResourceIdentifierException e) {
             response.sendError(SC_BAD_REQUEST,
                     String.format("Path contains empty element! %s", httpRequest.getRequestURI()));
+        } catch (final IllegalArgumentException e) {
+            // No Fedora request path provided, so just continue along.
         }
 
         // add the request URI to the list of URIs to retrieve the ACLs for
-        addURIToAuthorize(httpRequest, URI.create(httpRequest.getRequestURL().toString()));
+        addURIToAuthorize(httpRequest, URI.create(requestUrl));
 
         if (currentUser.isAuthenticated()) {
             log.debug("User is authenticated");


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3358

# What does this Pull Request do?
When deployed in Tomcat the WebAC filter might get a path that is not part of the fedora instance at all. In which case the HttpIdentifierConverter will throw an IllegalArgumentException.

This PR just swallows that exception and lets the processing continue.

# How should this be tested?

Deploy the WAR from main to a Tomcat instance.
Goto http://localhost:8080/fcrepo and see a 500 and stacktrace.
Pull in this PR, redeploy and try again.

# Interested parties
@fcrepo4/committers
