### PR TITLE
refactored FedoraId in attempt to make it slightly easier to understand

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -17,53 +17,6 @@
  */
 package org.fcrepo.http.api;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.MediaType.valueOf;
-import static javax.ws.rs.core.Response.created;
-import static javax.ws.rs.core.Response.noContent;
-import static javax.ws.rs.core.Response.ok;
-import static javax.ws.rs.core.Response.Status.CONFLICT;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
-import static org.apache.jena.riot.Lang.TTL;
-import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
-import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
-import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.ClientErrorException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Request;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.RDFDataMgr;
@@ -83,6 +36,51 @@ import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.WebacAclService;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.valueOf;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.created;
+import static javax.ws.rs.core.Response.noContent;
+import static javax.ws.rs.core.Response.ok;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.apache.jena.riot.Lang.TTL;
+import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
+import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
+import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * @author lsitu
@@ -130,7 +128,7 @@ public class FedoraAcl extends ContentExposingResource {
         }
         LOGGER.info("PUT acl resource '{}'", externalPath());
 
-        final FedoraId aclId = identifierConverter().pathToInternalId(externalPath()).resolve(FCR_ACL);
+        final FedoraId aclId = identifierConverter().pathToInternalId(externalPath()).asAcl();
         final boolean exists = resourceFactory.doesResourceExist(transaction(), aclId);
 
         final MediaType contentType =
@@ -178,7 +176,7 @@ public class FedoraAcl extends ContentExposingResource {
         }
 
         final FedoraId originalId = identifierConverter().pathToInternalId(externalPath());
