### PR TITLE
Remove ocfl id mappings on purge

### DIFF
--- a/fcrepo-common/pom.xml
+++ b/fcrepo-common/pom.xml
@@ -12,11 +12,6 @@
   <description>Common, generally useful utilities</description>
   <packaging>bundle</packaging>
   <properties>
-    <osgi.import.packages>
-      org.apache.jena.*,
-
-      *   
-    </osgi.import.packages>
     <osgi.export.packages>
       org.fcrepo.common.*;version=${project.version}
     </osgi.export.packages>

--- a/fcrepo-common/pom.xml
+++ b/fcrepo-common/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.fcrepo</groupId>
+    <artifactId>fcrepo</artifactId>
+    <version>6.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>fcrepo-common</artifactId>
+  <name>Fedora Repository Common Module</name>
+  <description>Common, generally useful utilities</description>
+  <packaging>bundle</packaging>
+  <properties>
+    <osgi.import.packages>
+      org.apache.jena.*,
+
+      *   
+    </osgi.import.packages>
+    <osgi.export.packages>
+      org.fcrepo.common.*;version=${project.version}
+    </osgi.export.packages>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- test gear -->  
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <!-- Package tests in a JAR for reuse. See: https://maven.apache.org/guides/mini/guide-attached-tests.html -->
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+
+  </build>
+</project>

--- a/fcrepo-common/src/main/java/org/fcrepo/common/db/DbPlatform.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/common/db/DbPlatform.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.common.db;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+
+/**
+ * Detects the database platform from a datasource.
+ *
+ * @author pwinckles
+ * @since 6.0.0
+ */
+public enum DbPlatform {
+
+    POSTGRESQL("PostgreSQL"),
+    H2("H2"),
+    MYSQL("MySQL"),
+    MARIADB("MariaDB");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DbPlatform.class);
+
+    private final String name;
+
+    DbPlatform(final String name) {
+        this.name = name;
+    }
+
+    public static DbPlatform fromDataSource(final DataSource dataSource) {
+        try (final var connection = dataSource.getConnection()) {
+            final var name = connection.getMetaData().getDatabaseProductName();
+            LOGGER.debug("Identified database as: {}", name);
+            return fromString(name);
+        } catch (final SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static DbPlatform fromString(final String name) {
+        for (var platform : values()) {
+            if (platform.name.equals(name)) {
+                return platform;
+            }
+        }
+        throw new IllegalArgumentException("Unknown database platform: " + name);
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -1032,8 +1032,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
             if (originalResource instanceof Tombstone) {
                 final String tombstoneUri = identifierConverter().toExternalId(
-                            originalResource.getFedoraId().asTombstone().getFullId()
-                    );
+                            originalResource.getFedoraId().asTombstone().getFullId());
                 throw new TombstoneException(fedoraResource, tombstoneUri);
             }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
@@ -85,7 +85,7 @@ public class FedoraTombstones extends ContentExposingResource {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
         final Tombstone tombstone = (Tombstone) resource;
-        LOGGER.info("Delete tombstone: {}", resource);
+        LOGGER.info("Delete tombstone: {}", resource.getFedoraId());
         purgeResourceService.perform(transaction(), tombstone.getDeletedObject(), getUserPrincipal());
         transaction().commitIfShortLived();
         return noContent().build();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -33,6 +33,7 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.StringEntity;
@@ -87,6 +88,7 @@ import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_ID_HEADER;
 import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
@@ -536,6 +538,18 @@ public abstract class AbstractResourceIT {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             return getLocation(response);
         }
+    }
+
+    /**
+     * Add a transaction id to a http request.
+     *
+     * @param req a http request object.
+     * @param txId the transaction id.
+     * @return the http request object with the transaction id added as a header.
+     */
+    protected <T extends HttpRequestBase> T addTxTo(final T req, final String txId) {
+        req.addHeader(ATOMIC_ID_HEADER, txId);
+        return req;
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/OcflPersistenceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/OcflPersistenceIT.java
@@ -17,9 +17,11 @@
  */
 package org.fcrepo.integration.http.api;
 
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.GONE;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 
@@ -29,6 +31,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -66,5 +69,60 @@ public class OcflPersistenceIT extends AbstractResourceIT {
 
         final HttpGet getChildAgain = new HttpGet(childLocation);
         assertEquals(GONE.getStatusCode(), getStatus(getChildAgain));
+    }
+
+    @Test
+    public void testCreateDeletePurgeCreateWholeObject() throws Exception {
+        final HttpPost httpPost = postObjMethod();
+        final String id;
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            id = getLocation(response);
+        }
+        assertEquals(OK.getStatusCode(), getStatus(new HttpGet(id)));
+
+        final HttpDelete deleteObj = new HttpDelete(id);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteObj));
+
+        final HttpDelete deleteTomb = new HttpDelete(id + "/" + FCR_TOMBSTONE);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteTomb));
+
+        final HttpGet getObj = new HttpGet(id);
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(getObj));
+
+        final HttpPut putObj = new HttpPut(id);
+        assertEquals(CREATED.getStatusCode(), getStatus(putObj));
+    }
+
+    @Test
+    public void testCreateDeletePurgeCreateSubpath() throws Exception {
+        final HttpPost httpPost = postObjMethod();
+        httpPost.setHeader("Link", "<http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel=\"type\"");
+        final String parent;
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            parent = getLocation(response);
+        }
+        assertEquals(OK.getStatusCode(), getStatus(new HttpGet(parent)));
+
+        final HttpPost postChild = new HttpPost(parent);
+        final String id;
+        try (final CloseableHttpResponse response = execute(postChild)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            id = getLocation(response);
+        }
+        assertEquals(OK.getStatusCode(), getStatus(new HttpGet(id)));
+
+        final HttpDelete deleteObj = new HttpDelete(id);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteObj));
+
+        final HttpDelete deleteTomb = new HttpDelete(id + "/" + FCR_TOMBSTONE);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteTomb));
+
+        final HttpGet getObj = new HttpGet(id);
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(getObj));
+
+        final HttpPut putObj = new HttpPut(id);
+        assertEquals(CREATED.getStatusCode(), getStatus(putObj));
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/OcflPersistenceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/OcflPersistenceIT.java
@@ -32,6 +32,7 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -124,5 +125,50 @@ public class OcflPersistenceIT extends AbstractResourceIT {
 
         final HttpPut putObj = new HttpPut(id);
         assertEquals(CREATED.getStatusCode(), getStatus(putObj));
+    }
+
+
+    /*
+     * Tests upsert mapping in fedoraToOcflIndex
+     */
+    @Ignore("Needs upsert in containment index - https://jira.lyrasis.org/browse/FCREPO-3369")
+    @Test
+    public void testUpsertMappingOcflIndex() throws Exception {
+        // Create a container.
+        final HttpPost post = postObjMethod();
+        final String id;
+        try (final CloseableHttpResponse response = execute(post)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            id = getLocation(response);
+        }
+        assertEquals(OK.getStatusCode(), getStatus(new HttpGet(id)));
+
+        final String txLocation = createTransaction();
+        // Inside a transaction delete the container.
+        final HttpDelete delete = new HttpDelete(id);
+        addTxTo(delete, txLocation);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(delete));
+        // Ensure the container is removed in the transaction.
+        final HttpGet getInside = new HttpGet(id);
+        addTxTo(getInside, txLocation);
+        assertEquals(GONE.getStatusCode(), getStatus(getInside));
+        // Inside a transaction delete the tombstone.
+        final HttpDelete deleteTomb = new HttpDelete(id + "/" + FCR_TOMBSTONE);
+        addTxTo(deleteTomb, txLocation);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteTomb));
+        // Ensure the container is totally removed in the transaction.
+        final HttpGet getInside2 = new HttpGet(id);
+        addTxTo(getInside2, txLocation);
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(getInside2));
+        // Inside the transaction put back the container.
+        final HttpPut putBack = new HttpPut(id);
+        addTxTo(putBack, txLocation);
+        assertEquals(CREATED.getStatusCode(), getStatus(putBack));
+        // Commit the transaction.
+        final HttpPut commitTx = new HttpPut(txLocation);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(commitTx));
+        // Verify you can still get the container.
+        assertEquals(OK.getStatusCode(), getStatus(new HttpGet(id)));
+
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Tombstone.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Tombstone.java
@@ -27,5 +27,6 @@ public interface Tombstone extends FedoraResource {
      * Return the object this tombstone is for.
      * @return the original deleted resource.
      */
-    public FedoraResource getDeletedObject();
+    FedoraResource getDeletedObject();
+
 }

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-persistence-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -208,12 +208,11 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     /*
      * Remove from the main table all rows from transaction operation table marked 'purge' for this transaction.
      */
-    private static final String COMMIT_PURGE_RECORDS = "DELETE FROM " + RESOURCES_TABLE + " WHERE " +
-            "EXISTS (SELECT * FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " +
-            TRANSACTION_ID_COLUMN + " = :transactionId AND " +  OPERATION_COLUMN + " = 'purge' AND " +
-            RESOURCES_TABLE + "." + FEDORA_ID_COLUMN + " = " + TRANSACTION_OPERATIONS_TABLE + "." + FEDORA_ID_COLUMN +
-            " AND " + RESOURCES_TABLE + "." + PARENT_COLUMN + " = " + TRANSACTION_OPERATIONS_TABLE + "." +
-            PARENT_COLUMN + ")";
+    private static final String COMMIT_PURGE_RECORDS = "DELETE FROM " + RESOURCES_TABLE + " r WHERE " +
+            "EXISTS (SELECT 1 FROM " + TRANSACTION_OPERATIONS_TABLE + " t WHERE t." +
+            TRANSACTION_ID_COLUMN + " = :transactionId AND t." +  OPERATION_COLUMN + " = 'purge' AND" +
+            " t." + FEDORA_ID_COLUMN + " = r." + FEDORA_ID_COLUMN +
+            " AND t." + PARENT_COLUMN + " = r." + PARENT_COLUMN + ")";
 
     /*
      * Query if a resource exists in the main table and is not deleted.
@@ -225,7 +224,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
      * Resource exists as a record in the transaction operations table with an 'add' operation and not also
      * exists as a 'delete' operation.
      */
