### PR TITLE
Add https://github.com/victims/maven-security-versions plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,8 @@
     <system-rules.version>1.18.0</system-rules.version>
     <mockito.version>2.22.0</mockito.version>
     <wiremock.version>2.13.0</wiremock.version>
-    <!-- fcrepo5-specific plugins -->
+    <!-- fcrepo-specific plugins -->
+    <security-versions.plugin.version>1.0.6</security-versions.plugin.version>
     <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
     <war.plugin.version>3.2.2</war.plugin.version>
     <!-- default properties that can be altered on the command line -->
@@ -680,6 +681,21 @@
 
       <plugin>
         <artifactId>maven-changelog-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <!-- Note this plugin does not fail the build if a vulnerability is found -->
+        <groupId>com.redhat.victims.maven</groupId>
+        <artifactId>security-versions</artifactId>
+        <version>${security-versions.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
**JIRA Ticket**: n/a

Follow-on to https://github.com/fcrepo4/fcrepo4/pull/1707

# What does this Pull Request do?
Adds the security-versions check

# How should this be tested?

Build it and see the plugin report (it does NOT halt on an identified vulnerability)
i.e.
```
> mvn clean install
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Fedora Commons :: Parent POM                                       [pom]
[INFO] Fedora Commons                                                     [pom]
[INFO] Fedora Repository Kernel API                                    [bundle]
[INFO] Fedora Repository Persistence API Module                        [bundle]
[INFO] Fedora Repository Persistence Common Module                     [bundle]
[INFO] Fedora Repository Kernel Implementation                         [bundle]
[INFO] Fedora Repository Configurations Module                         [bundle]
[INFO] Fedora Repository OCFL Persistence Impl                         [bundle]
[INFO] Fedora Repository HTTP Commons Module                           [bundle]
[INFO] Fedora Event Serialization                                      [bundle]
[INFO] Fedora Repository JMS Module                                    [bundle]
[INFO] Fedora Repository Search API                                    [bundle]
[INFO] Fedora Repository Authorization Commons Module                  [bundle]
[INFO] Fedora Repository Search Impl                                   [bundle]
[INFO] Fedora Repository HTTP API Module                               [bundle]
[INFO] Fedora Repository WebAC Authorization Module                    [bundle]
[INFO] Fedora Repository Deployable Web Application                       [war]
[INFO] Fedora Repository LDP integration tests Module                     [jar]
[INFO] Fedora Repository RDF integration tests Module                     [jar]
[INFO] 
[INFO] ----------------------< org.fcrepo:fcrepo-parent >----------------------
[INFO] Building Fedora Commons :: Parent POM 6.0.0-SNAPSHOT              [1/19]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ fcrepo-parent ---
[INFO] 
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ fcrepo-parent ---
[INFO] Installing /Users/whikloj/www/fcrepo4/fcrepo4/fcrepo-parent/pom.xml to /Users/whikloj/.m2/repository/org/fcrepo/fcrepo-parent/6.0.0-SNAPSHOT/fcrepo-parent-6.0.0-SNAPSHOT.pom
[INFO] 
[INFO] -------------------------< org.fcrepo:fcrepo >--------------------------
[INFO] Building Fedora Commons 6.0.0-SNAPSHOT                            [2/19]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ fcrepo ---
[INFO] Deleting /Users/whikloj/www/fcrepo4/fcrepo4/target
[INFO] 
[INFO] --- security-versions:1.0.6:check (default) @ fcrepo ---
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-kernel-api
[INFO] Syncing with the victims repository (based on the atom feed)
[INFO] Downloading: https://github.com/victims/victims-cve-db/commits.atom
[INFO] Already to the latest version.
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-kernel-impl
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-webapp
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-event-serialization
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-jms
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-http-commons
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-http-api
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-auth-common
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-configs
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-parent
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-integration-ldp
[ERROR] commons-beanutils:commons-beanutils is vulnerable to CVE-2014-0114
[ERROR] xerces:xercesImpl is vulnerable to CVE-2013-4002
[ERROR] com.fasterxml.jackson.core:jackson-databind is vulnerable to CVE-2017-7525
[ERROR] org.jboss.resteasy:resteasy-jaxrs is vulnerable to CVE-2014-7839
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-integration-rdf
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-auth-webac
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-persistence-api
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-persistence-common
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-persistence-ocfl
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-search-api
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo-search-impl
[INFO] Analyzing the dependencies for org.fcrepo:fcrepo
```

# Interested parties
@fcrepo4/committers
