### PR TITLE
Add support for creation of archival-groups in HTML UI

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -26,6 +26,7 @@ import static org.apache.jena.sparql.util.graph.GraphUtils.multiValueURI;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
 import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_ID_HEADER;
+import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
@@ -39,6 +40,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -202,6 +204,8 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
 
         final FedoraResource resource = getResourceFromSubject(subject.toString());
         context.put("isOriginalResource", (resource != null && resource.isOriginalResource()));
+        context.put("isArchivalGroup", (resource != null &&
+                resource.getSystemTypes(false).contains(URI.create(ARCHIVAL_GROUP.getURI()))));
         context.put("isVersion", (resource != null && resource.isMemento()));
         context.put("isLDPNR", (resource != null &&
                 (resource instanceof Binary || !resource.getDescribedResource().equals(resource))));

--- a/fcrepo-http-api/src/main/resources/views/common-metadata.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-metadata.vsl
@@ -5,6 +5,10 @@
     <dt>Last Modified at</dt> <dd>$helpers.getObjectsAsString($rdf, $originalResource, $rdfLexicon.LAST_MODIFIED_DATE, true)
     by $esc.html($helpers.getObjectsAsString($rdf, $originalResource, $rdfLexicon.LAST_MODIFIED_BY, true))</dd>
 
+    #if ($isArchivalGroup == true)
+        <dt>Archival Group</dt> <dd>true</dd>
+    #end
+
     <dt>Children <span class="badge">$helpers.getNumChildren($rdf, $originalResource) </span></dt>
     <dd>
         <ol id="childList">

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -38,6 +38,7 @@
         <option value="basic container">basic container</option>
         <option value="direct container">direct container</option>
         <option value="indirect container">indirect container</option>
+        <option value="archival group">archival group</option>
         <option value="binary">binary</option>
     </select>
         </div>

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -87,6 +87,8 @@
         headers.push(['Link', '<http://www.w3.org/ns/ldp#DirectContainer>; rel=\"type\"']);
       } else if (mixin == 'indirect container') {
         headers.push(['Link', '<http://www.w3.org/ns/ldp#IndirectContainer>; rel=\"type\"']);
+      } else if (mixin == 'archival group') {
+        headers.push(['Link', '<http://fedora.info/definitions/v4/repository#ArchivalGroup>; rel=\"type\"']);
       } else {
         alert("Unrecognized type: " + mixin);
         return;


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3336

# What does this Pull Request do?
This pull-requests adds the ability to create `Archival Groups` in the HTML UI.

# How should this be tested?

1. Start Fedora
1. Browse to the HTML UI
1. Create a new resource by selecting the "archival group" choice from the **Type** drop-down
   - Notice the new resource's HTML page indicates that it is an "Archival Group"
1. In the OCFL file system, navigate to the newly created resource
   - Notice the property: `"archivalGroup":true` is present

# Interested parties
@fcrepo4/committers
