### PR TITLE
Ensure files are marked as deleted

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -106,8 +106,8 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
                 }
             });
         } else if (fedoraResource instanceof Binary) {
-            //delete/purge described resource if binary
-            doAction(tx, pSession, fedoraResource.getDescribedResource().getFedoraId(), userPrincipal);
+            //delete/purge the description resource if binary
+            doAction(tx, pSession, fedoraResource.getDescription().getFedoraId(), userPrincipal);
         }
 
         //delete/purge the acl if this is not the acl

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -198,7 +198,7 @@ public class DeleteResourceServiceImplTest {
     public void testBinaryDeleteWithAcl() throws Exception {
         when(binary.getFedoraId()).thenReturn(RESOURCE_FEDORA_ID);
         when(binary.isAcl()).thenReturn(false);
-        when(binary.getDescribedResource()).thenReturn(binaryDesc);
+        when(binary.getDescription()).thenReturn(binaryDesc);
         when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_FEDORA_ID);
         when(binary.getAcl()).thenReturn(acl);
         when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_FEDORA_ID);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
@@ -192,7 +192,7 @@ public class PurgeResourceServiceImplTest {
     public void testBinaryPurgeWithAcl() throws Exception {
         when(binary.getFedoraId()).thenReturn(RESOURCE_FEDORA_ID);
         when(binary.isAcl()).thenReturn(false);
-        when(binary.getDescribedResource()).thenReturn(binaryDesc);
+        when(binary.getDescription()).thenReturn(binaryDesc);
         when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_FEDORA_ID);
         when(binary.getAcl()).thenReturn(acl);
         when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_FEDORA_ID);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -75,11 +75,6 @@ class DeleteResourcePersister extends AbstractPersister {
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             final var filePath = resolveExtensions(ocflSubPath, isRdf);
             deletePath(filePath, objectSession, headers, user, deleteTime);
-            if (!isRdf) {
-                // Delete the description too.
-                final var descPath = resolveExtensions(ocflSubPath + "-description", true);
-                deletePath(descPath, objectSession, user, deleteTime);
-            }
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -63,11 +63,6 @@ class PurgeResourcePersister extends AbstractPersister {
             final var sidecar = getSidecarSubpath(ocflSubPath);
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             purgePath(sidecar, objectSession);
-            if (!isRdf) {
-                // Delete the description sidecar file too.
-                final var descSidecar = getSidecarSubpath(ocflSubPath + "-description");
-                purgePath(descSidecar, objectSession);
-            }
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
@@ -83,26 +83,15 @@ public class DeleteResourcePersisterTest {
             "\"2020-04-14T03:42:00.765231Z\",\"stateToken\":\"6763672ED325A4B632B450545518B34B\"," +
             "\"archivalGroup\":false,\"objectRoot\":false}";
         final InputStream header_stream1 = new ByteArrayInputStream(header_string1.getBytes());
-        final String header_string2 = "{\"parent\":\"info:fedora/an-ocfl-object/sub-path\",\"id\":" +
-            "\"info:fedora/an-ocfl-object/some-subpath-desc\",\"lastModifiedDate\":" +
-            "\"2020-04-14T03:42:00.765231Z\",\"interactionModel\":" +
-            "\"http://fedora.info/definitions/v4/repository#NonRdfSourceDescription\"," +
-            "\"createdDate\":\"2020-04-14T03:42:00.765231Z\",\"stateToken\":\"6763672ED325A4B632B450545518B34B\"," +
-            "\"archivalGroup\":false,\"objectRoot\":false}";
-        final InputStream header_stream2 = new ByteArrayInputStream(header_string2.getBytes());
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream1);
-        when(session.read(".fcrepo/some-subpath-description.json")).thenReturn(header_stream2);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
         when(index.getMapping(anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
-        verify(session).delete("some-subpath-description.nt");
         verify(session).read(".fcrepo/some-subpath.json");
         verify(session).write(eq(".fcrepo/some-subpath.json"), any());
-        verify(session).read(".fcrepo/some-subpath-description.json");
-        verify(session).write(eq(".fcrepo/some-subpath-description.json"), any());
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
@@ -88,7 +88,6 @@ public class PurgeResourcePersisterTest {
         persister.persist(psSession, operation);
         verify(session).read(".fcrepo/some-subpath.json");
         verify(session).delete(".fcrepo/some-subpath.json");
-        verify(session).delete(".fcrepo/some-subpath-description.json");
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3338

# What does this Pull Request do?
Not entirely sure what was happening, but it appears that when deleting binaries we were executing 2 delete requests. The DeleteResourceService called `resource().getDescribedResource()` to delete, but that is the binary. Changed that to `getDescription()` and removed the check to delete the binary-description from the persister.

This seemed to resolve the issue, so maybe it was a race condition?

# How should this be tested?

Follow the steps in the ticket and with this PR, the deleted children of an AG stay deleted.

# Interested parties
@fcrepo4/committers