-    private static final String RESOURCE_EXISTS_IN_TRANSACTION = "SELECT " + FEDORA_ID_COLUMN + " FROM" +
+    private static final String RESOURCE_EXISTS_IN_TRANSACTION = "SELECT x." + FEDORA_ID_COLUMN + " FROM" +
             " (SELECT " + FEDORA_ID_COLUMN + " FROM " + RESOURCES_TABLE + " WHERE " + FEDORA_ID_COLUMN + " = :child" +
             " UNION SELECT " + FEDORA_ID_COLUMN + " FROM " + TRANSACTION_OPERATIONS_TABLE +
             " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + TRANSACTION_ID_COLUMN + " = :transactionId" +
@@ -233,7 +232,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
             " WHERE NOT EXISTS " +
             " (SELECT 1 FROM " + TRANSACTION_OPERATIONS_TABLE +
             " WHERE " + FEDORA_ID_COLUMN + " = :child AND " + TRANSACTION_ID_COLUMN + " = :transactionId" +
-            " AND " + OPERATION_COLUMN + " = 'delete')";
+            " AND " + OPERATION_COLUMN + " IN ('delete', 'purge'))";
 
     /*
      * Get the parent ID for this resource from the main table if not deleted.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -208,11 +208,11 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     /*
      * Remove from the main table all rows from transaction operation table marked 'purge' for this transaction.
      */
-    private static final String COMMIT_PURGE_RECORDS = "DELETE FROM " + RESOURCES_TABLE + " r WHERE " +
-            "EXISTS (SELECT 1 FROM " + TRANSACTION_OPERATIONS_TABLE + " t WHERE t." +
+    private static final String COMMIT_PURGE_RECORDS = "DELETE FROM " + RESOURCES_TABLE + " WHERE " +
+            "EXISTS (SELECT * FROM " + TRANSACTION_OPERATIONS_TABLE + " t WHERE t." +
             TRANSACTION_ID_COLUMN + " = :transactionId AND t." +  OPERATION_COLUMN + " = 'purge' AND" +
-            " t." + FEDORA_ID_COLUMN + " = r." + FEDORA_ID_COLUMN +
-            " AND t." + PARENT_COLUMN + " = r." + PARENT_COLUMN + ")";
+            " t." + FEDORA_ID_COLUMN + " = " + RESOURCES_TABLE + "." + FEDORA_ID_COLUMN +
+            " AND t." + PARENT_COLUMN + " = " + RESOURCES_TABLE + "." + PARENT_COLUMN + ")";
 
     /*
      * Query if a resource exists in the main table and is not deleted.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
@@ -42,4 +42,9 @@ public class TombstoneImpl extends FedoraResourceImpl implements Tombstone {
     public FedoraResource getDeletedObject() {
         return originalResource;
     }
+
+    @Override
+    public FedoraId getFedoraId() {
+        return this.originalResource.getFedoraId();
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -33,6 +33,7 @@ import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -96,7 +97,11 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
             children.forEach(childResourceId -> {
                 try {
                     final FedoraResource res = resourceFactory.getResource(tx, FedoraId.create(childResourceId));
-                    deleteDepthFirst(tx, pSession, res, userPrincipal);
+                    if (res instanceof Tombstone) {
+                        deleteDepthFirst(tx, pSession, ((Tombstone) res).getDeletedObject(), userPrincipal);
+                    } else {
+                        deleteDepthFirst(tx, pSession, res, userPrincipal);
+                    }
                 } catch (final PathNotFoundException ex) {
                     log.error("Path not found for {}: {}", fedoraId.getFullId(), ex.getMessage());
                     throw new PathNotFoundRuntimeException(ex);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -28,6 +28,7 @@ import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
@@ -104,6 +105,8 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
                             ex);
                 }
             });
+        } else if (fedoraResource instanceof Binary) {
+            doAction(tx, pSession, fedoraResource.getDescription().getFedoraId(), userPrincipal);
         }
 
         //delete/purge the acl if this is not the acl

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -28,7 +28,6 @@ import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
-import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
@@ -105,9 +104,6 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
                             ex);
                 }
             });
-        } else if (fedoraResource instanceof Binary) {
-            //delete/purge the description resource if binary
-            doAction(tx, pSession, fedoraResource.getDescription().getFedoraId(), userPrincipal);
         }
 
         //delete/purge the acl if this is not the acl

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -205,12 +205,11 @@ public class DeleteResourceServiceImplTest {
 
         service.perform(tx, binary, USER);
 
-        verify(pSession, times(3)).persist(operationCaptor.capture());
+        verify(pSession, times(2)).persist(operationCaptor.capture());
         final List<DeleteResourceOperation> operations = operationCaptor.getAllValues();
-        assertEquals(3, operations.size());
+        assertEquals(2, operations.size());
 
-        assertEquals(RESOURCE_DESCRIPTION_ID, operations.get(0).getResourceId());
-        assertEquals(RESOURCE_ACL_ID, operations.get(1).getResourceId());
-        assertEquals(RESOURCE_ID, operations.get(2).getResourceId());
+        assertEquals(RESOURCE_ACL_ID, operations.get(0).getResourceId());
+        assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
     }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -205,11 +205,12 @@ public class DeleteResourceServiceImplTest {
 
         service.perform(tx, binary, USER);
 
-        verify(pSession, times(2)).persist(operationCaptor.capture());
+        verify(pSession, times(3)).persist(operationCaptor.capture());
         final List<DeleteResourceOperation> operations = operationCaptor.getAllValues();
-        assertEquals(2, operations.size());
+        assertEquals(3, operations.size());
 
-        assertEquals(RESOURCE_ACL_ID, operations.get(0).getResourceId());
-        assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
+        assertEquals(RESOURCE_DESCRIPTION_ID, operations.get(0).getResourceId());
+        assertEquals(RESOURCE_ACL_ID, operations.get(1).getResourceId());
+        assertEquals(RESOURCE_ID, operations.get(2).getResourceId());
     }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
@@ -199,12 +199,11 @@ public class PurgeResourceServiceImplTest {
 
         service.perform(tx, binary, USER);
 
-        verify(pSession, times(3)).persist(operationCaptor.capture());
+        verify(pSession, times(2)).persist(operationCaptor.capture());
         final List<PurgeResourceOperation> operations = operationCaptor.getAllValues();
-        assertEquals(3, operations.size());
+        assertEquals(2, operations.size());
 
-        assertEquals(RESOURCE_DESCRIPTION_ID, operations.get(0).getResourceId());
-        assertEquals(RESOURCE_ACL_ID, operations.get(1).getResourceId());
-        assertEquals(RESOURCE_ID, operations.get(2).getResourceId());
+        assertEquals(RESOURCE_ACL_ID, operations.get(0).getResourceId());
+        assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
     }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
@@ -199,11 +199,12 @@ public class PurgeResourceServiceImplTest {
 
         service.perform(tx, binary, USER);
 
-        verify(pSession, times(2)).persist(operationCaptor.capture());
+        verify(pSession, times(3)).persist(operationCaptor.capture());
         final List<PurgeResourceOperation> operations = operationCaptor.getAllValues();
-        assertEquals(2, operations.size());
+        assertEquals(3, operations.size());
 
-        assertEquals(RESOURCE_ACL_ID, operations.get(0).getResourceId());
-        assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
+        assertEquals(RESOURCE_DESCRIPTION_ID, operations.get(0).getResourceId());
+        assertEquals(RESOURCE_ACL_ID, operations.get(1).getResourceId());
+        assertEquals(RESOURCE_ID, operations.get(2).getResourceId());
     }
 }

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-search-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOcflObjectIndex.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.persistence.ocfl.api;
 
+import javax.annotation.Nonnull;
+
 import org.fcrepo.persistence.ocfl.impl.FedoraOCFLMapping;
 
 /**
@@ -36,34 +38,52 @@ public interface FedoraToOcflObjectIndex {
      * Contrast this  with an Archival Group example:  if you pass in "my/archival-group/binary/fcr:metadata" the
      * resource returned in the mapping would be "my/archival-group".
      *
+     * @param sessionId id of the current session, or null for read-only.
      * @param fedoraResourceIdentifier the fedora resource identifier
      * @return the mapping
      * @throws FedoraOCFLMappingNotFoundException when no mapping exists for the specified identifier.
      */
-    FedoraOCFLMapping getMapping(final String fedoraResourceIdentifier) throws FedoraOCFLMappingNotFoundException;
+    FedoraOCFLMapping getMapping(final String sessionId, final String fedoraResourceIdentifier) throws
+            FedoraOCFLMappingNotFoundException;
 
     /**
      * Adds a mapping to the index
      *
+     * @param sessionId id of the current session.
      * @param fedoraResourceIdentifier The fedora resource
      * @param fedoraRootObjectIdentifier   The identifier of the root fedora object resource
      * @param ocflObjectId             The ocfl object id
      * @return  The newly created mapping
      */
-    FedoraOCFLMapping addMapping(final String fedoraResourceIdentifier, final String fedoraRootObjectIdentifier,
-                           final String ocflObjectId);
+    FedoraOCFLMapping addMapping(@Nonnull String sessionId, final String fedoraResourceIdentifier,
+                                 final String fedoraRootObjectIdentifier,  final String ocflObjectId);
 
     /**
      * Removes a mapping
      *
+     * @param sessionId id of the current session.
      * @param fedoraResourceIdentifier The fedora resource to remove the mapping for
      */
