### PR TITLE
Refactor to more broadly use FedoraId instead of a string

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.identifiers;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 import org.fcrepo.kernel.api.exception.InvalidMementoPathException;
 import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
@@ -97,6 +99,7 @@ public class FedoraId {
      * @param additions One or more strings to build an ID.
      * @return The FedoraId.
      */
+    @JsonCreator
     public static FedoraId create(final String... additions) {
         return new FedoraId(idBuilder(additions));
     }
@@ -196,6 +199,15 @@ public class FedoraId {
     }
 
     /**
+     * Behaves the same as {@link #getResourceId()} except it returns a FedoraId rather than a String.
+     *
+     * @return the ID of the associated physical resource
+     */
+    public FedoraId asResourceId() {
+        return FedoraId.create(getResourceId());
+    }
+
+    /**
      * Returns the ID string for the base ID the Fedora ID describes. This value is the equivalent of the full ID
      * with all extensions removed.
      *
@@ -209,6 +221,15 @@ public class FedoraId {
      */
     public String getBaseId() {
         return baseId;
+    }
+
+    /**
+     * Behaves the same as {@link #getBaseId()} except it returns a FedoraId rather than a String.
+     *
+     * @return the ID of the associated base resource
+     */
+    public FedoraId asBaseId() {
+        return FedoraId.create(getBaseId());
     }
 
     /**
@@ -386,6 +407,7 @@ public class FedoraId {
         return getFullId().hashCode();
     }
 
+    @JsonValue
     @Override
     public String toString() {
         return getFullId();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHeaders.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHeaders.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.models;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collection;
@@ -33,14 +35,14 @@ public interface ResourceHeaders {
      *
      * @return identifier for the resource.
      */
-    String getId();
+    FedoraId getId();
 
     /**
      * Get the identifier of the parent of the resource
      *
      * @return identifier of the parent
      */
-    String getParent();
+    FedoraId getParent();
 
     /**
      * Get the State Token value for the resource.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateNonRdfSourceOperationBuilder.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 import java.net.URI;
 import java.util.Collection;
 
@@ -45,7 +47,7 @@ public interface CreateNonRdfSourceOperationBuilder extends NonRdfSourceOperatio
      * @param parentId parent internal identifier
      * @return the builder
      */
-    CreateNonRdfSourceOperationBuilder parentId(String parentId);
+    CreateNonRdfSourceOperationBuilder parentId(FedoraId parentId);
 
     @Override
     CreateNonRdfSourceOperationBuilder userPrincipal(String userPrincipal);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateRdfSourceOperationBuilder.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.api.operations;
 
 import org.apache.jena.rdf.model.Model;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 
 /**
  * @author bbpennel
@@ -44,7 +45,7 @@ public interface CreateRdfSourceOperationBuilder extends RdfSourceOperationBuild
      * @param parentId parent internal identifier
      * @return the builder
      */
-    CreateRdfSourceOperationBuilder parentId(String parentId);
+    CreateRdfSourceOperationBuilder parentId(FedoraId parentId);
 
     /**
      * Indicates that this resource should be created as an Archival Group

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateResourceOperation.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateResourceOperation.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 
 /**
@@ -31,7 +33,7 @@ public interface CreateResourceOperation extends ResourceOperation {
      *
      * @return identifer of parent
      */
-    String getParentId();
+    FedoraId getParentId();
 
     /**
      * Get the interaction model of the resource being created

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/DeleteResourceOperationFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/DeleteResourceOperationFactory.java
@@ -18,6 +18,8 @@
 package org.fcrepo.kernel.api.operations;
 
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 /**
  * Factory for delete resource operations
  *
@@ -31,7 +33,7 @@ public interface DeleteResourceOperationFactory extends ResourceOperationFactory
      * @param rescId id of the resource to delete
      * @return new builder
      */
-    ResourceOperationBuilder deleteBuilder(String rescId);
+    ResourceOperationBuilder deleteBuilder(FedoraId rescId);
 
     /**
      * Get a builder for an operation to purge a deleted resource.
@@ -39,5 +41,5 @@ public interface DeleteResourceOperationFactory extends ResourceOperationFactory
      * @param rescId id of the resource to purge
      * @return new builder
      */
-    ResourceOperationBuilder purgeBuilder(String rescId);
+    ResourceOperationBuilder purgeBuilder(FedoraId rescId);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/NonRdfSourceOperationFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/NonRdfSourceOperationFactory.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 import java.io.InputStream;
 import java.net.URI;
 
@@ -35,7 +37,7 @@ public interface NonRdfSourceOperationFactory extends ResourceOperationFactory {
      * @param contentUri the URI of the external binary content
      * @return a new builder
      */
-    NonRdfSourceOperationBuilder updateExternalBinaryBuilder(String rescId, String handling, URI contentUri);
+    NonRdfSourceOperationBuilder updateExternalBinaryBuilder(FedoraId rescId, String handling, URI contentUri);
 
     /**
      * Get a builder for an internal binary update operation
@@ -44,7 +46,7 @@ public interface NonRdfSourceOperationFactory extends ResourceOperationFactory {
      * @param contentStream inputstream for the content of this binary
      * @return a new builder
      */
-    NonRdfSourceOperationBuilder updateInternalBinaryBuilder(String rescId, InputStream contentStream);
+    NonRdfSourceOperationBuilder updateInternalBinaryBuilder(FedoraId rescId, InputStream contentStream);
 
     /**
      * Get a builder for a external binary create operation
@@ -54,7 +56,7 @@ public interface NonRdfSourceOperationFactory extends ResourceOperationFactory {
      * @param contentUri the URI of the external binary content
      * @return a new builder
      */
-    CreateNonRdfSourceOperationBuilder createExternalBinaryBuilder(String rescId, String handling, URI contentUri);
+    CreateNonRdfSourceOperationBuilder createExternalBinaryBuilder(FedoraId rescId, String handling, URI contentUri);
 
     /**
      * Get a builder for an internal binary create operation
@@ -63,5 +65,5 @@ public interface NonRdfSourceOperationFactory extends ResourceOperationFactory {
      * @param contentStream inputstream for the content of this binary
      * @return a new builder
      */
-    CreateNonRdfSourceOperationBuilder createInternalBinaryBuilder(String rescId, InputStream contentStream);
+    CreateNonRdfSourceOperationBuilder createInternalBinaryBuilder(FedoraId rescId, InputStream contentStream);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/RdfSourceOperationFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/RdfSourceOperationFactory.java
@@ -18,6 +18,8 @@
 package org.fcrepo.kernel.api.operations;
 
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 /**
  * Factory for operations on rdf sources
  *
@@ -32,7 +34,7 @@ public interface RdfSourceOperationFactory extends ResourceOperationFactory {
      * @param interactionModel interaction model for the resource being created
      * @return new builder
      */
-    CreateRdfSourceOperationBuilder createBuilder(String rescId, String interactionModel);
+    CreateRdfSourceOperationBuilder createBuilder(FedoraId rescId, String interactionModel);
 
     /**
      * Get a builder for an operation to update an RDF source
@@ -40,7 +42,7 @@ public interface RdfSourceOperationFactory extends ResourceOperationFactory {
      * @param rescId id of the resource targeted by the operation
      * @return new builder
      */
-    RdfSourceOperationBuilder updateBuilder(String rescId);
+    RdfSourceOperationBuilder updateBuilder(FedoraId rescId);
 
     /**
      * Get a builder for an operation to perform a sparql update on an RDF source
@@ -49,5 +51,5 @@ public interface RdfSourceOperationFactory extends ResourceOperationFactory {
      * @param updateQuery sparql update query
      * @return new builder
      */
-    ResourceOperationBuilder sparqlUpdateBuilder(String rescId, String updateQuery);
+    ResourceOperationBuilder sparqlUpdateBuilder(FedoraId rescId, String updateQuery);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/ResourceOperation.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/ResourceOperation.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 /**
  * Operation for manipulating a resource
  *
@@ -29,7 +31,7 @@ public interface ResourceOperation {
      *
      * @return the ID.
      */
-    String getResourceId();
+    FedoraId getResourceId();
 
     /**
      * Returns the user principal performing this operation

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/VersionResourceOperationFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/VersionResourceOperationFactory.java
@@ -18,6 +18,8 @@
 
 package org.fcrepo.kernel.api.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 /**
  * Factory for creating {@link CreateVersionResourceOperationBuilder}s
  */
@@ -29,6 +31,6 @@ public interface VersionResourceOperationFactory extends ResourceOperationFactor
      * @param rescId the resource id
      * @return builder
      */
-    CreateVersionResourceOperationBuilder createBuilder(String rescId);
+    CreateVersionResourceOperationBuilder createBuilder(FedoraId rescId);
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -75,7 +75,7 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
     @Override
     public InputStream getContent() {
         try {
-            return getSession().getBinaryContent(getId(), getMementoDatetime());
+            return getSession().getBinaryContent(getFedoraId().asResourceId(), getMementoDatetime());
         } catch (final PersistentItemNotFoundException e) {
             throw new ItemNotFoundException("Unable to find content for " + getId()
                     + " version " + getMementoDatetime(), e);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -104,8 +104,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
 
             try {
                 // Resource ID for metadata or ACL contains their individual endopoints (ie. fcr:metadata, fcr:acl)
-                final String id = fedoraId.getResourceId();
-                final ResourceHeaders headers = psSession.getHeaders(id, fedoraId.getMementoInstant());
+                final ResourceHeaders headers = psSession.getHeaders(fedoraId, fedoraId.getMementoInstant());
                 return !headers.isDeleted();
             } catch (final PersistentItemNotFoundException e) {
                 // Object doesn't exist.
@@ -178,10 +177,9 @@ public class ResourceFactoryImpl implements ResourceFactory {
             throws PathNotFoundException {
         try {
             // For descriptions and ACLs we need the actual endpoint.
-            final String id = identifier.getResourceId();
             final var psSession = getSession(transaction);
             final Instant versionDateTime = identifier.isMemento() ? identifier.getMementoInstant() : null;
-            final var headers = psSession.getHeaders(id, versionDateTime);
+            final var headers = psSession.getHeaders(identifier, versionDateTime);
 
             // Determine the appropriate class from headers
             final var createClass = getClassForTypes(headers);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -86,7 +86,7 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
         setCreatedDate(originalResource.getCreatedDate());
         setLastModifiedBy(originalResource.getLastModifiedBy());
         setLastModifiedDate(originalResource.getLastModifiedDate());
-        setParentId(originalResource.getId());
+        setParentId(originalResource.getFedoraId().asResourceId());
         setEtag(originalResource.getEtagValue());
         setStateToken(originalResource.getStateToken());
     }
@@ -147,7 +147,7 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
     private List<Instant> getVersions() {
         if (versions == null) {
             try {
-                versions = getSession().listVersions(getId());
+                versions = getSession().listVersions(getFedoraId().asResourceId());
             } catch (final PersistentItemNotFoundException e) {
                 throw new ItemNotFoundException("Unable to retrieve versions for " + getId(), e);
             } catch (final PersistentStorageException e) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperation.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 
 /**
@@ -52,7 +53,7 @@ public abstract class AbstractNonRdfSourceOperation extends AbstractResourceOper
      * @param externalContentURI the URI of the external content.
      * @param externalHandling the type of external content handling (REDIRECT, PROXY)
      */
-    protected AbstractNonRdfSourceOperation(final String rescId, final URI externalContentURI,
+    protected AbstractNonRdfSourceOperation(final FedoraId rescId, final URI externalContentURI,
             final String externalHandling) {
         super(rescId);
         this.externalHandlingURI = externalContentURI;
@@ -65,7 +66,7 @@ public abstract class AbstractNonRdfSourceOperation extends AbstractResourceOper
      * @param rescId the internal identifier.
      * @param content the stream of the content.
      */
-    protected AbstractNonRdfSourceOperation(final String rescId, final InputStream content) {
+    protected AbstractNonRdfSourceOperation(final FedoraId rescId, final InputStream content) {
         super(rescId);
         this.content = content;
     }
@@ -75,7 +76,7 @@ public abstract class AbstractNonRdfSourceOperation extends AbstractResourceOper
      *
      * @param rescId The internal Fedora ID.
      */
-    protected AbstractNonRdfSourceOperation(final String rescId) {
+    protected AbstractNonRdfSourceOperation(final FedoraId rescId) {
         super(rescId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
 
 /**
@@ -30,7 +31,7 @@ import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
  */
 public abstract class AbstractNonRdfSourceOperationBuilder implements NonRdfSourceOperationBuilder {
 
-    protected String resourceId;
+    protected FedoraId resourceId;
 
     protected InputStream content;
 
@@ -55,7 +56,7 @@ public abstract class AbstractNonRdfSourceOperationBuilder implements NonRdfSour
      * @param handling the external content handling type.
      * @param externalUri the external content URI.
      */
-    protected AbstractNonRdfSourceOperationBuilder(final String rescId, final String handling,
+    protected AbstractNonRdfSourceOperationBuilder(final FedoraId rescId, final String handling,
             final URI externalUri) {
         this.resourceId = rescId;
         this.externalURI = externalUri;
@@ -68,7 +69,7 @@ public abstract class AbstractNonRdfSourceOperationBuilder implements NonRdfSour
      * @param rescId the internal identifier.
      * @param stream the content stream.
      */
-    protected AbstractNonRdfSourceOperationBuilder(final String rescId, final InputStream stream) {
+    protected AbstractNonRdfSourceOperationBuilder(final FedoraId rescId, final InputStream stream) {
         this.resourceId = rescId;
         this.content = stream;
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractRdfSourceOperation.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.impl.operations;
 import java.time.Instant;
 
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 
 /**
@@ -39,7 +40,7 @@ public abstract class AbstractRdfSourceOperation extends AbstractResourceOperati
 
     protected Instant createdDate;
 
-    protected AbstractRdfSourceOperation(final String rescId, final RdfStream triples) {
+    protected AbstractRdfSourceOperation(final FedoraId rescId, final RdfStream triples) {
         super(rescId);
         this.triples = triples;
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractRdfSourceOperationBuilder.java
@@ -30,6 +30,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationBuilder;
 
 /**
@@ -46,7 +47,7 @@ public abstract class AbstractRdfSourceOperationBuilder implements RdfSourceOper
     /**
      * String of the resource ID.
      */
-    protected final String resourceId;
+    protected final FedoraId resourceId;
 
     /**
      * The interaction model of this resource, null in case of update.
@@ -66,7 +67,7 @@ public abstract class AbstractRdfSourceOperationBuilder implements RdfSourceOper
 
     protected Instant createdDate;
 
-    protected AbstractRdfSourceOperationBuilder(final String rescId, final String model) {
+    protected AbstractRdfSourceOperationBuilder(final FedoraId rescId, final String model) {
         resourceId = rescId;
         interactionModel = model;
     }
@@ -87,7 +88,7 @@ public abstract class AbstractRdfSourceOperationBuilder implements RdfSourceOper
     public RdfSourceOperationBuilder relaxedProperties(final Model model) {
         // Has no affect if the server is not in relaxed mode
         if (model != null && isRelaxed()) {
-            final var resc = model.getResource(resourceId);
+            final var resc = model.getResource(resourceId.getResourceId());
             final var createdDateVal = getPropertyAsInstant(resc, CREATED_DATE);
             if (createdDateVal != null) {
                 this.createdDate = createdDateVal;

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractResourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractResourceOperation.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 
 /**
@@ -29,16 +30,16 @@ public abstract class AbstractResourceOperation implements ResourceOperation {
     /**
      * The internal Fedora ID.
      */
-    private final String rescId;
+    private final FedoraId rescId;
 
     private String userPrincipal;
 
-    protected AbstractResourceOperation(final String rescId) {
+    protected AbstractResourceOperation(final FedoraId rescId) {
         this.rescId = rescId;
     }
 
     @Override
-    public String getResourceId() {
+    public FedoraId getResourceId() {
         return rescId;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractResourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractResourceOperationBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
 
 /**
@@ -25,7 +26,7 @@ import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
  */
 abstract public class AbstractResourceOperationBuilder implements ResourceOperationBuilder {
 
-    protected String rescId;
+    protected FedoraId rescId;
 
     protected String userPrincipal;
 
@@ -33,7 +34,7 @@ abstract public class AbstractResourceOperationBuilder implements ResourceOperat
      * Constructor.
      * @param rescId the resource identifier.
      */
-    public AbstractResourceOperationBuilder(final String rescId) {
+    public AbstractResourceOperationBuilder(final FedoraId rescId) {
         this.rescId = rescId;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperation.java
@@ -22,6 +22,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import java.io.InputStream;
 import java.net.URI;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 
 /**
@@ -31,7 +32,7 @@ import org.fcrepo.kernel.api.operations.CreateResourceOperation;
  */
 public class CreateNonRdfSourceOperation extends AbstractNonRdfSourceOperation implements CreateResourceOperation {
 
-    private String parentId;
+    private FedoraId parentId;
 
     /**
      * Constructor for external content.
@@ -40,8 +41,8 @@ public class CreateNonRdfSourceOperation extends AbstractNonRdfSourceOperation i
      * @param externalContentURI the URI of the external content.
      * @param externalHandling the type of external content handling (REDIRECT, PROXY)
      */
-    protected CreateNonRdfSourceOperation(final String rescId, final URI externalContentURI,
-            final String externalHandling) {
+    protected CreateNonRdfSourceOperation(final FedoraId rescId, final URI externalContentURI,
+                                          final String externalHandling) {
         super(rescId, externalContentURI, externalHandling);
     }
 
@@ -51,7 +52,7 @@ public class CreateNonRdfSourceOperation extends AbstractNonRdfSourceOperation i
      * @param rescId the internal identifier.
      * @param content the stream of the content.
      */
-    protected CreateNonRdfSourceOperation(final String rescId, final InputStream content) {
+    protected CreateNonRdfSourceOperation(final FedoraId rescId, final InputStream content) {
         super(rescId, content);
     }
 
@@ -66,14 +67,14 @@ public class CreateNonRdfSourceOperation extends AbstractNonRdfSourceOperation i
     }
 
     @Override
-    public String getParentId() {
+    public FedoraId getParentId() {
         return parentId;
     }
 
     /**
      * @param parentId the parentId to set
      */
-    public void setParentId(final String parentId) {
+    public void setParentId(final FedoraId parentId) {
         this.parentId = parentId;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderImpl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateNonRdfSourceOperationBuilder;
 
 import java.io.InputStream;
@@ -32,7 +33,7 @@ import java.util.Collection;
 public class CreateNonRdfSourceOperationBuilderImpl extends AbstractNonRdfSourceOperationBuilder
         implements CreateNonRdfSourceOperationBuilder {
 
-    private String parentId;
+    private FedoraId parentId;
 
     /**
      * Constructor for external binary.
@@ -41,7 +42,7 @@ public class CreateNonRdfSourceOperationBuilderImpl extends AbstractNonRdfSource
      * @param handling    the external content handling type.
      * @param externalUri the external content URI.
      */
-    protected CreateNonRdfSourceOperationBuilderImpl(final String rescId, final String handling,
+    protected CreateNonRdfSourceOperationBuilderImpl(final FedoraId rescId, final String handling,
             final URI externalUri) {
         super(rescId, handling, externalUri);
     }
@@ -52,7 +53,7 @@ public class CreateNonRdfSourceOperationBuilderImpl extends AbstractNonRdfSource
      * @param rescId the internal identifier.
      * @param stream the content stream.
      */
-    protected CreateNonRdfSourceOperationBuilderImpl(final String rescId, final InputStream stream) {
+    protected CreateNonRdfSourceOperationBuilderImpl(final FedoraId rescId, final InputStream stream) {
         super(rescId, stream);
     }
 
@@ -82,7 +83,7 @@ public class CreateNonRdfSourceOperationBuilderImpl extends AbstractNonRdfSource
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilder parentId(final String parentId) {
+    public CreateNonRdfSourceOperationBuilder parentId(final FedoraId parentId) {
         this.parentId = parentId;
         return this;
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateRdfSourceOperationBuilderImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateRdfSourceOperationBuilderImpl.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.impl.operations;
 
 import org.apache.jena.rdf.model.Model;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperationBuilder;
 
@@ -30,7 +31,7 @@ import org.fcrepo.kernel.api.operations.CreateRdfSourceOperationBuilder;
 public class CreateRdfSourceOperationBuilderImpl extends AbstractRdfSourceOperationBuilder implements
         CreateRdfSourceOperationBuilder {
 
-    private String parentId;
+    private FedoraId parentId;
 
     private boolean archivalGroup = false;
     /**
@@ -39,7 +40,7 @@ public class CreateRdfSourceOperationBuilderImpl extends AbstractRdfSourceOperat
      * @param resourceId the internal identifier.
      * @param interactionModel interaction model
      */
-    public CreateRdfSourceOperationBuilderImpl(final String resourceId, final String interactionModel) {
+    public CreateRdfSourceOperationBuilderImpl(final FedoraId resourceId, final String interactionModel) {
         super(resourceId, interactionModel);
     }
 
@@ -69,7 +70,7 @@ public class CreateRdfSourceOperationBuilderImpl extends AbstractRdfSourceOperat
     }
 
     @Override
-    public CreateRdfSourceOperationBuilder parentId(final String parentId) {
+    public CreateRdfSourceOperationBuilder parentId(final FedoraId parentId) {
         this.parentId = parentId;
         return this;
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateRdfSourceOperationImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateRdfSourceOperationImpl.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.impl.operations;
 
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperation;
 
 /**
@@ -27,7 +28,7 @@ import org.fcrepo.kernel.api.operations.CreateRdfSourceOperation;
  */
 public class CreateRdfSourceOperationImpl extends AbstractRdfSourceOperation implements CreateRdfSourceOperation {
 
-    private String parentId;
+    private FedoraId parentId;
 
     /**
      * The interaction model
@@ -43,7 +44,7 @@ public class CreateRdfSourceOperationImpl extends AbstractRdfSourceOperation imp
      * @param interactionModel interaction model for the resource
      * @param triples triples stream for the resource
      */
-    protected CreateRdfSourceOperationImpl(final String rescId, final String interactionModel,
+    protected CreateRdfSourceOperationImpl(final FedoraId rescId, final String interactionModel,
                                            final RdfStream triples) {
         super(rescId, triples);
         this.interactionModel = interactionModel;
@@ -60,14 +61,14 @@ public class CreateRdfSourceOperationImpl extends AbstractRdfSourceOperation imp
     }
 
     @Override
-    public String getParentId() {
+    public FedoraId getParentId() {
         return parentId;
     }
 
     /**
      * @param parentId the parentId to set
      */
-    public void setParentId(final String parentId) {
+    public void setParentId(final FedoraId parentId) {
         this.parentId = parentId;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateVersionResourceOperationBuilderImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateVersionResourceOperationBuilderImpl.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateVersionResourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
@@ -27,7 +28,7 @@ import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
  */
 public class CreateVersionResourceOperationBuilderImpl implements CreateVersionResourceOperationBuilder {
 
-    private final String resourceId;
+    private final FedoraId resourceId;
     private String userPrincipal;
 
     /**
@@ -35,7 +36,7 @@ public class CreateVersionResourceOperationBuilderImpl implements CreateVersionR
      *
      * @param resourceId the resource id
      */
-    public CreateVersionResourceOperationBuilderImpl(final String resourceId) {
+    public CreateVersionResourceOperationBuilderImpl(final FedoraId resourceId) {
         this.resourceId = resourceId;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateVersionResourceOperationImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateVersionResourceOperationImpl.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
 
 /**
@@ -26,7 +27,7 @@ import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
 public class CreateVersionResourceOperationImpl extends AbstractResourceOperation
         implements CreateVersionResourceOperation {
 
-    protected CreateVersionResourceOperationImpl(final String rescId) {
+    protected CreateVersionResourceOperationImpl(final FedoraId rescId) {
         super(rescId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperation.java
@@ -18,6 +18,8 @@
 package org.fcrepo.kernel.impl.operations;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.DELETE;
+
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 
@@ -28,7 +30,7 @@ import org.fcrepo.kernel.api.operations.ResourceOperationType;
  */
 public class DeleteResourceOperation extends AbstractResourceOperation {
 
-    protected DeleteResourceOperation(final String rescId) {
+    protected DeleteResourceOperation(final FedoraId rescId) {
         super(rescId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperationBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
 
 
@@ -33,7 +34,7 @@ public class DeleteResourceOperationBuilder extends AbstractResourceOperationBui
      *
      * @param rescId identifier of the resource to delete
      */
-    public DeleteResourceOperationBuilder(final String rescId) {
+    public DeleteResourceOperationBuilder(final FedoraId rescId) {
         super(rescId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/DeleteResourceOperationFactoryImpl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.DeleteResourceOperationFactory;
 import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
 import org.springframework.stereotype.Component;
@@ -30,12 +31,12 @@ import org.springframework.stereotype.Component;
 public class DeleteResourceOperationFactoryImpl implements DeleteResourceOperationFactory {
 
     @Override
-    public DeleteResourceOperationBuilder deleteBuilder(final String rescId) {
+    public DeleteResourceOperationBuilder deleteBuilder(final FedoraId rescId) {
         return new DeleteResourceOperationBuilder(rescId);
     }
 
     @Override
-    public ResourceOperationBuilder purgeBuilder(final String rescId) {
+    public ResourceOperationBuilder purgeBuilder(final FedoraId rescId) {
         return new PurgeResourceOperationBuilder(rescId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImpl.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.impl.operations;
 import java.io.InputStream;
 import java.net.URI;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateNonRdfSourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
 import org.springframework.stereotype.Component;
@@ -33,26 +34,26 @@ import org.springframework.stereotype.Component;
 public class NonRdfSourceOperationFactoryImpl implements NonRdfSourceOperationFactory {
 
     @Override
-    public UpdateNonRdfSourceOperationBuilder updateExternalBinaryBuilder(final String rescId,
+    public UpdateNonRdfSourceOperationBuilder updateExternalBinaryBuilder(final FedoraId rescId,
                                                                     final String handling,
                                                                     final URI contentUri) {
         return new UpdateNonRdfSourceOperationBuilder(rescId, handling, contentUri);
     }
 
     @Override
-    public UpdateNonRdfSourceOperationBuilder updateInternalBinaryBuilder(final String rescId,
+    public UpdateNonRdfSourceOperationBuilder updateInternalBinaryBuilder(final FedoraId rescId,
                                                                     final InputStream contentStream) {
         return new UpdateNonRdfSourceOperationBuilder(rescId, contentStream);
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilder createExternalBinaryBuilder(final String rescId,
+    public CreateNonRdfSourceOperationBuilder createExternalBinaryBuilder(final FedoraId rescId,
             final String handling, final URI contentUri) {
         return new CreateNonRdfSourceOperationBuilderImpl(rescId, handling, contentUri);
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilder createInternalBinaryBuilder(final String rescId,
+    public CreateNonRdfSourceOperationBuilder createInternalBinaryBuilder(final FedoraId rescId,
             final InputStream contentStream) {
         return new CreateNonRdfSourceOperationBuilderImpl(rescId, contentStream);
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/PurgeResourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/PurgeResourceOperation.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 /**
@@ -27,7 +28,7 @@ import org.fcrepo.kernel.api.operations.ResourceOperationType;
  */
 public class PurgeResourceOperation extends AbstractResourceOperation {
 
-    protected PurgeResourceOperation(final String rescId) {
+    protected PurgeResourceOperation(final FedoraId rescId) {
         super(rescId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/PurgeResourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/PurgeResourceOperationBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
 
 /**
@@ -32,7 +33,7 @@ public class PurgeResourceOperationBuilder extends AbstractResourceOperationBuil
      *
      * @param rescId identifier of the resource to delete
      */
-    public PurgeResourceOperationBuilder(final String rescId) {
+    public PurgeResourceOperationBuilder(final FedoraId rescId) {
         super(rescId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/RdfSourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/RdfSourceOperationFactoryImpl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
@@ -33,17 +34,17 @@ import org.springframework.stereotype.Component;
 public class RdfSourceOperationFactoryImpl implements RdfSourceOperationFactory {
 
     @Override
-    public CreateRdfSourceOperationBuilder createBuilder(final String rescId, final String interactionModel) {
+    public CreateRdfSourceOperationBuilder createBuilder(final FedoraId rescId, final String interactionModel) {
         return new CreateRdfSourceOperationBuilderImpl(rescId, interactionModel);
     }
 
     @Override
-    public RdfSourceOperationBuilder updateBuilder(final String rescId) {
+    public RdfSourceOperationBuilder updateBuilder(final FedoraId rescId) {
         return new UpdateRdfSourceOperationBuilder(rescId);
     }
 
     @Override
-    public ResourceOperationBuilder sparqlUpdateBuilder(final String rescId, final String updateQuery) {
+    public ResourceOperationBuilder sparqlUpdateBuilder(final FedoraId rescId, final String updateQuery) {
         // TODO Auto-generated method stub
         return null;
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperation.java
@@ -22,6 +22,7 @@ import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
 import java.io.InputStream;
 import java.net.URI;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 /**
@@ -37,7 +38,7 @@ public class UpdateNonRdfSourceOperation extends AbstractNonRdfSourceOperation {
      * @param rescId the internal identifier.
      * @param content the stream of the content.
      */
-    protected UpdateNonRdfSourceOperation(final String rescId, final InputStream content) {
+    protected UpdateNonRdfSourceOperation(final FedoraId rescId, final InputStream content) {
         super(rescId, content);
     }
 
@@ -48,7 +49,7 @@ public class UpdateNonRdfSourceOperation extends AbstractNonRdfSourceOperation {
      * @param externalContentURI the URI of the external content.
      * @param externalHandling the type of external content handling (REDIRECT, PROXY)
      */
-    protected UpdateNonRdfSourceOperation(final String rescId, final URI externalContentURI,
+    protected UpdateNonRdfSourceOperation(final FedoraId rescId, final URI externalContentURI,
             final String externalHandling) {
         super(rescId, externalContentURI, externalHandling);
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilder.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 import java.io.InputStream;
 import java.net.URI;
 
@@ -26,11 +28,11 @@ import java.net.URI;
  * @author bbpennel
  */
 public class UpdateNonRdfSourceOperationBuilder extends AbstractNonRdfSourceOperationBuilder {
-    protected UpdateNonRdfSourceOperationBuilder(final String rescId, final InputStream stream) {
+    protected UpdateNonRdfSourceOperationBuilder(final FedoraId rescId, final InputStream stream) {
         super(rescId, stream);
     }
 
-    protected UpdateNonRdfSourceOperationBuilder(final String rescId, final String handling, final URI contentUri) {
+    protected UpdateNonRdfSourceOperationBuilder(final FedoraId rescId, final String handling, final URI contentUri) {
         super(rescId, handling, contentUri);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfSourceOperation.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.impl.operations;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE;
 
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 
@@ -30,7 +31,7 @@ import org.fcrepo.kernel.api.operations.ResourceOperationType;
  */
 public class UpdateRdfSourceOperation extends AbstractRdfSourceOperation {
 
-    protected UpdateRdfSourceOperation(final String rescId, final RdfStream triples) {
+    protected UpdateRdfSourceOperation(final FedoraId rescId, final RdfStream triples) {
         super(rescId, triples);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfSourceOperationBuilder.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.impl.operations;
 
 import org.apache.jena.rdf.model.Model;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 
 /**
@@ -33,7 +34,7 @@ public class UpdateRdfSourceOperationBuilder extends AbstractRdfSourceOperationB
      *
      * @param resourceId the internal identifier.
      */
-    public UpdateRdfSourceOperationBuilder(final String resourceId) {
+    public UpdateRdfSourceOperationBuilder(final FedoraId resourceId) {
         super(resourceId, null);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/VersionResourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/VersionResourceOperationFactoryImpl.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateVersionResourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.VersionResourceOperationFactory;
 import org.springframework.stereotype.Component;
@@ -29,7 +30,7 @@ import org.springframework.stereotype.Component;
 public class VersionResourceOperationFactoryImpl implements VersionResourceOperationFactory {
 
     @Override
-    public CreateVersionResourceOperationBuilder createBuilder(final String rescId) {
+    public CreateVersionResourceOperationBuilder createBuilder(final FedoraId rescId) {
         return new CreateVersionResourceOperationBuilderImpl(rescId);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -88,16 +88,16 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
         final CreateNonRdfSourceOperationBuilder builder;
         String mimeType = contentType;
         if (externalContent == null) {
-            builder = nonRdfSourceOperationFactory.createInternalBinaryBuilder(fedoraId.getFullId(), requestBody);
+            builder = nonRdfSourceOperationFactory.createInternalBinaryBuilder(fedoraId, requestBody);
         } else {
-            builder = nonRdfSourceOperationFactory.createExternalBinaryBuilder(fedoraId.getFullId(),
+            builder = nonRdfSourceOperationFactory.createExternalBinaryBuilder(fedoraId,
                     externalContent.getHandling(), URI.create(externalContent.getURL()));
             if (externalContent.getContentType() != null) {
                 mimeType = externalContent.getContentType();
             }
         }
         final ResourceOperation createOp = builder
-                .parentId(parentId.getFullId())
+                .parentId(parentId)
                 .userPrincipal(userPrincipal)
                 .contentDigests(digest)
                 .mimeType(mimeType)
@@ -118,10 +118,10 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             final FedoraId binaryId) {
         final var descId = binaryId.asDescription();
         final var createOp = rdfSourceOperationFactory.createBuilder(
-                    descId.getFullId(),
+                    descId,
                     FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI
                 ).userPrincipal(userPrincipal)
-                .parentId(binaryId.getFullId())
+                .parentId(binaryId)
                 .build();
         try {
             pSession.persist(createOp);
@@ -146,8 +146,8 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
         final RdfStream stream = fromModel(model.getResource(fedoraId.getFullId()).asNode(), model);
 
         final RdfSourceOperation createOp = rdfSourceOperationFactory
-                .createBuilder(fedoraId.getFullId(),interactionModel)
-                .parentId(parentId.getFullId())
+                .createBuilder(fedoraId, interactionModel)
+                .parentId(parentId)
                 .triples(stream)
                 .relaxedProperties(model)
                 .archivalGroup(rdfTypes.contains(ARCHIVAL_GROUP.getURI()))

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -180,7 +180,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
                 // Make sure the parent exists.
                 // TODO: object existence can be from the index, but we don't have interaction model. Should we add it?
                 final boolean parentExists = containmentIndex.resourceExists(txId, fedoraId);
-                parent = pSession.getHeaders(fedoraId.getResourceId(), null);
+                parent = pSession.getHeaders(fedoraId.asResourceId(), null);
             } catch (final PersistentItemNotFoundException exc) {
                 throw new ItemNotFoundException(String.format("Item %s was not found", fedoraId), exc);
             } catch (final PersistentStorageException exc) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
@@ -55,7 +55,7 @@ public class DeleteResourceServiceImpl extends AbstractDeleteResourceService imp
                             final FedoraId fedoraId, final String userPrincipal)
             throws PersistentStorageException {
         log.debug("starting delete of {}", fedoraId.getFullId());
-        final ResourceOperation deleteOp = deleteResourceFactory.deleteBuilder(fedoraId.getFullId())
+        final ResourceOperation deleteOp = deleteResourceFactory.deleteBuilder(fedoraId)
                 .userPrincipal(userPrincipal)
                 .build();
         pSession.persist(deleteOp);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
@@ -54,7 +54,7 @@ public class PurgeResourceServiceImpl extends AbstractDeleteResourceService impl
     protected void doAction(final Transaction tx, final PersistentStorageSession pSession, final FedoraId resourceId,
                   final String userPrincipal) throws PersistentStorageException {
         log.debug("starting purge of {}", resourceId.getFullId());
-        final ResourceOperation purgeOp = deleteResourceFactory.purgeBuilder(resourceId.getFullId())
+        final ResourceOperation purgeOp = deleteResourceFactory.purgeBuilder(resourceId)
                 .userPrincipal(userPrincipal)
                 .build();
         pSession.persist(purgeOp);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -67,9 +67,9 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
             String mimeType = contentType;
             final NonRdfSourceOperationBuilder builder;
             if (externalContent == null) {
-                builder = factory.updateInternalBinaryBuilder(fedoraId.getFullId(), contentBody);
+                builder = factory.updateInternalBinaryBuilder(fedoraId, contentBody);
             } else {
-                builder = factory.updateExternalBinaryBuilder(fedoraId.getFullId(),
+                builder = factory.updateExternalBinaryBuilder(fedoraId,
                         externalContent.getHandling(),
                         externalContent.getURI());
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -63,7 +63,7 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
 
             checkForSmtsLdpTypes(inputModel);
 
-            final ResourceOperation updateOp = factory.updateBuilder(fedoraId.getFullId())
+            final ResourceOperation updateOp = factory.updateBuilder(fedoraId)
                 .relaxedProperties(inputModel)
                 .userPrincipal(userPrincipal)
                 .triples(fromModel(inputModel.createResource(fedoraId.getFullId()).asNode(), inputModel))

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdatePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdatePropertiesServiceImpl.java
@@ -58,7 +58,7 @@ public class UpdatePropertiesServiceImpl extends AbstractService implements Upda
             throws MalformedRdfException, AccessDeniedException {
         try {
             final var psession = persistentStorageSessionManager.getSession(txId);
-            final var triples = psession.getTriples(fedoraId.getFullId(), null);
+            final var triples = psession.getTriples(fedoraId, null);
             final Model model = triples.collect(toModel());
             final UpdateRequest request = UpdateFactory.create(sparqlUpdateStatement, fedoraId.getFullId());
             UpdateAction.execute(request, model);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/VersionServiceImpl.java
@@ -46,7 +46,7 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
     @Override
     public void createVersion(final Transaction transaction, final FedoraId fedoraId, final String userPrincipal) {
         final var session = psManager.getSession(transaction.getId());
-        final var operation = versionOperationFactory.createBuilder(fedoraId.getResourceId())
+        final var operation = versionOperationFactory.createBuilder(fedoraId)
                 .userPrincipal(userPrincipal)
                 .build();
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
@@ -77,7 +77,7 @@ public class WebacAclServiceImpl extends AbstractService implements WebacAclServ
 
         final RdfSourceOperation createOp = rdfSourceOperationFactory
                 .createBuilder(fedoraId, FEDORA_WEBAC_ACL_URI)
-                .parentId(FedoraId.create(fedoraId.getBaseId()))
+                .parentId(fedoraId.asBaseId())
                 .triples(stream)
                 .relaxedProperties(model)
                 .userPrincipal(userPrincipal)

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
@@ -76,8 +76,8 @@ public class WebacAclServiceImpl extends AbstractService implements WebacAclServ
         final RdfStream stream = fromModel(model.getResource(fedoraId.getFullId()).asNode(), model);
 
         final RdfSourceOperation createOp = rdfSourceOperationFactory
-                .createBuilder(fedoraId.getResourceId(), FEDORA_WEBAC_ACL_URI)
-                .parentId(fedoraId.getBaseId())
+                .createBuilder(fedoraId, FEDORA_WEBAC_ACL_URI)
+                .parentId(FedoraId.create(fedoraId.getBaseId()))
                 .triples(stream)
                 .relaxedProperties(model)
                 .userPrincipal(userPrincipal)

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
@@ -135,10 +135,10 @@ public class FedoraResourceImplTest {
         userModel.add(subject, type, createResource(exampleType));
         final var userStream = fromModel(subject.asNode(), userModel);
         when(sessionManager.getReadOnlySession()).thenReturn(psSession);
-        when(psSession.getHeaders(eq(FEDORA_ID.getResourceId()),any())).thenReturn(headers);
+        when(psSession.getHeaders(eq(FEDORA_ID),any())).thenReturn(headers);
         when(headers.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
         when(headers.isArchivalGroup()).thenReturn(false);
-        when(psSession.getTriples(eq(FEDORA_ID.getResourceId()), any())).thenReturn(userStream);
+        when(psSession.getTriples(eq(FEDORA_ID), any())).thenReturn(userStream);
 
         final List<URI> expectedTypes = List.of(
                 create(exampleType),
@@ -173,10 +173,10 @@ public class FedoraResourceImplTest {
 
         when(resourceFactory.getResource(any(), eq(descriptionFedoraId))).thenReturn(description);
         when(sessionManager.getReadOnlySession()).thenReturn(psSession);
-        when(psSession.getHeaders(eq(FEDORA_ID.getResourceId()),any())).thenReturn(headers);
+        when(psSession.getHeaders(eq(FEDORA_ID),any())).thenReturn(headers);
         when(headers.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
         when(headers.isArchivalGroup()).thenReturn(false);
-        when(psSession.getTriples(eq(descriptionFedoraId.getResourceId()), any())).thenReturn(userStream);
+        when(psSession.getTriples(eq(descriptionFedoraId), any())).thenReturn(userStream);
 
         final List<URI> expectedTypes = List.of(
                 create(exampleType),

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
@@ -85,7 +85,7 @@ public class ResourceFactoryImplTest {
 
     private final static String STATE_TOKEN = "stately_value";
 
-    private final static long CONTENT_SIZE = 100l;
+    private final static long CONTENT_SIZE = 100L;
 
     private final static String MIME_TYPE = "text/plain";
 
@@ -144,12 +144,12 @@ public class ResourceFactoryImplTest {
         setField(factory, "containmentIndex", containmentIndex);
 
         resourceHeaders = new ResourceHeadersImpl();
-        resourceHeaders.setId(fedoraIdStr);
+        resourceHeaders.setId(fedoraId);
 
         when(sessionManager.getSession(sessionId)).thenReturn(psSession);
         when(sessionManager.getReadOnlySession()).thenReturn(psSession);
 
-        when(psSession.getHeaders(eq(fedoraIdStr), nullable(Instant.class))).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(eq(fedoraId), nullable(Instant.class))).thenReturn(resourceHeaders);
     }
 
     @After
@@ -163,7 +163,7 @@ public class ResourceFactoryImplTest {
 
     @Test(expected = PathNotFoundException.class)
     public void getResource_ObjectNotFound() throws Exception {
-        when(psSession.getHeaders(fedoraIdStr, null)).thenThrow(PersistentItemNotFoundException.class);
+        when(psSession.getHeaders(fedoraId, null)).thenThrow(PersistentItemNotFoundException.class);
 
         factory.getResource(fedoraId);
     }
@@ -199,7 +199,7 @@ public class ResourceFactoryImplTest {
     public void getResource_BasicContainer_WithParent() throws Exception {
         populateHeaders(resourceHeaders, BASIC_CONTAINER);
 
-        final var parentId = FEDORA_ID_PREFIX + UUID.randomUUID().toString();
+        final var parentId = FedoraId.create(FEDORA_ID_PREFIX + UUID.randomUUID().toString());
         resourceHeaders.setParent(parentId);
 
         final var parentHeaders = new ResourceHeadersImpl();
@@ -216,7 +216,7 @@ public class ResourceFactoryImplTest {
 
         final var parentResc = resc.getParent();
         assertTrue("Parent must be a container", parentResc instanceof Container);
-        assertEquals(parentId, parentResc.getId());
+        assertEquals(parentId, parentResc.getFedoraId());
         assertStateFieldsMatches(parentResc);
     }
 
@@ -296,7 +296,7 @@ public class ResourceFactoryImplTest {
 
     @Test(expected = RepositoryRuntimeException.class)
     public void getResource_Binary_StorageException() throws Exception {
-        when(psSession.getHeaders(fedoraIdStr, null)).thenThrow(new PersistentStorageException("Boom"));
+        when(psSession.getHeaders(fedoraId, null)).thenThrow(new PersistentStorageException("Boom"));
 
         populateHeaders(resourceHeaders, NON_RDF_SOURCE);
         populateInternalBinaryHeaders(resourceHeaders);
@@ -325,13 +325,12 @@ public class ResourceFactoryImplTest {
 
     @Test
     public void getNonRdfSourceDescription() throws Exception {
-        final String descId = FEDORA_ID_PREFIX + "/object1/fcr:metadata";
-        final FedoraId descFedoraId = FedoraId.create(descId);
+        final FedoraId descFedoraId = FedoraId.create(FEDORA_ID_PREFIX + "/object1/fcr:metadata");
 
         final var headers = new ResourceHeadersImpl();
-        headers.setId(descId);
+        headers.setId(descFedoraId);
         populateHeaders(headers, ResourceFactory.createResource(FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI));
-        when(psSession.getHeaders(descId, null)).thenReturn(headers);
+        when(psSession.getHeaders(descFedoraId, null)).thenReturn(headers);
 
         final var resc = factory.getResource(descFedoraId);
         assertTrue("Factory must return a NonRdfSourceDescripton", resc instanceof NonRdfSourceDescriptionImpl);
@@ -404,7 +403,7 @@ public class ResourceFactoryImplTest {
      */
     @Test(expected = RepositoryRuntimeException.class)
     public void doesResourceExist_Exception_WithSession() throws Exception {
-        when(psSession.getHeaders(fedoraMementoId.getResourceId(), fedoraMementoId.getMementoInstant()))
+        when(psSession.getHeaders(fedoraMementoId, fedoraMementoId.getMementoInstant()))
                 .thenThrow(PersistentSessionClosedException.class);
         factory.doesResourceExist(mockTx, fedoraMementoId);
     }
@@ -414,7 +413,7 @@ public class ResourceFactoryImplTest {
      */
     @Test(expected = RepositoryRuntimeException.class)
     public void doesResourceExist_Exception_WithoutSession() throws Exception {
-        when(psSession.getHeaders(fedoraMementoId.getResourceId(), fedoraMementoId.getMementoInstant()))
+        when(psSession.getHeaders(fedoraMementoId, fedoraMementoId.getMementoInstant()))
                 .thenThrow(PersistentSessionClosedException.class);
         factory.doesResourceExist(null, fedoraMementoId);
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
@@ -64,7 +64,7 @@ public class TimeMapImplTest {
     @Mock
     private ResourceFactory resourceFactory;
 
-    private final String defaultId = FEDORA_ID_PREFIX + "resource";
+    private final String defaultId = FEDORA_ID_PREFIX + "/resource";
 
     private TimeMapImpl timeMap;
 
@@ -144,9 +144,9 @@ public class TimeMapImplTest {
     private List<FedoraResource> mockListVersions(final String id, final Instant... versions)
             throws PersistentStorageException, PathNotFoundException {
         if (versions.length == 0) {
-            when(session.listVersions(id)).thenReturn(Collections.emptyList());
+            when(session.listVersions(FedoraId.create(id))).thenReturn(Collections.emptyList());
         } else {
-            when(session.listVersions(id)).thenReturn(List.of(versions));
+            when(session.listVersions(FedoraId.create(id))).thenReturn(List.of(versions));
         }
 
         final var mementos = new ArrayList<FedoraResource>();

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImplTest.java
@@ -284,19 +284,19 @@ public class EventAccumulatorImplTest {
     }
 
     private ResourceOperation createOp(final FedoraId fedoraId) {
-        return new RdfSourceOperationFactoryImpl().createBuilder(fedoraId.getResourceId(), RDF_SOURCE.toString())
+        return new RdfSourceOperationFactoryImpl().createBuilder(fedoraId, RDF_SOURCE.toString())
                 .userPrincipal(USER)
                 .build();
     }
 
     private ResourceOperation updateOp(final FedoraId fedoraId) {
-        return new RdfSourceOperationFactoryImpl().updateBuilder(fedoraId.getResourceId())
+        return new RdfSourceOperationFactoryImpl().updateBuilder(fedoraId)
                 .userPrincipal(USER)
                 .build();
     }
 
     private ResourceOperation deleteOp(final FedoraId fedoraId) {
-        return new DeleteResourceOperationFactoryImpl().deleteBuilder(fedoraId.getResourceId())
+        return new DeleteResourceOperationFactoryImpl().deleteBuilder(fedoraId)
                 .userPrincipal(USER)
                 .build();
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilderTest.java
@@ -46,7 +46,7 @@ public class ResourceOperationEventBuilderTest {
     @Test
     public void buildCreateEventFromCreateRdfOperation() {
         final var operation = new RdfSourceOperationFactoryImpl()
-                .createBuilder(FEDORA_ID.getResourceId(), RDF_SOURCE.toString())
+                .createBuilder(FEDORA_ID, RDF_SOURCE.toString())
                 .userPrincipal(USER)
                 .build();
 
@@ -62,7 +62,7 @@ public class ResourceOperationEventBuilderTest {
         final var fedoraId = FedoraId.create("/test/ab/c");
         final var user = "user2";
         final var operation = new NonRdfSourceOperationFactoryImpl()
-                .createInternalBinaryBuilder(fedoraId.getResourceId(), new ByteArrayInputStream(new byte[]{}))
+                .createInternalBinaryBuilder(fedoraId, new ByteArrayInputStream(new byte[]{}))
                 .userPrincipal(user)
                 .build();
 
@@ -80,7 +80,7 @@ public class ResourceOperationEventBuilderTest {
 
     @Test
     public void buildCreateEventFromVersionOperation() {
-        final var operation = new VersionResourceOperationFactoryImpl().createBuilder(FEDORA_ID.getResourceId())
+        final var operation = new VersionResourceOperationFactoryImpl().createBuilder(FEDORA_ID)
                 .userPrincipal(USER)
                 .build();
 
@@ -93,7 +93,7 @@ public class ResourceOperationEventBuilderTest {
 
     @Test
     public void buildDeleteEventFromDeleteOperation() {
-        final var operation = new DeleteResourceOperationFactoryImpl().deleteBuilder(FEDORA_ID.getResourceId())
+        final var operation = new DeleteResourceOperationFactoryImpl().deleteBuilder(FEDORA_ID)
                 .userPrincipal(USER)
                 .build();
 
@@ -106,7 +106,7 @@ public class ResourceOperationEventBuilderTest {
 
     @Test
     public void buildUpdateEventFromUpdateRdfOperation() {
-        final var operation = new RdfSourceOperationFactoryImpl().updateBuilder(FEDORA_ID.getResourceId())
+        final var operation = new RdfSourceOperationFactoryImpl().updateBuilder(FEDORA_ID)
                 .userPrincipal(USER)
                 .build();
 
@@ -120,7 +120,7 @@ public class ResourceOperationEventBuilderTest {
     @Test
     public void buildUpdateEventFromUpdateNonRdfOperation() {
         final var operation = new NonRdfSourceOperationFactoryImpl()
-                .updateInternalBinaryBuilder(FEDORA_ID.getResourceId(), new ByteArrayInputStream(new byte[]{}))
+                .updateInternalBinaryBuilder(FEDORA_ID, new ByteArrayInputStream(new byte[]{}))
                 .userPrincipal(USER)
                 .build();
 
@@ -134,7 +134,7 @@ public class ResourceOperationEventBuilderTest {
     @Test
     public void mergeValidObjects() {
         final var createOperation = new RdfSourceOperationFactoryImpl()
-                .createBuilder(FEDORA_ID.getResourceId(), RDF_SOURCE.toString())
+                .createBuilder(FEDORA_ID, RDF_SOURCE.toString())
                 .userPrincipal(USER)
                 .build();
 
@@ -142,7 +142,7 @@ public class ResourceOperationEventBuilderTest {
                 .withBaseUrl(BASE_URL);
 
         final var updateOperation = new NonRdfSourceOperationFactoryImpl()
-                .updateInternalBinaryBuilder(FEDORA_ID.getResourceId(), new ByteArrayInputStream(new byte[]{}))
+                .updateInternalBinaryBuilder(FEDORA_ID, new ByteArrayInputStream(new byte[]{}))
                 .userPrincipal(USER)
                 .build();
 
@@ -162,7 +162,7 @@ public class ResourceOperationEventBuilderTest {
     @Test
     public void populateOtherEventFields() {
         final var operation = new NonRdfSourceOperationFactoryImpl()
-                .updateInternalBinaryBuilder(FEDORA_ID.getResourceId(), new ByteArrayInputStream(new byte[]{}))
+                .updateInternalBinaryBuilder(FEDORA_ID, new ByteArrayInputStream(new byte[]{}))
                 .userPrincipal(USER)
                 .build();
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderTest.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.impl.operations;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.io.IOUtils;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ExternalContent;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
@@ -39,7 +40,7 @@ public class CreateNonRdfSourceOperationBuilderTest {
 
     private NonRdfSourceOperationBuilder internalBuilder;
 
-    final String resourceId = "info:fedora/test-subject";
+    final FedoraId resourceId = FedoraId.create("info:fedora/test-subject");
 
     @Before
     public void setUp() throws Exception {

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/CreateRdfSourceOperationBuilderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/CreateRdfSourceOperationBuilderTest.java
@@ -39,6 +39,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
@@ -56,11 +57,11 @@ public class CreateRdfSourceOperationBuilderTest {
 
     private RdfStream stream;
 
-    private static final String PARENT_ID = "info:fedora/parent";
+    private static final FedoraId PARENT_ID = FedoraId.create("info:fedora/parent");
 
-    private static final String RESOURCE_ID = "info:fedora/test-subject";
+    private static final FedoraId RESOURCE_ID = FedoraId.create("info:fedora/test-subject");
 
-    private final Node id = ResourceFactory.createResource(RESOURCE_ID).asNode();
+    private final Node id = ResourceFactory.createResource(RESOURCE_ID.getResourceId()).asNode();
 
     private static final String PROPERTY_ID = "http://example.org/isLinkedTo/";
 
@@ -81,7 +82,7 @@ public class CreateRdfSourceOperationBuilderTest {
         builder = new CreateRdfSourceOperationBuilderImpl(RESOURCE_ID, RDF_SOURCE.toString());
         model = ModelFactory.createDefaultModel();
         model.add(
-                ResourceFactory.createResource(RESOURCE_ID),
+                ResourceFactory.createResource(RESOURCE_ID.getResourceId()),
                 ResourceFactory.createProperty(PROPERTY_ID),
                 ResourceFactory.createPlainLiteral(OBJECT_VALUE)
         );
@@ -100,7 +101,7 @@ public class CreateRdfSourceOperationBuilderTest {
 
     @Test
     public void testRelaxedPropertiesAllFields() {
-        final var resc = model.getResource(RESOURCE_ID);
+        final var resc = model.getResource(RESOURCE_ID.getResourceId());
         resc.addLiteral(LAST_MODIFIED_DATE, Date.from(MODIFIED_INSTANT));
         resc.addLiteral(LAST_MODIFIED_BY, USER_PRINCIPAL);
         resc.addLiteral(CREATED_DATE, Date.from(CREATED_INSTANT));
@@ -116,7 +117,7 @@ public class CreateRdfSourceOperationBuilderTest {
 
     @Test
     public void testRelaxedPropertiesNonDate() {
-        final var resc = model.getResource(RESOURCE_ID);
+        final var resc = model.getResource(RESOURCE_ID.getResourceId());
         resc.addLiteral(LAST_MODIFIED_DATE, "Notadate");
         resc.addLiteral(LAST_MODIFIED_BY, USER_PRINCIPAL);
         resc.addLiteral(CREATED_DATE, "Notadate");
@@ -132,7 +133,7 @@ public class CreateRdfSourceOperationBuilderTest {
 
     @Test
     public void testRelaxedPropertiesNotRelaxed() {
-        final var resc = model.getResource(RESOURCE_ID);
+        final var resc = model.getResource(RESOURCE_ID.getResourceId());
         resc.addLiteral(LAST_MODIFIED_DATE, Date.from(MODIFIED_INSTANT));
         resc.addLiteral(LAST_MODIFIED_BY, USER_PRINCIPAL);
         resc.addLiteral(CREATED_DATE, Date.from(CREATED_INSTANT));

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/NonRdfSourceOperationFactoryImplTest.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.impl.operations;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.io.IOUtils;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
 import org.junit.Before;
@@ -36,12 +37,12 @@ public class NonRdfSourceOperationFactoryImplTest {
 
     private NonRdfSourceOperationFactory factory;
 
-    private String randomId;
+    private FedoraId randomId;
 
     @Before
     public void setUp() throws Exception {
         factory = new NonRdfSourceOperationFactoryImpl();
-        randomId = UUID.randomUUID().toString();
+        randomId = FedoraId.create(UUID.randomUUID().toString());
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/RdfSourceOperationFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/RdfSourceOperationFactoryImplTest.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.impl.operations;
 
 import static org.junit.Assert.assertEquals;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.junit.Before;
@@ -32,13 +33,13 @@ import java.util.UUID;
 public class RdfSourceOperationFactoryImplTest {
 
     private RdfSourceOperationFactory factory;
-    private String randomId;
+    private FedoraId randomId;
 
 
     @Before
     public void setUp() {
         factory = new RdfSourceOperationFactoryImpl();
-        randomId = UUID.randomUUID().toString();
+        randomId = FedoraId.create(UUID.randomUUID().toString());
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilderTest.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.util.Collection;
 
 import org.apache.commons.io.IOUtils;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationBuilder;
 import org.junit.Test;
@@ -38,13 +39,13 @@ import org.junit.Test;
  */
 public class UpdateNonRdfSourceOperationBuilderTest {
 
-    private final String RESOURCE_ID = "info:fedora/test-subject";
+    private final FedoraId RESOURCE_ID = FedoraId.create("info:fedora/test-subject");
 
     private final String MIME_TYPE = "text/plain";
 
     private final String FILENAME = "someFile.txt";
 
-    private final Long FILESIZE = 123l;
+    private final Long FILESIZE = 123L;
 
     private final Collection<URI> DIGESTS = asList(URI.create("urn:sha1:1234abcd"), URI.create("urn:md5:zyxw9876"));
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -200,7 +200,7 @@ public class CreateResourceServiceImplTest {
     public void testNoParentRdf() throws Exception {
         final FedoraId fedoraId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraId childId = fedoraId.resolve("child");
-        when(psSession.getHeaders(fedoraId.getFullId(), null)).thenThrow(PersistentItemNotFoundException.class);
+        when(psSession.getHeaders(fedoraId, null)).thenThrow(PersistentItemNotFoundException.class);
         createResourceService.perform(TX_ID, USER_PRINCIPAL, childId, null, model);
     }
 
@@ -213,7 +213,7 @@ public class CreateResourceServiceImplTest {
         final FedoraId childId = fedoraId.resolve("child");
         containmentIndex.addContainedBy(TX_ID, rootId, fedoraId);
         when(resourceHeaders.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
-        when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         createResourceService.perform(TX_ID, USER_PRINCIPAL, childId, null, model);
     }
 
@@ -226,7 +226,7 @@ public class CreateResourceServiceImplTest {
         final FedoraId childId = fedoraId.resolve("child");
         containmentIndex.addContainedBy(TX_ID, rootId, fedoraId);
         when(resourceHeaders.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
-        when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         createResourceService.perform(TX_ID, USER_PRINCIPAL, childId, null, FILENAME, CONTENT_SIZE, null,
                 DIGESTS, null, null);
     }
@@ -241,7 +241,7 @@ public class CreateResourceServiceImplTest {
         final FedoraId childId = fedoraId.resolve("child");
         containmentIndex.addContainedBy(TX_ID, rootId, fedoraId);
         when(resourceHeaders.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
-        when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         createResourceService.perform(TX_ID, USER_PRINCIPAL, childId, null, FILENAME, CONTENT_SIZE, null,
                 DIGESTS, null, extContent);
     }
@@ -254,7 +254,7 @@ public class CreateResourceServiceImplTest {
         final FedoraId fedoraId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraId childId = fedoraId.resolve("child");
         containmentIndex.addContainedBy(TX_ID, rootId, fedoraId);
-        when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
         createResourceService.perform(TX_ID, USER_PRINCIPAL, childId, null, model);
         cleanupList.add(fedoraId);
@@ -274,7 +274,7 @@ public class CreateResourceServiceImplTest {
         final FedoraId fedoraId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraId childId = fedoraId.resolve("child");
         containmentIndex.addContainedBy(TX_ID, rootId, fedoraId);
-        when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
         createResourceService.perform(TX_ID, USER_PRINCIPAL, childId, CONTENT_TYPE,
                 FILENAME, CONTENT_SIZE, null, DIGESTS, null, null);
@@ -309,8 +309,8 @@ public class CreateResourceServiceImplTest {
         resc.addLiteral(CREATED_DATE, Date.from(createdDate));
         resc.addLiteral(CREATED_BY, relaxedUser);
 
-        when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
-        when(psSession.getHeaders(childId.getFullId(), null)).thenThrow(PersistentItemNotFoundException.class);
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(childId, null)).thenThrow(PersistentItemNotFoundException.class);
 
         when(resourceHeaders.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
         try {
@@ -348,8 +348,8 @@ public class CreateResourceServiceImplTest {
         final FedoraId childId = fedoraId.resolve("testSlug");
         containmentIndex.addContainedBy(TX_ID, fedoraId, childId);
         containmentIndex.commitTransaction(transaction.getId());
-        when(psSession.getHeaders(fedoraId.getFullId(), null)).thenReturn(resourceHeaders);
-        when(psSession.getHeaders(childId.getFullId(), null)).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);
+        when(psSession.getHeaders(childId, null)).thenReturn(resourceHeaders);
         when(resourceHeaders.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
         createResourceService.perform(TX_ID, USER_PRINCIPAL, childId,
                 CONTENT_TYPE, FILENAME, CONTENT_SIZE, null, DIGESTS, null, null);
@@ -358,7 +358,7 @@ public class CreateResourceServiceImplTest {
         final List<ResourceOperation> operations = operationCaptor.getAllValues();
         final var operation = getOperation(operations, CreateNonRdfSourceOperation.class);
         final FedoraId persistedId = operation.getResourceId();
-        assertNotEquals(fedoraId.getFullId(), persistedId);
+        assertNotEquals(fedoraId, persistedId);
         assertEquals(childId, persistedId);
         assertTrue(persistedId.getFullId().startsWith(fedoraId.getFullId()));
         assertBinaryPropertiesPresent(operation);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -148,7 +148,7 @@ public class CreateResourceServiceImplTest {
 
     private static final String CONTENT_TYPE = "text/html";
 
-    private static final Long CONTENT_SIZE = 100l;
+    private static final Long CONTENT_SIZE = 100L;
 
     private static final String EXTERNAL_URL = "http://example.org/rest/object";
 
@@ -259,9 +259,9 @@ public class CreateResourceServiceImplTest {
         createResourceService.perform(TX_ID, USER_PRINCIPAL, childId, null, model);
         cleanupList.add(fedoraId);
         verify(psSession).persist(operationCaptor.capture());
-        final String persistedId = operationCaptor.getValue().getResourceId();
+        final FedoraId persistedId = operationCaptor.getValue().getResourceId();
         assertNotEquals(fedoraId, persistedId);
-        assertTrue(persistedId.startsWith(fedoraId.getFullId()));
+        assertTrue(persistedId.getFullId().startsWith(fedoraId.getFullId()));
         when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
         assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
     }
@@ -282,11 +282,11 @@ public class CreateResourceServiceImplTest {
         verify(psSession, times(2)).persist(operationCaptor.capture());
         final List<ResourceOperation> operations = operationCaptor.getAllValues();
         final var operation = getOperation(operations, CreateNonRdfSourceOperation.class);
-        final String persistedId = operation.getResourceId();
+        final FedoraId persistedId = operation.getResourceId();
         assertNotEquals(fedoraId, persistedId);
-        assertTrue(persistedId.startsWith(fedoraId.getFullId()));
+        assertTrue(persistedId.getFullId().startsWith(fedoraId.getFullId()));
         assertBinaryPropertiesPresent(operation);
-        assertEquals(fedoraId.getFullId(), operation.getParentId());
+        assertEquals(fedoraId, operation.getParentId());
         when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
         assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
     }
@@ -324,10 +324,10 @@ public class CreateResourceServiceImplTest {
         verify(psSession).persist(operationCaptor.capture());
 
         final var operation = operationCaptor.getValue();
-        final String persistedId = operation.getResourceId();
+        final FedoraId persistedId = operation.getResourceId();
         assertNotEquals(fedoraId, persistedId);
-        assertTrue(persistedId.startsWith(fedoraId.getFullId()));
-        assertEquals(persistedId, childId.getFullId());
+        assertTrue(persistedId.getFullId().startsWith(fedoraId.getFullId()));
+        assertEquals(persistedId, childId);
 
         final var rdfOp = (RdfSourceOperation) operation;
         assertEquals(relaxedUser, rdfOp.getCreatedBy());
@@ -357,15 +357,15 @@ public class CreateResourceServiceImplTest {
         verify(psSession, times(2)).persist(operationCaptor.capture());
         final List<ResourceOperation> operations = operationCaptor.getAllValues();
         final var operation = getOperation(operations, CreateNonRdfSourceOperation.class);
-        final String persistedId = operation.getResourceId();
+        final FedoraId persistedId = operation.getResourceId();
         assertNotEquals(fedoraId.getFullId(), persistedId);
-        assertEquals(childId.getFullId(), persistedId);
-        assertTrue(persistedId.startsWith(fedoraId.getFullId()));
+        assertEquals(childId, persistedId);
+        assertTrue(persistedId.getFullId().startsWith(fedoraId.getFullId()));
         assertBinaryPropertiesPresent(operation);
-        assertEquals(fedoraId.getFullId(), operation.getParentId());
+        assertEquals(fedoraId, operation.getParentId());
 
         final var descOperation = getOperation(operations, CreateRdfSourceOperation.class);
-        assertEquals(persistedId + "/fcr:metadata", descOperation.getResourceId());
+        assertEquals(persistedId.asDescription(), descOperation.getResourceId());
         when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
         assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -105,14 +105,11 @@ public class DeleteResourceServiceImplTest {
     @InjectMocks
     private DeleteResourceServiceImpl service;
 
-    private static final String RESOURCE_ID =  FEDORA_ID_PREFIX + "test-resource";
-    private static final FedoraId RESOURCE_FEDORA_ID = FedoraId.create(RESOURCE_ID);
-    private static final String CHILD_RESOURCE_ID = FEDORA_ID_PREFIX + "test-resource-child";
-    private static final FedoraId CHILD_RESOURCE_FEDORA_ID = FedoraId.create(CHILD_RESOURCE_ID);
-    private static final String RESOURCE_DESCRIPTION_ID = FEDORA_ID_PREFIX + "test-resource-description";
-    private static final FedoraId RESOURCE_DESCRIPTION_FEDORA_ID = FedoraId.create(RESOURCE_DESCRIPTION_ID);
-    private static final String RESOURCE_ACL_ID = FEDORA_ID_PREFIX + "test-resource-acl";
-    private static final FedoraId RESOURCE_ACL_FEDORA_ID = FedoraId.create(RESOURCE_ACL_ID);
+    private static final FedoraId RESOURCE_ID = FedoraId.create(FEDORA_ID_PREFIX + "test-resource");
+    private static final FedoraId CHILD_RESOURCE_ID = FedoraId.create(FEDORA_ID_PREFIX + "test-resource-child");
+    private static final FedoraId RESOURCE_DESCRIPTION_ID =
+            FedoraId.create(FEDORA_ID_PREFIX + "test-resource-description");
+    private static final FedoraId RESOURCE_ACL_ID = FedoraId.create(FEDORA_ID_PREFIX + "test-resource-acl");
 
     @Before
     public void setup() {
@@ -124,7 +121,7 @@ public class DeleteResourceServiceImplTest {
         setField(service, "deleteResourceFactory", factoryImpl);
         setField(service, "containmentIndex", containmentIndex);
         setField(service, "eventAccumulator", eventAccumulator);
-        when(container.getFedoraId()).thenReturn(RESOURCE_FEDORA_ID);
+        when(container.getFedoraId()).thenReturn(RESOURCE_ID);
     }
 
     @After
@@ -142,18 +139,18 @@ public class DeleteResourceServiceImplTest {
 
         service.perform(tx, container, USER);
         containmentIndex.commitTransaction(tx.getId());
-        verifyResourceOperation(RESOURCE_FEDORA_ID, operationCaptor, pSession);
+        verifyResourceOperation(RESOURCE_ID, operationCaptor, pSession);
     }
 
     @Test
     public void testRecursiveDelete() throws Exception {
         when(container.isAcl()).thenReturn(false);
         when(container.getAcl()).thenReturn(null);
-        when(childContainer.getFedoraId()).thenReturn(CHILD_RESOURCE_FEDORA_ID);
+        when(childContainer.getFedoraId()).thenReturn(CHILD_RESOURCE_ID);
         when(childContainer.isAcl()).thenReturn(false);
         when(childContainer.getAcl()).thenReturn(null);
 
-        when(resourceFactory.getResource(tx, CHILD_RESOURCE_FEDORA_ID)).thenReturn(childContainer);
+        when(resourceFactory.getResource(tx, CHILD_RESOURCE_ID)).thenReturn(childContainer);
         containmentIndex.addContainedBy(tx.getId(), container.getFedoraId(), childContainer.getFedoraId());
 
         when(container.isAcl()).thenReturn(false);
@@ -177,31 +174,31 @@ public class DeleteResourceServiceImplTest {
                                          final PersistentStorageSession pSession) throws Exception {
         verify(pSession).persist(captor.capture());
         final DeleteResourceOperation containerOperation = captor.getValue();
-        assertEquals(fedoraID.getFullId(), containerOperation.getResourceId());
+        assertEquals(fedoraID, containerOperation.getResourceId());
     }
 
     @Test
     public void testAclDelete() throws Exception {
-        when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_FEDORA_ID);
+        when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_ID);
         when(acl.isAcl()).thenReturn(true);
         service.perform(tx, acl, USER);
-        verifyResourceOperation(RESOURCE_ACL_FEDORA_ID, operationCaptor, pSession);
+        verifyResourceOperation(RESOURCE_ACL_ID, operationCaptor, pSession);
     }
 
     @Test(expected = RepositoryRuntimeException.class)
     public void testBinaryDescriptionDelete() throws Exception {
-        when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_FEDORA_ID);
+        when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_ID);
         service.perform(tx, binaryDesc, USER);
     }
 
     @Test
     public void testBinaryDeleteWithAcl() throws Exception {
-        when(binary.getFedoraId()).thenReturn(RESOURCE_FEDORA_ID);
+        when(binary.getFedoraId()).thenReturn(RESOURCE_ID);
         when(binary.isAcl()).thenReturn(false);
         when(binary.getDescription()).thenReturn(binaryDesc);
-        when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_FEDORA_ID);
+        when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_ID);
         when(binary.getAcl()).thenReturn(acl);
-        when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_FEDORA_ID);
+        when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_ID);
 
         service.perform(tx, binary, USER);
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
@@ -107,14 +107,11 @@ public class PurgeResourceServiceImplTest {
     @InjectMocks
     private PurgeResourceServiceImpl service;
 
-    private static final String RESOURCE_ID =  FEDORA_ID_PREFIX + "test-resource";
-    private static final FedoraId RESOURCE_FEDORA_ID = FedoraId.create(RESOURCE_ID);
-    private static final String CHILD_RESOURCE_ID = FEDORA_ID_PREFIX + "test-resource-child";
-    private static final FedoraId CHILD_RESOURCE_FEDORA_ID = FedoraId.create(CHILD_RESOURCE_ID);
-    private static final String RESOURCE_DESCRIPTION_ID = FEDORA_ID_PREFIX + "test-resource-description";
-    private static final FedoraId RESOURCE_DESCRIPTION_FEDORA_ID = FedoraId.create(RESOURCE_DESCRIPTION_ID);
-    private static final String RESOURCE_ACL_ID = FEDORA_ID_PREFIX + "test-resource-acl";
-    private static final FedoraId RESOURCE_ACL_FEDORA_ID = FedoraId.create(RESOURCE_ACL_ID);
+    private static final FedoraId RESOURCE_ID =  FedoraId.create(FEDORA_ID_PREFIX + "test-resource");
+    private static final FedoraId CHILD_RESOURCE_ID = FedoraId.create(FEDORA_ID_PREFIX + "test-resource-child");
+    private static final FedoraId RESOURCE_DESCRIPTION_ID =
+            FedoraId.create(FEDORA_ID_PREFIX + "test-resource-description");
+    private static final FedoraId RESOURCE_ACL_ID = FedoraId.create(FEDORA_ID_PREFIX + "test-resource-acl");
     private static final String TX_ID = "tx-1234";
 
     @Before
@@ -126,7 +123,7 @@ public class PurgeResourceServiceImplTest {
         setField(service, "deleteResourceFactory", factoryImpl);
         setField(service, "containmentIndex", containmentIndex);
         setField(service, "eventAccumulator", eventAccumulator);
-        when(container.getFedoraId()).thenReturn(RESOURCE_FEDORA_ID);
+        when(container.getFedoraId()).thenReturn(RESOURCE_ID);
     }
 
     @Test
@@ -135,18 +132,18 @@ public class PurgeResourceServiceImplTest {
         when(container.getAcl()).thenReturn(null);
 
         service.perform(tx, container, USER);
-        verifyResourceOperation(RESOURCE_FEDORA_ID, operationCaptor, pSession);
+        verifyResourceOperation(RESOURCE_ID, operationCaptor, pSession);
     }
 
     @Test
     public void testRecursivePurge() throws Exception {
         when(container.isAcl()).thenReturn(false);
         when(container.getAcl()).thenReturn(null);
-        when(childContainer.getFedoraId()).thenReturn(CHILD_RESOURCE_FEDORA_ID);
+        when(childContainer.getFedoraId()).thenReturn(CHILD_RESOURCE_ID);
         when(childContainer.isAcl()).thenReturn(false);
         when(childContainer.getAcl()).thenReturn(null);
 
-        when(resourceFactory.getResource(tx, CHILD_RESOURCE_FEDORA_ID)).thenReturn(childContainer);
+        when(resourceFactory.getResource(tx, CHILD_RESOURCE_ID)).thenReturn(childContainer);
         containmentIndex.addContainedBy(tx.getId(), container.getFedoraId(), childContainer.getFedoraId());
         containmentIndex.commitTransaction(tx.getId());
         containmentIndex.removeContainedBy(tx.getId(), container.getFedoraId(), childContainer.getFedoraId());
@@ -171,31 +168,31 @@ public class PurgeResourceServiceImplTest {
                                          final PersistentStorageSession pSession) throws Exception {
         verify(pSession).persist(captor.capture());
         final PurgeResourceOperation containerOperation = captor.getValue();
-        assertEquals(fedoraID.getFullId(), containerOperation.getResourceId());
+        assertEquals(fedoraID, containerOperation.getResourceId());
     }
 
     @Test
     public void testAclPurge() throws Exception {
-        when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_FEDORA_ID);
+        when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_ID);
         when(acl.isAcl()).thenReturn(true);
         service.perform(tx, acl, USER);
-        verifyResourceOperation(RESOURCE_ACL_FEDORA_ID, operationCaptor, pSession);
+        verifyResourceOperation(RESOURCE_ACL_ID, operationCaptor, pSession);
     }
 
     @Test(expected = RepositoryRuntimeException.class)
     public void testBinaryDescriptionPurge() throws Exception {
-        when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_FEDORA_ID);
+        when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_ID);
         service.perform(tx, binaryDesc, USER);
     }
 
     @Test
     public void testBinaryPurgeWithAcl() throws Exception {
-        when(binary.getFedoraId()).thenReturn(RESOURCE_FEDORA_ID);
+        when(binary.getFedoraId()).thenReturn(RESOURCE_ID);
         when(binary.isAcl()).thenReturn(false);
         when(binary.getDescription()).thenReturn(binaryDesc);
-        when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_FEDORA_ID);
+        when(binaryDesc.getFedoraId()).thenReturn(RESOURCE_DESCRIPTION_ID);
         when(binary.getAcl()).thenReturn(acl);
-        when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_FEDORA_ID);
+        when(acl.getFedoraId()).thenReturn(RESOURCE_ACL_ID);
 
         service.perform(tx, binary, USER);
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
@@ -64,7 +64,7 @@ public class ReplaceBinariesServiceImplTest {
 
     private static final String USER_PRINCIPAL = "fedoraUser";
 
-    private static final String FEDORA_ID = "info:fedora/resource1";
+    private static final FedoraId FEDORA_ID = FedoraId.create("info:fedora/resource1");
 
     private static final String TX_ID = "tx-1234";
 
@@ -72,7 +72,7 @@ public class ReplaceBinariesServiceImplTest {
 
     private final String FILENAME = "someFile.txt";
 
-    private final Long FILESIZE = 123l;
+    private final Long FILESIZE = 123L;
 
     private final Collection<URI> DIGESTS = asList(URI.create("urn:sha1:1234abcd"), URI.create("urn:md5:zyxw9876"));
 
@@ -93,8 +93,6 @@ public class ReplaceBinariesServiceImplTest {
 
     private NonRdfSourceOperationFactory factory;
 
-    private FedoraId fedoraId = FedoraId.create(FEDORA_ID);
-
     @InjectMocks
     private ReplaceBinariesServiceImpl service;
 
@@ -114,7 +112,7 @@ public class ReplaceBinariesServiceImplTest {
         final String contentString = "This is some test data";
         final var stream = toInputStream(contentString, UTF_8);
 
-        service.perform(TX_ID, USER_PRINCIPAL, fedoraId, FILENAME, MIME_TYPE, DIGESTS, stream, FILESIZE,
+        service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, MIME_TYPE, DIGESTS, stream, FILESIZE,
                 null);
         verify(pSession).persist(operationCaptor.capture());
         final NonRdfSourceOperation op = operationCaptor.getValue();
@@ -130,7 +128,7 @@ public class ReplaceBinariesServiceImplTest {
         when(externalContent.getURI()).thenReturn(uri);
         when(externalContent.getHandling()).thenReturn(COPY);
 
-        service.perform(TX_ID, USER_PRINCIPAL, fedoraId, FILENAME, MIME_TYPE, DIGESTS, null, FILESIZE,
+        service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, MIME_TYPE, DIGESTS, null, FILESIZE,
                 externalContent);
         verify(pSession).persist(operationCaptor.capture());
         final NonRdfSourceOperation op = operationCaptor.getValue();
@@ -151,7 +149,7 @@ public class ReplaceBinariesServiceImplTest {
         when(externalContent.getHandling()).thenReturn(COPY);
         when(externalContent.getContentType()).thenReturn(MIME_TYPE);
 
-        service.perform(TX_ID, USER_PRINCIPAL, fedoraId, FILENAME, "application/octet-stream",
+        service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, "application/octet-stream",
                 DIGESTS, null, FILESIZE, externalContent);
         verify(pSession).persist(operationCaptor.capture());
         final NonRdfSourceOperation op = operationCaptor.getValue();
@@ -171,7 +169,7 @@ public class ReplaceBinariesServiceImplTest {
 
         final var stream = toInputStream("Some content", UTF_8);
 
-        service.perform(TX_ID, USER_PRINCIPAL, fedoraId, FILENAME, MIME_TYPE, DIGESTS, stream, FILESIZE,
+        service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, MIME_TYPE, DIGESTS, stream, FILESIZE,
                 null);
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
@@ -87,7 +87,7 @@ public class ReplacePropertiesServiceImplTest {
     @Captor
     private ArgumentCaptor<UpdateRdfSourceOperation> operationCaptor;
 
-    private static final String FEDORA_ID = "info:fedora/resource1";
+    private static final FedoraId FEDORA_ID = FedoraId.create("info:fedora/resource1");
     private static final String TX_ID = "tx-1234";
     private static final String RDF =
             "<" + FEDORA_ID + "> <" + DC.getURI() + "title> 'fancy title' .\n" +
@@ -100,7 +100,7 @@ public class ReplacePropertiesServiceImplTest {
         setField(service, "eventAccumulator", eventAccumulator);
         when(tx.getId()).thenReturn(TX_ID);
         when(psManager.getSession(anyString())).thenReturn(pSession);
-        when(resource.getId()).thenReturn(FEDORA_ID);
+        when(resource.getId()).thenReturn(FEDORA_ID.getFullId());
     }
 
     @Test
@@ -116,10 +116,10 @@ public class ReplacePropertiesServiceImplTest {
         final RdfStream stream = operationCaptor.getValue().getTriples();
         final Model captureModel = stream.collect(RdfCollectors.toModel());
 
-        assertTrue(captureModel.contains(ResourceFactory.createResource(FEDORA_ID),
+        assertTrue(captureModel.contains(ResourceFactory.createResource(FEDORA_ID.getResourceId()),
                 ResourceFactory.createProperty("http://purl.org/dc/elements/1.1/title"),
                 "another fancy title"));
-        assertTrue(captureModel.contains(ResourceFactory.createResource(FEDORA_ID),
+        assertTrue(captureModel.contains(ResourceFactory.createResource(FEDORA_ID.getResourceId()),
                 ResourceFactory.createProperty("http://purl.org/dc/elements/1.1/title"),
                 "fancy title"));
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/VersionServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/VersionServiceImplTest.java
@@ -79,7 +79,7 @@ public class VersionServiceImplTest {
         verify(session).persist(captor.capture());
         final var captured = captor.getValue();
 
-        assertEquals(fedoraId.getResourceId(), captured.getResourceId());
+        assertEquals(fedoraId, captured.getResourceId());
         assertEquals(user, captured.getUserPrincipal());
     }
 

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.List;
 
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -39,7 +40,7 @@ public interface PersistentStorageSession {
      *
      * @return the session id.
      */
-    public String getId();
+    String getId();
 
     /**
      * Perform a persistence operation on a resource
@@ -47,7 +48,7 @@ public interface PersistentStorageSession {
      * @param operation The persistence operation to perform
      * @throws PersistentStorageException Error persisting the resource.
      */
-    public void persist(final ResourceOperation operation)
+    void persist(final ResourceOperation operation)
             throws PersistentStorageException;
 
     /**
@@ -59,7 +60,7 @@ public interface PersistentStorageSession {
      * @return header information
      * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
-    public ResourceHeaders getHeaders(final String identifier, final Instant version)
+    ResourceHeaders getHeaders(final FedoraId identifier, final Instant version)
             throws PersistentStorageException;
 
     /**
@@ -71,7 +72,7 @@ public interface PersistentStorageSession {
      * @return the triples as an RdfStream.
      * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
-    public RdfStream getTriples(final String identifier, final Instant version)
+    RdfStream getTriples(final FedoraId identifier, final Instant version)
             throws PersistentStorageException;
 
     /**
@@ -83,7 +84,7 @@ public interface PersistentStorageSession {
      * @return the binary content.
      * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
-    public InputStream getBinaryContent(final String identifier, final Instant version)
+    InputStream getBinaryContent(final FedoraId identifier, final Instant version)
             throws PersistentStorageException;
 
     /**
@@ -93,20 +94,20 @@ public interface PersistentStorageSession {
      * @return The list of instants that map to the underlying versions
      * @throws PersistentStorageException  Either a PersistentItemNotFoundException or PersistentSessionClosedException
      */
-    List<Instant> listVersions(final String identifier)
+    List<Instant> listVersions(final FedoraId identifier)
             throws PersistentStorageException;
 
     /**
      * Commits any changes in the current sesssion to persistent storage.
      * @throws PersistentStorageException Error during commit.
      */
-    public void commit() throws PersistentStorageException;
+    void commit() throws PersistentStorageException;
 
     /**
      * Rolls back any changes in the current session.
      *
      * @throws PersistentStorageException Error completing rollback.
      */
-    public void rollback() throws PersistentStorageException;
+    void rollback() throws PersistentStorageException;
 
 }

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeaderUtils.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeaderUtils.java
@@ -18,6 +18,7 @@
 package org.fcrepo.persistence.common;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 
 import java.net.URI;
 import java.time.Instant;
@@ -45,11 +46,11 @@ public class ResourceHeaderUtils {
      * @param interactionModel interaction model of the resource
      * @return new resource headers object
      */
-    public static ResourceHeadersImpl newResourceHeaders(final String parentId, final String fedoraId,
-            final String interactionModel) {
+    public static ResourceHeadersImpl newResourceHeaders(final FedoraId parentId, final FedoraId fedoraId,
+                                                         final String interactionModel) {
         final ResourceHeadersImpl headers = new ResourceHeadersImpl();
-        headers.setId(fedoraId);
-        headers.setParent(parentId);
+        headers.setId(fedoraId.getFullId());
+        headers.setParent(parentId.getFullId());
         headers.setInteractionModel(interactionModel);
 
         return headers;

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeaderUtils.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeaderUtils.java
@@ -49,8 +49,8 @@ public class ResourceHeaderUtils {
     public static ResourceHeadersImpl newResourceHeaders(final FedoraId parentId, final FedoraId fedoraId,
                                                          final String interactionModel) {
         final ResourceHeadersImpl headers = new ResourceHeadersImpl();
-        headers.setId(fedoraId.getFullId());
-        headers.setParent(parentId.getFullId());
+        headers.setId(fedoraId);
+        headers.setParent(parentId);
         headers.setInteractionModel(interactionModel);
 
         return headers;

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeadersImpl.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeadersImpl.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.Collection;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 
 /**
@@ -30,9 +31,9 @@ import org.fcrepo.kernel.api.models.ResourceHeaders;
  */
 public class ResourceHeadersImpl implements ResourceHeaders {
 
-    private String id;
+    private FedoraId id;
 
-    private String parent;
+    private FedoraId parent;
 
     private String stateToken;
 
@@ -65,26 +66,26 @@ public class ResourceHeadersImpl implements ResourceHeaders {
     private boolean deleted;
 
     @Override
-    public String getId() {
+    public FedoraId getId() {
         return id;
     }
 
     /**
      * @param id the fedora id to set
      */
-    public void setId(final String id) {
+    public void setId(final FedoraId id) {
         this.id = id;
     }
 
     @Override
-    public String getParent() {
+    public FedoraId getParent() {
         return parent;
     }
 
     /**
      * @param parent the parent to set
      */
-    public void setParent(final String parent) {
+    public void setParent(final FedoraId parent) {
         this.parent = parent;
     }
 

--- a/fcrepo-persistence-common/src/test/java/org/fcrepo/persistence/common/ResourceHeaderSerializationUtilsTest.java
+++ b/fcrepo-persistence-common/src/test/java/org/fcrepo/persistence/common/ResourceHeaderSerializationUtilsTest.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.Collection;
 
 import org.apache.commons.io.IOUtils;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.junit.Test;
 
@@ -44,9 +45,9 @@ import org.junit.Test;
  */
 public class ResourceHeaderSerializationUtilsTest {
 
-    private static final String PARENT_ID = "info:fedora/parent";
+    private static final FedoraId PARENT_ID = FedoraId.create("info:fedora/parent");
 
-    private static final String RESOURCE_ID = "info:fedora/resource";
+    private static final FedoraId RESOURCE_ID = FedoraId.create("info:fedora/resource");
 
     private static final String USER_PRINCIPAL = "someUser";
 
@@ -58,7 +59,7 @@ public class ResourceHeaderSerializationUtilsTest {
 
     private static final String FILENAME = "file.txt";
 
-    private static final Long FILESIZE = 3431l;
+    private static final Long FILESIZE = 3431L;
 
     private static final Collection<URI> DIGESTS = asList(URI.create("sha1:123456789"));
 
@@ -117,8 +118,8 @@ public class ResourceHeaderSerializationUtilsTest {
 
         final var resultHeaders = deserializeHeaders(headerStream);
 
-        assertEquals(PARENT_ID, resultHeaders.getParent());
-        assertEquals(RESOURCE_ID, resultHeaders.getId());
+        assertEquals(PARENT_ID.getFullId(), resultHeaders.getParent());
+        assertEquals(RESOURCE_ID.getFullId(), resultHeaders.getId());
         assertEquals(BASIC_CONTAINER.toString(), resultHeaders.getInteractionModel());
 
         assertEquals(USER_PRINCIPAL, resultHeaders.getCreatedBy());
@@ -147,8 +148,8 @@ public class ResourceHeaderSerializationUtilsTest {
 
         final var resultHeaders = deserializeHeaders(headerStream);
 
-        assertEquals(PARENT_ID, resultHeaders.getParent());
-        assertEquals(RESOURCE_ID, resultHeaders.getId());
+        assertEquals(PARENT_ID.getFullId(), resultHeaders.getParent());
+        assertEquals(RESOURCE_ID.getFullId(), resultHeaders.getId());
         assertEquals(NON_RDF_SOURCE.toString(), resultHeaders.getInteractionModel());
 
         assertEquals(USER_PRINCIPAL, resultHeaders.getCreatedBy());

--- a/fcrepo-persistence-common/src/test/java/org/fcrepo/persistence/common/ResourceHeaderSerializationUtilsTest.java
+++ b/fcrepo-persistence-common/src/test/java/org/fcrepo/persistence/common/ResourceHeaderSerializationUtilsTest.java
@@ -118,8 +118,8 @@ public class ResourceHeaderSerializationUtilsTest {
 
         final var resultHeaders = deserializeHeaders(headerStream);
 
-        assertEquals(PARENT_ID.getFullId(), resultHeaders.getParent());
-        assertEquals(RESOURCE_ID.getFullId(), resultHeaders.getId());
+        assertEquals(PARENT_ID, resultHeaders.getParent());
+        assertEquals(RESOURCE_ID, resultHeaders.getId());
         assertEquals(BASIC_CONTAINER.toString(), resultHeaders.getInteractionModel());
 
         assertEquals(USER_PRINCIPAL, resultHeaders.getCreatedBy());
@@ -148,8 +148,8 @@ public class ResourceHeaderSerializationUtilsTest {
 
         final var resultHeaders = deserializeHeaders(headerStream);
 
-        assertEquals(PARENT_ID.getFullId(), resultHeaders.getParent());
-        assertEquals(RESOURCE_ID.getFullId(), resultHeaders.getId());
+        assertEquals(PARENT_ID, resultHeaders.getParent());
+        assertEquals(RESOURCE_ID, resultHeaders.getId());
         assertEquals(NON_RDF_SOURCE.toString(), resultHeaders.getInteractionModel());
 
         assertEquals(USER_PRINCIPAL, resultHeaders.getCreatedBy());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -40,7 +40,6 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_ROOT;
 
@@ -74,25 +73,27 @@ public class RepositoryInitializer {
 
         indexBuilder.rebuildIfNecessary();
 
+        final var root = FedoraId.getRepositoryRootId();
+
         try {
             try {
-                session.getHeaders(FEDORA_ID_PREFIX, null);
+                session.getHeaders(root, null);
             } catch (PersistentItemNotFoundException e) {
-                LOGGER.info("Repository root ({}) not found. Creating...", FEDORA_ID_PREFIX);
+                LOGGER.info("Repository root ({}) not found. Creating...", root);
                 final Stream<Triple> repositoryRootTriples = Stream.of(
-                        new Triple(createURI(FEDORA_ID_PREFIX), RDF.type.asNode(), REPOSITORY_ROOT.asNode())
+                        new Triple(createURI(root.getFullId()), RDF.type.asNode(), REPOSITORY_ROOT.asNode())
                 );
 
-                final RdfStream repositoryRootStream = new DefaultRdfStream(createURI(FEDORA_ID_PREFIX),
+                final RdfStream repositoryRootStream = new DefaultRdfStream(createURI(root.getFullId()),
                         repositoryRootTriples);
-                final RdfSourceOperation operation = this.operationFactory.createBuilder(FedoraId.getRepositoryRootId(),
+                final RdfSourceOperation operation = this.operationFactory.createBuilder(root,
                         BASIC_CONTAINER.getURI())
-                        .parentId(FedoraId.getRepositoryRootId())
+                        .parentId(root)
                         .triples(repositoryRootStream).build();
 
                 session.persist(operation);
                 session.commit();
-                LOGGER.info("Successfully create repository root ({}).", FEDORA_ID_PREFIX);
+                LOGGER.info("Successfully create repository root ({}).", root);
             }
 
         } catch (PersistentStorageException ex) {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -22,6 +22,7 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
@@ -84,8 +85,10 @@ public class RepositoryInitializer {
 
                 final RdfStream repositoryRootStream = new DefaultRdfStream(createURI(FEDORA_ID_PREFIX),
                         repositoryRootTriples);
-                final RdfSourceOperation operation = this.operationFactory.createBuilder(FEDORA_ID_PREFIX,
-                        BASIC_CONTAINER.getURI()).parentId(FEDORA_ID_PREFIX).triples(repositoryRootStream).build();
+                final RdfSourceOperation operation = this.operationFactory.createBuilder(FedoraId.getRepositoryRootId(),
+                        BASIC_CONTAINER.getURI())
+                        .parentId(FedoraId.getRepositoryRootId())
+                        .triples(repositoryRootStream).build();
 
                 session.persist(operation);
                 session.commit();

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOcflObjectIndex.java
@@ -19,6 +19,7 @@ package org.fcrepo.persistence.ocfl.api;
 
 import javax.annotation.Nonnull;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.persistence.ocfl.impl.FedoraOcflMapping;
 
 /**
@@ -43,7 +44,7 @@ public interface FedoraToOcflObjectIndex {
      * @return the mapping
      * @throws FedoraOcflMappingNotFoundException when no mapping exists for the specified identifier.
      */
-    FedoraOcflMapping getMapping(final String sessionId, final String fedoraResourceIdentifier) throws
+    FedoraOcflMapping getMapping(final String sessionId, final FedoraId fedoraResourceIdentifier) throws
             FedoraOcflMappingNotFoundException;
 
     /**
@@ -55,8 +56,8 @@ public interface FedoraToOcflObjectIndex {
      * @param ocflObjectId             The ocfl object id
      * @return  The newly created mapping
      */
-    FedoraOcflMapping addMapping(@Nonnull String sessionId, final String fedoraResourceIdentifier,
-                                 final String fedoraRootObjectIdentifier, final String ocflObjectId);
+    FedoraOcflMapping addMapping(@Nonnull String sessionId, final FedoraId fedoraResourceIdentifier,
+                                 final FedoraId fedoraRootObjectIdentifier, final String ocflObjectId);
 
     /**
      * Removes a mapping
@@ -64,7 +65,7 @@ public interface FedoraToOcflObjectIndex {
      * @param sessionId id of the current session.
      * @param fedoraResourceIdentifier The fedora resource to remove the mapping for
      */
-    void removeMapping(@Nonnull final String sessionId, final String fedoraResourceIdentifier);
+    void removeMapping(@Nonnull final String sessionId, final FedoraId fedoraResourceIdentifier);
 
     /**
      * Remove all persistent state associated with the index.

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
@@ -30,6 +30,7 @@ import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.resolv
 
 import java.util.List;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
@@ -75,11 +76,11 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
      * @throws PersistentStorageException thrown if writing fails
      */
     protected void persistNonRDFSource(final ResourceOperation operation,
-                                       final OcflObjectSession objectSession, final String rootIdentifier)
+                                       final OcflObjectSession objectSession, final FedoraId rootIdentifier)
             throws PersistentStorageException {
         final var resourceId = operation.getResourceId();
-        final var fedoraSubpath = relativizeSubpath(rootIdentifier, resourceId.getResourceId());
-        final var subpath = resolveOCFLSubpath(rootIdentifier, fedoraSubpath);
+        final var fedoraSubpath = relativizeSubpath(rootIdentifier.getResourceId(), resourceId.getResourceId());
+        final var subpath = resolveOCFLSubpath(rootIdentifier.getResourceId(), fedoraSubpath);
         log.debug("persisting ({}) to {}", resourceId, subpath);
         // write user content
         final var nonRdfSourceOperation = (NonRdfSourceOperation) operation;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
@@ -78,7 +78,7 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
                                        final OcflObjectSession objectSession, final String rootIdentifier)
             throws PersistentStorageException {
         final var resourceId = operation.getResourceId();
-        final var fedoraSubpath = relativizeSubpath(rootIdentifier, resourceId);
+        final var fedoraSubpath = relativizeSubpath(rootIdentifier, resourceId.getResourceId());
         final var subpath = resolveOCFLSubpath(rootIdentifier, fedoraSubpath);
         log.debug("persisting ({}) to {}", resourceId, subpath);
         // write user content

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -102,10 +102,10 @@ abstract class AbstractPersister implements Persister {
      * @return The associated mapping
      * @throws PersistentStorageException When no mapping is found.
      */
-    protected FedoraOcflMapping getMapping(final String transactionId, final String resourceId)
+    protected FedoraOcflMapping getMapping(final String transactionId, final FedoraId resourceId)
             throws PersistentStorageException {
         try {
-            return this.index.getMapping(transactionId, resourceId);
+            return this.index.getMapping(transactionId, resourceId.getResourceId());
         } catch (final FedoraOcflMappingNotFoundException e){
             throw new PersistentStorageException(e.getMessage());
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -105,7 +105,7 @@ abstract class AbstractPersister implements Persister {
     protected FedoraOcflMapping getMapping(final String transactionId, final FedoraId resourceId)
             throws PersistentStorageException {
         try {
-            return this.index.getMapping(transactionId, resourceId.getResourceId());
+            return this.index.getMapping(transactionId, resourceId);
         } catch (final FedoraOcflMappingNotFoundException e){
             throw new PersistentStorageException(e.getMessage());
         }
@@ -132,7 +132,7 @@ abstract class AbstractPersister implements Persister {
             final var resourceId = fedoraId.getResourceId();
 
             try {
-                final var headers = session.getHeaders(resourceId, null);
+                final var headers = session.getHeaders(fedoraId.asResourceId(), null);
                 if (headers != null && headers.isArchivalGroup()) {
                     return Optional.of(fedoraId);
                 }
@@ -156,7 +156,7 @@ abstract class AbstractPersister implements Persister {
      */
     protected String mapToOcflId(final String sessionId, final FedoraId fedoraId) {
         try {
-            final var mapping = index.getMapping(sessionId, fedoraId.getBaseId());
+            final var mapping = index.getMapping(sessionId, fedoraId.asBaseId());
             return mapping.getOcflObjectId();
         } catch (final FedoraOcflMappingNotFoundException e) {
             // If the a mapping doesn't already exist, use a one-to-one Fedora ID to OCFL ID mapping

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractRdfSourcePersister.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
@@ -65,13 +66,13 @@ abstract class AbstractRdfSourcePersister extends AbstractPersister {
      * @throws PersistentStorageException
      */
     protected void persistRDF(final OcflObjectSession session, final ResourceOperation operation,
-                              final String rootId) throws PersistentStorageException {
+                              final FedoraId rootId) throws PersistentStorageException {
 
         final RdfSourceOperation rdfSourceOp = (RdfSourceOperation)operation;
         log.debug("persisting RDFSource ({}) to OCFL", operation.getResourceId());
 
-        final String subpath = relativizeSubpath(rootId, operation.getResourceId().getResourceId());
-        final String resolvedSubpath = resolveOCFLSubpath(rootId, subpath);
+        final String subpath = relativizeSubpath(rootId.getResourceId(), operation.getResourceId().getResourceId());
+        final String resolvedSubpath = resolveOCFLSubpath(rootId.getResourceId(), subpath);
         //write user triples
         final var outcome = writeRDF(session, rdfSourceOp.getTriples(), resolvedSubpath);
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractRdfSourcePersister.java
@@ -70,7 +70,7 @@ abstract class AbstractRdfSourcePersister extends AbstractPersister {
         final RdfSourceOperation rdfSourceOp = (RdfSourceOperation)operation;
         log.debug("persisting RDFSource ({}) to OCFL", operation.getResourceId());
 
-        final String subpath = relativizeSubpath(rootId, operation.getResourceId());
+        final String subpath = relativizeSubpath(rootId, operation.getResourceId().getResourceId());
         final String resolvedSubpath = resolveOCFLSubpath(rootId, subpath);
         //write user triples
         final var outcome = writeRDF(session, rdfSourceOp.getTriples(), resolvedSubpath);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -49,12 +48,11 @@ class CreateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
     public void persist(final OcflPersistentStorageSession session, final ResourceOperation operation)
             throws PersistentStorageException {
         final var resourceId = operation.getResourceId();
-        final var fedoraId = FedoraId.create(resourceId);
         log.debug("persisting {} to {}", resourceId, session);
-        final var rootObjectId = resolveRootObjectId(fedoraId, session);
+        final var rootObjectId = resolveRootObjectId(resourceId, session);
         final String ocflId = mapToOcflId(session.getId(), rootObjectId);
         final OcflObjectSession ocflObjectSession = session.findOrCreateSession(ocflId);
         persistNonRDFSource(operation, ocflObjectSession, rootObjectId.getBaseId());
-        index.addMapping(session.getId(), resourceId, rootObjectId.getBaseId(), ocflId);
+        index.addMapping(session.getId(), resourceId.getResourceId(), rootObjectId.getBaseId(), ocflId);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
@@ -52,7 +52,7 @@ class CreateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
         final var rootObjectId = resolveRootObjectId(resourceId, session);
         final String ocflId = mapToOcflId(session.getId(), rootObjectId);
         final OcflObjectSession ocflObjectSession = session.findOrCreateSession(ocflId);
-        persistNonRDFSource(operation, ocflObjectSession, rootObjectId.getBaseId());
-        index.addMapping(session.getId(), resourceId.getResourceId(), rootObjectId.getBaseId(), ocflId);
+        persistNonRDFSource(operation, ocflObjectSession, rootObjectId.asBaseId());
+        index.addMapping(session.getId(), resourceId.asResourceId(), rootObjectId.asBaseId(), ocflId);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRdfSourcePersister.java
@@ -53,7 +53,6 @@ class CreateRdfSourcePersister extends AbstractRdfSourcePersister {
             throws PersistentStorageException {
 
         final var resourceId = operation.getResourceId();
-        final var fedoraId = FedoraId.create(resourceId);
         log.debug("persisting {} to {}", resourceId, session);
 
         final CreateResourceOperation createResourceOp = ((CreateResourceOperation)operation);
@@ -62,18 +61,18 @@ class CreateRdfSourcePersister extends AbstractRdfSourcePersister {
         final FedoraId rootObjectId;
         if (archivalGroup) {
             //if archival group, ensure that there are no archival group ancestors
-            if (findArchivalGroupInAncestry(fedoraId, session).isPresent()) {
+            if (findArchivalGroupInAncestry(resourceId, session).isPresent()) {
                 throw new PersistentItemConflictException("Nesting an ArchivalGroup within an ArchivalGroup is not " +
                         "permitted");
             }
-            rootObjectId = fedoraId;
+            rootObjectId = resourceId;
         } else {
-            rootObjectId = resolveRootObjectId(fedoraId, session);
+            rootObjectId = resolveRootObjectId(resourceId, session);
         }
 
         final String ocflObjectId = mapToOcflId(session.getId(), rootObjectId);
         final OcflObjectSession ocflObjectSession = session.findOrCreateSession(ocflObjectId);
         persistRDF(ocflObjectSession, operation, rootObjectId.getBaseId());
-        index.addMapping(session.getId(), resourceId, rootObjectId.getBaseId(), ocflObjectId);
+        index.addMapping(session.getId(), resourceId.getResourceId(), rootObjectId.getBaseId(), ocflObjectId);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateRdfSourcePersister.java
@@ -72,7 +72,7 @@ class CreateRdfSourcePersister extends AbstractRdfSourcePersister {
 
         final String ocflObjectId = mapToOcflId(session.getId(), rootObjectId);
         final OcflObjectSession ocflObjectSession = session.findOrCreateSession(ocflObjectId);
-        persistRDF(ocflObjectSession, operation, rootObjectId.getBaseId());
-        index.addMapping(session.getId(), resourceId.getResourceId(), rootObjectId.getBaseId(), ocflObjectId);
+        persistRDF(ocflObjectSession, operation, rootObjectId.asBaseId());
+        index.addMapping(session.getId(), resourceId.asResourceId(), rootObjectId.asBaseId(), ocflObjectId);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
@@ -18,7 +18,6 @@
 
 package org.fcrepo.persistence.ocfl.impl;
 
-import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
@@ -46,12 +45,11 @@ public class CreateVersionPersister extends AbstractPersister {
             throws PersistentStorageException {
 
         final var resourceId = operation.getResourceId();
-        final var fedoraId = FedoraId.create(resourceId);
         LOG.debug("creating new version of <{}> in session <{}>", resourceId, session);
 
-        final var archivalGroupId = findArchivalGroupInAncestry(fedoraId, session);
+        final var archivalGroupId = findArchivalGroupInAncestry(resourceId, session);
 
-        if (archivalGroupId.isPresent() && !archivalGroupId.get().equals(fedoraId)) {
+        if (archivalGroupId.isPresent() && !archivalGroupId.get().equals(resourceId)) {
             throw new PersistentItemConflictException(
                     String.format("Resource <%s> is contained in Archival Group <%s> and cannot be versioned directly."
                             + " Version the Archival Group instead.", resourceId, archivalGroupId));

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -27,7 +27,6 @@ import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.resolv
 import java.time.Instant;
 import java.util.Objects;
 
-import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageRuntimeException;
@@ -54,7 +53,7 @@ class DeleteResourcePersister extends AbstractPersister {
     public void persist(final OcflPersistentStorageSession session, final ResourceOperation operation)
             throws PersistentStorageException {
         final var mapping = getMapping(session.getId(), operation.getResourceId());
-        final var fedoraResourceRoot = FedoraId.create(mapping.getRootObjectIdentifier());
+        final var fedoraResourceRoot = mapping.getRootObjectIdentifier();
         final var resourceId = operation.getResourceId();
         final var objectSession = session.findOrCreateSession(mapping.getOcflObjectId());
         final var user = operation.getUserPrincipal();

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -27,6 +27,7 @@ import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.resolv
 import java.time.Instant;
 import java.util.Objects;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageRuntimeException;
@@ -53,7 +54,7 @@ class DeleteResourcePersister extends AbstractPersister {
     public void persist(final OcflPersistentStorageSession session, final ResourceOperation operation)
             throws PersistentStorageException {
         final var mapping = getMapping(session.getId(), operation.getResourceId());
-        final var fedoraResourceRoot = mapping.getRootObjectIdentifier();
+        final var fedoraResourceRoot = FedoraId.create(mapping.getRootObjectIdentifier());
         final var resourceId = operation.getResourceId();
         final var objectSession = session.findOrCreateSession(mapping.getOcflObjectId());
         final var user = operation.getUserPrincipal();
@@ -74,8 +75,9 @@ class DeleteResourcePersister extends AbstractPersister {
                 throw new PersistentStorageException(exc);
             }
         } else {
-            final var relativeSubPath = relativizeSubpath(fedoraResourceRoot, operation.getResourceId());
-            final var ocflSubPath = resolveOCFLSubpath(fedoraResourceRoot, relativeSubPath);
+            final var relativeSubPath = relativizeSubpath(fedoraResourceRoot.getResourceId(),
+                    operation.getResourceId().getResourceId());
+            final var ocflSubPath = resolveOCFLSubpath(fedoraResourceRoot.getResourceId(), relativeSubPath);
             final var headers = (ResourceHeadersImpl) readHeaders(objectSession, ocflSubPath);
             final boolean isRdf = !Objects.equals(NON_RDF_SOURCE.toString(), headers.getInteractionModel());
             final var filePath = resolveExtensions(ocflSubPath, isRdf);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOcflMapping.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOcflMapping.java
@@ -27,8 +27,8 @@ import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToStrin
  * @author dbernstein
  */
 public class FedoraOcflMapping {
-    private String rootObjectIdentifier;
-    private String ocflObjectId;
+    private final String rootObjectIdentifier;
+    private final String ocflObjectId;
 
     /**
      * Default constructor

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOcflMapping.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraOcflMapping.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 import java.util.Objects;
 
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
@@ -27,7 +29,8 @@ import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToStrin
  * @author dbernstein
  */
 public class FedoraOcflMapping {
-    private final String rootObjectIdentifier;
+
+    private final FedoraId rootObjectIdentifier;
     private final String ocflObjectId;
 
     /**
@@ -35,7 +38,7 @@ public class FedoraOcflMapping {
      * @param rootObjectIdentifier The fedora root object resource identifier
      * @param ocflObjectId The OCFL Object identitifer
      */
-    public FedoraOcflMapping(final String rootObjectIdentifier, final String ocflObjectId){
+    public FedoraOcflMapping(final FedoraId rootObjectIdentifier, final String ocflObjectId){
         this.rootObjectIdentifier = rootObjectIdentifier;
         this.ocflObjectId = ocflObjectId;
     }
@@ -44,7 +47,7 @@ public class FedoraOcflMapping {
      * The id for the fedora resource which represents this ocfl object
      * @return the fedora root object identifier
      */
-    public String getRootObjectIdentifier() {
+    public FedoraId getRootObjectIdentifier() {
         return rootObjectIdentifier;
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
@@ -33,6 +33,7 @@ import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.system.StreamRDF;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
@@ -180,9 +181,9 @@ public class OcflPersistentStorageUtils {
      * @param fedoraIdentifier The fedora identifier
      * @return The resolved topic
      */
-    public static  String resolveTopic(final String fedoraIdentifier) {
-        if (fedoraIdentifier.endsWith(FEDORA_METADATA_SUFFIX)) {
-            return fedoraIdentifier.substring(0, fedoraIdentifier.indexOf(FEDORA_METADATA_SUFFIX));
+    public static FedoraId resolveTopic(final FedoraId fedoraIdentifier) {
+        if (fedoraIdentifier.isDescription()) {
+            return FedoraId.create(fedoraIdentifier.getBaseId());
         } else {
             return fedoraIdentifier;
         }
@@ -246,7 +247,7 @@ public class OcflPersistentStorageUtils {
      * @return the RDF stream
      * @throws PersistentStorageException If unable to read the specified rdf stream.
      */
-    public static RdfStream getRdfStream(final String identifier,
+    public static RdfStream getRdfStream(final FedoraId identifier,
                                          final OcflObjectSession objSession,
                                          final String subpath,
                                          final Instant version) throws PersistentStorageException {
@@ -254,8 +255,8 @@ public class OcflPersistentStorageUtils {
         try (final InputStream is = readFile(objSession, subpath, versionId)) {
             final Model model = createDefaultModel();
             RDFDataMgr.read(model, is, DEFAULT_RDF_FORMAT.getLang());
-            final String topic = resolveTopic(identifier);
-            return DefaultRdfStream.fromModel(createURI(topic), model);
+            final FedoraId topic = resolveTopic(identifier);
+            return DefaultRdfStream.fromModel(createURI(topic.getFullId()), model);
         } catch (final IOException ex) {
             throw new PersistentStorageException(format("unable to read %s ;  version = %s", identifier, version), ex);
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
@@ -181,7 +181,7 @@ public class OcflPersistentStorageUtils {
      * @param fedoraIdentifier The fedora identifier
      * @return The resolved topic
      */
-    public static FedoraId resolveTopic(final FedoraId fedoraIdentifier) {
+    private static FedoraId resolveTopic(final FedoraId fedoraIdentifier) {
         if (fedoraIdentifier.isDescription()) {
             return FedoraId.create(fedoraIdentifier.getBaseId());
         } else {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
@@ -46,7 +45,7 @@ class PurgeResourcePersister extends AbstractPersister {
     public void persist(final OcflPersistentStorageSession session, final ResourceOperation operation)
             throws PersistentStorageException {
         final var mapping = getMapping(session.getId(), operation.getResourceId());
-        final var fedoraResourceRoot = FedoraId.create(mapping.getRootObjectIdentifier());
+        final var fedoraResourceRoot = mapping.getRootObjectIdentifier();
         final var resourceId = operation.getResourceId();
         final var objectSession = session.findOrCreateSession(mapping.getOcflObjectId());
         log.debug("Deleting {} from {}", resourceId, mapping.getOcflObjectId());
@@ -60,7 +59,7 @@ class PurgeResourcePersister extends AbstractPersister {
             final var sidecar = getSidecarSubpath(ocflSubPath);
             purgePath(sidecar, objectSession);
         }
-        index.removeMapping(session.getId(), resourceId.getResourceId());
+        index.removeMapping(session.getId(), resourceId.asResourceId());
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.DeleteResourceOperationFactory;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
@@ -89,7 +90,7 @@ public class NonRdfSourcesPersistenceIT {
     @Autowired
     private OcflPropsConfig ocflPropsConfig;
 
-    private String rescId;
+    private FedoraId rescId;
 
     @Before
     public void setup() {
@@ -104,6 +105,7 @@ public class NonRdfSourcesPersistenceIT {
                     rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
                 .filename("test.txt")
                 .mimeType("text/plain")
+                .parentId(FedoraId.getRepositoryRootId())
                 .build();
 
         storageSession.persist(op);
@@ -113,8 +115,8 @@ public class NonRdfSourcesPersistenceIT {
         final var readSession = sessionManager.getReadOnlySession();
         assertContentPersisted(BINARY_CONTENT, readSession, rescId);
 
-        final var headers = readSession.getHeaders(rescId, null);
-        assertEquals(rescId, headers.getId());
+        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
+        assertEquals(rescId.getFullId(), headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("test.txt", headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
@@ -129,6 +131,7 @@ public class NonRdfSourcesPersistenceIT {
                     rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
                 .contentDigests(asList(CONTENT_SHA1, CONTENT_MD5))
                 .mimeType("text/plain")
+                .parentId(FedoraId.getRepositoryRootId())
                 .build();
 
         storageSession.persist(op);
@@ -138,8 +141,8 @@ public class NonRdfSourcesPersistenceIT {
         final var readSession = sessionManager.getReadOnlySession();
         assertContentPersisted(BINARY_CONTENT, readSession, rescId);
 
-        final var headers = readSession.getHeaders(rescId, null);
-        assertEquals(rescId, headers.getId());
+        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
+        assertEquals(rescId.getFullId(), headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
         assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
@@ -156,14 +159,15 @@ public class NonRdfSourcesPersistenceIT {
         final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
                     rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
                 .mimeType("text/plain")
+                .parentId(FedoraId.getRepositoryRootId())
                 .build();
 
         storageSession.persist(op);
 
         assertContentPersisted(BINARY_CONTENT, storageSession, rescId);
 
-        final var headers = storageSession.getHeaders(rescId, null);
-        assertEquals(rescId, headers.getId());
+        final var headers = storageSession.getHeaders(rescId.getResourceId(), null);
+        assertEquals(rescId.getFullId(), headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
         assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
@@ -200,6 +204,7 @@ public class NonRdfSourcesPersistenceIT {
                 .filename("test.txt")
                 .mimeType("text/plain")
                 .contentDigests(asList(CONTENT_SHA1))
+                .parentId(FedoraId.getRepositoryRootId())
                 .build();
 
         storageSession.persist(op);
@@ -216,8 +221,8 @@ public class NonRdfSourcesPersistenceIT {
         final var readSession = sessionManager.getReadOnlySession();
         assertContentPersisted(UPDATED_CONTENT, readSession, rescId);
 
-        final var headers = readSession.getHeaders(rescId, null);
-        assertEquals(rescId, headers.getId());
+        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
+        assertEquals(rescId.getFullId(), headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertNull(headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
@@ -233,6 +238,7 @@ public class NonRdfSourcesPersistenceIT {
                 rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
             .filename("test.txt")
             .mimeType("text/plain")
+            .parentId(FedoraId.getRepositoryRootId())
             .build();
 
         storageSession.persist(op);
@@ -251,8 +257,8 @@ public class NonRdfSourcesPersistenceIT {
         final var readSession = sessionManager.getReadOnlySession();
         assertContentPersisted(BINARY_CONTENT, readSession, rescId);
 
-        final var headers = readSession.getHeaders(rescId, null);
-        assertEquals(rescId, headers.getId());
+        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
+        assertEquals(rescId.getFullId(), headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("test.txt", headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
@@ -265,10 +271,11 @@ public class NonRdfSourcesPersistenceIT {
     public void createInternalNonRdfResourceInAG() throws Exception {
         final var agOp = rdfSourceOpFactory.createBuilder(rescId, BASIC_CONTAINER.getURI())
                 .archivalGroup(true)
+                .parentId(FedoraId.getRepositoryRootId())
                 .build();
         storageSession.persist(agOp);
 
-        final var binId = makeRescId(rescId);
+        final var binId = rescId.resolve(UUID.randomUUID().toString());
         final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
                     binId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
                 .parentId(rescId)
@@ -281,17 +288,17 @@ public class NonRdfSourcesPersistenceIT {
 
         final var readSession = sessionManager.getReadOnlySession();
         // Check the persisted AG details
-        final var agHeaders = readSession.getHeaders(rescId, null);
-        assertEquals(rescId, agHeaders.getId());
-        assertNull(agHeaders.getParent());
+        final var agHeaders = readSession.getHeaders(rescId.getResourceId(), null);
+        assertEquals(rescId.getFullId(), agHeaders.getId());
+        assertEquals(FedoraId.getRepositoryRootId().getFullId(), agHeaders.getParent());
         assertEquals(BASIC_CONTAINER.getURI(), agHeaders.getInteractionModel());
 
         // Check the binary details
         assertContentPersisted(BINARY_CONTENT, readSession, binId);
 
-        final var headers = readSession.getHeaders(binId, null);
-        assertEquals(binId, headers.getId());
-        assertEquals(rescId, headers.getParent());
+        final var headers = readSession.getHeaders(binId.getResourceId(), null);
+        assertEquals(binId.getFullId(), headers.getId());
+        assertEquals(rescId.getFullId(), headers.getParent());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
         assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
@@ -306,6 +313,7 @@ public class NonRdfSourcesPersistenceIT {
                 .filename("test.txt")
                 .mimeType("text/plain")
                 .contentDigests(asList(CONTENT_SHA1))
+                .parentId(FedoraId.getRepositoryRootId())
                 .build();
 
         storageSession.persist(op);
@@ -320,14 +328,14 @@ public class NonRdfSourcesPersistenceIT {
 
         final var readSession = sessionManager.getReadOnlySession();
         try {
-            readSession.getBinaryContent(rescId, null);
+            readSession.getBinaryContent(rescId.getResourceId(), null);
             fail("Binary file must no longer exist");
         } catch (final PersistentItemNotFoundException e) {
             // expected
         }
 
-        final var headers = readSession.getHeaders(rescId, null);
-        assertEquals(rescId, headers.getId());
+        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
+        assertEquals(rescId.getFullId(), headers.getId());
         assertTrue("Headers must indicate object deleted", headers.isDeleted());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
     }
@@ -338,14 +346,15 @@ public class NonRdfSourcesPersistenceIT {
                     rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
                 .filename("test.txt")
                 .mimeType("text/plain")
+                .parentId(FedoraId.getRepositoryRootId())
                 .build();
 
         storageSession.persist(op);
 
         // Modify the file after staging to simulate a transmission error
         final Path ocflStagingDir = ocflPropsConfig.getFedoraOcflStaging();
-        final String rawId = StringUtils.substringAfterLast(rescId, "/");
-        final String digest = DigestUtils.sha256Hex(rescId);
+        final String rawId = StringUtils.substringAfterLast(rescId.getFullId(), "/");
+        final String digest = DigestUtils.sha256Hex(rescId.getFullId());
         final Path stagedFile = Paths.get(ocflStagingDir.toString(), storageSession.getId(), digest, rawId);
         Files.write(stagedFile, "oops".getBytes(), StandardOpenOption.APPEND);
 
@@ -359,8 +368,8 @@ public class NonRdfSourcesPersistenceIT {
     }
 
     private void assertContentPersisted(final String expectedContent, final PersistentStorageSession session,
-            final String rescId) throws Exception {
-        final var resultContent = session.getBinaryContent(rescId, null);
+            final FedoraId rescId) throws Exception {
+        final var resultContent = session.getBinaryContent(rescId.getResourceId(), null);
         assertEquals("Binary content did not match expectations",
                 expectedContent, IOUtils.toString(resultContent, UTF_8));
     }
@@ -370,12 +379,12 @@ public class NonRdfSourcesPersistenceIT {
         return sessionManager.getSession(sessionId);
     }
 
-    private String makeRescId(final String... parentIds) {
+    private FedoraId makeRescId(final String... parentIds) {
         String parents = "";
         if (parentIds != null && parentIds.length > 0) {
             parents = Arrays.stream(parentIds).map(p -> p.replace("info:fedora/", ""))
                     .collect(Collectors.joining("/", "", "/"));
         }
-        return "info:fedora/" + parents + UUID.randomUUID().toString();
+        return FedoraId.create( "info:fedora/" + parents + UUID.randomUUID().toString());
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
@@ -115,8 +115,8 @@ public class NonRdfSourcesPersistenceIT {
         final var readSession = sessionManager.getReadOnlySession();
         assertContentPersisted(BINARY_CONTENT, readSession, rescId);
 
-        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
-        assertEquals(rescId.getFullId(), headers.getId());
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("test.txt", headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
@@ -141,8 +141,8 @@ public class NonRdfSourcesPersistenceIT {
         final var readSession = sessionManager.getReadOnlySession();
         assertContentPersisted(BINARY_CONTENT, readSession, rescId);
 
-        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
-        assertEquals(rescId.getFullId(), headers.getId());
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
         assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
@@ -166,8 +166,8 @@ public class NonRdfSourcesPersistenceIT {
 
         assertContentPersisted(BINARY_CONTENT, storageSession, rescId);
 
-        final var headers = storageSession.getHeaders(rescId.getResourceId(), null);
-        assertEquals(rescId.getFullId(), headers.getId());
+        final var headers = storageSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
         assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
@@ -221,8 +221,8 @@ public class NonRdfSourcesPersistenceIT {
         final var readSession = sessionManager.getReadOnlySession();
         assertContentPersisted(UPDATED_CONTENT, readSession, rescId);
 
-        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
-        assertEquals(rescId.getFullId(), headers.getId());
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertNull(headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
@@ -257,8 +257,8 @@ public class NonRdfSourcesPersistenceIT {
         final var readSession = sessionManager.getReadOnlySession();
         assertContentPersisted(BINARY_CONTENT, readSession, rescId);
 
-        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
-        assertEquals(rescId.getFullId(), headers.getId());
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("test.txt", headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
@@ -288,17 +288,17 @@ public class NonRdfSourcesPersistenceIT {
 
         final var readSession = sessionManager.getReadOnlySession();
         // Check the persisted AG details
-        final var agHeaders = readSession.getHeaders(rescId.getResourceId(), null);
-        assertEquals(rescId.getFullId(), agHeaders.getId());
-        assertEquals(FedoraId.getRepositoryRootId().getFullId(), agHeaders.getParent());
+        final var agHeaders = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, agHeaders.getId());
+        assertEquals(FedoraId.getRepositoryRootId(), agHeaders.getParent());
         assertEquals(BASIC_CONTAINER.getURI(), agHeaders.getInteractionModel());
 
         // Check the binary details
         assertContentPersisted(BINARY_CONTENT, readSession, binId);
 
-        final var headers = readSession.getHeaders(binId.getResourceId(), null);
-        assertEquals(binId.getFullId(), headers.getId());
-        assertEquals(rescId.getFullId(), headers.getParent());
+        final var headers = readSession.getHeaders(binId, null);
+        assertEquals(binId, headers.getId());
+        assertEquals(rescId, headers.getParent());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
         assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
@@ -328,14 +328,14 @@ public class NonRdfSourcesPersistenceIT {
 
         final var readSession = sessionManager.getReadOnlySession();
         try {
-            readSession.getBinaryContent(rescId.getResourceId(), null);
+            readSession.getBinaryContent(rescId, null);
             fail("Binary file must no longer exist");
         } catch (final PersistentItemNotFoundException e) {
             // expected
         }
 
-        final var headers = readSession.getHeaders(rescId.getResourceId(), null);
-        assertEquals(rescId.getFullId(), headers.getId());
+        final var headers = readSession.getHeaders(rescId, null);
+        assertEquals(rescId, headers.getId());
         assertTrue("Headers must indicate object deleted", headers.isDeleted());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
     }
@@ -369,7 +369,7 @@ public class NonRdfSourcesPersistenceIT {
 
     private void assertContentPersisted(final String expectedContent, final PersistentStorageSession session,
             final FedoraId rescId) throws Exception {
-        final var resultContent = session.getBinaryContent(rescId.getResourceId(), null);
+        final var resultContent = session.getBinaryContent(rescId, null);
         assertEquals("Binary content did not match expectations",
                 expectedContent, IOUtils.toString(resultContent, UTF_8));
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
@@ -19,6 +19,7 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
@@ -95,9 +96,9 @@ public class CreateNonRdfSourcePersisterTest {
     @Mock
     private OcflPersistentStorageSession psSession;
 
-    private static final String RESOURCE_ID = "info:fedora/parent/child";
+    private static final FedoraId RESOURCE_ID = FedoraId.create("info:fedora/parent/child");
 
-    private static final String ROOT_RESOURCE_ID = "info:fedora/parent";
+    private static final FedoraId ROOT_RESOURCE_ID = FedoraId.create("info:fedora/parent");
 
     private static final String USER_PRINCIPAL = "fedoraUser";
 
@@ -113,7 +114,7 @@ public class CreateNonRdfSourcePersisterTest {
 
     private static final String EXTERNAL_HANDLING = "proxy";
 
-    private static final Long EXTERNAL_CONTENT_SIZE = 526632l;
+    private static final Long EXTERNAL_CONTENT_SIZE = 526632L;
 
     private CreateNonRdfSourcePersister persister;
 
@@ -122,7 +123,7 @@ public class CreateNonRdfSourcePersisterTest {
     @Before
     public void setUp() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("object-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
+        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID.getFullId());
 
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
         when(session.getObjectDigestAlgorithm()).thenReturn(DIGEST_ALGORITHM.SHA1);
@@ -135,7 +136,7 @@ public class CreateNonRdfSourcePersisterTest {
         when(nonRdfSourceOperation.getType()).thenReturn(CREATE);
         when(((CreateResourceOperation)nonRdfSourceOperation).getParentId()).thenReturn(ROOT_RESOURCE_ID);
 
-        when(psSession.getHeaders(((CreateResourceOperation) nonRdfSourceOperation).getParentId(), null))
+        when(psSession.getHeaders(((CreateResourceOperation) nonRdfSourceOperation).getParentId().getFullId(), null))
                 .thenReturn(headers);
         when(psSession.getId()).thenReturn(SESSION_ID);
 
@@ -211,7 +212,7 @@ public class CreateNonRdfSourcePersisterTest {
         final InputStream content = IOUtils.toInputStream(CONTENT_BODY, "UTF-8");
 
         when(nonRdfSourceOperation.getContentStream()).thenReturn(content);
-        when(nonRdfSourceOperation.getContentSize()).thenReturn(99l);
+        when(nonRdfSourceOperation.getContentSize()).thenReturn(99L);
         when(((CreateResourceOperation) nonRdfSourceOperation).getInteractionModel())
                 .thenReturn(NON_RDF_SOURCE.toString());
         when(headers.isArchivalGroup()).thenReturn(false);

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
@@ -123,7 +123,7 @@ public class CreateNonRdfSourcePersisterTest {
     @Before
     public void setUp() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("object-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID.getFullId());
+        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
 
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
         when(session.getObjectDigestAlgorithm()).thenReturn(DIGEST_ALGORITHM.SHA1);
@@ -136,7 +136,7 @@ public class CreateNonRdfSourcePersisterTest {
         when(nonRdfSourceOperation.getType()).thenReturn(CREATE);
         when(((CreateResourceOperation)nonRdfSourceOperation).getParentId()).thenReturn(ROOT_RESOURCE_ID);
 
-        when(psSession.getHeaders(((CreateResourceOperation) nonRdfSourceOperation).getParentId().getFullId(), null))
+        when(psSession.getHeaders(((CreateResourceOperation) nonRdfSourceOperation).getParentId(), null))
                 .thenReturn(headers);
         when(psSession.getId()).thenReturn(SESSION_ID);
 
@@ -145,7 +145,7 @@ public class CreateNonRdfSourcePersisterTest {
         persister = new CreateNonRdfSourcePersister(index);
 
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
 
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateRdfSourcePersisterTest.java
@@ -165,15 +165,15 @@ public class CreateRdfSourcePersisterTest {
         final var ocflId = "ocfl-id-1";
 
         final String sessionId = "some-id";
-        index.addMapping(sessionId, ROOT_RESOURCE_ID.getResourceId(), ROOT_RESOURCE_ID.getResourceId(), ocflId);
+        index.addMapping(sessionId, ROOT_RESOURCE_ID, ROOT_RESOURCE_ID, ocflId);
         index.commit(sessionId);
 
         when(operation.getResourceId()).thenReturn(RESOURCE_ID);
         when(((CreateResourceOperation) operation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(((CreateResourceOperation) operation).getInteractionModel()).thenReturn(RDF_SOURCE.toString());
         when(operation.getTriples()).thenReturn(userTriplesStream);
-        when(psSession.getHeaders(RESOURCE_ID.getResourceId(), null)).thenReturn(null);
-        when(psSession.getHeaders(ROOT_RESOURCE_ID.getResourceId(), null)).thenReturn(parentHeaders);
+        when(psSession.getHeaders(RESOURCE_ID, null)).thenReturn(null);
+        when(psSession.getHeaders(ROOT_RESOURCE_ID, null)).thenReturn(parentHeaders);
 
         persister.persist(psSession, operation);
 
@@ -187,7 +187,7 @@ public class CreateRdfSourcePersisterTest {
         final var headers = retrievePersistedHeaders("child");
 
         assertEquals(RDF_SOURCE.toString(), headers.getInteractionModel());
-        assertEquals(ocflId, index.getMapping(null, RESOURCE_ID.getResourceId()).getOcflObjectId());
+        assertEquals(ocflId, index.getMapping(null, RESOURCE_ID).getOcflObjectId());
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
@@ -54,7 +54,7 @@ public class CreateVersionPersisterTest {
 
     @Test
     public void setCommitToNewVersionWhenNoChildOfAg() throws PersistentStorageException {
-        final var resourceId = "info:fedora/blah";
+        final var resourceId = FedoraId.create("info:fedora/blah");
         final var ocflId = "blah";
 
         final var objectSession = addMapping(resourceId, ocflId);
@@ -66,7 +66,7 @@ public class CreateVersionPersisterTest {
 
     @Test
     public void setCommitToNewVersionWhenAg() throws PersistentStorageException {
-        final var resourceId = "info:fedora/blah";
+        final var resourceId = FedoraId.create("info:fedora/blah");
         final var ocflId = "blah";
 
         final var objectSession = addMapping(resourceId, ocflId);
@@ -78,43 +78,43 @@ public class CreateVersionPersisterTest {
 
     @Test(expected = PersistentItemConflictException.class)
     public void failVersionCreationWhenChildOfAg() throws PersistentStorageException {
-        final var resourceId = "info:fedora/ag/blah";
+        final var resourceId = FedoraId.create("info:fedora/ag/blah");
 
         expectArchivalGroup(resourceId, false);
-        expectArchivalGroup("info:fedora/ag", true);
+        expectArchivalGroup(FedoraId.create("info:fedora/ag"), true);
 
         persister.persist(session, operation(resourceId));
     }
 
     @Test(expected = PersistentStorageException.class)
     public void failVersionCreationWhenNoOclfMapping() throws PersistentStorageException {
-        final var resourceId = "info:fedora/bogus";
+        final var resourceId = FedoraId.create("info:fedora/bogus");
         final var ocflId = "blah";
 
-        addMapping("info:fedora/blah", ocflId);
+        addMapping(FedoraId.create("info:fedora/blah"), ocflId);
         expectArchivalGroup(resourceId, false);
 
         persister.persist(session, operation(resourceId));
     }
 
-    private void expectArchivalGroup(final String resourceId, final boolean isAgChild)
+    private void expectArchivalGroup(final FedoraId resourceId, final boolean isAgChild)
             throws PersistentStorageException {
         final var headers = new ResourceHeadersImpl();
         headers.setArchivalGroup(isAgChild);
         when(session.getHeaders(resourceId, null)).thenReturn(headers);
     }
 
-    private OcflObjectSession addMapping(final String resourceId, final String ocflId) {
+    private OcflObjectSession addMapping(final FedoraId resourceId, final String ocflId) {
         index.addMapping("not-used", resourceId, resourceId, ocflId);
         final var objectSession = mock(OcflObjectSession.class);
         when(session.findOrCreateSession(ocflId)).thenReturn(objectSession);
         return objectSession;
     }
 
-    private CreateVersionResourceOperation operation(final String resourceId) {
+    private CreateVersionResourceOperation operation(final FedoraId resourceId) {
         final var operation = mock(CreateVersionResourceOperation.class);
         when(operation.getType()).thenReturn(ResourceOperationType.UPDATE);
-        when(operation.getResourceId()).thenReturn(FedoraId.create(resourceId));
+        when(operation.getResourceId()).thenReturn(resourceId);
         return operation;
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.persistence.ocfl.impl;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
 import org.fcrepo.persistence.api.CommitOption;
@@ -113,7 +114,7 @@ public class CreateVersionPersisterTest {
     private CreateVersionResourceOperation operation(final String resourceId) {
         final var operation = mock(CreateVersionResourceOperation.class);
         when(operation.getType()).thenReturn(ResourceOperationType.UPDATE);
-        when(operation.getResourceId()).thenReturn(resourceId);
+        when(operation.getResourceId()).thenReturn(FedoraId.create(resourceId));
         return operation;
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.persistence.ocfl.api.FedoraOcflMappingNotFoundException;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -35,10 +36,10 @@ import java.util.UUID;
  */
 public class DbFedoraToOcflObjectIndexTest {
 
-    private static final String RESOURCE_ID_1 = "info:fedora/parent/child1";
-    private static final String RESOURCE_ID_2 = "info:fedora/parent/child2";
-    private static final String RESOURCE_ID_3 = "info:fedora/resource3";
-    private static final String ROOT_RESOURCE_ID = "info:fedora/parent";
+    private static final FedoraId RESOURCE_ID_1 = FedoraId.create("info:fedora/parent/child1");
+    private static final FedoraId RESOURCE_ID_2 = FedoraId.create("info:fedora/parent/child2");
+    private static final FedoraId RESOURCE_ID_3 = FedoraId.create("info:fedora/resource3");
+    private static final FedoraId ROOT_RESOURCE_ID = FedoraId.create("info:fedora/parent");
     private static final String OCFL_ID = "ocfl-id";
     private static final String OCFL_ID_RESOURCE_3 = "ocfl-id-resource-3";
 
@@ -174,7 +175,7 @@ public class DbFedoraToOcflObjectIndexTest {
         }
     }
 
-    private void verifyMapping(final FedoraOcflMapping mapping1, final String rootResourceId, final String ocflId) {
+    private void verifyMapping(final FedoraOcflMapping mapping1, final FedoraId rootResourceId, final String ocflId) {
         assertEquals(rootResourceId, mapping1.getRootObjectIdentifier());
         assertEquals(ocflId, mapping1.getOcflObjectId());
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.stream.Stream;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -88,7 +89,7 @@ public class DeleteResourcePersisterTest {
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream1);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
@@ -107,7 +108,7 @@ public class DeleteResourcePersisterTest {
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath.nt");
@@ -119,7 +120,7 @@ public class DeleteResourcePersisterTest {
     public void testDeleteSubPathDoesNotExist() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         when(session.read(".fcrepo/some-subpath.json")).thenThrow(
                 new PersistentStorageException("error")
@@ -131,7 +132,7 @@ public class DeleteResourcePersisterTest {
     public void testDeleteFullObjectDoesNotExist() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenThrow(new FedoraOcflMappingNotFoundException("error"));
 
         persister.persist(psSession, operation);
@@ -151,7 +152,7 @@ public class DeleteResourcePersisterTest {
         when(session.read(".fcrepo/some-ocfl-id.json")).thenReturn(rdf_header_stream);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
@@ -181,7 +182,7 @@ public class DeleteResourcePersisterTest {
         when(session.read(".fcrepo/some-ocfl-id-description.json")).thenReturn(header_stream2);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
@@ -197,7 +198,7 @@ public class DeleteResourcePersisterTest {
     public void testNotPartOfObject() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/some-wrong-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
@@ -88,9 +88,9 @@ public class DeleteResourcePersisterTest {
         final InputStream header_stream1 = new ByteArrayInputStream(header_string1.getBytes());
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream1);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
         verify(session).read(".fcrepo/some-subpath.json");
@@ -107,9 +107,9 @@ public class DeleteResourcePersisterTest {
         final InputStream header_stream = new ByteArrayInputStream(header_string.getBytes());
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath.nt");
         verify(session).read(".fcrepo/some-subpath.json");
@@ -119,9 +119,9 @@ public class DeleteResourcePersisterTest {
     @Test(expected = PersistentStorageException.class)
     public void testDeleteSubPathDoesNotExist() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         when(session.read(".fcrepo/some-subpath.json")).thenThrow(
                 new PersistentStorageException("error")
         );
@@ -131,9 +131,9 @@ public class DeleteResourcePersisterTest {
     @Test(expected = PersistentStorageException.class)
     public void testDeleteFullObjectDoesNotExist() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenThrow(new FedoraOcflMappingNotFoundException("error"));
+        when(index.getMapping(eq(SESSION_ID), any())).thenThrow(new FedoraOcflMappingNotFoundException("error"));
 
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
@@ -151,9 +151,9 @@ public class DeleteResourcePersisterTest {
         when(session.listHeadSubpaths()).thenReturn(Stream.of("some-ocfl-id.nt", ".fcrepo/some-ocfl-id.json"));
         when(session.read(".fcrepo/some-ocfl-id.json")).thenReturn(rdf_header_stream);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
         verify(session).delete("some-ocfl-id.nt");
@@ -181,9 +181,9 @@ public class DeleteResourcePersisterTest {
         when(session.read(".fcrepo/some-ocfl-id.json")).thenReturn(header_stream1);
         when(session.read(".fcrepo/some-ocfl-id-description.json")).thenReturn(header_stream2);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
         verify(session).delete("some-ocfl-id");
@@ -197,9 +197,9 @@ public class DeleteResourcePersisterTest {
     @Test(expected = IllegalArgumentException.class)
     public void testNotPartOfObject() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/some-wrong-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/some-wrong-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         persister.persist(psSession, operation);
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
@@ -187,7 +187,8 @@ public class IndexBuilderImplTest {
             throws PersistentStorageException {
         final var operation = mock(RdfSourceOperation.class, withSettings().extraInterfaces(
                 CreateResourceOperation.class));
-        when(operation.getResourceId()).thenReturn(resourceId.getResourceId());
+        when(operation.getResourceId()).thenReturn(resourceId);
+        when(((CreateResourceOperation) operation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(operation.getType()).thenReturn(CREATE);
         when(((CreateResourceOperation)operation).isArchivalGroup()).thenReturn(isArchivalGroup);
         session.persist(operation);
@@ -198,7 +199,7 @@ public class IndexBuilderImplTest {
             throws PersistentStorageException {
         final var operation = mock(NonRdfSourceOperation.class, withSettings().extraInterfaces(
                 CreateResourceOperation.class));
-        when(operation.getResourceId()).thenReturn(childId.getResourceId());
+        when(operation.getResourceId()).thenReturn(childId);
         when(operation.getType()).thenReturn(CREATE);
         final var bytes = "test".getBytes();
         final var stream = new ByteArrayInputStream(bytes);
@@ -206,7 +207,7 @@ public class IndexBuilderImplTest {
         when(operation.getContentStream()).thenReturn(stream);
         when(operation.getMimeType()).thenReturn("text/plain");
         when(operation.getFilename()).thenReturn("test");
-        when(((CreateResourceOperation)operation).getParentId()).thenReturn(parentId.getResourceId());
+        when(((CreateResourceOperation)operation).getParentId()).thenReturn(parentId);
         session.persist(operation);
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
@@ -169,7 +169,7 @@ public class IndexBuilderImplTest {
 
     private void assertDoesNotHaveOcflId(final FedoraId resourceId) {
         try {
-            index.getMapping(null, resourceId.getResourceId());
+            index.getMapping(null, resourceId);
             fail(resourceId + " should not exist in index");
         } catch (final FedoraOcflMappingNotFoundException e) {
             //do nothing - expected
@@ -179,7 +179,7 @@ public class IndexBuilderImplTest {
     private void assertHasOcflId(final String expectedOcflId, final FedoraId resourceId)
             throws FedoraOcflMappingNotFoundException {
         assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expectedOcflId,
-                index.getMapping(null, resourceId.getResourceId()).getOcflObjectId());
+                index.getMapping(null, resourceId).getOcflObjectId());
     }
 
     private void createResource(final PersistentStorageSession session,

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -23,6 +23,7 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.vocabulary.DC;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
@@ -205,7 +206,8 @@ public class OcflPersistentStorageSessionTest {
     private void mockResourceOperation(final RdfSourceOperation rdfSourceOperation, final RdfStream userStream,
                                        final String userPrincipal, final String resourceId) {
         when(rdfSourceOperation.getTriples()).thenReturn(userStream);
-        when(rdfSourceOperation.getResourceId()).thenReturn(resourceId);
+        when(rdfSourceOperation.getResourceId()).thenReturn(FedoraId.create(resourceId));
+        when(((CreateResourceOperation) rdfSourceOperation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(rdfSourceOperation.getType()).thenReturn(CREATE);
         when(rdfSourceOperation.getUserPrincipal()).thenReturn(userPrincipal);
     }
@@ -660,7 +662,7 @@ public class OcflPersistentStorageSessionTest {
 
         final var session2 = createSession(index, objectSessionFactory);
         mockResourceOperation(rdfSourceOperation, userStream, USER_PRINCIPAL, childId);
-        when(((CreateResourceOperation) rdfSourceOperation).getParentId()).thenReturn(RESOURCE_ID);
+        when(((CreateResourceOperation) rdfSourceOperation).getParentId()).thenReturn(FedoraId.create(RESOURCE_ID));
 
         session2.persist(rdfSourceOperation);
         session2.commit();
@@ -802,7 +804,8 @@ public class OcflPersistentStorageSessionTest {
         final var contentStream = new ByteArrayInputStream(content.getBytes());
         when(binOperation.getContentStream()).thenReturn(contentStream);
         when(binOperation.getContentSize()).thenReturn((long) content.length());
-        when(binOperation.getResourceId()).thenReturn(resourceId);
+        when(binOperation.getResourceId()).thenReturn(FedoraId.create(resourceId));
+        when(((CreateResourceOperation) binOperation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(binOperation.getType()).thenReturn(CREATE);
         when(binOperation.getUserPrincipal()).thenReturn(userPrincipal);
         return binOperation;

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -117,17 +117,17 @@ public class OcflPersistentStorageSessionTest {
 
     private DefaultOcflObjectSessionFactory objectSessionFactory;
 
-    private static final String ROOT_OBJECT_ID = "info:fedora/resource1";
+    private static final FedoraId ROOT_OBJECT_ID = FedoraId.create("info:fedora/resource1");
 
-    private static final String RESOURCE_ID = ROOT_OBJECT_ID;
+    private static final FedoraId RESOURCE_ID = ROOT_OBJECT_ID;
 
-    private static final String OCFL_RESOURCE_ID = RESOURCE_ID;
+    private static final String OCFL_RESOURCE_ID = RESOURCE_ID.getResourceId();
 
-    private static final String ROOT_OBJECT_ID_2 = "info:fedora/resource2";
+    private static final FedoraId ROOT_OBJECT_ID_2 = FedoraId.create("info:fedora/resource2");
 
-    private static final String RESOURCE_ID2 = ROOT_OBJECT_ID_2;
+    private static final FedoraId RESOURCE_ID2 = ROOT_OBJECT_ID_2;
 
-    private static final String OCFL_RESOURCE_ID2 = RESOURCE_ID2;
+    private static final String OCFL_RESOURCE_ID2 = RESOURCE_ID2.getResourceId();
 
     private static final String USER_PRINCIPAL = "fedoraUser";
 
@@ -179,51 +179,52 @@ public class OcflPersistentStorageSessionTest {
                 objectSessionFactory);
     }
 
-    private void mockNoIndex(final String resourceId) throws FedoraOcflMappingNotFoundException {
-        when(index.getMapping(any(), eq(resourceId))).thenThrow(new FedoraOcflMappingNotFoundException(resourceId));
+    private void mockNoIndex(final FedoraId resourceId) throws FedoraOcflMappingNotFoundException {
+        when(index.getMapping(any(), eq(resourceId)))
+                .thenThrow(new FedoraOcflMappingNotFoundException(resourceId.getFullId()));
     }
 
-    private void mockMappingAndIndexWithNoIndex(final String ocflObjectId, final String resourceId,
-                                                final String rootObjectId, final FedoraOcflMapping mapping)
+    private void mockMappingAndIndexWithNoIndex(final String ocflObjectId, final FedoraId resourceId,
+                                                final FedoraId rootObjectId, final FedoraOcflMapping mapping)
             throws FedoraOcflMappingNotFoundException {
         mockMapping(ocflObjectId, rootObjectId, mapping);
         when(index.getMapping(any(), eq(resourceId)))
-                .thenThrow(new FedoraOcflMappingNotFoundException(resourceId))
+                .thenThrow(new FedoraOcflMappingNotFoundException(resourceId.getFullId()))
                 .thenReturn(mapping);
     }
 
-    private void mockMappingAndIndex(final String ocflObjectId, final String resourceId, final String rootObjectId,
+    private void mockMappingAndIndex(final String ocflObjectId, final FedoraId resourceId, final FedoraId rootObjectId,
                                      final FedoraOcflMapping mapping) throws FedoraOcflMappingNotFoundException {
         mockMapping(ocflObjectId, rootObjectId, mapping);
         when(index.getMapping(anyString(), eq(resourceId))).thenReturn(mapping);
     }
 
-    private void mockMapping(final String ocflObjectId, final String rootObjectId, final FedoraOcflMapping mapping) {
+    private void mockMapping(final String ocflObjectId, final FedoraId rootObjectId, final FedoraOcflMapping mapping) {
         when(mapping.getOcflObjectId()).thenReturn(ocflObjectId);
         when(mapping.getRootObjectIdentifier()).thenReturn(rootObjectId);
     }
 
     private void mockResourceOperation(final RdfSourceOperation rdfSourceOperation, final RdfStream userStream,
-                                       final String userPrincipal, final String resourceId) {
+                                       final String userPrincipal, final FedoraId resourceId) {
         when(rdfSourceOperation.getTriples()).thenReturn(userStream);
-        when(rdfSourceOperation.getResourceId()).thenReturn(FedoraId.create(resourceId));
+        when(rdfSourceOperation.getResourceId()).thenReturn(FedoraId.create(resourceId.getFullId()));
         when(((CreateResourceOperation) rdfSourceOperation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(rdfSourceOperation.getType()).thenReturn(CREATE);
         when(rdfSourceOperation.getUserPrincipal()).thenReturn(userPrincipal);
     }
 
-    private void mockResourceOperation(final RdfSourceOperation rdfSourceOperation, final String resourceId) {
-        final Node resourceUri = createURI(resourceId);
+    private void mockResourceOperation(final RdfSourceOperation rdfSourceOperation, final FedoraId resourceId) {
+        final Node resourceUri = createURI(resourceId.getFullId());
         mockResourceOperation(rdfSourceOperation, new DefaultRdfStream(resourceUri, Stream.empty()),
                 USER_PRINCIPAL,
-                resourceUri.getURI());
+                resourceId);
     }
 
     @Test
     public void roundtripCreateContainerCreation() throws Exception {
         mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, ROOT_OBJECT_ID, mapping);
 
-        final Node resourceUri = createURI(RESOURCE_ID);
+        final Node resourceUri = createURI(RESOURCE_ID.getFullId());
 
         //create some test user triples
         final String title = "my title";
@@ -234,7 +235,7 @@ public class OcflPersistentStorageSessionTest {
         //perform the create rdf operation
         session.persist(rdfSourceOperation);
 
-        final var node = createURI(RESOURCE_ID);
+        final var node = createURI(RESOURCE_ID.getFullId());
 
         //verify get triples within the transaction
         var retrievedUserStream = session.getTriples(RESOURCE_ID, null);
@@ -274,11 +275,11 @@ public class OcflPersistentStorageSessionTest {
     @Test
     public void getTriplesOfBinaryDescription() throws Exception {
 
-        final String descriptionResource = RESOURCE_ID + "/" + FedoraTypes.FCR_METADATA;
+        final FedoraId descriptionResource = RESOURCE_ID.resolve(FedoraTypes.FCR_METADATA);
         mockMappingAndIndexWithNoIndex(OCFL_RESOURCE_ID, descriptionResource, ROOT_OBJECT_ID, mapping);
         mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, ROOT_OBJECT_ID, mapping);
 
-        final Node resourceUri = createURI(RESOURCE_ID);
+        final Node resourceUri = createURI(RESOURCE_ID.getFullId());
 
         //create some test user triples
         final String title = "my title";
@@ -601,7 +602,7 @@ public class OcflPersistentStorageSessionTest {
         objectSessionFactory.setAutoVersioningEnabled(true);
         mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, ROOT_OBJECT_ID, mapping);
 
-        final Node resourceUri = createURI(RESOURCE_ID);
+        final Node resourceUri = createURI(RESOURCE_ID.getFullId());
 
         //mock the operation
         final String title = "my title";
@@ -627,7 +628,7 @@ public class OcflPersistentStorageSessionTest {
 
         //verify get triples from version
         final RdfStream retrievedUserStream = newSession.getTriples(RESOURCE_ID, version);
-        final var node = createURI(RESOURCE_ID);
+        final var node = createURI(RESOURCE_ID.getFullId());
         assertEquals(node, retrievedUserStream.topic());
         assertEquals(dcTitleTriple, retrievedUserStream.findFirst().get());
     }
@@ -635,7 +636,7 @@ public class OcflPersistentStorageSessionTest {
     @Test
     public void listVersionsOfAResourceContainedInAnArchivalGroup() throws Exception {
         objectSessionFactory.setAutoVersioningEnabled(true);
-        final Node resourceUri = createURI(RESOURCE_ID);
+        final Node resourceUri = createURI(RESOURCE_ID.getFullId());
 
         mockMapping(OCFL_RESOURCE_ID, ROOT_OBJECT_ID, mapping);
         final var mappingCount = new AtomicInteger(0);
@@ -652,7 +653,7 @@ public class OcflPersistentStorageSessionTest {
         session.persist(createArchivalGroupOperation);
         session.commit();
 
-        final var childId = RESOURCE_ID + "/child";
+        final var childId = RESOURCE_ID.resolve("child");
         when(index.getMapping(anyString(), eq(childId))).thenReturn(mapping);
 
         final String title = "title";
@@ -662,7 +663,8 @@ public class OcflPersistentStorageSessionTest {
 
         final var session2 = createSession(index, objectSessionFactory);
         mockResourceOperation(rdfSourceOperation, userStream, USER_PRINCIPAL, childId);
-        when(((CreateResourceOperation) rdfSourceOperation).getParentId()).thenReturn(FedoraId.create(RESOURCE_ID));
+        when(((CreateResourceOperation) rdfSourceOperation).getParentId())
+                .thenReturn(RESOURCE_ID);
 
         session2.persist(rdfSourceOperation);
         session2.commit();
@@ -760,7 +762,7 @@ public class OcflPersistentStorageSessionTest {
     public void shouldRemoveStagingDirectoryOnCommitSuccess() throws Exception {
         mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, ROOT_OBJECT_ID, mapping);
 
-        final Node resourceUri = createURI(RESOURCE_ID);
+        final Node resourceUri = createURI(RESOURCE_ID.getFullId());
 
         final String title = "my title";
         final var dcTitleTriple = Triple.create(resourceUri, DC.title.asNode(), createLiteral(title));
@@ -780,7 +782,7 @@ public class OcflPersistentStorageSessionTest {
     public void shouldRemoveStagingDirectoryOnCommitRollback() throws Exception {
         mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, ROOT_OBJECT_ID, mapping);
 
-        final Node resourceUri = createURI(RESOURCE_ID);
+        final Node resourceUri = createURI(RESOURCE_ID.getFullId());
 
         final String title = "my title";
         final var dcTitleTriple = Triple.create(resourceUri, DC.title.asNode(), createLiteral(title));
@@ -797,14 +799,14 @@ public class OcflPersistentStorageSessionTest {
     }
 
     private NonRdfSourceOperation mockNonRdfSourceOperation(final String content,
-            final String userPrincipal, final String resourceId) {
+            final String userPrincipal, final FedoraId resourceId) {
         final var binOperation = mock(NonRdfSourceOperation.class,
                 withSettings().extraInterfaces(CreateResourceOperation.class));
 
         final var contentStream = new ByteArrayInputStream(content.getBytes());
         when(binOperation.getContentStream()).thenReturn(contentStream);
         when(binOperation.getContentSize()).thenReturn((long) content.length());
-        when(binOperation.getResourceId()).thenReturn(FedoraId.create(resourceId));
+        when(binOperation.getResourceId()).thenReturn(resourceId);
         when(((CreateResourceOperation) binOperation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(binOperation.getType()).thenReturn(CREATE);
         when(binOperation.getUserPrincipal()).thenReturn(userPrincipal);

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -87,7 +88,7 @@ public class PurgeResourcePersisterTest {
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream1);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete(".fcrepo/some-subpath.json");
@@ -104,7 +105,7 @@ public class PurgeResourcePersisterTest {
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete(".fcrepo/some-subpath.json");
@@ -114,7 +115,7 @@ public class PurgeResourcePersisterTest {
     public void testPurgeSubPathDoesNotExist() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object/some-subpath");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         doThrow(new PersistentStorageException("error"))
             .when(session).delete(".fcrepo/some-subpath.json");
@@ -125,7 +126,7 @@ public class PurgeResourcePersisterTest {
     public void testPurgeFullObjectDoesNotExist() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenThrow(new FedoraOcflMappingNotFoundException("error"));
 
         persister.persist(psSession, operation);
@@ -136,7 +137,7 @@ public class PurgeResourcePersisterTest {
     public void testPurgeFullObjectRdf() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
@@ -147,7 +148,7 @@ public class PurgeResourcePersisterTest {
     public void testPurgeFullObjectBinary() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
@@ -158,7 +159,7 @@ public class PurgeResourcePersisterTest {
     public void testNotPartOfObject() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
         when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/some-wrong-object");
-        when(operation.getResourceId()).thenReturn("info:fedora/an-ocfl-object");
+        when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
         persister.persist(psSession, operation);
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersisterTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -87,9 +88,9 @@ public class PurgeResourcePersisterTest {
         final InputStream header_stream1 = new ByteArrayInputStream(header_string1.getBytes());
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream1);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete(".fcrepo/some-subpath.json");
     }
@@ -104,9 +105,9 @@ public class PurgeResourcePersisterTest {
         final InputStream header_stream = new ByteArrayInputStream(header_string.getBytes());
         when(session.read(".fcrepo/some-subpath.json")).thenReturn(header_stream);
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         persister.persist(psSession, operation);
         verify(session).delete(".fcrepo/some-subpath.json");
     }
@@ -114,9 +115,9 @@ public class PurgeResourcePersisterTest {
     @Test(expected = PersistentStorageException.class)
     public void testPurgeSubPathDoesNotExist() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object/some-subpath"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         doThrow(new PersistentStorageException("error"))
             .when(session).delete(".fcrepo/some-subpath.json");
         persister.persist(psSession, operation);
@@ -125,9 +126,9 @@ public class PurgeResourcePersisterTest {
     @Test(expected = PersistentStorageException.class)
     public void testPurgeFullObjectDoesNotExist() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenThrow(new FedoraOcflMappingNotFoundException("error"));
+        when(index.getMapping(eq(SESSION_ID), any())).thenThrow(new FedoraOcflMappingNotFoundException("error"));
 
         persister.persist(psSession, operation);
         verify(session).delete("some-subpath");
@@ -136,9 +137,9 @@ public class PurgeResourcePersisterTest {
     @Test
     public void testPurgeFullObjectRdf() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
         verify(session).deleteObject();
@@ -147,9 +148,9 @@ public class PurgeResourcePersisterTest {
     @Test
     public void testPurgeFullObjectBinary() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/an-ocfl-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
 
         persister.persist(psSession, operation);
         verify(session).deleteObject();
@@ -158,9 +159,9 @@ public class PurgeResourcePersisterTest {
     @Test(expected = IllegalArgumentException.class)
     public void testNotPartOfObject() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("some-ocfl-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn("info:fedora/some-wrong-object");
+        when(mapping.getRootObjectIdentifier()).thenReturn(FedoraId.create("info:fedora/some-wrong-object"));
         when(operation.getResourceId()).thenReturn(FedoraId.create("info:fedora/an-ocfl-object"));
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         persister.persist(psSession, operation);
     }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/TestOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/TestOcflObjectIndex.java
@@ -19,6 +19,7 @@ package org.fcrepo.persistence.ocfl.impl;
 
 import javax.annotation.Nonnull;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.persistence.ocfl.api.FedoraOcflMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.slf4j.Logger;
@@ -35,16 +36,16 @@ public class TestOcflObjectIndex implements FedoraToOcflObjectIndex {
 
     private static Logger LOGGER = LoggerFactory.getLogger(TestOcflObjectIndex.class);
 
-    private Map<String, FedoraOcflMapping> fedoraOcflMappingMap = Collections.synchronizedMap(new HashMap<>());
+    private Map<FedoraId, FedoraOcflMapping> fedoraOcflMappingMap = Collections.synchronizedMap(new HashMap<>());
 
     @Override
-    public FedoraOcflMapping getMapping(final String transactionId, final String fedoraResourceIdentifier)
+    public FedoraOcflMapping getMapping(final String transactionId, final FedoraId fedoraResourceIdentifier)
             throws FedoraOcflMappingNotFoundException {
 
         LOGGER.debug("getting {}", fedoraResourceIdentifier);
         final FedoraOcflMapping m = fedoraOcflMappingMap.get(fedoraResourceIdentifier);
         if (m == null) {
-            throw new FedoraOcflMappingNotFoundException(fedoraResourceIdentifier);
+            throw new FedoraOcflMappingNotFoundException(fedoraResourceIdentifier.getFullId());
         }
 
         return m;
@@ -52,8 +53,8 @@ public class TestOcflObjectIndex implements FedoraToOcflObjectIndex {
 
     @Override
     public FedoraOcflMapping addMapping(@Nonnull final String transactionId,
-                                        final String fedoraResourceIdentifier,
-                                        final String fedoraRootObjectResourceId,
+                                        final FedoraId fedoraResourceIdentifier,
+                                        final FedoraId fedoraRootObjectResourceId,
                                         final String ocflObjectId) {
         FedoraOcflMapping mapping = fedoraOcflMappingMap.get(fedoraRootObjectResourceId);
 
@@ -71,8 +72,8 @@ public class TestOcflObjectIndex implements FedoraToOcflObjectIndex {
     }
 
     @Override
-    public void removeMapping(@Nonnull final String transactionId, final String fedoraResourceIdentifier) {
-        fedoraOcflMappingMap.remove(fedoraResourceIdentifier);
+    public void removeMapping(@Nonnull final String transactionId, final FedoraId fedoraResourceIdentifier) {
+            fedoraOcflMappingMap.remove(fedoraResourceIdentifier);
     }
 
     @Override

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
@@ -105,7 +105,7 @@ public class UpdateNonRdfSourcePersisterTest {
     @Before
     public void setUp() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("object-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID.getFullId());
+        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
         when(psSession.getId()).thenReturn(SESSION_ID);
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
         when(session.getObjectDigestAlgorithm()).thenReturn(DIGEST_ALGORITHM.SHA1);
@@ -118,14 +118,14 @@ public class UpdateNonRdfSourcePersisterTest {
 
         when(writeOutcome.getContentSize()).thenReturn(LOCAL_CONTENT_SIZE);
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         when(nonRdfSourceOperation.getType()).thenReturn(UPDATE);
 
 
         persister = new UpdateNonRdfSourcePersister(index);
 
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
 
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
@@ -87,9 +88,9 @@ public class UpdateNonRdfSourcePersisterTest {
     @Mock
     private OcflPersistentStorageSession psSession;
 
-    private static final String RESOURCE_ID = "info:fedora/parent/child";
+    private static final FedoraId RESOURCE_ID = FedoraId.create("info:fedora/parent/child");
 
-    private static final String ROOT_RESOURCE_ID = "info:fedora/parent";
+    private static final FedoraId ROOT_RESOURCE_ID = FedoraId.create("info:fedora/parent");
 
     private static final String USER_PRINCIPAL = "fedoraUser";
 
@@ -104,7 +105,7 @@ public class UpdateNonRdfSourcePersisterTest {
     @Before
     public void setUp() throws Exception {
         when(mapping.getOcflObjectId()).thenReturn("object-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
+        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID.getFullId());
         when(psSession.getId()).thenReturn(SESSION_ID);
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
         when(session.getObjectDigestAlgorithm()).thenReturn(DIGEST_ALGORITHM.SHA1);

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
@@ -116,7 +116,7 @@ public class UpdateRDFSourcePersisterTest {
         when(psSession.getId()).thenReturn(SESSION_ID);
         when(session.write(anyString(), any(InputStream.class))).thenReturn(writeOutcome);
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
-        when(index.getMapping(eq(SESSION_ID), anyString())).thenReturn(mapping);
+        when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);
         when(operation.getType()).thenReturn(UPDATE);
 
         persister = new UpdateRdfSourcePersister(this.index);
@@ -134,7 +134,7 @@ public class UpdateRDFSourcePersisterTest {
         final RdfStream userTriplesStream = constructTitleStream(RESOURCE_ID, TITLE);
 
         when(mapping.getOcflObjectId()).thenReturn("object-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID.getResourceId());
+        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
 
         when(operation.getResourceId()).thenReturn(RESOURCE_ID);
         when(operation.getTriples()).thenReturn(userTriplesStream);

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRDFSourcePersisterTest.java
@@ -50,6 +50,7 @@ import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.vocabulary.DC;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
@@ -72,9 +73,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class UpdateRDFSourcePersisterTest {
 
-    private static final String RESOURCE_ID = "info:fedora/parent/child";
+    private static final FedoraId RESOURCE_ID = FedoraId.create("info:fedora/parent/child");
 
-    private static final String ROOT_RESOURCE_ID = "info:fedora/parent";
+    private static final FedoraId ROOT_RESOURCE_ID = FedoraId.create("info:fedora/parent");
 
     private static final String USER_PRINCIPAL = "fedoraUser";
 
@@ -133,7 +134,7 @@ public class UpdateRDFSourcePersisterTest {
         final RdfStream userTriplesStream = constructTitleStream(RESOURCE_ID, TITLE);
 
         when(mapping.getOcflObjectId()).thenReturn("object-id");
-        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID);
+        when(mapping.getRootObjectIdentifier()).thenReturn(ROOT_RESOURCE_ID.getResourceId());
 
         when(operation.getResourceId()).thenReturn(RESOURCE_ID);
         when(operation.getTriples()).thenReturn(userTriplesStream);
@@ -153,7 +154,7 @@ public class UpdateRDFSourcePersisterTest {
         // verify user triples
         final Model userModel = retrievePersistedUserModel("child");
 
-        assertTrue(userModel.contains(userModel.createResource(RESOURCE_ID),
+        assertTrue(userModel.contains(userModel.createResource(RESOURCE_ID.getResourceId()),
                 DC.title, TITLE));
 
         // verify server triples
@@ -167,8 +168,8 @@ public class UpdateRDFSourcePersisterTest {
                 || originalModified.isBefore(resultHeaders.getLastModifiedDate()));
     }
 
-    private RdfStream constructTitleStream(final String resourceId, final String title) {
-        final Node resourceUri = createURI(resourceId);
+    private RdfStream constructTitleStream(final FedoraId resourceId, final String title) {
+        final Node resourceUri = createURI(resourceId.getResourceId());
         // create some test user triples
         final Stream<Triple> userTriples = Stream.of(Triple.create(resourceUri,
                 DC.title.asNode(),

--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
@@ -199,7 +199,7 @@ public class DbSearchIndexImpl implements SearchIndex {
 
     @Override
     public void addUpdateIndex(final ResourceHeaders resourceHeaders) {
-        final var fullId = resourceHeaders.getId();
+        final var fullId = resourceHeaders.getId().getFullId();
         final var selectParams = new MapSqlParameterSource();
         selectParams.addValue(FEDORA_ID_PARAM, fullId);
         final var result =

--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/SearchIndexUpdater.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/SearchIndexUpdater.java
@@ -78,7 +78,7 @@ public class SearchIndexUpdater {
                 this.searchIndex.removeFromIndex(fedoraId);
             } else if (types.contains(RESOURCE_CREATION) || types.contains(RESOURCE_MODIFICATION)) {
                 final var session = persistentStorageSessionManager.getReadOnlySession();
-                final var headers = session.getHeaders(fedoraId.getFullId(), null);
+                final var headers = session.getHeaders(fedoraId, null);
                 this.searchIndex.addUpdateIndex(headers);
             }
         } catch (final PersistentStorageException e) {


### PR DESCRIPTION
**JIRA Ticket**: none

# What does this Pull Request do?

Refactors the code to more broadly use FedoraId rather than a string to represent an identifier.

There are a handful of methods that I intentionally did not update `OcflPersistentStorageUtils` because they are removed in the next PR.

# How should this be tested?

No functionality changes. Tests should pass, and everything should continue to work the same as before.

# Interested parties
@fcrepo4/committers