-        final FedoraId aclId = originalId.resolve(FCR_ACL);
+        final FedoraId aclId = originalId.asAcl();
         final FedoraResource aclResource;
         try {
              aclResource = resourceFactory.getResource(transaction(), aclId);
@@ -241,7 +239,7 @@ public class FedoraAcl extends ContentExposingResource {
         LOGGER.info("GET resource '{}'", externalPath());
 
         final FedoraId originalId = identifierConverter().pathToInternalId(externalPath());
-        final FedoraId aclId = originalId.resolve(FCR_ACL);
+        final FedoraId aclId = originalId.asAcl();
         final boolean exists = resourceFactory.doesResourceExist(transaction(), aclId);
 
         if (!exists) {
@@ -281,7 +279,7 @@ public class FedoraAcl extends ContentExposingResource {
         LOGGER.info("Delete resource '{}'", externalPath);
 
         final FedoraId originalId = identifierConverter().pathToInternalId(externalPath());
-        final FedoraId aclId = originalId.resolve(FCR_ACL);
+        final FedoraId aclId = originalId.asAcl();
         try {
             final var aclResource = resourceFactory.getResource(transaction(), aclId);
             deleteResourceService.perform(transaction(), aclResource, getUserPrincipal());

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapperTest.java
@@ -17,25 +17,6 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-
-import static java.time.ZoneOffset.UTC;
-import static java.time.format.DateTimeFormatter.ISO_INSTANT;
-
-import static javax.ws.rs.core.HttpHeaders.LINK;
-import static javax.ws.rs.core.Response.Status.GONE;
-
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.ext.ExceptionMapper;
-
-import java.time.Instant;
-
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.kernel.api.exception.TombstoneException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -43,6 +24,21 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.time.Instant;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.Response.Status.GONE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * @author cabeer
@@ -79,7 +75,7 @@ public class TombstoneExceptionMapperTest {
 
     @Test
     public void testExceptionWithUri() {
-        final String tombstone = idConverter.toExternalId(fedoraId.resolve(FCR_TOMBSTONE).getFullId());
+        final String tombstone = idConverter.toExternalId(fedoraId.asTombstone().getFullId());
         final Response response = testObj.toResponse(new TombstoneException(mockResource, tombstone));
         assertEquals(GONE.getStatusCode(), response.getStatus());
         assertTombstone(response, fedoraId.getFullIdPath(), tombstone);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/VersionService.java
@@ -17,13 +17,13 @@
  */
 package org.fcrepo.kernel.api.services;
 
-import static java.time.ZoneOffset.UTC;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 
 import java.time.format.DateTimeFormatter;
 
-import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.identifiers.FedoraId;
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 
 /**
  * Service for creating versions of resources

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
@@ -17,23 +17,25 @@
  */
 package org.fcrepo.kernel.api.identifiers;
 
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
-import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.fcrepo.kernel.api.FedoraTypes;
+import org.fcrepo.kernel.api.exception.InvalidMementoPathException;
+import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
+import org.junit.Test;
 
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.fcrepo.kernel.api.exception.InvalidMementoPathException;
-import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
-import org.junit.Test;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class FedoraIdTest {
 
@@ -60,7 +62,7 @@ public class FedoraIdTest {
     @Test(expected = InvalidResourceIdentifierException.class)
     public void testEmptyPath() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object//second-object";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        FedoraId.create(testID);
     }
 
     @Test
@@ -73,7 +75,7 @@ public class FedoraIdTest {
     @Test(expected = InvalidResourceIdentifierException.class)
     public void testNormalAclException() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_ACL + "/garbage";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        FedoraId.create(testID);
     }
 
     @Test
@@ -86,7 +88,7 @@ public class FedoraIdTest {
     @Test(expected = InvalidResourceIdentifierException.class)
     public void testNormalDescriptionException() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/test-garbage";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        FedoraId.create(testID);
     }
 
     @Test
@@ -111,27 +113,27 @@ public class FedoraIdTest {
     public void testNormalMementoException() throws Exception {
         final String mementoString = "00001221010304";
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_VERSIONS + "/" + mementoString;
-        final FedoraId fedoraID = FedoraId.create(testID);
+        FedoraId.create(testID);
     }
 
     @Test(expected = InvalidMementoPathException.class)
     public void testNormalMementoException2() throws Exception {
         final String mementoString = "other-text";
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_VERSIONS + "/" + mementoString;
-        final FedoraId fedoraID = FedoraId.create(testID);
+        FedoraId.create(testID);
     }
 
     @Test(expected = InvalidResourceIdentifierException.class)
     public void testMetadataAcl() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_ACL;
-        final FedoraId fedoraID = FedoraId.create(testID);
+        FedoraId.create(testID);
     }
 
 
     @Test(expected = InvalidResourceIdentifierException.class)
     public void testMetadataAclException() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_ACL + "/garbage";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        FedoraId.create(testID);
     }
 
     @Test
@@ -299,28 +301,28 @@ public class FedoraIdTest {
     @Test
     public void testResourceIdAddition() {
         final FedoraId fedoraID = FedoraId.create("core-object", FCR_VERSIONS);
-        final FedoraId fedoraId1 = fedoraID.resolve("/" + FCR_ACL);
+        final FedoraId fedoraId1 = fedoraID.asAcl();
         assertEquals(FEDORA_ID_PREFIX + "/core-object/" + FCR_ACL, fedoraId1.getFullId());
     }
 
     @Test
     public void testFullIdAddition() {
-        final FedoraId fedoraID = FedoraId.create("core-object", FCR_VERSIONS);
-        final FedoraId fedoraId1 = fedoraID.resolve("20200401101900");
+        final FedoraId fedoraID = FedoraId.create("core-object");
+        final FedoraId fedoraId1 = fedoraID.asMemento("20200401101900");
         assertEquals(FEDORA_ID_PREFIX + "/core-object/" + FCR_VERSIONS + "/20200401101900", fedoraId1.getFullId());
     }
 
     @Test
     public void testResourceIdAdditionMultiple() {
         final FedoraId fedoraID = FedoraId.create("core-object", FCR_ACL);
-        final FedoraId fedoraId1 = fedoraID.resolve("/" + FCR_VERSIONS, "20200401110400");
+        final FedoraId fedoraId1 = fedoraID.asMemento("20200401110400");
         assertEquals(FEDORA_ID_PREFIX + "/core-object/" + FCR_VERSIONS + "/20200401110400", fedoraId1.getFullId());
     }
 
     @Test
     public void testFullIdAdditionMultiple() {
         final FedoraId fedoraID = FedoraId.create("core-object", FCR_METADATA);
-        final FedoraId fedoraId1 = fedoraID.resolve(FCR_VERSIONS, "20200401110400");
+        final FedoraId fedoraId1 = fedoraID.asMemento("20200401110400");
         assertEquals(FEDORA_ID_PREFIX + "/core-object/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401110400",
                 fedoraId1.getFullId());
     }
@@ -328,7 +330,7 @@ public class FedoraIdTest {
     @Test(expected = IllegalArgumentException.class)
     public void testResolveBlank() {
         final FedoraId fedoraId = FedoraId.create("core-object");
-        fedoraId.resolve();
+        fedoraId.resolve(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -339,9 +341,130 @@ public class FedoraIdTest {
 
     @Test(expected = InvalidResourceIdentifierException.class)
     public void testDoubleAcl() {
-        final FedoraId fedoraId = FedoraId.create("core-object/" + FCR_ACL).resolve(FCR_ACL);
+        FedoraId.create("core-object/" + FCR_ACL + "/" +FCR_ACL);
     }
 
+    @Test
+    public void testAsMemento() {
+        assertAsMemento("original/" + FCR_METADATA + "/" + FCR_VERSIONS,
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101900");
+        assertAsMemento("original/" + FCR_METADATA + "#blah",
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101900#blah");
+        assertAsMemento("original/" + FCR_VERSIONS,
+                "original/" + FCR_VERSIONS + "/20200401101900");
+        assertAsMemento("original/" + FCR_TOMBSTONE,
+                "original/" + FCR_VERSIONS + "/20200401101900");
+        assertAsMemento("original/" + FCR_ACL,
+                "original/" + FCR_VERSIONS + "/20200401101900");
+        assertAsMemento("original/" + FCR_VERSIONS + "/20200401101901",
+                "original/" + FCR_VERSIONS + "/20200401101901");
+        assertAsMemento("original/child",
+                "original/child/" + FCR_VERSIONS + "/20200401101900");
+        assertAsMemento("original/child#sad",
+                "original/child/" + FCR_VERSIONS + "/20200401101900#sad");
+    }
+
+    @Test
+    public void testAsTimemap() {
+        assertAsTimemap("original/" + FCR_METADATA + "/" + FCR_VERSIONS,
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS);
+        assertAsTimemap("original/" + FCR_METADATA + "#blah",
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS);
+        assertAsTimemap("original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101901",
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS);
+        assertAsTimemap("original/" + FCR_VERSIONS,
+                "original/" + FCR_VERSIONS);
+        assertAsTimemap("original/" + FCR_TOMBSTONE,
+                "original/" + FCR_VERSIONS);
+        assertAsTimemap("original/" + FCR_ACL,
+                "original/" + FCR_VERSIONS);
+        assertAsTimemap("original/" + FCR_VERSIONS + "/20200401101900",
+                "original/" + FCR_VERSIONS);
+        assertAsTimemap("original/child",
+                "original/child/" + FCR_VERSIONS);
+        assertAsTimemap("original/child#sad",
+                "original/child/" + FCR_VERSIONS);
+    }
+
+    @Test
+    public void testAsDescription() {
+        assertAsDescription("original/" + FCR_METADATA + "/" + FCR_VERSIONS,
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS);
+        assertAsDescription("original/" + FCR_METADATA + "#blah",
+                "original/" + FCR_METADATA + "#blah");
+        assertAsDescription("original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101901",
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101901");
+        assertAsDescription("original/" + FCR_VERSIONS,
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS);
+        assertAsDescription("original/" + FCR_TOMBSTONE,
+                "original/" + FCR_METADATA);
+        assertAsDescription("original/" + FCR_ACL,
+                "original/" + FCR_METADATA);
+        assertAsDescription("original/" + FCR_VERSIONS + "/20200401101900",
+                "original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101900");
+        assertAsDescription("original/child",
+                "original/child/" + FCR_METADATA);
+        assertAsDescription("original/child#sad",
+                "original/child/" + FCR_METADATA + "#sad");
+    }
+
+    @Test
+    public void testAsTombstone() {
+        final var tombstone = "original/" + FCR_TOMBSTONE;
+        assertAsTombstone("original/" + FCR_METADATA + "/" + FCR_VERSIONS, tombstone);
+        assertAsTombstone("original/" + FCR_METADATA + "#blah", tombstone);
+        assertAsTombstone("original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101901", tombstone);
+        assertAsTombstone("original/" + FCR_VERSIONS, tombstone);
+        assertAsTombstone("original/" + FCR_TOMBSTONE, tombstone);
+        assertAsTombstone("original/" + FCR_ACL, tombstone);
+        assertAsTombstone("original/" + FCR_VERSIONS + "/20200401101900", tombstone);
+        assertAsTombstone("original/child", "original/child/" + FCR_TOMBSTONE);
+        assertAsTombstone("original/child#sad", "original/child/" + FCR_TOMBSTONE);
+    }
+
+    @Test
+    public void testAsAcl() {
+        final var acl = "original/" + FCR_ACL;
+        assertAsAcl("original/" + FCR_METADATA + "/" + FCR_VERSIONS, acl);
+        assertAsAcl("original/" + FCR_METADATA + "#blah", acl);
+        assertAsAcl("original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101901", acl);
+        assertAsAcl("original/" + FCR_VERSIONS, acl);
+        assertAsAcl("original/" + FCR_TOMBSTONE, acl);
+        assertAsAcl("original/" + FCR_ACL, acl);
+        assertAsAcl("original/" + FCR_VERSIONS + "/20200401101900", acl);
+        assertAsAcl("original/child", "original/child/" + FCR_ACL);
+        assertAsAcl("original/child#sad", "original/child/" + FCR_ACL);
+    }
+
+    private void assertAsMemento(final String original, final String expected) {
+        final var id = FedoraId.create(original);
+        assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expected,
+                id.asMemento("20200401101900").getFullId());
+    }
+
+    private void assertAsTimemap(final String original, final String expected) {
+        final var id = FedoraId.create(original);
+        assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expected,
+                id.asTimemap().getFullId());
+    }
+
+    private void assertAsTombstone(final String original, final String expected) {
+        final var id = FedoraId.create(original);
+        assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expected,
+                id.asTombstone().getFullId());
+    }
+
+    private void assertAsAcl(final String original, final String expected) {
+        final var id = FedoraId.create(original);
+        assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expected,
+                id.asAcl().getFullId());
+    }
+
+    private void assertAsDescription(final String original, final String expected) {
+        final var id = FedoraId.create(original);
+        assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expected,
+                id.asDescription().getFullId());
+    }
 
     /**
      * Utility to test a FedoraId against expectations.
@@ -394,6 +517,6 @@ public class FedoraIdTest {
             assertFalse(fedoraID.isTimemap());
         }
         assertEquals(fullID, fedoraID.getFullId());
-        assertEquals(shortID, fedoraID.getContainingId());
+        assertEquals(shortID, fedoraID.getBaseId());
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -514,7 +514,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     @Override
     public boolean resourceExists(final String txID, final FedoraId fedoraID) {
         // Get the containing ID because fcr:metadata will not exist here but MUST exist if the containing resource does
-        final String resourceID = fedoraID.getContainingId();
+        final String resourceID = fedoraID.getBaseId();
         LOGGER.debug("Checking if {} exists in transaction {}", resourceID, txID);
         if (fedoraID.isRepositoryRoot()) {
             // Root always exists.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -17,14 +17,6 @@
  */
 package org.fcrepo.kernel.impl.models;
 
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
-import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
-
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Collection;
-
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
@@ -40,6 +32,12 @@ import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+
+import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
 
 
 /**
@@ -137,10 +135,9 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
     @Override
     public FedoraResource getDescription() {
         try {
-            final FedoraId descId = getFedoraId().resolve("/" + FCR_METADATA);
+            final FedoraId descId = getFedoraId().asDescription();
             if (this.isMemento()) {
-                return resourceFactory.getResource(tx, descId.resolve(FCR_VERSIONS,
-                        this.getMementoDateTimeAsUriString()));
+                return resourceFactory.getResource(tx, descId.asMemento(getMementoDatetime()));
             }
             return resourceFactory.getResource(tx, descId);
         } catch (final PathNotFoundException e) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -42,16 +42,13 @@ import java.util.stream.Stream;
 
 import static java.net.URI.create;
 import static java.util.stream.Collectors.toList;
-
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.vocabulary.RDF.type;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
-import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
 
 /**
  * Implementation of a Fedora resource, containing functionality common to the more concrete resource implementations.
@@ -182,7 +179,7 @@ public class FedoraResourceImpl implements FedoraResource {
             return this;
         }
         try {
-            final var aclId = fedoraID.resolve("/" + FCR_ACL);
+            final var aclId = fedoraID.asAcl();
             return resourceFactory.getResource(tx, aclId);
         } catch (final PathNotFoundException e) {
             return null;
@@ -410,11 +407,4 @@ public class FedoraResourceImpl implements FedoraResource {
         this.isMemento = isMemento;
     }
 
-    /**
-     * Get the Memento Instant as YYYYMMDDHHIISS string.
-     * @return The string.
-     */
-    protected String getMementoDateTimeAsUriString() {
-        return MEMENTO_LABEL_FORMATTER.format(getMementoDatetime());
-    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -67,7 +67,7 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
     @Override
     public FedoraResource getDescribedResource() {
         // Get a FedoraId for the binary
-        final FedoraId describedId = FedoraId.create(this.getFedoraId().getContainingId());
+        final FedoraId describedId = FedoraId.create(this.getFedoraId().getBaseId());
         try {
             return this.resourceFactory.getResource(tx, describedId);
         } catch (final PathNotFoundException e) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -202,7 +202,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
             populateResourceHeaders(rescImpl, headers, versionDateTime);
 
             if (headers.isDeleted()) {
-                final var rootId = FedoraId.create(identifier.getContainingId());
+                final var rootId = FedoraId.create(identifier.getBaseId());
                 final var tombstone = new TombstoneImpl(rootId, transaction, persistentStorageSessionManager,
                         this, rescImpl);
                 tombstone.setLastModifiedDate(headers.getLastModifiedDate());

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -17,19 +17,6 @@
  */
 package org.fcrepo.kernel.impl.models;
 
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
-import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
-import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
-import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
-
-import static java.net.URI.create;
-
-import java.net.URI;
-import java.time.Instant;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.impl.StatementImpl;
@@ -48,6 +35,17 @@ import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.net.URI.create;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 
 /**
  * FedoraResource implementation that represents a Memento TimeMap of the base resource.
@@ -81,7 +79,7 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
             final Transaction tx,
             final PersistentStorageSessionManager pSessionManager,
             final ResourceFactory resourceFactory) {
-        super(originalResource.getFedoraId().resolve(FCR_VERSIONS), tx, pSessionManager, resourceFactory);
+        super(originalResource.getFedoraId().asTimemap(), tx, pSessionManager, resourceFactory);
 
         this.originalResource = originalResource;
         setCreatedBy(originalResource.getCreatedBy());
@@ -169,8 +167,7 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
      * @return the new FedoraId for the current TimeMap and the version.
      */
     private FedoraId getInstantFedoraId(final Instant version) {
-        final String versionTime = MEMENTO_LABEL_FORMATTER.format(version);
-        return getFedoraId().resolve(versionTime);
+        return getFedoraId().asMemento(version);
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
@@ -45,7 +45,7 @@ public class WebacAclImpl extends ContainerImpl implements WebacAcl {
 
     @Override
     public FedoraResource getContainer() {
-        final var originalId = FedoraId.create(getFedoraId().getContainingId());
+        final var originalId = FedoraId.create(getFedoraId().getBaseId());
         try {
             return resourceFactory.getResource(tx, originalId);
         } catch (final PathNotFoundException exc) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -17,24 +17,6 @@
  */
 package org.fcrepo.kernel.impl.services;
 
-import static java.util.Collections.emptyList;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
-import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
-import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI;
-import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_PAIR_TREE;
-import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
-import static org.springframework.util.CollectionUtils.isEmpty;
-
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-import javax.ws.rs.core.Link;
-
 import org.apache.jena.rdf.model.Model;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
@@ -55,6 +37,22 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Link;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_PAIR_TREE;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 /**
  * Create a RdfSource resource.
@@ -118,7 +116,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
     private void createDescription(final PersistentStorageSession pSession, final String userPrincipal,
             final FedoraId binaryId) {
-        final var descId = binaryId.resolve("/" + FCR_METADATA);
+        final var descId = binaryId.asDescription();
         final var createOp = rdfSourceOperationFactory.createBuilder(
                     descId.getFullId(),
                     FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
@@ -77,7 +77,7 @@ public class WebacAclServiceImpl extends AbstractService implements WebacAclServ
 
         final RdfSourceOperation createOp = rdfSourceOperationFactory
                 .createBuilder(fedoraId.getResourceId(), FEDORA_WEBAC_ACL_URI)
-                .parentId(fedoraId.getContainingId())
+                .parentId(fedoraId.getBaseId())
                 .triples(stream)
                 .relaxedProperties(model)
                 .userPrincipal(userPrincipal)

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
@@ -37,10 +37,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.net.URI.create;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.apache.jena.vocabulary.RDF.type;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
@@ -56,8 +56,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-
-import static java.net.URI.create;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class FedoraResourceImplTest {
@@ -163,7 +161,7 @@ public class FedoraResourceImplTest {
 
     @Test
     public void testTypesNonRdfSource() throws Exception {
-        final var descriptionFedoraId = FEDORA_ID.resolve(FCR_METADATA);
+        final var descriptionFedoraId = FEDORA_ID.asDescription();
         final var subject = createResource(ID);
         final String exampleType = "http://example.org/customType";
         final Model userModel = createDefaultModel();

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
@@ -17,32 +17,6 @@
  */
 package org.fcrepo.kernel.impl.models;
 
-import static java.util.Arrays.asList;
-
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
-import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI;
-import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
-
-import javax.inject.Inject;
-
-import java.net.URI;
-import java.time.Instant;
-import java.util.Collection;
-import java.util.UUID;
-
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.fcrepo.kernel.api.ContainmentIndex;
@@ -69,6 +43,29 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.inject.Inject;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI;
+import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 /**
  * @author bbpennel
@@ -352,7 +349,7 @@ public class ResourceFactoryImplTest {
     @Test
     public void doesResourceExist_Exists_Description_WithSession() {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
-        final FedoraId descId = fedoraId.resolve("/" + FCR_METADATA);
+        final FedoraId descId = fedoraId.asDescription();
         final boolean answerIn = factory.doesResourceExist(mockTx, descId);
         assertTrue(answerIn);
         final boolean answerOut = factory.doesResourceExist(null, descId);
@@ -371,7 +368,7 @@ public class ResourceFactoryImplTest {
     public void doesResourceExist_Exists_Description_WithoutSession() {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
         containmentIndex.commitTransaction(mockTx.getId());
-        final FedoraId descId = fedoraId.resolve("/" + FCR_METADATA);
+        final FedoraId descId = fedoraId.asDescription();
         final boolean answer = factory.doesResourceExist(null, descId);
         assertTrue(answer);
     }
@@ -384,7 +381,7 @@ public class ResourceFactoryImplTest {
 
     @Test
     public void doesResourceExist_DoesntExists_Description_WithSession() {
-        final FedoraId descId = fedoraId.resolve("/" + FCR_METADATA);
+        final FedoraId descId = fedoraId.asDescription();
         final boolean answer = factory.doesResourceExist(mockTx, descId);
         assertFalse(answer);
     }
@@ -397,7 +394,7 @@ public class ResourceFactoryImplTest {
 
     @Test
     public void doesResourceExist_DoesntExists_Description_WithoutSession() {
-        final FedoraId descId = fedoraId.resolve("/" + FCR_METADATA);
+        final FedoraId descId = fedoraId.asDescription();
         final boolean answer = factory.doesResourceExist(null, descId);
         assertFalse(answer);
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -118,7 +118,7 @@ abstract class AbstractPersister implements Persister {
     protected FedoraId resolveRootObjectId(final FedoraId fedoraId,
                                        final OCFLPersistentStorageSession session) {
         final var archivalGroupId = findArchivalGroupInAncestry(fedoraId, session);
-        return archivalGroupId.orElseGet(() -> FedoraId.create(fedoraId.getContainingId()));
+        return archivalGroupId.orElseGet(() -> FedoraId.create(fedoraId.getBaseId()));
     }
 
     protected Optional<FedoraId> findArchivalGroupInAncestry(final FedoraId fedoraId,
@@ -153,11 +153,11 @@ abstract class AbstractPersister implements Persister {
      */
     protected String mapToOcflId(final FedoraId fedoraId) {
         try {
-            final var mapping = index.getMapping(fedoraId.getContainingId());
+            final var mapping = index.getMapping(fedoraId.getBaseId());
             return mapping.getOcflObjectId();
         } catch (FedoraOCFLMappingNotFoundException e) {
             // If the a mapping doesn't already exist, use a one-to-one Fedora ID to OCFL ID mapping
-            return fedoraId.getContainingId();
+            return fedoraId.getBaseId();
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
@@ -54,7 +54,7 @@ class CreateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
         final var rootObjectId = resolveRootObjectId(fedoraId, session);
         final String ocflId = mapToOcflId(rootObjectId);
         final OCFLObjectSession ocflObjectSession = session.findOrCreateSession(ocflId);
-        persistNonRDFSource(operation, ocflObjectSession, rootObjectId.getContainingId());
-        index.addMapping(resourceId, rootObjectId.getContainingId(), ocflId);
+        persistNonRDFSource(operation, ocflObjectSession, rootObjectId.getBaseId());
+        index.addMapping(resourceId, rootObjectId.getBaseId(), ocflId);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
@@ -73,7 +73,7 @@ class CreateRDFSourcePersister extends AbstractRDFSourcePersister {
 
         final String ocflObjectId = mapToOcflId(rootObjectId);
         final OCFLObjectSession ocflObjectSession = session.findOrCreateSession(ocflObjectId);
-        persistRDF(ocflObjectSession, operation, rootObjectId.getContainingId());
-        index.addMapping(resourceId, rootObjectId.getContainingId(), ocflObjectId);
+        persistRDF(ocflObjectSession, operation, rootObjectId.getBaseId());
+        index.addMapping(resourceId, rootObjectId.getBaseId(), ocflObjectId);
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3381

# What does this Pull Request do?

Refactors FedoarId in attempt to make it easier to understand. Changes:

1. `resolve()` now only adds a single child to the end of the original id's base id. The old method had extremely confusing behavior depending on whether of not the joining part was prefixed with a `/`.
2. Added a bunch of `asX()` methods that can be use to create versions of the original id that reference a related "sub" resource, like a memento or binary description.

# How should this be tested?

Fire it up and create a resource. There's no new functionality to test or broken functionality that is now fixed that I know of.

# Interested parties
@fcrepo4/committers
