### PR TITLE
Adds support for order_by and order search parameters.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
@@ -112,7 +112,7 @@ public class FedoraSearch extends FedoraBaseResource {
                 orderByField = Condition.Field.fromString(orderBy);
             } catch (final Exception e) {
                 throw new InvalidQueryException("The order_by field must contain a valid value such as " +
-                        StringUtils.join(Condition.Field.values()));
+                        StringUtils.join(Condition.Field.values(), ","));
             }
 
             if (!(order.equalsIgnoreCase("asc") || order.equalsIgnoreCase("desc"))) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
@@ -84,8 +84,7 @@ public class FedoraSearch extends FedoraBaseResource {
                              @DefaultValue("100") @QueryParam("max_results") final int maxResults,
                              @DefaultValue("0") @QueryParam("offset") final int offset,
                              @DefaultValue("asc") @QueryParam("order") final String order,
-                             @DefaultValue("fedora_id") @QueryParam("order_by") final String orderBy
-    ) {
+                             @DefaultValue("fedora_id") @QueryParam("order_by") final String orderBy) {
 
         try {
             final var conditionList = new ArrayList<Condition>();
@@ -117,8 +116,7 @@ public class FedoraSearch extends FedoraBaseResource {
             }
 
             if (!(order.equalsIgnoreCase("asc") || order.equalsIgnoreCase("desc"))) {
-                throw new InvalidQueryException("The order field is invalid:  valid values are \"asc\" and \"desc\"" +
-                        StringUtils.join(Condition.Field.values()));
+                throw new InvalidQueryException("The order field is invalid:  valid values are \"asc\" and \"desc\"");
             }
 
             final var params = new SearchParameters(parsedFields, conditionList, maxResults, offset, orderByField,

--- a/fcrepo-search-api/src/main/java/org/fcrepo/search/api/SearchParameters.java
+++ b/fcrepo-search-api/src/main/java/org/fcrepo/search/api/SearchParameters.java
@@ -36,19 +36,28 @@ public class SearchParameters {
 
     private final int maxResults;
 
+    private final Condition.Field orderBy;
+
+    private final String order;
+
     /**
      * Constructoor
-     * @param fields The fields to be returned in the results
+     *
+     * @param fields     The fields to be returned in the results
      * @param conditions The conditions
      * @param maxResults The max results
      * @param offset     The offset
+     * @param orderBy    The field by which to order the results
+     * @param order      The order: ie "asc" or "desc"
      */
     public SearchParameters(final List<Condition.Field> fields, final List<Condition> conditions, final int maxResults,
-                            final int offset) {
+                            final int offset, final Condition.Field orderBy, final String order) {
         this.fields = fields;
         this.conditions = conditions;
         this.maxResults = maxResults;
         this.offset = offset;
+        this.orderBy = orderBy;
+        this.order = order;
     }
 
     /**
@@ -80,10 +89,29 @@ public class SearchParameters {
 
     /**
      * Returns the list of fields to display in the results.
+     *
      * @return
      */
     public List<Condition.Field> getFields() {
         return fields;
+    }
+
+    /**
+     * Returns the field by which to order the results.
+     *
+     * @return
+     */
+    public Condition.Field getOrderBy() {
+        return orderBy;
+    }
+
+    /**
+     * Returns the order direction (asc or desc) of the results.
+     *
+     * @return
+     */
+    public String getOrder() {
+        return order;
     }
 
     @Override
@@ -93,6 +121,8 @@ public class SearchParameters {
         helper.add("maxResults", maxResults);
         helper.add("offset", offset);
         helper.add("fields", fields);
+        helper.add("orderBy", orderBy);
+        helper.add("order", order);
         return helper.toString();
     }
 }

--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
@@ -171,7 +171,7 @@ public class DbSearchIndexImpl implements SearchIndex {
                 }
             }
         }
-        sql.append(" ORDER BY " + FEDORA_ID);
+        sql.append(" ORDER BY " +  parameters.getOrderBy() + " " + parameters.getOrder());
         sql.append(" LIMIT :limit OFFSET :offset");
         parameterSource.addValue("limit", parameters.getMaxResults());
         parameterSource.addValue("offset", parameters.getOffset());


### PR DESCRIPTION
**Adds support for order_by and order search parameters**
* * *

**JIRA Ticket**: Resolves: https://jira.lyrasis.org/browse/FCREPO-3343

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
You can now add order_by=<field> and order=<asc|desc> to your search querystring.
# How should this be tested?
```
# create two binary resources resources
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest -H "Slug:b-text" -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain"  -X POST --data "test" -i
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest -H "Slug:a-video" -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: video/mpeg4"  -X POST --data "test" -i

# return default ordering (fedora_id asc)
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/fcr:search | jq
# verify the result is order by fedora id asc.

# reverse the order
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/fcr:search?order=desc" | jq

# order by mime_type desc
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/fcr:searc?order_by=mime_type&order=desc" | jq

```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
