### PR TITLE
only create staging directories when resources are written

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOcflObjectSessionFactory.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DefaultOcflObjectSessionFactory.java
@@ -28,9 +28,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.fcrepo.persistence.api.CommitOption.NEW_VERSION;
@@ -59,7 +56,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
     @Override
     public OcflObjectSession create(final String ocflId,
                                     final Path sessionStagingDir) {
-        return new DefaultOcflObjectSession(ocflId, createStagingDir(sessionStagingDir, ocflId),
+        return new DefaultOcflObjectSession(ocflId, objectStagingDir(sessionStagingDir, ocflId),
                 this.ocflRepository, defaultCommitOption());
     }
 
@@ -79,13 +76,9 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
         this.autoVersioningEnabled = autoVersioningEnabled;
     }
 
-    private Path createStagingDir(final Path sessionStaging, final String objectIdentifier) {
+    private Path objectStagingDir(final Path sessionStaging, final String objectIdentifier) {
         final var digest = DigestUtils.sha256Hex(objectIdentifier);
-        try {
-            return Files.createDirectories(sessionStaging.resolve(digest));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return sessionStaging.resolve(digest);
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManager.java
@@ -86,7 +86,7 @@ public class OcflPersistentSessionManager implements PersistentStorageSessionMan
         return sessionMap.computeIfAbsent(sessionId, key -> new OcflPersistentStorageSession(
                 key,
                 fedoraOcflIndex,
-                createSessionStagingDir(sessionId),
+                sessionStagingDir(sessionId),
                 objectSessionFactory));
     }
 
@@ -99,7 +99,7 @@ public class OcflPersistentSessionManager implements PersistentStorageSessionMan
                 localSession = this.readOnlySession;
                 if (localSession == null) {
                     this.readOnlySession = new OcflPersistentStorageSession(fedoraOcflIndex,
-                            createSessionStagingDir(null), objectSessionFactory);
+                            sessionStagingDir(null), objectSessionFactory);
                     localSession = this.readOnlySession;
                 }
             }
@@ -108,13 +108,8 @@ public class OcflPersistentSessionManager implements PersistentStorageSessionMan
         return localSession;
     }
 
-    private Path createSessionStagingDir(final String sessionId) {
-        try {
-            return Files.createDirectories(sessionStagingRoot.resolve(
-                    sessionId == null ? "read-only" : sessionId));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+    private Path sessionStagingDir(final String sessionId) {
+        return sessionStagingRoot.resolve(sessionId == null ? "read-only" : sessionId);
     }
 
 }


### PR DESCRIPTION
**JIRA Ticket**: na

# What does this Pull Request do?

Does not per-emptively create staging directories. Previously, these empty directories would linger on the filesystem until the transaction that created them expired. Primarily a cosmetic issue.

# How should this be tested?

```
mvn -Dfcrepo.home=target/fcrepo clean jetty:run
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/foo -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "bar"
curl -u fedoraAdmin:fedoraAdmin -v http://localhost:8080/rest/foo
```

Check the staging directory and you won't see any directories.

# Interested parties
@fcrepo4/committers