-    void removeMapping(final String fedoraResourceIdentifier);
+    void removeMapping(@Nonnull final String sessionId, final String fedoraResourceIdentifier);
 
     /**
      * Remove all persistent state associated with the index.
      */
     void reset();
+
+    /**
+     * Commit mapping changes for the session.
+     *
+     * @param sessionId id of the session to commit.
+     */
+    void commit(@Nonnull final String sessionId);
+
+    /**
+     * Rollback mapping changes for the session.
+     *
+     * @param sessionId id of the session to rollback.
+     */
+    void rollback(@Nonnull final String sessionId);
 
 }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -97,14 +97,16 @@ abstract class AbstractPersister implements Persister {
 
     /**
      *
+     * @param transactionId The storage session/transaction identifier.
      * @param resourceId The fedora resource identifier
      * @return The associated mapping
      * @throws PersistentStorageException When no mapping is found.
      */
-    protected FedoraOCFLMapping getMapping(final String resourceId) throws PersistentStorageException {
+    protected FedoraOCFLMapping getMapping(final String transactionId, final String resourceId)
+            throws PersistentStorageException {
         try {
-            return this.index.getMapping(resourceId);
-        } catch (FedoraOCFLMappingNotFoundException e){
+            return this.index.getMapping(transactionId, resourceId);
+        } catch (final FedoraOCFLMappingNotFoundException e){
             throw new PersistentStorageException(e.getMessage());
         }
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -149,15 +149,16 @@ abstract class AbstractPersister implements Persister {
     }
 
     /**
-     * Maps the Fedor ID to an OCFL ID.
+     * Maps the Fedora ID to an OCFL ID.
+     * @param sessionId The session ID.
      * @param fedoraId The fedora identifier for the root OCFL object
      * @return The OCFL ID
      */
-    protected String mapToOcflId(final FedoraId fedoraId) {
+    protected String mapToOcflId(final String sessionId, final FedoraId fedoraId) {
         try {
-            final var mapping = index.getMapping(fedoraId.getBaseId());
+            final var mapping = index.getMapping(sessionId, fedoraId.getBaseId());
             return mapping.getOcflObjectId();
-        } catch (FedoraOCFLMappingNotFoundException e) {
+        } catch (final FedoraOCFLMappingNotFoundException e) {
             // If the a mapping doesn't already exist, use a one-to-one Fedora ID to OCFL ID mapping
             return fedoraId.getBaseId();
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
@@ -55,6 +55,6 @@ class CreateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
         final String ocflId = mapToOcflId(rootObjectId);
         final OCFLObjectSession ocflObjectSession = session.findOrCreateSession(ocflId);
         persistNonRDFSource(operation, ocflObjectSession, rootObjectId.getBaseId());
-        index.addMapping(resourceId, rootObjectId.getBaseId(), ocflId);
+        index.addMapping(session.getId(), resourceId, rootObjectId.getBaseId(), ocflId);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
@@ -52,7 +52,7 @@ class CreateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
         final var fedoraId = FedoraId.create(resourceId);
         log.debug("persisting {} to {}", resourceId, session);
         final var rootObjectId = resolveRootObjectId(fedoraId, session);
-        final String ocflId = mapToOcflId(rootObjectId);
+        final String ocflId = mapToOcflId(session.getId(), rootObjectId);
         final OCFLObjectSession ocflObjectSession = session.findOrCreateSession(ocflId);
         persistNonRDFSource(operation, ocflObjectSession, rootObjectId.getBaseId());
         index.addMapping(session.getId(), resourceId, rootObjectId.getBaseId(), ocflId);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
@@ -74,6 +74,6 @@ class CreateRDFSourcePersister extends AbstractRDFSourcePersister {
         final String ocflObjectId = mapToOcflId(rootObjectId);
         final OCFLObjectSession ocflObjectSession = session.findOrCreateSession(ocflObjectId);
         persistRDF(ocflObjectSession, operation, rootObjectId.getBaseId());
-        index.addMapping(resourceId, rootObjectId.getBaseId(), ocflObjectId);
+        index.addMapping(session.getId(), resourceId, rootObjectId.getBaseId(), ocflObjectId);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersister.java
@@ -71,7 +71,7 @@ class CreateRDFSourcePersister extends AbstractRDFSourcePersister {
             rootObjectId = resolveRootObjectId(fedoraId, session);
         }
 
-        final String ocflObjectId = mapToOcflId(rootObjectId);
+        final String ocflObjectId = mapToOcflId(session.getId(), rootObjectId);
         final OCFLObjectSession ocflObjectSession = session.findOrCreateSession(ocflObjectId);
         persistRDF(ocflObjectSession, operation, rootObjectId.getBaseId());
         index.addMapping(session.getId(), resourceId, rootObjectId.getBaseId(), ocflObjectId);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
@@ -57,7 +57,7 @@ public class CreateVersionPersister extends AbstractPersister {
                             + " Version the Archival Group instead.", resourceId, archivalGroupId));
         }
 
-        final var ocflMapping = getMapping(resourceId);
+        final var ocflMapping = getMapping(session.getId(), resourceId);
         final var ocflObjectSession = session.findOrCreateSession(ocflMapping.getOcflObjectId());
 
         // The version is not actually created until the session is committed

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
@@ -92,11 +92,7 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
             FEDORA_ID_COLUMN + " = :fedoraId" +
             " UNION SELECT " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + " FROM " + TRANSACTION_OPERATIONS_TABLE +
             " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId AND " + TRANSACTION_ID_COLUMN + " = :transactionId" +
-            " AND " + OPERATION_COLUMN + " = 'add') x" +
-            " WHERE NOT EXISTS " +
-            " (SELECT 1 FROM " + TRANSACTION_OPERATIONS_TABLE +
-            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId" +
-            " AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'delete')";
+            " AND " + OPERATION_COLUMN + " = 'add') x";
 
     /*
      * Add an 'add' operation to the transaction table.

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
@@ -206,14 +206,6 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
 
     @PostConstruct
     public void setup() {
-        final var ddl = lookupDdl();
-        LOGGER.info("Applying ddl: {}", ddl);
-        DatabasePopulatorUtils.execute(
-                new ResourceDatabasePopulator(new DefaultResourceLoader().getResource("classpath:" + ddl)),
-                dataSource);
-    }
-
-    private String lookupDdl() {
         try (final var connection = dataSource.getConnection()) {
             databaseProductName = connection.getMetaData().getDatabaseProductName();
             LOGGER.debug("Identified database as: {}", databaseProductName);
@@ -221,7 +213,10 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
             if (ddl == null) {
                 throw new IllegalStateException("Unknown database platform: " + databaseProductName);
             }
-            return ddl;
+            LOGGER.info("Applying ddl: {}", ddl);
+            DatabasePopulatorUtils.execute(
+                    new ResourceDatabasePopulator(new DefaultResourceLoader().getResource("classpath:" + ddl)),
+                    dataSource);
         } catch (final SQLException e) {
             throw new RuntimeException(e);
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.persistence.ocfl.impl;
 
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.slf4j.Logger;
@@ -25,15 +26,23 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Maps Fedora IDs to the OCFL IDs of the OCFL objects the Fedora resource is stored in. This implementation is backed
@@ -54,24 +63,125 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
 
     private static final String OCFL_ID_COLUMN = "ocfl_id";
 
-    private static final String LOOKUP_MAPPING = "SELECT * FROM " + MAPPING_TABLE +
-            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId";
+    private static final String TRANSACTION_OPERATIONS_TABLE = "ocfl_id_map_session_operations";
 
-    private static final String INSERT_MAPPING = "INSERT INTO " + MAPPING_TABLE +
-            " (" + FEDORA_ID_COLUMN + ", " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + ")" +
-            " VALUES (:fedoraId, :fedoraRootId, :ocflId)";
+    private static final String TRANSACTION_ID_COLUMN = "session_id";
 
-    private static final String REMOVE_MAPPING = "DELETE FROM " + MAPPING_TABLE +
-            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId";
+    private static final String OPERATION_COLUMN = "operation";
+
+    /*
+     * Lookup all mappings for the resource id.
+     */
+    private static final String LOOKUP_MAPPING = "SELECT " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + " FROM " +
+            MAPPING_TABLE + " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId";
+
+    /*
+     * Lookup all mappings from the mapping table as well as any new 'add's and excluding any 'delete's in this
+     * transaction.
+     */
+    private static final String LOOKUP_MAPPING_IN_TRANSACTION = "SELECT x." + FEDORA_ROOT_ID_COLUMN + "," +
+            " x." + OCFL_ID_COLUMN + " FROM" +
+            " (SELECT " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + " FROM " + MAPPING_TABLE + " WHERE " +
+            FEDORA_ID_COLUMN + " = :fedoraId" +
+            " UNION SELECT " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + " FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId AND " + TRANSACTION_ID_COLUMN + " = :transactionId" +
+            " AND " + OPERATION_COLUMN + " = 'add') x" +
+            " WHERE NOT EXISTS " +
+            " (SELECT 1 FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId" +
+            " AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'delete')";
+
+    /*
+     * Add an 'add' operation to the transaction table.
+     */
+    private static final String INSERT_MAPPING = "INSERT INTO " + TRANSACTION_OPERATIONS_TABLE +
+            " (" + FEDORA_ID_COLUMN + ", " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + ", " +
+            TRANSACTION_ID_COLUMN + ", " + OPERATION_COLUMN + ")" +
+            " VALUES (:fedoraId, :fedoraRootId, :ocflId, :transactionId, 'add')";
+
+    /*
+     * Is there an add operation for the same mapping in the same transaction?
+     */
+    private static final String IS_MAPPING_ADDED_IN_TRANSACTION = "SELECT TRUE FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " +
+            OPERATION_COLUMN + " = 'add'";
+
+    /*
+     * Undo an add operation for the same mapping in the same transaction.
+     */
+    private static final String UNDO_ADD_MAPPING_IN_TRANSACTION = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " +
+            OPERATION_COLUMN + " = 'add'";
+
+    /*
+     * Add a delete operation to the transaction table.
+     */
+    private static final String REMOVE_MAPPING = "INSERT INTO " + TRANSACTION_OPERATIONS_TABLE +
+            " (" + FEDORA_ID_COLUMN + ", " + TRANSACTION_ID_COLUMN + ", " + OPERATION_COLUMN + ")" +
+            " VALUES (:fedoraId, :transactionId, 'delete')";
+
+    /*
+     * Add records to the mapping table that are to be added in this transaction.
+     */
+    private static final String COMMIT_ADD_RECORDS = "INSERT INTO " + MAPPING_TABLE + " ( " + FEDORA_ID_COLUMN + ", "
+            + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + " ) SELECT " + FEDORA_ID_COLUMN + ", " +
+            FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + " FROM " +
+            TRANSACTION_OPERATIONS_TABLE + " WHERE " + TRANSACTION_ID_COLUMN + " = :transactionId AND " +
+            OPERATION_COLUMN + " = 'add'";
+
+    /*
+     * Delete records from the mapping table that are to be deleted in this transaction.
+     */
+    private static final String COMMIT_DELETE_RECORDS = "DELETE FROM " + MAPPING_TABLE + " WHERE " +
+            "EXISTS (SELECT * FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " +
+            TRANSACTION_ID_COLUMN + " = :transactionId AND " +  OPERATION_COLUMN + " = 'delete' AND " +
+            MAPPING_TABLE + "." + FEDORA_ID_COLUMN + " = " + TRANSACTION_OPERATIONS_TABLE + "." + FEDORA_ID_COLUMN +
+            ")";
+
+    /*
+     * Is there a mapping 'delete'd in this session?
+     */
+    private static final String IS_MAPPING_REMOVED_IN_TRANSACTION = "SELECT TRUE FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId AND " + FEDORA_ROOT_ID_COLUMN + " = :fedoraRootId AND " +
+            OCFL_ID_COLUMN + " = :ocflId AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN +
+            " = 'delete'";
+
+    /*
+     * Delete the mapping from the session table.
+     */
+    private static final String UNDO_REMOVE_MAPPING_IN_TRANSACTION = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE +
+            " WHERE " + FEDORA_ID_COLUMN + " = :fedoraId AND " + FEDORA_ROOT_ID_COLUMN + " = :fedoraRootId AND " +
+            OCFL_ID_COLUMN + " = :ocflId AND " + TRANSACTION_ID_COLUMN + " = :transactionId AND " + OPERATION_COLUMN +
+            " = 'delete'";
+
 
     private static final String TRUNCATE_MAPPINGS = "TRUNCATE TABLE " + MAPPING_TABLE;
+
+    private static final String TRUNCATE_TRANSACTIONS = "TRUNCATE TABLE " + TRANSACTION_OPERATIONS_TABLE;
+
+    /*
+     * Delete all records from the transaction table for the specified transaction.
+     */
+    private static final String DELETE_ENTIRE_TRANSACTION = "DELETE FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " +
+            TRANSACTION_ID_COLUMN + " = :transactionId";
+
+    /*
+     * Row mapper for the Lookup queries.
+     */
+    private static final RowMapper<FedoraOCFLMapping> GET_MAPPING_ROW_MAPPER = (resultSet, i) -> new FedoraOCFLMapping(
+            resultSet.getString(1),
+            resultSet.getString(2)
+    );
 
     private final DataSource dataSource;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
+    private PlatformTransactionManager platformTransactionManager;
+
     public DbFedoraToOcflObjectIndex(@Autowired final DataSource dataSource) {
         this.dataSource = dataSource;
+        this.platformTransactionManager = new DataSourceTransactionManager(dataSource);
         this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
     }
 
@@ -84,37 +194,97 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
     }
 
     @Override
-    public FedoraOCFLMapping getMapping(final String fedoraId) throws FedoraOCFLMappingNotFoundException {
+    public FedoraOCFLMapping getMapping(final String transactionId, final String fedoraId)
+            throws FedoraOCFLMappingNotFoundException {
         try {
-            return jdbcTemplate.queryForObject(LOOKUP_MAPPING,
-                    Map.of("fedoraId", fedoraId), (rs, rowNum) -> {
-                        return new FedoraOCFLMapping(
-                                rs.getString(2),    // fedoraIdRoot
-                                rs.getString(3)     // ocflId
-                        );
-                    });
-        } catch (EmptyResultDataAccessException e) {
+            final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+            parameterSource.addValue("fedoraId", fedoraId);
+            if (transactionId != null) {
+                parameterSource.addValue("transactionId", transactionId);
+                return jdbcTemplate.queryForObject(LOOKUP_MAPPING_IN_TRANSACTION, parameterSource,
+                        GET_MAPPING_ROW_MAPPER);
+            } else {
+                return jdbcTemplate.queryForObject(LOOKUP_MAPPING, parameterSource, GET_MAPPING_ROW_MAPPER);
+            }
+        } catch (final EmptyResultDataAccessException e) {
             throw new FedoraOCFLMappingNotFoundException("No OCFL mapping found for " + fedoraId);
         }
     }
 
     @Override
-    public FedoraOCFLMapping addMapping(final String fedoraId, final String fedoraRootId, final String ocflId) {
-        jdbcTemplate.update(INSERT_MAPPING, Map.of(
-                "fedoraId", fedoraId,
-                "fedoraRootId", fedoraRootId,
-                "ocflId", ocflId));
+    public FedoraOCFLMapping addMapping(@Nonnull final String transactionId, final String fedoraId,
+                                        final String fedoraRootId, final String ocflId) {
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+        parameterSource.addValue("fedoraId", fedoraId);
+        parameterSource.addValue("fedoraRootId", fedoraRootId);
+        parameterSource.addValue("ocflId", ocflId);
+        parameterSource.addValue("transactionId", transactionId);
+        final boolean isRemovedInTx = !jdbcTemplate.queryForList(IS_MAPPING_REMOVED_IN_TRANSACTION, parameterSource)
+                .isEmpty();
+        if (isRemovedInTx) {
+            jdbcTemplate.update(UNDO_REMOVE_MAPPING_IN_TRANSACTION, parameterSource);
+        } else {
+            jdbcTemplate.update(INSERT_MAPPING, parameterSource);
+        }
         return new FedoraOCFLMapping(fedoraRootId, ocflId);
     }
 
     @Override
-    public void removeMapping(final String fedoraId) {
-        jdbcTemplate.update(REMOVE_MAPPING, Map.of("fedoraId", fedoraId));
+    public void removeMapping(@Nonnull final String transactionId, final String fedoraId) {
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+        parameterSource.addValue("fedoraId", fedoraId);
+        parameterSource.addValue("transactionId", transactionId);
+        final boolean isAddedInTx = !jdbcTemplate.queryForList(IS_MAPPING_ADDED_IN_TRANSACTION, parameterSource)
+                .isEmpty();
+        if (isAddedInTx) {
+            jdbcTemplate.update(UNDO_ADD_MAPPING_IN_TRANSACTION, parameterSource);
+        } else {
+            jdbcTemplate.update(REMOVE_MAPPING, parameterSource);
+        }
     }
 
     @Override
     public void reset() {
-        jdbcTemplate.update(TRUNCATE_MAPPINGS, Collections.EMPTY_MAP);
+        final String tempSessionId = UUID.randomUUID().toString();
+        executeInDbTransaction(tempSessionId, status -> {
+            try {
+                jdbcTemplate.update(TRUNCATE_MAPPINGS, Collections.emptyMap());
+                jdbcTemplate.update(TRUNCATE_TRANSACTIONS, Collections.emptyMap());
+                return null;
+            } catch (final Exception e) {
+                status.setRollbackOnly();
+                throw new RepositoryRuntimeException("Failed to truncate FedoraToOcfl index tables", e);
+            }
+        });
     }
 
+    @Override
+    public void commit(@Nonnull final String sessionId) {
+        final Map<String, String> map = Map.of("transactionId", sessionId);
+        executeInDbTransaction(sessionId, status -> {
+            try {
+                jdbcTemplate.update(COMMIT_DELETE_RECORDS, map);
+                jdbcTemplate.update(COMMIT_ADD_RECORDS, map);
+                jdbcTemplate.update(DELETE_ENTIRE_TRANSACTION, map);
+                return null;
+            } catch (final Exception e) {
+                status.setRollbackOnly();
+                LOGGER.warn("Unable to commit FedoraToOcfl index transaction {}: {}", sessionId, e.getMessage());
+                throw new RepositoryRuntimeException("Unable to commit FedoraToOcfl index transaction", e);
+            }
+        });
+    }
+
+    @Override
+    public void rollback(@Nonnull final String sessionId) {
+        jdbcTemplate.update(DELETE_ENTIRE_TRANSACTION, Map.of("transactionId", sessionId));
+    }
+
+    private <T> void executeInDbTransaction(final String txId, final TransactionCallback<T> callback) {
+        final TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+        // Seemingly setting the name ensures that we don't re-use a transaction.
+        transactionTemplate.setName("tx-" + txId);
+        transactionTemplate.setPropagationBehavior(TransactionTemplate.PROPAGATION_REQUIRED);
+        transactionTemplate.execute(callback);
+    }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
@@ -119,6 +119,7 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
     private static final String UPSERT_MAPPING_TX_H2 = "MERGE INTO " + TRANSACTION_OPERATIONS_TABLE +
             " (" + FEDORA_ID_COLUMN + ", " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + ", " +
             TRANSACTION_ID_COLUMN + ", " + OPERATION_COLUMN + ")" +
+            " KEY (" + FEDORA_ID_COLUMN + ", " + TRANSACTION_ID_COLUMN + ")" +
             " VALUES (:fedoraId, :fedoraRootId, :ocflId, :transactionId, :operation)";
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -80,11 +80,6 @@ class DeleteResourcePersister extends AbstractPersister {
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             final var filePath = resolveExtensions(ocflSubPath, isRdf);
             deletePath(filePath, objectSession, headers, user, deleteTime);
-            if (!isRdf) {
-                // Delete the description too.
-                final var descPath = resolveExtensions(ocflSubPath + "-description", true);
-                deletePath(descPath, objectSession, user, deleteTime);
-            }
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -80,6 +80,11 @@ class DeleteResourcePersister extends AbstractPersister {
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             final var filePath = resolveExtensions(ocflSubPath, isRdf);
             deletePath(filePath, objectSession, headers, user, deleteTime);
+            if (!isRdf) {
+                // Delete the description too.
+                final var descPath = resolveExtensions(ocflSubPath + "-description", true);
+                deletePath(descPath, objectSession, user, deleteTime);
+            }
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -52,7 +52,7 @@ class DeleteResourcePersister extends AbstractPersister {
     @Override
     public void persist(final OCFLPersistentStorageSession session, final ResourceOperation operation)
             throws PersistentStorageException {
-        final var mapping = getMapping(operation.getResourceId());
+        final var mapping = getMapping(session.getId(), operation.getResourceId());
         final var fedoraResourceRoot = mapping.getRootObjectIdentifier();
         final var resourceId = operation.getResourceId();
         final var objectSession = session.findOrCreateSession(mapping.getOcflObjectId());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -48,7 +48,7 @@ class PurgeResourcePersister extends AbstractPersister {
     @Override
     public void persist(final OCFLPersistentStorageSession session, final ResourceOperation operation)
             throws PersistentStorageException {
-        final var mapping = getMapping(operation.getResourceId());
+        final var mapping = getMapping(session.getId(), operation.getResourceId());
         final var fedoraResourceRoot = mapping.getRootObjectIdentifier();
         final var resourceId = operation.getResourceId();
         final var objectSession = session.findOrCreateSession(mapping.getOcflObjectId());
@@ -64,6 +64,7 @@ class PurgeResourcePersister extends AbstractPersister {
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             purgePath(sidecar, objectSession);
         }
+        index.removeMapping(session.getId(), resourceId);
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -63,11 +63,6 @@ class PurgeResourcePersister extends AbstractPersister {
             final var sidecar = getSidecarSubpath(ocflSubPath);
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             purgePath(sidecar, objectSession);
-            if (!isRdf) {
-                // Delete the description sidecar file too.
-                final var descSidecar = getSidecarSubpath(ocflSubPath + "-description");
-                purgePath(descSidecar, objectSession);
-            }
         }
         index.removeMapping(session.getId(), resourceId);
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -17,14 +17,6 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.fcrepo.kernel.api.operations.ResourceOperationType.PURGE;
-import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.getSidecarSubpath;
-import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.relativizeSubpath;
-import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.resolveOCFLSubpath;
-
-import java.util.Objects;
-
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.common.ResourceHeadersImpl;
@@ -32,6 +24,11 @@ import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.PURGE;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.getSidecarSubpath;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.relativizeSubpath;
+import static org.fcrepo.persistence.ocfl.impl.OCFLPersistentStorageUtils.resolveOCFLSubpath;
 
 /**
  * Purge Resource Persister
@@ -61,7 +58,6 @@ class PurgeResourcePersister extends AbstractPersister {
             final var ocflSubPath = resolveOCFLSubpath(fedoraResourceRoot, relativeSubPath);
             final var headers = (ResourceHeadersImpl) readHeaders(objectSession, ocflSubPath);
             final var sidecar = getSidecarSubpath(ocflSubPath);
-            final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             purgePath(sidecar, objectSession);
         }
         index.removeMapping(session.getId(), resourceId);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -19,7 +19,6 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
-import org.fcrepo.persistence.common.ResourceHeadersImpl;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.fcrepo.persistence.ocfl.api.OCFLObjectSession;
 import org.slf4j.Logger;
@@ -56,7 +55,6 @@ class PurgeResourcePersister extends AbstractPersister {
         } else {
             final var relativeSubPath = relativizeSubpath(fedoraResourceRoot, operation.getResourceId());
             final var ocflSubPath = resolveOCFLSubpath(fedoraResourceRoot, relativeSubPath);
-            final var headers = (ResourceHeadersImpl) readHeaders(objectSession, ocflSubPath);
             final var sidecar = getSidecarSubpath(ocflSubPath);
             purgePath(sidecar, objectSession);
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -63,6 +63,11 @@ class PurgeResourcePersister extends AbstractPersister {
             final var sidecar = getSidecarSubpath(ocflSubPath);
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             purgePath(sidecar, objectSession);
+            if (!isRdf) {
+                // Delete the description sidecar file too.
+                final var descSidecar = getSidecarSubpath(ocflSubPath + "-description");
+                purgePath(descSidecar, objectSession);
+            }
         }
         index.removeMapping(session.getId(), resourceId);
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersister.java
@@ -49,7 +49,7 @@ class UpdateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
             throws PersistentStorageException {
         final var resourceId = operation.getResourceId();
         log.debug("persisting {} to {}", resourceId, session);
-        final FedoraOCFLMapping mapping = getMapping(resourceId);
+        final FedoraOCFLMapping mapping = getMapping(session.getId(), resourceId);
         log.debug("retrieved mapping: {}", mapping);
         final OCFLObjectSession objSession = session.findOrCreateSession(mapping.getOcflObjectId());
         persistNonRDFSource(operation, objSession, mapping.getRootObjectIdentifier());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersister.java
@@ -51,7 +51,7 @@ class UpdateRDFSourcePersister extends AbstractRDFSourcePersister {
         final var resourceId = operation.getResourceId();
         log.debug("persisting {} to {}", resourceId, session);
 
-        final var fedoraOCFLMapping = getMapping(resourceId);
+        final var fedoraOCFLMapping = getMapping(session.getId(), resourceId);
         final var ocflId = fedoraOCFLMapping.getOcflObjectId();
         final OCFLObjectSession objSession = session.findOrCreateSession(ocflId);
         persistRDF(objSession, operation, fedoraOCFLMapping.getRootObjectIdentifier());

--- a/fcrepo-persistence-ocfl/src/main/resources/sql/default-ocfl-index.sql
+++ b/fcrepo-persistence-ocfl/src/main/resources/sql/default-ocfl-index.sql
@@ -1,9 +1,26 @@
 -- DDL for setting up the table that maps Fedora IDs to OCFL IDs
 -- MySQL 8 will only supports varchar up to 503 characters
 
--- Maps FedoarID to OCFL ID
+-- Maps FedoraID to OCFL ID
 CREATE TABLE IF NOT EXISTS ocfl_id_map (
     fedora_id varchar(503) NOT NULL PRIMARY KEY,
     fedora_root_id varchar(503) NOT NULL,
     ocfl_id varchar(503) NOT NULL
 );
+
+-- Holds operations to add or delete mappings from the ocfl_id_map table.
+CREATE TABLE IF NOT EXISTS ocfl_id_map_session_operations (
+    fedora_id varchar(503) NOT NULL PRIMARY KEY,
+    fedora_root_id varchar(503) NULL,
+    ocfl_id varchar(503) NULL,
+    session_id varchar(255) NOT NULL,
+    operation varchar(10) NOT NULL
+);
+
+-- Create an index to speed searches for records related to adding/excluding transaction records
+CREATE INDEX IF NOT EXISTS ocfl_id_map_idx1
+    ON ocfl_id_map_session_operations (fedora_id, session_id, operation);
+
+-- Create an index to speed finding records related to a transaction.
+CREATE INDEX IF NOT EXISTS ocfl_id_map_idx2
+    ON ocfl_id_map_session_operations (session_id);

--- a/fcrepo-persistence-ocfl/src/main/resources/sql/default-ocfl-index.sql
+++ b/fcrepo-persistence-ocfl/src/main/resources/sql/default-ocfl-index.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS ocfl_id_map (
 
 -- Holds operations to add or delete mappings from the ocfl_id_map table.
 CREATE TABLE IF NOT EXISTS ocfl_id_map_session_operations (
-    fedora_id varchar(503) NOT NULL PRIMARY KEY,
+    fedora_id varchar(503) NOT NULL,
     fedora_root_id varchar(503) NULL,
     ocfl_id varchar(503) NULL,
     session_id varchar(255) NOT NULL,
@@ -22,5 +22,5 @@ CREATE INDEX IF NOT EXISTS ocfl_id_map_idx1
     ON ocfl_id_map_session_operations (fedora_id, session_id, operation);
 
 -- Create an index to speed finding records related to a transaction.
-CREATE INDEX IF NOT EXISTS ocfl_id_map_idx2
-    ON ocfl_id_map_session_operations (session_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ocfl_id_map_idx2
+    ON ocfl_id_map_session_operations (fedora_id, session_id);

--- a/fcrepo-persistence-ocfl/src/main/resources/sql/mysql-ocfl-index.sql
+++ b/fcrepo-persistence-ocfl/src/main/resources/sql/mysql-ocfl-index.sql
@@ -1,0 +1,34 @@
+-- DDL for setting up the table that maps Fedora IDs to OCFL IDs
+-- MySQL 8 will only supports varchar up to 503 characters
+
+-- Maps FedoraID to OCFL ID
+CREATE TABLE IF NOT EXISTS ocfl_id_map (
+    fedora_id varchar(503) NOT NULL PRIMARY KEY,
+    fedora_root_id varchar(503) NOT NULL,
+    ocfl_id varchar(503) NOT NULL
+);
+
+-- Holds operations to add or delete mappings from the ocfl_id_map table.
+CREATE TABLE IF NOT EXISTS ocfl_id_map_session_operations (
+    fedora_id varchar(503) NOT NULL PRIMARY KEY,
+    fedora_root_id varchar(503) NULL,
+    ocfl_id varchar(503) NULL,
+    session_id varchar(255) NOT NULL,
+    operation varchar(10) NOT NULL
+);
+
+-- Create an index to speed searches for records related to adding/excluding transaction records
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'ocfl_id_map_session_operations' AND index_name = 'ocfl_id_map_idx1' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX ocfl_id_map_idx1 ON ocfl_id_map_session_operations (fedora_id, session_id, operation)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+-- Create an index to speed finding records related to a transaction.
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'ocfl_id_map_session_operations' AND index_name = 'ocfl_id_map_idx2' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX ocfl_id_map_idx2 ON ocfl_id_map_session_operations (session_id)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;

--- a/fcrepo-persistence-ocfl/src/main/resources/sql/mysql-ocfl-index.sql
+++ b/fcrepo-persistence-ocfl/src/main/resources/sql/mysql-ocfl-index.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS ocfl_id_map (
 
 -- Holds operations to add or delete mappings from the ocfl_id_map table.
 CREATE TABLE IF NOT EXISTS ocfl_id_map_session_operations (
-    fedora_id varchar(503) NOT NULL PRIMARY KEY,
+    fedora_id varchar(503) NOT NULL,
     fedora_root_id varchar(503) NULL,
     ocfl_id varchar(503) NULL,
     session_id varchar(255) NOT NULL,
@@ -29,6 +29,6 @@ EXECUTE stmt;
 SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
     WHERE table_name = 'ocfl_id_map_session_operations' AND index_name = 'ocfl_id_map_idx2' AND table_schema = database());
 SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
-    'CREATE INDEX ocfl_id_map_idx2 ON ocfl_id_map_session_operations (session_id)');
+    'CREATE UNIQUE INDEX ocfl_id_map_idx2 ON ocfl_id_map_session_operations (fedora_id, session_id)');
 PREPARE stmt FROM @sqlstmt;
 EXECUTE stmt;

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
@@ -117,6 +117,8 @@ public class CreateNonRdfSourcePersisterTest {
 
     private CreateNonRdfSourcePersister persister;
 
+    private static final String SESSION_ID = "SOME-SESSION-ID";
+
     @Before
     public void setUp() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("object-id");
@@ -135,13 +137,14 @@ public class CreateNonRdfSourcePersisterTest {
 
         when(psSession.getHeaders(((CreateResourceOperation) nonRdfSourceOperation).getParentId(), null))
                 .thenReturn(headers);
+        when(psSession.getId()).thenReturn(SESSION_ID);
 
         when(writeOutcome.getContentSize()).thenReturn(LOCAL_CONTENT_SIZE);
 
         persister = new CreateNonRdfSourcePersister(index);
 
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateRDFSourcePersisterTest.java
@@ -162,7 +162,9 @@ public class CreateRDFSourcePersisterTest {
 
         final var ocflId = "ocfl-id-1";
 
-        index.addMapping(ROOT_RESOURCE_ID, ROOT_RESOURCE_ID, ocflId);
+        final String sessionId = "some-id";
+        index.addMapping(sessionId, ROOT_RESOURCE_ID, ROOT_RESOURCE_ID, ocflId);
+        index.commit(sessionId);
 
         when(operation.getResourceId()).thenReturn(RESOURCE_ID);
         when(((CreateResourceOperation) operation).getInteractionModel()).thenReturn(RDF_SOURCE.toString());
@@ -182,7 +184,7 @@ public class CreateRDFSourcePersisterTest {
         final var headers = retrievePersistedHeaders("child");
 
         assertEquals(RDF_SOURCE.toString(), headers.getInteractionModel());
-        assertEquals(ocflId, index.getMapping(RESOURCE_ID).getOcflObjectId());
+        assertEquals(ocflId, index.getMapping(null, RESOURCE_ID).getOcflObjectId());
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
@@ -104,7 +104,7 @@ public class CreateVersionPersisterTest {
     }
 
     private OCFLObjectSession addMapping(final String resourceId, final String ocflId) {
-        index.addMapping(resourceId, resourceId, ocflId);
+        index.addMapping("not-used", resourceId, resourceId, ocflId);
         final var objectSession = mock(OCFLObjectSession.class);
         when(session.findOrCreateSession(ocflId)).thenReturn(objectSession);
         return objectSession;

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
@@ -120,12 +120,8 @@ public class DbFedoraToOcflObjectIndexTest {
         // Should still appear to outside the transaction.
         assertEquals(mapping, index.getMapping(null, RESOURCE_ID_1));
 
-        try {
-            index.getMapping(sessId, RESOURCE_ID_1);
-            fail("expected exception");
-        } catch (final FedoraOCFLMappingNotFoundException e) {
-            // expected mapping to not exist
-        }
+        // Should also still appear inside the transaction or we can't access files on disk.
+        assertEquals(mapping, index.getMapping(sessId, RESOURCE_ID_1));
 
         index.commit(sessId);
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
+import java.util.UUID;
+
 /**
  * @author dbernstein
  * @since 6.0.0
@@ -59,21 +61,31 @@ public class DbFedoraToOcflObjectIndexTest {
 
     @Test
     public void test() throws Exception {
-        index.addMapping(ROOT_RESOURCE_ID, ROOT_RESOURCE_ID, OCFL_ID);
-        index.addMapping(RESOURCE_ID_1, ROOT_RESOURCE_ID, OCFL_ID);
-        index.addMapping(RESOURCE_ID_2, ROOT_RESOURCE_ID, OCFL_ID);
-        index.addMapping(RESOURCE_ID_3, RESOURCE_ID_3, OCFL_ID_RESOURCE_3);
+        final String sessId = UUID.randomUUID().toString();
+        index.addMapping(sessId, ROOT_RESOURCE_ID, ROOT_RESOURCE_ID, OCFL_ID);
+        index.addMapping(sessId, RESOURCE_ID_1, ROOT_RESOURCE_ID, OCFL_ID);
+        index.addMapping(sessId, RESOURCE_ID_2, ROOT_RESOURCE_ID, OCFL_ID);
+        index.addMapping(sessId, RESOURCE_ID_3, RESOURCE_ID_3, OCFL_ID_RESOURCE_3);
 
-        final FedoraOCFLMapping mapping1 = index.getMapping(RESOURCE_ID_1);
-        final FedoraOCFLMapping mapping2 = index.getMapping(RESOURCE_ID_2);
-        final FedoraOCFLMapping mapping3 = index.getMapping(ROOT_RESOURCE_ID);
+        final FedoraOCFLMapping mapping1 = index.getMapping(sessId, RESOURCE_ID_1);
+        final FedoraOCFLMapping mapping2 = index.getMapping(sessId, RESOURCE_ID_2);
+        final FedoraOCFLMapping mapping3 = index.getMapping(sessId, ROOT_RESOURCE_ID);
 
         assertEquals(mapping1, mapping2);
         assertEquals(mapping2, mapping3);
 
         verifyMapping(mapping1, ROOT_RESOURCE_ID, OCFL_ID);
 
-        final FedoraOCFLMapping mapping4 = index.getMapping(RESOURCE_ID_3);
+        index.commit(sessId);
+
+        final FedoraOCFLMapping mapping1_1 = index.getMapping(null, RESOURCE_ID_1);
+        final FedoraOCFLMapping mapping1_2 = index.getMapping(null, RESOURCE_ID_2);
+        final FedoraOCFLMapping mapping1_3 = index.getMapping(null, ROOT_RESOURCE_ID);
+
+        assertEquals(mapping1_1, mapping1_2);
+        assertEquals(mapping1_2, mapping1_3);
+
+        final FedoraOCFLMapping mapping4 = index.getMapping(null, RESOURCE_ID_3);
         assertNotEquals(mapping4, mapping3);
 
         verifyMapping(mapping4, RESOURCE_ID_3, OCFL_ID_RESOURCE_3);
@@ -84,19 +96,42 @@ public class DbFedoraToOcflObjectIndexTest {
 
     @Test(expected = FedoraOCFLMappingNotFoundException.class)
     public void testNotExists() throws Exception {
-        index.getMapping(RESOURCE_ID_1);
+        index.getMapping(null, RESOURCE_ID_1);
     }
 
     @Test
     public void removeIndexWhenExists() throws FedoraOCFLMappingNotFoundException {
-        final var mapping = index.addMapping(RESOURCE_ID_1, RESOURCE_ID_1, OCFL_ID);
+        final String sessId = UUID.randomUUID().toString();
+        final var mapping = index.addMapping(sessId, RESOURCE_ID_1, RESOURCE_ID_1, OCFL_ID);
 
-        assertEquals(mapping, index.getMapping(RESOURCE_ID_1));
+        assertEquals(mapping, index.getMapping(sessId, RESOURCE_ID_1));
+        try {
+            index.getMapping(null, RESOURCE_ID_1);
+            fail("This mapping should not be accessible to everyone yet.");
+        } catch (final FedoraOCFLMappingNotFoundException e) {
+            // This should happen and is okay.
+        }
+        index.commit(sessId);
 
-        index.removeMapping(RESOURCE_ID_1);
+        assertEquals(mapping, index.getMapping(null, RESOURCE_ID_1));
+
+        index.removeMapping(sessId, RESOURCE_ID_1);
+
+        // Should still appear to outside the transaction.
+        assertEquals(mapping, index.getMapping(null, RESOURCE_ID_1));
 
         try {
-            index.getMapping(RESOURCE_ID_1);
+            index.getMapping(sessId, RESOURCE_ID_1);
+            fail("expected exception");
+        } catch (final FedoraOCFLMappingNotFoundException e) {
+            // expected mapping to not exist
+        }
+
+        index.commit(sessId);
+
+        try {
+            // No longer accessible to anyone.
+            index.getMapping(null, RESOURCE_ID_1);
             fail("expected exception");
         } catch (final FedoraOCFLMappingNotFoundException e) {
             // expected mapping to not exist
@@ -104,14 +139,42 @@ public class DbFedoraToOcflObjectIndexTest {
     }
 
     @Test
-    public void removeIndexWhenNotExists() throws FedoraOCFLMappingNotFoundException {
-        index.removeMapping(RESOURCE_ID_1);
+    public void removeIndexWhenNotExists() {
+        final String sessId = UUID.randomUUID().toString();
+        index.removeMapping(sessId, RESOURCE_ID_1);
+        index.commit(sessId);
 
         try {
-            index.getMapping(RESOURCE_ID_1);
+            index.getMapping(null, RESOURCE_ID_1);
             fail("expected exception");
         } catch (final FedoraOCFLMappingNotFoundException e) {
             // expected mapping to not exist
+        }
+    }
+
+    @Test
+    public void testRollback() throws Exception {
+        final String sessId = UUID.randomUUID().toString();
+        index.addMapping(sessId, RESOURCE_ID_1, ROOT_RESOURCE_ID, OCFL_ID);
+
+        final FedoraOCFLMapping expected = new FedoraOCFLMapping(ROOT_RESOURCE_ID, OCFL_ID);
+        assertEquals(expected, index.getMapping(sessId, RESOURCE_ID_1));
+
+        try {
+            // Not yet committed
+            index.getMapping(null, RESOURCE_ID_1);
+            fail();
+        } catch (final FedoraOCFLMappingNotFoundException e) {
+            // The exception is expected.
+        }
+
+        index.rollback(sessId);
+
+        try {
+            index.getMapping(sessId, RESOURCE_ID_1);
+            fail();
+        } catch (final FedoraOCFLMappingNotFoundException e) {
+            // The exception is expected.
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
@@ -85,15 +85,26 @@ public class DeleteResourcePersisterTest {
             "\"2020-04-14T03:42:00.765231Z\",\"stateToken\":\"6763672ED325A4B632B450545518B34B\"," +
             "\"archivalGroup\":false,\"objectRoot\":false}";
         final InputStream header_stream1 = new ByteArrayInputStream(header_string1.getBytes());
+        final String header_string2 = "{\"parent\":\"info:fedora/an-ocfl-object/sub-path\",\"id\":" +
+                "\"info:fedora/an-ocfl-object/some-subpath-desc\",\"lastModifiedDate\":" +
+                "\"2020-04-14T03:42:00.765231Z\",\"interactionModel\":" +
+                "\"http://fedora.info/definitions/v4/repository#NonRdfSourceDescription\"," +
+                "\"createdDate\":\"2020-04-14T03:42:00.765231Z\",\"stateToken\":\"6763672ED325A4B632B450545518B34B\"," +
+                "\"archivalGroup\":false,\"objectRoot\":false}";
+        final InputStream header_stream2 = new ByteArrayInputStream(header_string2.getBytes());
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream1);
+        when(session.read(".fcrepo/some-subpath-description.json")).thenReturn(header_stream2);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
+        verify(session).delete("some-subpath-description.nt");
         verify(session).read(".fcrepo/some-subpath.json");
         verify(session).write(eq(".fcrepo/some-subpath.json"), any());
+        verify(session).read(".fcrepo/some-subpath-description.json");
+        verify(session).write(eq(".fcrepo/some-subpath-description.json"), any());
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
@@ -85,26 +85,15 @@ public class DeleteResourcePersisterTest {
             "\"2020-04-14T03:42:00.765231Z\",\"stateToken\":\"6763672ED325A4B632B450545518B34B\"," +
             "\"archivalGroup\":false,\"objectRoot\":false}";
         final InputStream header_stream1 = new ByteArrayInputStream(header_string1.getBytes());
-        final String header_string2 = "{\"parent\":\"info:fedora/an-ocfl-object/sub-path\",\"id\":" +
-                "\"info:fedora/an-ocfl-object/some-subpath-desc\",\"lastModifiedDate\":" +
-                "\"2020-04-14T03:42:00.765231Z\",\"interactionModel\":" +
-                "\"http://fedora.info/definitions/v4/repository#NonRdfSourceDescription\"," +
-                "\"createdDate\":\"2020-04-14T03:42:00.765231Z\",\"stateToken\":\"6763672ED325A4B632B450545518B34B\"," +
-                "\"archivalGroup\":false,\"objectRoot\":false}";
-        final InputStream header_stream2 = new ByteArrayInputStream(header_string2.getBytes());
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream1);
-        when(session.read(".fcrepo/some-subpath-description.json")).thenReturn(header_stream2);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
-        verify(session).delete("some-subpath-description.nt");
         verify(session).read(".fcrepo/some-subpath.json");
         verify(session).write(eq(".fcrepo/some-subpath.json"), any());
-        verify(session).read(".fcrepo/some-subpath-description.json");
-        verify(session).write(eq(".fcrepo/some-subpath-description.json"), any());
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
@@ -67,11 +67,13 @@ public class DeleteResourcePersisterTest {
 
     private DeleteResourcePersister persister;
 
+    private static final String SESSION_ID = "SOME-SESSION-ID";
+
     @Before
     public void setup() throws Exception {
         operation = mock(ResourceOperation.class);
         persister = new DeleteResourcePersister(this.index);
-
+        when(psSession.getId()).thenReturn(SESSION_ID);
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
     }
 
@@ -87,7 +89,7 @@ public class DeleteResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
         verify(session).read(".fcrepo/some-subpath.json");
@@ -106,7 +108,7 @@ public class DeleteResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath.nt");
         verify(session).read(".fcrepo/some-subpath.json");
@@ -118,7 +120,7 @@ public class DeleteResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         when(session.read(".fcrepo/some-subpath.json")).thenThrow(
                 new PersistentStorageException("error")
         );
@@ -130,7 +132,7 @@ public class DeleteResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
-        when(index.getMapping(anyString())).thenThrow(new FedoraOCFLMappingNotFoundException("error"));
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenThrow(new FedoraOCFLMappingNotFoundException("error"));
 
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
@@ -150,7 +152,7 @@ public class DeleteResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
         verify(session).delete("some-ocfl-id.nt");
@@ -180,7 +182,7 @@ public class DeleteResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
         verify(session).delete("some-ocfl-id");
@@ -196,7 +198,7 @@ public class DeleteResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/some-wrong-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
@@ -169,7 +169,7 @@ public class IndexBuilderImplTest {
 
     private void assertDoesNotHaveOcflId(final FedoraId resourceId) {
         try {
-            index.getMapping(resourceId.getResourceId());
+            index.getMapping(null, resourceId.getResourceId());
             fail(resourceId + " should not exist in index");
         } catch (final FedoraOCFLMappingNotFoundException e) {
             //do nothing - expected
@@ -179,7 +179,7 @@ public class IndexBuilderImplTest {
     private void assertHasOcflId(final String expectedOcflId, final FedoraId resourceId)
             throws FedoraOCFLMappingNotFoundException {
         assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expectedOcflId,
-                index.getMapping(resourceId.getResourceId()).getOcflObjectId());
+                index.getMapping(null, resourceId.getResourceId()).getOcflObjectId());
     }
 
     private void createResource(final PersistentStorageSession session,

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -88,7 +88,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
  *
  * @author dbernstein
  */
-@RunWith(MockitoJUnitRunner.Silent.class)
+@RunWith(MockitoJUnitRunner.class)
 public class OCFLPersistentStorageSessionTest {
 
     private OCFLPersistentStorageSession session;

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -179,14 +179,14 @@ public class OCFLPersistentStorageSessionTest {
     }
 
     private void mockNoIndex(final String resourceId) throws FedoraOCFLMappingNotFoundException {
-        when(index.getMapping(resourceId)).thenThrow(new FedoraOCFLMappingNotFoundException(resourceId));
+        when(index.getMapping(any(), eq(resourceId))).thenThrow(new FedoraOCFLMappingNotFoundException(resourceId));
     }
 
     private void mockMappingAndIndexWithNoIndex(final String ocflObjectId, final String resourceId,
                                                 final String rootObjectId, final FedoraOCFLMapping mapping)
             throws FedoraOCFLMappingNotFoundException {
         mockMapping(ocflObjectId, rootObjectId, mapping);
-        when(index.getMapping(resourceId))
+        when(index.getMapping(any(), eq(resourceId)))
                 .thenThrow(new FedoraOCFLMappingNotFoundException(resourceId))
                 .thenReturn(mapping);
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OCFLPersistentStorageSessionTest.java
@@ -88,7 +88,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
  *
  * @author dbernstein
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class OCFLPersistentStorageSessionTest {
 
     private OCFLPersistentStorageSession session;
@@ -194,7 +194,7 @@ public class OCFLPersistentStorageSessionTest {
     private void mockMappingAndIndex(final String ocflObjectId, final String resourceId, final String rootObjectId,
                                      final FedoraOCFLMapping mapping) throws FedoraOCFLMappingNotFoundException {
         mockMapping(ocflObjectId, rootObjectId, mapping);
-        when(index.getMapping(resourceId)).thenReturn(mapping);
+        when(index.getMapping(anyString(), eq(resourceId))).thenReturn(mapping);
     }
 
     private void mockMapping(final String ocflObjectId, final String rootObjectId, final FedoraOCFLMapping mapping) {
@@ -637,7 +637,8 @@ public class OCFLPersistentStorageSessionTest {
 
         mockMapping(OCFL_RESOURCE_ID, ROOT_OBJECT_ID, mapping);
         final var mappingCount = new AtomicInteger(0);
-        when(index.getMapping(RESOURCE_ID)).thenAnswer((Answer<FedoraOCFLMapping>) invocationOnMock -> {
+        when(index.getMapping(anyString(), eq(RESOURCE_ID))).thenAnswer((Answer<FedoraOCFLMapping>) invocationOnMock ->
+        {
             final var current = mappingCount.getAndIncrement();
             if (current == 0) {
                 throw new FedoraOCFLMappingNotFoundException("");
@@ -650,7 +651,7 @@ public class OCFLPersistentStorageSessionTest {
         session.commit();
 
         final var childId = RESOURCE_ID + "/child";
-        when(index.getMapping(childId)).thenReturn(mapping);
+        when(index.getMapping(anyString(), eq(childId))).thenReturn(mapping);
 
         final String title = "title";
         final var dcTitleTriple = Triple.create(resourceUri, DC.title.asNode(), createLiteral(title));

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
@@ -18,6 +18,7 @@
 package org.fcrepo.persistence.ocfl.impl;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,11 +65,13 @@ public class PurgeResourcePersisterTest {
 
     private PurgeResourcePersister persister;
 
+    private static String SESSION_ID = "SOME-SESSION-ID";
+
     @Before
     public void setup() throws Exception {
         operation = mock(ResourceOperation.class);
         persister = new PurgeResourcePersister(this.index);
-
+        when(psSession.getId()).thenReturn(SESSION_ID);
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
     }
 
@@ -84,7 +87,7 @@ public class PurgeResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).read(".fcrepo/some-subpath.json");
         verify(session).delete(".fcrepo/some-subpath.json");
@@ -102,7 +105,7 @@ public class PurgeResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete(".fcrepo/some-subpath.json");
     }
@@ -112,7 +115,7 @@ public class PurgeResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         when(session.read(".fcrepo/some-subpath.json")).thenThrow(
                 new PersistentStorageException("error")
         );
@@ -124,7 +127,7 @@ public class PurgeResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
-        when(index.getMapping(anyString())).thenThrow(new FedoraOCFLMappingNotFoundException("error"));
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenThrow(new FedoraOCFLMappingNotFoundException("error"));
 
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
@@ -135,7 +138,7 @@ public class PurgeResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
         verify(session).deleteObject();
@@ -146,7 +149,7 @@ public class PurgeResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
         verify(session).deleteObject();
@@ -157,7 +160,7 @@ public class PurgeResourcePersisterTest {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/some-wrong-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
@@ -91,7 +91,6 @@ public class PurgeResourcePersisterTest {
         persister.persist(psSession, operation);
         verify(session).read(".fcrepo/some-subpath.json");
         verify(session).delete(".fcrepo/some-subpath.json");
-        verify(session).delete(".fcrepo/some-subpath-description.json");
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
@@ -91,6 +91,7 @@ public class PurgeResourcePersisterTest {
         persister.persist(psSession, operation);
         verify(session).read(".fcrepo/some-subpath.json");
         verify(session).delete(".fcrepo/some-subpath.json");
+        verify(session).delete(".fcrepo/some-subpath-description.json");
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
@@ -19,6 +19,7 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -89,7 +90,6 @@ public class PurgeResourcePersisterTest {
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
-        verify(session).read(".fcrepo/some-subpath.json");
         verify(session).delete(".fcrepo/some-subpath.json");
     }
 
@@ -116,9 +116,8 @@ public class PurgeResourcePersisterTest {
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
         when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
-        when(session.read(".fcrepo/some-subpath.json")).thenThrow(
-                new PersistentStorageException("error")
-        );
+        doThrow(new PersistentStorageException("error"))
+            .when(session).delete(".fcrepo/some-subpath.json");
         persister.persist(psSession, operation);
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/TestOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/TestOcflObjectIndex.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import javax.annotation.Nonnull;
+
 import org.fcrepo.persistence.ocfl.api.FedoraOCFLMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.slf4j.Logger;
@@ -36,7 +38,7 @@ public class TestOcflObjectIndex implements FedoraToOcflObjectIndex {
     private Map<String, FedoraOCFLMapping> fedoraOCFLMappingMap = Collections.synchronizedMap(new HashMap<>());
 
     @Override
-    public FedoraOCFLMapping getMapping(final String fedoraResourceIdentifier)
+    public FedoraOCFLMapping getMapping(final String transactionId, final String fedoraResourceIdentifier)
             throws FedoraOCFLMappingNotFoundException {
 
         LOGGER.debug("getting {}", fedoraResourceIdentifier);
@@ -49,7 +51,8 @@ public class TestOcflObjectIndex implements FedoraToOcflObjectIndex {
     }
 
     @Override
-    public FedoraOCFLMapping addMapping(final String fedoraResourceIdentifier,
+    public FedoraOCFLMapping addMapping(@Nonnull final String transactionId,
+                                        final String fedoraResourceIdentifier,
                                         final String fedoraRootObjectResourceId,
                                         final String ocflObjectId) {
         FedoraOCFLMapping mapping = fedoraOCFLMappingMap.get(fedoraRootObjectResourceId);
@@ -68,13 +71,23 @@ public class TestOcflObjectIndex implements FedoraToOcflObjectIndex {
     }
 
     @Override
-    public void removeMapping(final String fedoraResourceIdentifier) {
+    public void removeMapping(@Nonnull final String transactionId, final String fedoraResourceIdentifier) {
         fedoraOCFLMappingMap.remove(fedoraResourceIdentifier);
     }
 
     @Override
     public void reset() {
         fedoraOCFLMappingMap.clear();
+    }
+
+    @Override
+    public void commit(@Nonnull final String sessionId) {
+
+    }
+
+    @Override
+    public void rollback(@Nonnull final String sessionId) {
+
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
@@ -99,11 +99,13 @@ public class UpdateNonRdfSourcePersisterTest {
 
     private UpdateNonRdfSourcePersister persister;
 
+    private static final String SESSION_ID = "SOME-SESSION-ID";
+
     @Before
     public void setUp() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("object-id");
         when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
-
+        when(psSession.getId()).thenReturn(SESSION_ID);
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
         when(session.getObjectDigestAlgorithm()).thenReturn(DIGEST_ALGORITHM.SHA1);
 
@@ -115,14 +117,14 @@ public class UpdateNonRdfSourcePersisterTest {
 
         when(writeOutcome.getContentSize()).thenReturn(LOCAL_CONTENT_SIZE);
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         when(nonRdfSourceOperation.getType()).thenReturn(UPDATE);
 
 
         persister = new UpdateNonRdfSourcePersister(index);
 
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
@@ -106,13 +106,16 @@ public class UpdateRDFSourcePersisterTest {
 
     private UpdateRDFSourcePersister persister;
 
+    private static final String SESSION_ID = "SOME-SESSION-ID";
+
     @Before
     public void setup() throws Exception {
         operation = mock(RdfSourceOperation.class);
 
+        when(psSession.getId()).thenReturn(SESSION_ID);
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
-        when(index.getMapping(anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         when(operation.getType()).thenReturn(UPDATE);
 
         persister = new UpdateRDFSourcePersister(this.index);

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <fcrepo.test.context.path />
   </properties>
   <modules>
+    <module>fcrepo-common</module>
     <module>fcrepo-kernel-api</module>
     <module>fcrepo-kernel-impl</module>
     <module>fcrepo-webapp</module>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3357

Original PR: https://github.com/fcrepo4/fcrepo4/pull/1710

# What does this Pull Request do?

1. OCFL ID mapping changes are accumulated in a transaction table and only applied when a transaction is committed
1. When resources are purged their associated mappings are removed from the OCFL ID map table

# How should this be tested?

1. Start Fedora against a DB like Postgres.

2. Fire up the DB's CLI and execute: `select * from ocfl_id_map;`

3. Create resources:

```
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/ag-02 -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -H'Link: <http://fedora.info/definitions/v4/repository#ArchivalGroup>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'AG Parent 2'"

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/ag-02/child -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'AG 2 Child'"

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/ag-02/child/grand -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'AG 2 grandchild'"

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/ag-02/child/grand/great -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'AG 2 great grandchild'"

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/ag-02/child/grand/great/foo -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "bar"
```

4. Verify the mappings in the DB

5. Purge a resource:

```
curl -u fedoraAdmin:fedoraAdmin -v -XDELETE http://localhost:8080/rest/ag-02/child
curl -u fedoraAdmin:fedoraAdmin -v -XDELETE http://localhost:8080/rest/ag-02/child/fcr:tombstone
```

6. Verify the mapping, and all child mappings, were removed from the DB

7. Create a new resource:

```
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/foo -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "bar"
```

8. Purge the resource within a transaction (DO NOT COMMIT):

```
curl -u fedoraAdmin:fedoraAdmin -v -XPOST http://localhost:8080/rest/fcr:tx
txid=ebeb046a-64e0-4e46-9ed6-38b3cd1e20a2
curl -u fedoraAdmin:fedoraAdmin -v -H"Atomic-ID: ${txid}" -XDELETE http://localhost:8080/rest/foo
curl -u fedoraAdmin:fedoraAdmin -v -H"Atomic-ID: ${txid}" -XDELETE http://localhost:8080/rest/foo/fcr:tombstone
```

9. Verify the resource still exists in the DB and is access outside the transaction, but not within:

```
curl -u fedoraAdmin:fedoraAdmin -H"Atomic-ID: ${txid}" -v http://localhost:8080/rest/foo

curl -u fedoraAdmin:fedoraAdmin -v http://localhost:8080/rest/foo
```

10. Commit the transaction:

```
curl -u fedoraAdmin:fedoraAdmin -X PUT -v http://localhost:8080/rest/fcr:tx/${txid}
```

11. Verify the resource no longer exists in the DB and can no longer be accessed

# Interested parties
@fcrepo4/committers
