### PR TITLE
improved rollback logic

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -34,25 +34,25 @@ public interface ContainmentIndex {
     /**
      * Return a stream of fedora identifiers contained by the specified fedora resource.
      *
-     * @param tx The transaction.  If no transaction, null is okay.
+     * @param txId The transaction id, or null if no transaction
      * @param fedoraResource The containing fedora resource
      * @return A stream of contained identifiers
      */
-    Stream<String> getContains(String tx, FedoraResource fedoraResource);
+    Stream<String> getContains(String txId, FedoraResource fedoraResource);
 
     /**
      * Return a stream of fedora identifiers contained by the specified fedora resource that have deleted
      * relationships.
      *
-     * @param tx The transaction.  If no transaction, null is okay.
+     * @param txId The transaction id, or null if no transaction
      * @param fedoraResource The containing fedora resource
      * @return A stream of contained identifiers
      */
-    Stream<String> getContainsDeleted(String tx, FedoraResource fedoraResource);
+    Stream<String> getContainsDeleted(String txId, FedoraResource fedoraResource);
 
     /**
      * Return the ID of the containing resource for resourceID.
-     * @param txID The transaction. If no transaction, null is okay.
+     * @param txID The transaction id, or null if no transaction
      * @param resource The FedoraId of the resource to find the containing resource for.
      * @return The id of the containing resource or null if none found.
      */
@@ -107,7 +107,7 @@ public interface ContainmentIndex {
     /**
      * Check if the resourceID exists in the containment index. Which should mean it exists.
      *
-     * @param txID The transaction ID or null if not transaction.
+     * @param txID The transaction id, or null if no transaction
      * @param fedoraID The resource's FedoraId.
      * @return True if it is in the index.
      */
@@ -115,7 +115,7 @@ public interface ContainmentIndex {
 
     /**
      * Find the ID for the container of the provided resource by iterating up the path until you find a real resource.
-     * @param txID The transaction ID or null if no transaction.
+     * @param txID The transaction id, or null if no transaction
      * @param fedoraId The resource's ID.
      * @return The container ID.
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -17,12 +17,11 @@
  */
 package org.fcrepo.kernel.api;
 
-import javax.annotation.Nonnull;
-
-import java.util.stream.Stream;
-
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.FedoraResource;
+
+import javax.annotation.Nonnull;
+import java.util.stream.Stream;
 
 /**
  * An interface for retrieving resource IDs by their containment relationships.
@@ -39,7 +38,7 @@ public interface ContainmentIndex {
      * @param fedoraResource The containing fedora resource
      * @return A stream of contained identifiers
      */
-    Stream<String> getContains(Transaction tx, FedoraResource fedoraResource);
+    Stream<String> getContains(String tx, FedoraResource fedoraResource);
 
     /**
      * Return a stream of fedora identifiers contained by the specified fedora resource that have deleted
@@ -49,7 +48,7 @@ public interface ContainmentIndex {
      * @param fedoraResource The containing fedora resource
      * @return A stream of contained identifiers
      */
-    Stream<String> getContainsDeleted(Transaction tx, FedoraResource fedoraResource);
+    Stream<String> getContainsDeleted(String tx, FedoraResource fedoraResource);
 
     /**
      * Return the ID of the containing resource for resourceID.
@@ -95,15 +94,15 @@ public interface ContainmentIndex {
 
     /**
      * Commit the changes made in the transaction.
-     * @param tx The transaction.
+     * @param txId The transaction id.
      */
-    void commitTransaction(final Transaction tx);
+    void commitTransaction(final String txId);
 
     /**
      * Rollback the containment index changes in the transaction.
-     * @param tx The transaction.
+     * @param txId The transaction id.
      */
-    void rollbackTransaction(final Transaction tx);
+    void rollbackTransaction(final String txId);
 
     /**
      * Check if the resourceID exists in the containment index. Which should mean it exists.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImpl.java
@@ -71,7 +71,7 @@ public class EventAccumulatorImpl implements EventAccumulator {
 
     @Override
     public void emitEvents(final String transactionId, final String baseUrl, final String userAgent) {
-        LOG.info("Emitting events for transaction {}", transactionId);
+        LOG.debug("Emitting events for transaction {}", transactionId);
 
         final var eventMap = transactionEventMap.remove(transactionId);
 
@@ -100,7 +100,7 @@ public class EventAccumulatorImpl implements EventAccumulator {
 
     @Override
     public void clearEvents(final String transactionId) {
-        LOG.info("Clearing events for transaction {}", transactionId);
+        LOG.debug("Clearing events for transaction {}", transactionId);
         transactionEventMap.remove(transactionId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -51,6 +51,7 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.kernel.api.ContainmentIndex;
+import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.ACLAuthorizationConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RequestWithAclLinkHeaderException;
@@ -235,6 +236,10 @@ public abstract class AbstractService {
                         createResource(authSubject),
                         WEBAC_ACCESS_TO_PROPERTY,
                         createResource(currentResourcePath));
+    }
+
+    protected String txId(final Transaction tx) {
+        return tx == null ? null : tx.getId();
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImpl.java
@@ -17,13 +17,6 @@
  */
 package org.fcrepo.kernel.impl.services;
 
-import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
-
-import javax.inject.Inject;
-
-import java.util.stream.Stream;
-
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.fcrepo.kernel.api.ContainmentIndex;
@@ -31,6 +24,12 @@ import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.services.ContainmentTriplesService;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.stream.Stream;
+
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 
 /**
  * Containment Triples service.
@@ -46,7 +45,12 @@ public class ContainmentTriplesServiceImpl implements ContainmentTriplesService 
     @Override
     public Stream<Triple> get(final Transaction tx, final FedoraResource resource) {
         final Node currentNode = createURI(resource.getFedoraId().getFullId());
-        return containmentIndex.getContains(tx, resource).map(c ->
+        return containmentIndex.getContains(txId(tx), resource).map(c ->
                 new Triple(currentNode, CONTAINS.asNode(), createURI(c)));
     }
+
+    private String txId(final Transaction tx) {
+        return tx == null ? null : tx.getId();
+    }
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
@@ -47,7 +47,7 @@ public class DeleteResourceServiceImpl extends AbstractDeleteResourceService imp
 
     @Override
     protected Stream<String> getContained(final Transaction tx, final FedoraResource resource) {
-        return containmentIndex.getContains(tx, resource);
+        return containmentIndex.getContains(txId(tx), resource);
     }
 
     @Override
@@ -63,4 +63,9 @@ public class DeleteResourceServiceImpl extends AbstractDeleteResourceService imp
         recordEvent(tx.getId(), fedoraId, deleteOp);
         log.debug("deleted {}", fedoraId.getFullId());
     }
+
+    private String txId(final Transaction tx) {
+        return tx == null ? null : tx.getId();
+    }
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
@@ -64,8 +64,4 @@ public class DeleteResourceServiceImpl extends AbstractDeleteResourceService imp
         log.debug("deleted {}", fedoraId.getFullId());
     }
 
-    private String txId(final Transaction tx) {
-        return tx == null ? null : tx.getId();
-    }
-
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
@@ -17,10 +17,6 @@
  */
 package org.fcrepo.kernel.impl.services;
 
-import javax.inject.Inject;
-
-import java.util.stream.Stream;
-
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -32,6 +28,9 @@ import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.stream.Stream;
 
 /**
  * Implementation of purge resource service.
@@ -62,10 +61,6 @@ public class PurgeResourceServiceImpl extends AbstractDeleteResourceService impl
         containmentIndex.purgeResource(tx.getId(), resourceId);
         recordEvent(tx.getId(), resourceId, purgeOp);
         log.debug("purged {}", resourceId.getFullId());
-    }
-
-    private String txId(final Transaction tx) {
-        return tx == null ? null : tx.getId();
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
@@ -48,7 +48,7 @@ public class PurgeResourceServiceImpl extends AbstractDeleteResourceService impl
 
     @Override
     protected Stream<String> getContained(final Transaction tx, final FedoraResource resource) {
-        return containmentIndex.getContainsDeleted(tx, resource);
+        return containmentIndex.getContainsDeleted(txId(tx), resource);
     }
 
     @Override
@@ -63,4 +63,9 @@ public class PurgeResourceServiceImpl extends AbstractDeleteResourceService impl
         recordEvent(tx.getId(), resourceId, purgeOp);
         log.debug("purged {}", resourceId.getFullId());
     }
+
+    private String txId(final Transaction tx) {
+        return tx == null ? null : tx.getId();
+    }
+
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -103,8 +103,8 @@ public class ContainmentIndexImplTest {
     @After
     public void cleanUp() {
         // Rollback any in-process transactions.
-        containmentIndex.rollbackTransaction(transaction1);
-        containmentIndex.rollbackTransaction(transaction2);
+        containmentIndex.rollbackTransaction(transaction1.getId());
+        containmentIndex.rollbackTransaction(transaction2.getId());
     }
 
     @Test
@@ -114,15 +114,15 @@ public class ContainmentIndexImplTest {
         stubObject("transaction1");
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1, parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         // outside of the transaction, the containment shouldn't show up
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
     }
 
@@ -132,19 +132,19 @@ public class ContainmentIndexImplTest {
         stubObject("child1");
         stubObject("transaction1");
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
     }
 
     @Test
@@ -153,24 +153,24 @@ public class ContainmentIndexImplTest {
         stubObject("child1");
         stubObject("transaction1");
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(1, containmentIndex.getContainsDeleted(transaction1, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(1, containmentIndex.getContainsDeleted(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
     }
 
     @Test
@@ -179,22 +179,22 @@ public class ContainmentIndexImplTest {
         stubObject("child1");
         stubObject("transaction1");
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
         containmentIndex.purgeResource(transaction1.getId(), child1.getFedoraId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
     }
 
     @Test
@@ -203,25 +203,25 @@ public class ContainmentIndexImplTest {
         stubObject("child1");
         stubObject("transaction1");
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(1, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(1, containmentIndex.getContainsDeleted(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
         containmentIndex.purgeResource(transaction1.getId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
     }
 
     @Test
@@ -230,20 +230,20 @@ public class ContainmentIndexImplTest {
         stubObject("child1");
         stubObject("transaction1");
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1, parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
-        containmentIndex.rollbackTransaction(transaction1);
+        containmentIndex.rollbackTransaction(transaction1.getId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
     }
@@ -254,24 +254,24 @@ public class ContainmentIndexImplTest {
         stubObject("child2");
         stubObject("transaction1");
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child2.getFedoraId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1, parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child2.getFedoraId()));
         assertNull(containmentIndex.getContainedBy(null, child2.getFedoraId()));
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(child2.getFedoraId().getFullId(),
                 containmentIndex.getContains(null, parent1).findFirst().get());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child2.getFedoraId()));
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1, parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child2.getFedoraId()));
     }
@@ -285,7 +285,7 @@ public class ContainmentIndexImplTest {
         stubObject("transaction2");
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         assertEquals(child1.getFedoraId().getFullId(),
                 containmentIndex.getContains(null, parent1).findFirst().get());
@@ -296,22 +296,22 @@ public class ContainmentIndexImplTest {
         assertEquals(child1.getFedoraId().getFullId(),
                 containmentIndex.getContains(null, parent1).findFirst().get());
         // Still the same in a different transaction
-        assertEquals(1, containmentIndex.getContains(transaction2, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction2, parent1).findFirst().get());
+                containmentIndex.getContains(transaction2.getId(), parent1).findFirst().get());
         // Inside it has changed
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1, parent1).findFirst().get());
-        containmentIndex.commitTransaction(transaction1);
+                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
+        containmentIndex.commitTransaction(transaction1.getId());
         // After commit() it is the same outside transactions.
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         assertEquals(child2.getFedoraId().getFullId(),
                 containmentIndex.getContains(null, parent1).findFirst().get());
         // And now the same in a different transaction
-        assertEquals(1, containmentIndex.getContains(transaction2, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction2, parent1).findFirst().get());
+                containmentIndex.getContains(transaction2.getId(), parent1).findFirst().get());
     }
 
     @Test
@@ -324,24 +324,24 @@ public class ContainmentIndexImplTest {
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child2.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(2, containmentIndex.getContains(null, parent1).count());
         // Delete one object in separate transactions.
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.removeContainedBy(transaction2.getId(), parent1.getFedoraId(), child2.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction2, parent1).count());
-        containmentIndex.commitTransaction(transaction1);
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        containmentIndex.commitTransaction(transaction1.getId());
         // Now only one record was removed
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
         // Except in the second transaction as it should now have 0
-        assertEquals(0, containmentIndex.getContains(transaction2, parent1).count());
-        containmentIndex.commitTransaction(transaction2);
+        assertEquals(0, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        containmentIndex.commitTransaction(transaction2.getId());
         // Now all are gone
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction2, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction2.getId(), parent1).count());
     }
 
     @Test
@@ -354,23 +354,23 @@ public class ContainmentIndexImplTest {
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child2.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(2, containmentIndex.getContains(null, parent1).count());
         // Delete one object in separate transactions.
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.removeContainedBy(transaction2.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction2, parent1).count());
-        containmentIndex.commitTransaction(transaction1);
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        containmentIndex.commitTransaction(transaction1.getId());
         // Now only one record was removed
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction2, parent1).count());
-        containmentIndex.commitTransaction(transaction2);
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        containmentIndex.commitTransaction(transaction2.getId());
         // No change as the first transaction already committed.
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction2, parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
     }
 
     @Test
@@ -385,10 +385,10 @@ public class ContainmentIndexImplTest {
         containmentIndex.addContainedBy(transaction1.getId(), parent2.getFedoraId(), child1.getFedoraId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         assertEquals(0, containmentIndex.getContains(null, parent2).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent2).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2).count());
         try {
-            containmentIndex.commitTransaction(transaction1);
+            containmentIndex.commitTransaction(transaction1.getId());
             // We should get an exception.
             fail();
         } catch (final RepositoryRuntimeException e) {
@@ -397,8 +397,8 @@ public class ContainmentIndexImplTest {
         // This should be rolled back so the additions should still be in the transaction operation table.
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         assertEquals(0, containmentIndex.getContains(null, parent2).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1, parent2).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2).count());
     }
 
     @Test
@@ -410,7 +410,7 @@ public class ContainmentIndexImplTest {
         assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId()));
         assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction2.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction2);
+        containmentIndex.commitTransaction(transaction2.getId());
         assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId()));
         assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
     }
@@ -430,7 +430,7 @@ public class ContainmentIndexImplTest {
         assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
         assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
         // Rollback transaction.
-        containmentIndex.rollbackTransaction(transaction1);
+        containmentIndex.rollbackTransaction(transaction1.getId());
         assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId()));
         assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
         assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
@@ -440,7 +440,7 @@ public class ContainmentIndexImplTest {
         assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
         assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
         // Commit and visible everywhere.
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId()));
         assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
         assertTrue(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
@@ -452,12 +452,12 @@ public class ContainmentIndexImplTest {
         stubObject("child1");
         stubObject("transaction1");
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
         containmentIndex.removeResource(transaction1.getId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
     }
@@ -471,21 +471,21 @@ public class ContainmentIndexImplTest {
         stubObject("transaction2");
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction2.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction2);
+        containmentIndex.commitTransaction(transaction2.getId());
         containmentIndex.addContainedBy(transaction1.getId(), parent2.getFedoraId(), child1.getFedoraId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertEquals(1, containmentIndex.getContains(transaction1, parent2).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1, parent2).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent2).findFirst().get());
         containmentIndex.removeResource(transaction2.getId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction2);
+        containmentIndex.commitTransaction(transaction2.getId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertEquals(1, containmentIndex.getContains(transaction1, parent2).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1, parent2).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent2).findFirst().get());
     }
 
     @Test
@@ -496,7 +496,7 @@ public class ContainmentIndexImplTest {
         stubObject("transaction1");
         stubObject("transaction2");
         containmentIndex.addContainedBy(transaction2.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction2);
+        containmentIndex.commitTransaction(transaction2.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
@@ -504,11 +504,11 @@ public class ContainmentIndexImplTest {
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
-        containmentIndex.commitTransaction(transaction1);
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(0, containmentIndex.getContains(null, parent1).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertEquals(0, containmentIndex.getContains(transaction1, parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
     }
 
     /**
@@ -521,7 +521,7 @@ public class ContainmentIndexImplTest {
         stubObject("transaction1");
         final FedoraId fedoraID = FedoraId.create(child1.getFedoraId().getFullId());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
@@ -539,7 +539,7 @@ public class ContainmentIndexImplTest {
         stubObject("transaction1");
         final FedoraId fedoraID = FedoraId.create(child1.getFedoraId().getFullId() + "/");
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        containmentIndex.commitTransaction(transaction1);
+        containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
@@ -158,10 +158,10 @@ public class ResourceFactoryImplTest {
     @After
     public void cleanUp() {
         when(mockResource.getFedoraId()).thenReturn(rootId);
-        containmentIndex.rollbackTransaction(mockTx);
+        containmentIndex.rollbackTransaction(mockTx.getId());
         containmentIndex.getContains(null, mockResource).forEach(c ->
                 containmentIndex.removeContainedBy(mockTx.getId(), rootId, FedoraId.create(c)));
-        containmentIndex.commitTransaction(mockTx);
+        containmentIndex.commitTransaction(mockTx.getId());
     }
 
     @Test(expected = PathNotFoundException.class)
@@ -362,7 +362,7 @@ public class ResourceFactoryImplTest {
     @Test
     public void doesResourceExist_Exists_WithoutSession() throws Exception {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
-        containmentIndex.commitTransaction(mockTx);
+        containmentIndex.commitTransaction(mockTx.getId());
         final boolean answer = factory.doesResourceExist(null, fedoraId);
         assertTrue(answer);
     }
@@ -370,7 +370,7 @@ public class ResourceFactoryImplTest {
     @Test
     public void doesResourceExist_Exists_Description_WithoutSession() {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
-        containmentIndex.commitTransaction(mockTx);
+        containmentIndex.commitTransaction(mockTx.getId());
         final FedoraId descId = fedoraId.resolve("/" + FCR_METADATA);
         final boolean answer = factory.doesResourceExist(null, descId);
         assertTrue(answer);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImplTest.java
@@ -78,7 +78,7 @@ public class ContainmentTriplesServiceImplTest {
 
     @After
     public void cleanUp() {
-        containmentIndex.getContains(transaction, parentResource).forEach(c ->
+        containmentIndex.getContains(transaction.getId(), parentResource).forEach(c ->
                 containmentIndex.removeContainedBy(transaction.getId(), parentResource.getFedoraId(),
                         FedoraId.create(c)));
     }
@@ -143,7 +143,7 @@ public class ContainmentTriplesServiceImplTest {
         final Model received = containmentTriplesService.get(transaction, parentResource).collect(toModel());
         matchModels(expectedModel, received);
         // Commit and ensure we can see the child.
-        containmentIndex.commitTransaction(transaction);
+        containmentIndex.commitTransaction(transaction.getId());
         final Model received2 = containmentTriplesService.get(null, parentResource).collect(toModel());
         matchModels(expectedModel, received2);
         // Now remove the child in a transaction, but verify we can still see it outside the transaction.
@@ -151,7 +151,7 @@ public class ContainmentTriplesServiceImplTest {
         final Model received3 = containmentTriplesService.get(null, parentResource).collect(toModel());
         matchModels(expectedModel, received3);
         // Now commit the transaction and ensure it disappears.
-        containmentIndex.commitTransaction(transaction2);
+        containmentIndex.commitTransaction(transaction2.getId());
         assertEquals(0, containmentTriplesService.get(null, parentResource).count());
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -184,10 +184,10 @@ public class CreateResourceServiceImplTest {
     public void cleanUp() {
         cleanupList.forEach(parentID -> {
             when(fedoraResource.getFedoraId()).thenReturn(parentID);
-            containmentIndex.getContains(transaction, fedoraResource).forEach(c ->
+            containmentIndex.getContains(transaction.getId(), fedoraResource).forEach(c ->
                     containmentIndex.removeContainedBy(TX_ID, parentID, FedoraId.create(c)));
         });
-        cleanupList.removeAll(cleanupList);
+        cleanupList.clear();
     }
 
 
@@ -263,7 +263,7 @@ public class CreateResourceServiceImplTest {
         assertNotEquals(fedoraId, persistedId);
         assertTrue(persistedId.startsWith(fedoraId.getFullId()));
         when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction, fedoraResource).count());
+        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
     }
 
     /**
@@ -288,7 +288,7 @@ public class CreateResourceServiceImplTest {
         assertBinaryPropertiesPresent(operation);
         assertEquals(fedoraId.getFullId(), operation.getParentId());
         when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction, fedoraResource).count());
+        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
     }
 
     /**
@@ -335,7 +335,7 @@ public class CreateResourceServiceImplTest {
         assertEquals(createdDate, rdfOp.getCreatedDate());
         assertEquals(lastModifiedDate, rdfOp.getLastModifiedDate());
         when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction, fedoraResource).count());
+        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
     }
 
     /**
@@ -347,7 +347,7 @@ public class CreateResourceServiceImplTest {
         final FedoraId fedoraId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraId childId = fedoraId.resolve("testSlug");
         containmentIndex.addContainedBy(TX_ID, fedoraId, childId);
-        containmentIndex.commitTransaction(transaction);
+        containmentIndex.commitTransaction(transaction.getId());
         when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
         when(psSession.getHeaders(childId.getFullId(), null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
@@ -367,7 +367,7 @@ public class CreateResourceServiceImplTest {
         final var descOperation = getOperation(operations, CreateRdfSourceOperation.class);
         assertEquals(persistedId + "/fcr:metadata", descOperation.getResourceId());
         when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction, fedoraResource).count());
+        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -129,10 +129,10 @@ public class DeleteResourceServiceImplTest {
 
     @After
     public void cleanUp() {
-        containmentIndex.rollbackTransaction(tx);
+        containmentIndex.rollbackTransaction(tx.getId());
         containmentIndex.getContains(null, container).forEach(c ->
                 containmentIndex.removeContainedBy(tx.getId(), container.getFedoraId(), FedoraId.create(c)));
-        containmentIndex.commitTransaction(tx);
+        containmentIndex.commitTransaction(tx.getId());
     }
 
     @Test
@@ -141,7 +141,7 @@ public class DeleteResourceServiceImplTest {
         when(container.getAcl()).thenReturn(null);
 
         service.perform(tx, container, USER);
-        containmentIndex.commitTransaction(tx);
+        containmentIndex.commitTransaction(tx.getId());
         verifyResourceOperation(RESOURCE_FEDORA_ID, operationCaptor, pSession);
     }
 
@@ -159,7 +159,7 @@ public class DeleteResourceServiceImplTest {
         when(container.isAcl()).thenReturn(false);
         when(container.getAcl()).thenReturn(null);
 
-        assertEquals(1, containmentIndex.getContains(tx, container).count());
+        assertEquals(1, containmentIndex.getContains(tx.getId(), container).count());
         service.perform(tx, container, USER);
 
         verify(pSession, times(2)).persist(operationCaptor.capture());
@@ -169,7 +169,7 @@ public class DeleteResourceServiceImplTest {
         assertEquals(CHILD_RESOURCE_ID, operations.get(0).getResourceId());
         assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
 
-        assertEquals(0, containmentIndex.getContains(tx, container).count());
+        assertEquals(0, containmentIndex.getContains(tx.getId(), container).count());
     }
 
     private void verifyResourceOperation(final FedoraId fedoraID,

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
@@ -148,7 +148,7 @@ public class PurgeResourceServiceImplTest {
 
         when(resourceFactory.getResource(tx, CHILD_RESOURCE_FEDORA_ID)).thenReturn(childContainer);
         containmentIndex.addContainedBy(tx.getId(), container.getFedoraId(), childContainer.getFedoraId());
-        containmentIndex.commitTransaction(tx);
+        containmentIndex.commitTransaction(tx.getId());
         containmentIndex.removeContainedBy(tx.getId(), container.getFedoraId(), childContainer.getFedoraId());
 
         when(container.isAcl()).thenReturn(false);
@@ -163,7 +163,7 @@ public class PurgeResourceServiceImplTest {
         assertEquals(CHILD_RESOURCE_ID, operations.get(0).getResourceId());
         assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
 
-        assertEquals(0, containmentIndex.getContains(tx, container).count());
+        assertEquals(0, containmentIndex.getContains(tx.getId(), container).count());
     }
 
     private void verifyResourceOperation(final FedoraId fedoraID,

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/IndexBuilder.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/IndexBuilder.java
@@ -33,10 +33,5 @@ public interface IndexBuilder {
      */
     void rebuildIfNecessary();
 
-    /**
-     * Rebuilds the index from the OCFL repository regardless of the index's current state
-     */
-    void rebuild();
-
 }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSession.java
@@ -24,7 +24,6 @@ import org.fcrepo.persistence.api.WriteOutcome;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 import java.io.InputStream;
-import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -33,7 +32,7 @@ import java.util.stream.Stream;
  *
  * @author bbpennel
  */
-public interface OCFLObjectSession {
+public interface OCFLObjectSession extends AutoCloseable {
 
     /**
      * Write the provided content to specified subpath.
@@ -120,10 +119,8 @@ public interface OCFLObjectSession {
 
     /**
      * Close this session without committing changes.
-     *
-     * @throws PersistentStorageException if unable to close the session.
      */
-    void close() throws PersistentStorageException;
+    void close();
 
     /**
      * Return the list of immutable versions associated with this OCFL Object in chronological order.
@@ -143,12 +140,6 @@ public interface OCFLObjectSession {
      *                                    or for some other reason.
      */
     List<OCFLVersion> listVersions(String subpath) throws PersistentStorageException;
-
-    /**
-     * The instant at which the session was created.
-     * @return
-     */
-    Instant getCreated();
 
     /**
      * Lists the subpaths associated with the HEAD (ie the latest committed state)
@@ -182,4 +173,5 @@ public interface OCFLObjectSession {
      * @return true if this OCFL object is being deleted or has not been persisted yet.
      */
     boolean isNewInSession();
+
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/OCFLObjectSessionFactory.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.persistence.ocfl.api;
 
+import java.nio.file.Path;
+
 /**
  * A factory interface for creating {@link org.fcrepo.persistence.ocfl.api.OCFLObjectSession}.
  * @author dbernstein
@@ -27,8 +29,9 @@ public interface OCFLObjectSessionFactory {
     /**
      * Create new session.
      * @param ocflId The OCFL Object identifier
-     * @param persistentStorageSessionId The id of the persistent storage session associated with this session.
+     * @param sessionStagingDir path to the staging directory for the storage session
      * @return The newly created session.
      */
-    OCFLObjectSession create(final String ocflId, final String persistentStorageSessionId);
+    OCFLObjectSession create(final String ocflId, final Path sessionStagingDir);
+
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
@@ -89,8 +89,7 @@ public class IndexBuilderImpl implements IndexBuilder {
         }
     }
 
-    @Override
-    public void rebuild() {
+    private void rebuild() {
         LOGGER.info("Initiating index rebuild.");
 
         fedoraToOCFLObjectIndex.reset();
@@ -220,7 +219,7 @@ public class IndexBuilderImpl implements IndexBuilder {
 
     private void cleanupStaging(final Path stagingDir) {
         if (!FileUtils.deleteQuietly(stagingDir.toFile())) {
-            LOGGER.warn("Failed to cleanup staging directory: " + stagingDir);
+            LOGGER.warn("Failed to cleanup staging directory: {}", stagingDir);
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
@@ -18,22 +18,30 @@
 package org.fcrepo.persistence.ocfl.impl;
 
 import edu.wisc.library.ocfl.api.OcflRepository;
+import org.apache.commons.io.FileUtils;
 import org.fcrepo.kernel.api.ContainmentIndex;
-import org.fcrepo.kernel.api.TransactionManager;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.fcrepo.persistence.ocfl.api.IndexBuilder;
+import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 import org.fcrepo.search.api.SearchIndex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.lang.String.format;
@@ -67,10 +75,10 @@ public class IndexBuilderImpl implements IndexBuilder {
     private SearchIndex searchIndex;
 
     @Inject
-    private TransactionManager transactionManager;
-
-    @Inject
     private OcflRepository ocflRepository;
+
+    @Value("#{ocflPropsConfig.fedoraOcflStaging}")
+    private Path sessionStagingRoot;
 
     @Override
     public void rebuildIfNecessary() {
@@ -89,80 +97,92 @@ public class IndexBuilderImpl implements IndexBuilder {
         containmentIndex.reset();
         searchIndex.reset();
 
+        final var txId = UUID.randomUUID().toString();
+        final var stagingDir = createStagingDir(txId);
 
-        final var transaction = transactionManager.create();
-        final var txId = transaction.getId();
-        LOGGER.debug("Reading object ids...");
+        try {
+            LOGGER.debug("Reading object ids...");
 
-        try (final var ocflIds = ocflRepository.listObjectIds()) {
-            ocflIds.forEach(ocflId -> {
-                LOGGER.debug("Reading {}", ocflId);
-                final var objSession = objectSessionFactory.create(ocflId, null);
+            try (final var ocflIds = ocflRepository.listObjectIds()) {
+                ocflIds.forEach(ocflId -> {
+                    LOGGER.debug("Reading {}", ocflId);
+                    try (final var session = objectSessionFactory.create(ocflId, stagingDir)) {
+                        indexOcflObject(ocflId, txId, session);
+                    }
+                });
+            }
 
-                //list all the subpaths
-                try (final var subpaths = objSession.listHeadSubpaths()) {
+            containmentIndex.commitTransaction(txId);
+            LOGGER.info("Index rebuild complete");
+        } catch (RuntimeException e) {
+            execQuietly("Failed to rollback db transaction " +txId, () -> {
+                containmentIndex.rollbackTransaction(txId);
+                return null;
+            });
+            throw e;
+        } finally {
+            cleanupStaging(stagingDir);
+        }
+    }
 
-                    final var rootId = new AtomicReference<String>();
-                    final var fedoraIds = new ArrayList<String>();
+    private void indexOcflObject(final String ocflId, final String txId, final OCFLObjectSession session) {
+        try (final var subpaths = session.listHeadSubpaths()) {
+            final var rootId = new AtomicReference<String>();
+            final var fedoraIds = new ArrayList<String>();
 
-                    subpaths.forEach(subpath -> {
-                        if (isSidecarSubpath(subpath)) {
-                            //we're only interested in sidecar subpaths
-                            try {
-                                final var headers = deserializeHeaders(objSession.read(subpath));
-                                final var fedoraId = FedoraId.create(headers.getId());
-                                fedoraIds.add(fedoraId.getFullId());
-                                if (headers.isArchivalGroup() || headers.isObjectRoot()) {
-                                    rootId.set(headers.getId());
+            subpaths.forEach(subpath -> {
+                if (isSidecarSubpath(subpath)) {
+                    //we're only interested in sidecar subpaths
+                    try {
+                        final var headers = deserializeHeaders(session.read(subpath));
+                        final var fedoraId = FedoraId.create(headers.getId());
+                        fedoraIds.add(fedoraId.getFullId());
+                        if (headers.isArchivalGroup() || headers.isObjectRoot()) {
+                            rootId.set(headers.getId());
+                        }
+
+                        if (!fedoraId.isRepositoryRoot()) {
+                            var parentId = headers.getParent();
+
+                            if (parentId == null) {
+                                if (headers.isObjectRoot()) {
+                                    parentId = FedoraId.getRepositoryRootId().getFullId();
                                 }
+                            }
 
-                                if (!fedoraId.isRepositoryRoot()) {
-                                    var parentId = headers.getParent();
-
-                                    if (parentId == null) {
-                                        if (headers.isObjectRoot()) {
-                                            parentId = FedoraId.getRepositoryRootId().getFullId();
-                                        }
-                                    }
-
-                                    if (parentId != null) {
-                                        this.containmentIndex.addContainedBy(txId, FedoraId.create(parentId),
-                                                FedoraId.create(headers.getId()));
-                                    }
-                                }
-
-                                searchIndex.addUpdateIndex(headers);
-
-                            } catch (PersistentStorageException e) {
-                                throw new RepositoryRuntimeException(format("fedora-to-ocfl index rebuild failed: %s",
-                                        e.getMessage()), e);
+                            if (parentId != null) {
+                                this.containmentIndex.addContainedBy(txId, FedoraId.create(parentId),
+                                        FedoraId.create(headers.getId()));
                             }
                         }
-                    });
 
-                    // if a resource is not an AG then there should only be a single resource per OCFL object
-                    if (fedoraIds.size() == 1 && rootId.get() == null) {
-                        rootId.set(fedoraIds.get(0));
+                        searchIndex.addUpdateIndex(headers);
+
+                    } catch (PersistentStorageException e) {
+                        throw new RepositoryRuntimeException(format("fedora-to-ocfl index rebuild failed: %s",
+                                e.getMessage()), e);
                     }
-
-                    fedoraIds.forEach(fedoraIdentifier -> {
-                        var rootFedoraIdentifier = rootId.get();
-                        if (rootFedoraIdentifier == null) {
-                            rootFedoraIdentifier = fedoraIdentifier;
-                        }
-                        fedoraToOCFLObjectIndex.addMapping(fedoraIdentifier, rootFedoraIdentifier, ocflId);
-                        LOGGER.debug("Rebuilt fedora-to-ocfl object index entry for {}", fedoraIdentifier);
-                    });
-
-                } catch (final PersistentStorageException e) {
-                    throw new RepositoryRuntimeException("Failed to rebuild fedora-to-ocfl index: " +
-                            e.getMessage(), e);
                 }
             });
-        }
 
-        containmentIndex.commitTransaction(transaction);
-        LOGGER.info("Index rebuild complete");
+            // if a resource is not an AG then there should only be a single resource per OCFL object
+            if (fedoraIds.size() == 1 && rootId.get() == null) {
+                rootId.set(fedoraIds.get(0));
+            }
+
+            fedoraIds.forEach(fedoraIdentifier -> {
+                var rootFedoraIdentifier = rootId.get();
+                if (rootFedoraIdentifier == null) {
+                    rootFedoraIdentifier = fedoraIdentifier;
+                }
+                fedoraToOCFLObjectIndex.addMapping(fedoraIdentifier, rootFedoraIdentifier, ocflId);
+                LOGGER.debug("Rebuilt fedora-to-ocfl object index entry for {}", fedoraIdentifier);
+            });
+
+        } catch (final PersistentStorageException e) {
+            throw new RepositoryRuntimeException("Failed to rebuild fedora-to-ocfl index: " +
+                    e.getMessage(), e);
+        }
     }
 
     private boolean shouldRebuild() {
@@ -188,6 +208,34 @@ public class IndexBuilderImpl implements IndexBuilder {
 
     private boolean repoContainsObjects() {
         return ocflRepository.listObjectIds().findFirst().isPresent();
+    }
+
+    private Path createStagingDir(final String txId) {
+        try {
+            return Files.createDirectories(sessionStagingRoot.resolve(txId));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void cleanupStaging(final Path stagingDir) {
+        if (!FileUtils.deleteQuietly(stagingDir.toFile())) {
+            LOGGER.warn("Failed to cleanup staging directory: " + stagingDir);
+        }
+    }
+
+    /**
+     * Executes the closure, capturing all exceptions, and logging them as errors.
+     *
+     * @param failureMessage what to print if the closure fails
+     * @param callable closure to execute
+     */
+    private void execQuietly(final String failureMessage, final Callable<Void> callable) {
+        try {
+            callable.call();
+        } catch (Exception e) {
+            LOGGER.error(failureMessage, e);
+        }
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSession.java
@@ -438,7 +438,7 @@ public class OCFLPersistentStorageSession implements PersistentStorageSession {
 
     private void cleanupStagingDir() {
         if (!FileUtils.deleteQuietly(sessionStagingDir.toFile())) {
-            LOGGER.warn("Failed to cleanup session staging directory at " + sessionStagingDir);
+            LOGGER.warn("Failed to cleanup session staging directory at {}", sessionStagingDir);
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
@@ -17,24 +17,6 @@
  */
 package org.fcrepo.integration.persistence.ocfl.impl;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.asList;
-import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -53,6 +35,26 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author bbpennel
@@ -351,7 +353,8 @@ public class NonRdfSourcesPersistenceIT {
             storageSession.commit();
             fail("Expected commit to fail to due fixity failure");
         } catch (final PersistentStorageException e) {
-            assertTrue(e.getMessage().matches(".*due to fixity check failure.*"));
+            assertThat(e.getMessage(), containsString("Failed to commit object"));
+            assertThat(e.getCause().getMessage(), containsString("due to fixity check failure"));
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentSessionManagerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentSessionManagerTest.java
@@ -23,13 +23,17 @@ import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSessionFactory;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.IOException;
+
 import static java.util.UUID.randomUUID;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 /**
  * Test class for {@link OCFLPersistentSessionManager}
@@ -39,7 +43,6 @@ import static java.util.UUID.randomUUID;
 @RunWith(MockitoJUnitRunner.class)
 public class OCFLPersistentSessionManagerTest {
 
-    @InjectMocks
     private OCFLPersistentSessionManager sessionManager;
 
     private PersistentStorageSession readWriteSession;
@@ -60,9 +63,15 @@ public class OCFLPersistentSessionManagerTest {
     @Mock
     private OCFLObjectSessionFactory objectSessionFactory;
 
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
+        this.sessionManager = new OCFLPersistentSessionManager(tempFolder.newFolder().toPath());
         readWriteSession = this.sessionManager.getSession(testSessionId);
+        setField(sessionManager, "objectSessionFactory", objectSessionFactory);
+        setField(sessionManager, "fedoraOcflIndex", index);
         readOnlySession = this.sessionManager.getReadOnlySession();
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3350

# What does this Pull Request do?

1. Exceptions during rollbacks are logged; not rethrown
2. Staging directories are always cleaned up
3. General logic and logging cleanup 

# How should this be tested?

Start F6:

```
mvn -Dfcrepo.home=target/fcrepo -Dfcrepo.log=DEBUG clean jetty:run
```

Create a resource in a transaction:

```
curl -u fedoraAdmin:fedoraAdmin -v -XPOST http://localhost:8080/rest/fcr:tx
txid=<TX_ID>
curl -u fedoraAdmin:fedoraAdmin -H"Atomic-ID: ${txid}" http://localhost:8080/rest/foo -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "bar"
```

See the staging directory:

```
ls target/fcrepo/data/staging
```

Commit the transaction:

```
curl -u fedoraAdmin:fedoraAdmin -X PUT -v http://localhost:8080/rest/fcr:tx/${txid}
```

Verify the staging directory is now gone.

Do the same steps a second time, but, instead of committing the transaction, wait for it to expire and the confirm that the staging directory was removed.

# Interested parties

@fcrepo4/committers
