### PR TITLE
updated containment commit query to work on postgres

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -199,12 +199,12 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     /*
      * Mark deleted in the main table all rows from transaction operation table marked 'delete' for this transaction.
      */
-    private static final String COMMIT_DELETE_RECORDS = "UPDATE " + RESOURCES_TABLE + " r " +
-            "SET r." + IS_DELETED_COLUMN + " = TRUE WHERE EXISTS " +
-            "(SELECT * from " + TRANSACTION_OPERATIONS_TABLE + " t WHERE " +
-            "r." + FEDORA_ID_COLUMN + " = " + "t." + FEDORA_ID_COLUMN + " AND " +
+    private static final String COMMIT_DELETE_RECORDS = "UPDATE " + RESOURCES_TABLE +
+            " r SET " + IS_DELETED_COLUMN + " = TRUE WHERE EXISTS " +
+            "(SELECT TRUE FROM " + TRANSACTION_OPERATIONS_TABLE + " t WHERE " +
+            "t." + FEDORA_ID_COLUMN + " = r." + FEDORA_ID_COLUMN + " AND " +
             "t." + TRANSACTION_ID_COLUMN + " = :transactionId AND t." +  OPERATION_COLUMN + " = 'delete' AND " +
-            "r." + PARENT_COLUMN + " = t." + PARENT_COLUMN + ")";
+            "t." + PARENT_COLUMN + " = r." + PARENT_COLUMN + ")";
 
     /*
      * Remove from the main table all rows from transaction operation table marked 'purge' for this transaction.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3362

# What does this Pull Request do?

Fixes a containment index query so that it works on Postgres again.

# How should this be tested?

Start Postgres:

```
docker run --name f6-postgres -e POSTGRES_USER=fcrepo-user -e POSTGRES_PASSWORD=fcrepo-pw -e POSTGRES_DB=fcrepo -p 5432:5432 -d postgres:12.3
```

Start Fedora:

```
mvn -Dfcrepo.home=target/fcrepo -Dfcrepo.db.url=jdbc:postgresql://localhost:5432/fcrepo -Dfcrepo.db.user=fcrepo-user -Dfcrepo.db.password=fcrepo-pw clean jetty:run
```

It should now start without throwing exceptions.

# Interested parties
@fcrepo4/committers
