### PR TITLE
changed the mapping of fedora ids to ocfl ids to be one-to-one

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -51,9 +51,7 @@ import org.fcrepo.http.commons.test.util.ContainerWrapper;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.inject.Inject;
@@ -113,9 +111,6 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("/spring-test/test-container.xml")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@TestExecutionListeners(listeners = { ClearDbTestExecutionListener.class },
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public abstract class AbstractResourceIT {
 
     protected static Logger logger;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ClearDbTestExecutionListener.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ClearDbTestExecutionListener.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import org.fcrepo.http.commons.test.util.ContainerWrapper;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import javax.sql.DataSource;
+
+/**
+ * Clears out the h2 db so that it doesn't affect other tests
+ *
+ * @author pwinckles
+ */
+public class ClearDbTestExecutionListener extends AbstractTestExecutionListener {
+
+    @Override
+    public void afterTestClass(final TestContext testContext) throws Exception {
+        final var containerWrapper = testContext.getApplicationContext()
+                .getBean(ContainerWrapper.class);
+        final var dataSource = containerWrapper.getSpringAppContext().getBean(DataSource.class);
+
+        try (var conn = dataSource.getConnection()) {
+            try (var queryStmt = conn.prepareStatement(
+                    "SELECT DISTINCT table_name FROM information_schema.tables WHERE table_schema = 'PUBLIC'")) {
+                try (var resultSet = queryStmt.executeQuery()) {
+                    while (resultSet.next()) {
+                        try (var truncStmt = conn.prepareStatement(
+                                "TRUNCATE TABLE " + resultSet.getString(1))) {
+                            truncStmt.executeUpdate();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RebuildIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RebuildIT.java
@@ -30,7 +30,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.List;
 
@@ -50,7 +49,6 @@ import static org.springframework.test.util.AssertionErrors.assertTrue;
  * @author awooods
  * @since 2020-03-04
  */
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class RebuildIT extends AbstractResourceIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RebuildIT.class);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RebuildIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RebuildIT.java
@@ -20,16 +20,13 @@ package org.fcrepo.integration.http.api;
 
 import edu.wisc.library.ocfl.api.OcflRepository;
 import org.apache.http.client.methods.HttpGet;
-import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.fcrepo.persistence.ocfl.api.IndexBuilder;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.test.context.TestExecutionListeners;
 
 import java.util.List;
 
@@ -49,29 +46,17 @@ import static org.springframework.test.util.AssertionErrors.assertTrue;
  * @author awooods
  * @since 2020-03-04
  */
+@TestExecutionListeners(listeners = { RebuildTestExecutionListener.class },
+        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class RebuildIT extends AbstractResourceIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RebuildIT.class);
 
     private OcflRepository ocflRepository;
 
-    private IndexBuilder indexBuilder;
-
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty(OcflPropsConfig.FCREPO_OCFL_ROOT, "target/test-classes/test-rebuild-ocfl/ocfl-root");
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        System.clearProperty(OcflPropsConfig.FCREPO_OCFL_ROOT);
-    }
-
     @Before
     public void setUp() {
         ocflRepository = getBean(OcflRepository.class);
-        indexBuilder = getBean(IndexBuilder.class);
-        indexBuilder.rebuild();
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.persistence.ocfl.impl;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
@@ -45,11 +46,12 @@ public class CreateVersionPersister extends AbstractPersister {
             throws PersistentStorageException {
 
         final var resourceId = operation.getResourceId();
+        final var fedoraId = FedoraId.create(resourceId);
         LOG.debug("creating new version of <{}> in session <{}>", resourceId, session);
 
-        final var archivalGroupId = findArchivalGroupInAncestry(resourceId, session);
+        final var archivalGroupId = findArchivalGroupInAncestry(fedoraId, session);
 
-        if (archivalGroupId != null && !archivalGroupId.equals(resourceId)) {
+        if (archivalGroupId.isPresent() && !archivalGroupId.get().equals(fedoraId)) {
             throw new PersistentItemConflictException(
                     String.format("Resource <%s> is contained in Archival Group <%s> and cannot be versioned directly."
                             + " Version the Archival Group instead.", resourceId, archivalGroupId));

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSession.java
@@ -30,7 +30,7 @@ import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import edu.wisc.library.ocfl.api.model.VersionDetails;
 import edu.wisc.library.ocfl.api.model.VersionId;
 import edu.wisc.library.ocfl.core.util.FileUtil;
-
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -53,6 +53,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -121,7 +122,8 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
     public DefaultOCFLObjectSession(final String objectIdentifier, final Path stagingPath,
             final MutableOcflRepository ocflRepository, final CommitOption commitOption) {
         this.objectIdentifier = objectIdentifier;
-        this.stagingPath = stagingPath.resolve(encode(objectIdentifier));
+        this.stagingPath = stagingPath.resolve(createStagingDirectory(stagingPath, objectIdentifier));
+        log.debug("OCFL object <{}> is staging files at <{}>", objectIdentifier, stagingPath);
         this.ocflRepository = ocflRepository;
         this.commitOption = commitOption;
         this.deletePaths = new HashSet<>();
@@ -129,6 +131,15 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
         this.sessionClosed = false;
         this.created = Instant.now();
         this.subpathToDigest = new HashMap<>();
+    }
+
+    private static Path createStagingDirectory(final Path sessionStaging, final String objectIdentifier) {
+        final var digest = DigestUtils.sha256Hex(objectIdentifier);
+        try {
+            return Files.createDirectories(sessionStaging.resolve(digest));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private String encode(final String value) {
@@ -501,7 +512,9 @@ public class DefaultOCFLObjectSession implements OCFLObjectSession {
     public synchronized void close() throws PersistentStorageException {
         sessionClosed = true;
 
-        cleanupStaging();
+        if (!FileUtils.deleteQuietly(stagingPath.toFile())) {
+            log.warn("Failed to delete staging directory: {}", stagingPath);
+        }
     }
 
     @Override

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageUtils.java
@@ -32,7 +32,6 @@ import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.system.StreamRDF;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfStream;
-import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
@@ -347,37 +346,6 @@ public class OCFLPersistentStorageUtils {
      */
     public static String getInternalFedoraDirectory() {
         return INTERNAL_FEDORA_DIRECTORY + "/";
-    }
-
-
-    /**
-     * Mints an OCFL ID for the specified identifier
-     * @param fedoraIdentifier The fedora identifier for the root OCFL object
-     * @return The OCFL ID
-     */
-    public static String mintOCFLObjectId(final String fedoraIdentifier) {
-        //TODO make OCFL Object Id minting more configurable.
-        String bareFedoraIdentifier = fedoraIdentifier;
-        if (fedoraIdentifier.indexOf(FEDORA_ID_PREFIX) == 0) {
-            bareFedoraIdentifier = fedoraIdentifier.substring(FEDORA_ID_PREFIX.length());
-        }
-        // strip any leading slashes
-        bareFedoraIdentifier = bareFedoraIdentifier.replaceFirst("\\/", "");
-
-        //ensure no accidental collisions with the root ocfl identifier
-        if (bareFedoraIdentifier.equals(DEFAULT_REPOSITORY_ROOT_OCFL_OBJECT_ID)) {
-            throw new RepositoryRuntimeException(bareFedoraIdentifier + " is a reserved identifier");
-        }
-
-        bareFedoraIdentifier = bareFedoraIdentifier.replace("/", "_");
-
-        if (bareFedoraIdentifier.length() == 0) {
-            bareFedoraIdentifier = DEFAULT_REPOSITORY_ROOT_OCFL_OBJECT_ID;
-        }
-
-        log.debug("minted new ocfl object id:  {}", bareFedoraIdentifier);
-
-        return bareFedoraIdentifier;
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.fcrepo.config.OcflPropsConfig;
@@ -342,7 +343,8 @@ public class NonRdfSourcesPersistenceIT {
         // Modify the file after staging to simulate a transmission error
         final Path ocflStagingDir = ocflPropsConfig.getFedoraOcflStaging();
         final String rawId = StringUtils.substringAfterLast(rescId, "/");
-        final Path stagedFile = Paths.get(ocflStagingDir.toString(), storageSession.getId(), rawId, rawId);
+        final String digest = DigestUtils.sha256Hex(rescId);
+        final Path stagedFile = Paths.get(ocflStagingDir.toString(), storageSession.getId(), digest, rawId);
         Files.write(stagedFile, "oops".getBytes(), StandardOpenOption.APPEND);
 
         try {

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
@@ -17,34 +17,8 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.asList;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
-import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
-import static org.fcrepo.persistence.common.ResourceHeaderSerializationUtils.RESOURCE_HEADER_EXTENSION;
-import static org.fcrepo.persistence.common.ResourceHeaderSerializationUtils.deserializeHeaders;
-import static org.fcrepo.persistence.ocfl.api.OCFLPersistenceConstants.DEFAULT_REPOSITORY_ROOT_OCFL_OBJECT_ID;
-import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.getInternalFedoraDirectory;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
-
-import java.io.InputStream;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
-import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
@@ -64,6 +38,29 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
+import static org.fcrepo.persistence.common.ResourceHeaderSerializationUtils.RESOURCE_HEADER_EXTENSION;
+import static org.fcrepo.persistence.common.ResourceHeaderSerializationUtils.deserializeHeaders;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.getInternalFedoraDirectory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 /**
  * @author dbernstein
@@ -210,20 +207,6 @@ public class CreateNonRdfSourcePersisterTest {
 
         final InputStream content = IOUtils.toInputStream(CONTENT_BODY, "UTF-8");
 
-        when(nonRdfSourceOperation.getContentStream()).thenReturn(content);
-        when(nonRdfSourceOperation.getContentSize()).thenReturn(99l);
-        when(((CreateResourceOperation) nonRdfSourceOperation).getInteractionModel())
-                .thenReturn(NON_RDF_SOURCE.toString());
-        when(headers.isArchivalGroup()).thenReturn(false);
-
-        persister.persist(psSession, nonRdfSourceOperation);
-    }
-
-    @Test(expected = RepositoryRuntimeException.class)
-    public void testPersistNewRootResource() throws Exception {
-        final String rootResourceId = FEDORA_ID_PREFIX + "/" + DEFAULT_REPOSITORY_ROOT_OCFL_OBJECT_ID;
-        final InputStream content = IOUtils.toInputStream(CONTENT_BODY, "UTF-8");
-        when(nonRdfSourceOperation.getResourceId()).thenReturn(rootResourceId);
         when(nonRdfSourceOperation.getContentStream()).thenReturn(content);
         when(nonRdfSourceOperation.getContentSize()).thenReturn(99l);
         when(((CreateResourceOperation) nonRdfSourceOperation).getInteractionModel())

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DefaultOCFLObjectSessionTest.java
@@ -36,6 +36,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
 import static org.fcrepo.persistence.api.CommitOption.UNVERSIONED;
@@ -328,12 +330,12 @@ public class DefaultOCFLObjectSessionTest {
         session.write(FILE1_SUBPATH, fileStream(FILE_CONTENT1));
 
         assertEquals(1, stagingPath.toFile().listFiles().length);
-        assertEquals(1, stagingPath.resolve(OBJ_ID).toFile().listFiles().length);
+        assertEquals(1, stagingPath.resolve(objectDir(OBJ_ID)).toFile().listFiles().length);
 
         session.delete(FILE1_SUBPATH);
 
         assertEquals(1, stagingPath.toFile().listFiles().length);
-        assertEquals(0, stagingPath.resolve(OBJ_ID).toFile().listFiles().length);
+        assertEquals(0, stagingPath.resolve(objectDir(OBJ_ID)).toFile().listFiles().length);
     }
 
     @Test
@@ -873,6 +875,10 @@ public class DefaultOCFLObjectSessionTest {
             throws PersistentStorageException {
         session.setCommitOption(option);
         return session.commit();
+    }
+
+    private String objectDir(final String objectId) {
+        return DigestUtils.sha256Hex(objectId);
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
@@ -18,6 +18,7 @@
 package org.fcrepo.persistence.ocfl.impl;
 
 import org.fcrepo.kernel.api.ContainmentIndex;
+import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -154,7 +155,7 @@ public class IndexBuilderImplTest {
         session.commit();
 
         assertHasOcflId("resource1", resource1);
-        assertHasOcflId("resource1_resource2", resource2);
+        assertHasOcflId("resource1/resource2", resource2);
 
         index.reset();
 
@@ -164,7 +165,7 @@ public class IndexBuilderImplTest {
         indexBuilder.rebuildIfNecessary();
 
         assertHasOcflId("resource1", resource1);
-        assertHasOcflId("resource1_resource2", resource2);
+        assertHasOcflId("resource1/resource2", resource2);
 
         verify(transaction).getId();
         verify(transactionManager).create();
@@ -185,7 +186,8 @@ public class IndexBuilderImplTest {
 
     private void assertHasOcflId(final String expectedOcflId, final FedoraId resourceId)
             throws FedoraOCFLMappingNotFoundException {
-        assertEquals(expectedOcflId, index.getMapping(resourceId.getResourceId()).getOcflObjectId());
+        assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expectedOcflId,
+                index.getMapping(resourceId.getResourceId()).getOcflObjectId());
     }
 
     private void createResource(final PersistentStorageSession session,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3317

# What does this Pull Request do?

I didn't read the ticket (which I had also written...) carefully enough, and I mistakenly updated how Fedora IDs are mapped to OCFL IDs before realizing that I was actually just supposed to be fixing a bug related to not using the mapping index when adding resources to AGs. So... I did them both.

The changes here are that now Fedora IDs are mapped directly to OCFL IDs, and the resource creation code correctly checks the mapping index for the OCFL ID when it adds a resources to an AG.

# How should this be tested?

Start Fedora and create one or more resources. Check the OCFL storage root and you will find objects with OCFL IDs that match their corresponding Fedora ID.

# Interested parties
@fcrepo4/committers
