### PR TITLE
Adds support for the ocfl_id parameter and return field in simple search.

### DIFF
--- a/fcrepo-search-api/src/main/java/org/fcrepo/search/api/Condition.java
+++ b/fcrepo-search-api/src/main/java/org/fcrepo/search/api/Condition.java
@@ -59,7 +59,8 @@ public class Condition {
         MODIFIED,
         CREATED,
         CONTENT_SIZE,
-        MIME_TYPE;
+        MIME_TYPE,
+        OCFL_ID;
 
         @Override
         public String toString() {

--- a/fcrepo-search-api/src/main/java/org/fcrepo/search/api/SearchIndex.java
+++ b/fcrepo-search-api/src/main/java/org/fcrepo/search/api/SearchIndex.java
@@ -48,6 +48,7 @@ public interface SearchIndex {
      */
     SearchResult doSearch(SearchParameters parameters) throws InvalidQueryException;
 
+
     /**
      * Remove all persistent state associated with the index.
      */

--- a/fcrepo-search-impl/pom.xml
+++ b/fcrepo-search-impl/pom.xml
@@ -42,6 +42,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-persistence-ocfl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/fcrepo-search-impl/src/main/resources/sql/default-search-index.sql
+++ b/fcrepo-search-impl/src/main/resources/sql/default-search-index.sql
@@ -1,6 +1,7 @@
 -- simple search
 CREATE TABLE IF NOT EXISTS simple_search (
     fedora_id  varchar(503) NOT NULL PRIMARY KEY,
+    ocfl_id varchar(503) NOT NULL,
     created timestamp NOT NULL,
     modified timestamp NOT NULL,
     content_size bigint DEFAULT NULL,


### PR DESCRIPTION

Resolves: 

**Adds support for the ocfl_id parameter and return field in simple search.**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3372

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
1.  returns the ocfl_id field by default in the search results
2. allows user to specify ocfl_id field in the _fields_ parameter
3. allows user to  specify the ocfl_id in a _condition_ clause (wildcard chars "*" are also allowed)

# How should this be tested?
It is covered by integration tests.
You can test manually like so: 
```
# create a resource
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test1 -X PUT
# see the default results return the ocfl_id field.
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/fcr:search
# return only the ocfl_id 
curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/fcr:search?fields=ocfl_id"
# return results based on ocfl_id match
 curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/fcr:search?condition=ocfl_id%3D<insert ocfl_id returned above>"
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
