### PR TITLE
FCREPO-3239 - External Binary implementation

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -195,6 +195,7 @@ public class ExternalContentHandler implements ExternalContent {
         } else if ("http".equals(scheme) || "https".equals(scheme)) {
             try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
                 final HttpHead httpHead = new HttpHead(uri);
+                httpHead.setHeader("Accept-Encoding", "identity");
                 try (CloseableHttpResponse response = httpClient.execute(httpHead)) {
                     if (response.getStatusLine().getStatusCode() != SC_OK) {
                         throw new ExternalMessageBodyException("Unable to access external binary at URI " + uri

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -115,27 +115,27 @@ public class ExternalContentHandler implements ExternalContent {
 
     @Override
     public String getURL() {
-        return link != null ? link.getUri().toString() : null;
+        return link.getUri().toString();
     }
 
     @Override
     public URI getURI() {
-        return link != null ? link.getUri() : null;
+        return link.getUri();
     }
 
     @Override
     public boolean isCopy() {
-        return handling != null && handling.equals(COPY);
+        return COPY.equals(handling);
     }
 
     @Override
     public boolean isRedirect() {
-        return handling != null && handling.equals(REDIRECT);
+        return REDIRECT.equals(handling);
     }
 
     @Override
     public boolean isProxy() {
-        return handling != null && handling.equals(PROXY);
+        return PROXY.equals(handling);
     }
 
     @Override

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -49,7 +49,7 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
 
     private static final Set<String> ALLOWED_SCHEMES = new HashSet<>(Arrays.asList("file", "http", "https"));
 
-    private static final Pattern SCHEME_PATTERN = Pattern.compile("^(http|https|file):/.*");
+    private static final Pattern SCHEME_PATTERN = Pattern.compile("^(http|https|file):/.*", Pattern.CASE_INSENSITIVE);
 
     // Pattern to check that an http uri contains a / after the domain if a domain is present
     private static final Pattern HTTP_DOMAIN_PATTERN = Pattern.compile("^(http|https)://([^/]+/.*|$)");
@@ -76,7 +76,7 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
             throw new ExternalMessageBodyException("External content path was empty");
         }
 
-        final String path = normalizePath(extPath.toLowerCase());
+        final String path = normalizeUri(extPath);
 
         final URI uri;
         try {
@@ -117,12 +117,20 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
         throw new ExternalMessageBodyException("Path did not match any allowed external content paths: " + extPath);
     }
 
-    private String normalizePath(final String path) {
-        // file uris can have between 1 and 3 slashes depending on if the authority is present
-        if (path.startsWith("file://")) {
-            return NORMALIZE_FILE_URI.matcher(path).replaceFirst("file:/");
+    private String normalizeUri(final String path) {
+        // lowercase the scheme since it is case insensitive
+        final String[] parts = path.split(":", 2);
+        final String normalized;
+        if (parts.length > 1) {
+            normalized = parts[0].toLowerCase() + ":" + parts[1];
+        } else {
+            return path;
         }
-        return path;
+        // file uris can have between 1 and 3 slashes depending on if the authority is present
+        if (normalized.startsWith("file://")) {
+            return NORMALIZE_FILE_URI.matcher(normalized).replaceFirst("file:/");
+        }
+        return normalized;
     }
 
     /**
@@ -134,7 +142,7 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
     protected synchronized void loadConfiguration() throws IOException {
         LOGGER.info("Loading list of allowed external content locations from {}", configPath);
         try (final Stream<String> stream = Files.lines(Paths.get(configPath))) {
-            allowedList = stream.map(line -> normalizePath(line.trim().toLowerCase()))
+            allowedList = stream.map(line -> normalizeUri(line.trim()))
                     .filter(line -> isAllowanceValid(line))
                     .collect(Collectors.toList());
         }
@@ -149,7 +157,7 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
             return false;
         }
 
-        final String protocol = schemeMatcher.group(1);
+        final String protocol = schemeMatcher.group(1).toLowerCase();
         if ("file".equals(protocol)) {
             // If a file uri ends with / it must be a directory, otherwise it must be a file.
             final File allowing = new File(URI.create(allowance).getPath());

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentPathValidator.java
@@ -121,7 +121,7 @@ public class ExternalContentPathValidator extends AutoReloadingConfiguration {
         // lowercase the scheme since it is case insensitive
         final String[] parts = path.split(":", 2);
         final String normalized;
-        if (parts.length > 1) {
+        if (parts.length == 2) {
             normalized = parts[0].toLowerCase() + ":" + parts[1];
         } else {
             return path;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -95,13 +95,11 @@ import org.fcrepo.http.commons.domain.PATCH;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
-import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
-import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.Binary;
@@ -629,32 +627,6 @@ public class FedoraLdp extends ContentExposingResource {
 
         final var resource = getFedoraResource(transaction, newFedoraId);
         return createUpdateResponse(resource, true);
-    }
-
-    /**
-     * @param rootThrowable The original throwable
-     * @param throwable The throwable under direct scrutiny.
-     */
-    @Override
-    protected void checkForInsufficientStorageException(final Throwable rootThrowable, final Throwable throwable)
-            throws InvalidChecksumException {
-        final String message = throwable.getMessage();
-        if (throwable instanceof IOException && message != null && message.contains(
-                INSUFFICIENT_SPACE_IDENTIFYING_MESSAGE)) {
-            throw new InsufficientStorageException(throwable.getMessage(), rootThrowable);
-        }
-
-        if (throwable.getCause() != null) {
-            checkForInsufficientStorageException(rootThrowable, throwable.getCause());
-        }
-
-        if (rootThrowable instanceof InvalidChecksumException) {
-            throw (InvalidChecksumException) rootThrowable;
-        } else if (rootThrowable instanceof RuntimeException) {
-            throw (RuntimeException) rootThrowable;
-        } else {
-            throw new RepositoryRuntimeException(rootThrowable);
-        }
     }
 
     @Override

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -429,11 +429,6 @@ public class FedoraLdp extends ContentExposingResource {
             } else {
                 contentSize = contentDisposition.getSize();
             }
-            InputStream stream = requestBodyStream;
-            if (extContent != null && extContent.isCopy()) {
-                LOGGER.debug("External content COPY '{}', '{}'", externalPath, extContent.getURL());
-                stream = extContent.fetchExternalContent();
-            }
 
             if (resourceExists) {
                 replaceBinariesService.perform(transaction.getId(),
@@ -442,7 +437,7 @@ public class FedoraLdp extends ContentExposingResource {
                                                originalFileName,
                                                contentType,
                                                checksums,
-                                               stream,
+                                               requestBodyStream,
                                                contentSize,
                                                extContent);
             } else {
@@ -454,7 +449,7 @@ public class FedoraLdp extends ContentExposingResource {
                                               contentSize,
                                               links,
                                               checksums,
-                                              stream,
+                                              requestBodyStream,
                                               extContent);
                 created = true;
             }
@@ -608,11 +603,6 @@ public class FedoraLdp extends ContentExposingResource {
             } else {
                 contentSize = contentDisposition.getSize();
             }
-            InputStream stream = requestBodyStream;
-            if (extContent != null && extContent.isCopy()) {
-                LOGGER.debug("External content COPY '{}', '{}'", externalPath, extContent.getURL());
-                stream = extContent.fetchExternalContent();
-            }
 
             createResourceService.perform(transaction.getId(),
                                           getUserPrincipal(),
@@ -622,7 +612,7 @@ public class FedoraLdp extends ContentExposingResource {
                                           contentSize,
                                           links,
                                           checksums,
-                                          stream,
+                                          requestBodyStream,
                                           extContent);
         } else {
             final var contentType = requestContentType != null ? requestContentType : DEFAULT_RDF_CONTENT_TYPE;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -429,6 +429,11 @@ public class FedoraLdp extends ContentExposingResource {
             } else {
                 contentSize = contentDisposition.getSize();
             }
+            InputStream stream = requestBodyStream;
+            if (extContent != null && extContent.isCopy()) {
+                LOGGER.debug("External content COPY '{}', '{}'", externalPath, extContent.getURL());
+                stream = extContent.fetchExternalContent();
+            }
 
             if (resourceExists) {
                 replaceBinariesService.perform(transaction.getId(),
@@ -437,7 +442,7 @@ public class FedoraLdp extends ContentExposingResource {
                                                originalFileName,
                                                contentType,
                                                checksums,
-                                               requestBodyStream,
+                                               stream,
                                                contentSize,
                                                extContent);
             } else {
@@ -449,7 +454,7 @@ public class FedoraLdp extends ContentExposingResource {
                                               contentSize,
                                               links,
                                               checksums,
-                                              requestBodyStream,
+                                              stream,
                                               extContent);
                 created = true;
             }
@@ -603,6 +608,11 @@ public class FedoraLdp extends ContentExposingResource {
             } else {
                 contentSize = contentDisposition.getSize();
             }
+            InputStream stream = requestBodyStream;
+            if (extContent != null && extContent.isCopy()) {
+                LOGGER.debug("External content COPY '{}', '{}'", externalPath, extContent.getURL());
+                stream = extContent.fetchExternalContent();
+            }
 
             createResourceService.perform(transaction.getId(),
                                           getUserPrincipal(),
@@ -612,7 +622,7 @@ public class FedoraLdp extends ContentExposingResource {
                                           contentSize,
                                           links,
                                           checksums,
-                                          requestBodyStream,
+                                          stream,
                                           extContent);
         } else {
             final var contentType = requestContentType != null ? requestContentType : DEFAULT_RDF_CONTENT_TYPE;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -231,9 +231,33 @@ public class ExternalContentPathValidatorTest {
     }
 
     @Test
-    public void testCaseInsensitive() throws Exception {
-        final String goodPath = "FILE://" + dataDir.toURI().getPath() + "/";
-        final String extPath = dataUri + "/file.txt";
+    public void testCaseInsensitiveFileScheme() throws Exception {
+        final String goodPath = "FILE://" + dataDir.toURI().getPath();
+        final String extPath = dataUri + "file.txt";
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test
+    public void testVaryingSensitiveFilePath() throws Exception {
+        final File subfolder = tmpDir.newFolder("CAPSLOCK");
+        final File file = new File(subfolder, "OoOoOooOOooo.txt");
+        file.createNewFile();
+
+        final String goodPath = subfolder.toURI().toString();
+        final String extPath = file.toURI().toString();
+
+        addAllowedPath(goodPath);
+
+        validator.validate(extPath);
+    }
+
+    @Test
+    public void testVaryingCaseHttpUri() throws Exception {
+        final String goodPath = "http://sensitive.example.com/PATH/to/";
+        final String extPath = "http://sensitive.example.com/PATH/to/stuff";
 
         addAllowedPath(goodPath);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -83,7 +83,6 @@ import java.net.URI;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -244,7 +243,7 @@ public class FedoraLdpTest {
     @Mock
     private Principal principal;
 
-    private List<URI> typeList = new ArrayList<>();
+    private final List<URI> typeList = new ArrayList<>();
 
     private static final Logger log = getLogger(FedoraLdpTest.class);
 
@@ -1145,21 +1144,17 @@ public class FedoraLdpTest {
         }
     }
 
-    @Ignore("Not sure if this is still relevant")
+    @Ignore("Insufficient space root exception not thrown and checkForInsufficientStorageException is not called")
     @Test(expected = InsufficientStorageException.class)
     public void testCreateNewBinaryWithInsufficientResources() throws Exception {
         final var finalId = pathId.resolve("b");
         when(resourceFactory.getResource(any(), eq(finalId))).thenReturn(mockBinary);
 
         try (final InputStream content = toInputStream("x", UTF_8)) {
-
             final RuntimeException ex = new RuntimeException(new IOException("root exception", new IOException(
                     FedoraLdp.INSUFFICIENT_SPACE_IDENTIFYING_MESSAGE)));
-            doThrow(ex).when(mockBinary).setContent(content, APPLICATION_OCTET_STREAM_TYPE.toString(),
-                    Collections
-                    .emptySet(),
-                    "",
-                    null);
+            doThrow(ex).when(createResourceService).perform(anyString(), anyString(), eq(finalId), anyString(),
+                    anyString(), any(Long.class), anyList(), isNull(), any(InputStream.class), isNull());
 
             testObj.createObject(null, APPLICATION_OCTET_STREAM_TYPE, "b", content, nonRDFSourceLink, null);
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -81,7 +81,8 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
     private static final String TEST_MD5_DIGEST_HEADER_VALUE = "md5=baed005300234f3d1503c50a48ce8e6f";
 
-    private static final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling().build();
+    private static final CloseableHttpClient noFollowClient = HttpClientBuilder.create()
+            .disableRedirectHandling().build();
 
     @Before
     public void setup() throws Exception {
@@ -1141,7 +1142,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
     private void assertBodyContains(final CloseableHttpResponse response, final String expected) throws IOException {
         final String body = IOUtils.toString(response.getEntity().getContent(), UTF_8);
-        assertTrue("Expected response to contain '" + expected + "' but was '" + body +"'",
+        assertTrue("Expected response to contain '" + expected + "' but was '" + body + "'",
                 body.contains(expected));
     }
 
@@ -1151,7 +1152,8 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
     }
 
     private void assertContentLength(final CloseableHttpResponse response, final long expectedLength) {
-        assertEquals("Content-length header did not match", expectedLength, Long.parseLong(response.getFirstHeader(CONTENT_LENGTH).getValue()));
+        assertEquals("Content-length header did not match", expectedLength, Long.parseLong(response
+                .getFirstHeader(CONTENT_LENGTH).getValue()));
     }
 
     private void assertContentType(final CloseableHttpResponse response, final String expected) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -51,7 +51,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -156,7 +155,6 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore
     @Test
     public void testProxyWithWantDigestForLocalFile() throws IOException {
 
@@ -182,7 +180,6 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         checkExternalDataStreamResponseHeader(getObjMethod, fileUri, expectedDigestHeaderValue);
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCopyWithWantDigestForLocalFile() throws IOException {
 
@@ -208,7 +205,6 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         checkExternalDataStreamResponseHeader(getObjMethod, null, expectedDigestHeaderValue);
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testProxyWithWantDigestForHttpUri() throws Exception {
 
@@ -232,7 +228,6 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         checkExternalDataStreamResponseHeader(getObjMethod, dsUrl, expectedDigestHeaderValue);
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCopyWithWantDigestForHttpUri() throws Exception {
 
@@ -256,7 +251,6 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         checkExternalDataStreamResponseHeader(getObjMethod, null, expectedDigestHeaderValue);
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testProxyWithWantDigestMultipleForLocalFile() throws IOException {
 
@@ -394,7 +388,6 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testRedirectWithWantDigest() throws Exception {
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -22,16 +22,19 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.TEMPORARY_REDIRECT;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.apache.http.HttpHeaders.CONTENT_LENGTH;
 import static org.apache.http.HttpStatus.SC_CREATED;
@@ -40,6 +43,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
@@ -49,6 +53,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.fcrepo.kernel.api.FedoraTypes;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.junit.Before;
 import org.junit.Rule;
@@ -75,6 +80,8 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
     private static final String TEST_SHA_DIGEST_HEADER_VALUE = "sha=9578f951955d37f20b601c26591e260c1e5389bf";
 
     private static final String TEST_MD5_DIGEST_HEADER_VALUE = "md5=baed005300234f3d1503c50a48ce8e6f";
+
+    private static final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling().build();
 
     @Before
     public void setup() throws Exception {
@@ -440,22 +447,17 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
         final String externalLocation = createHttpResource(TEST_BINARY_CONTENT);
 
-        // we need a client that won't automatically follow redirects
-        try (final CloseableHttpClient noFollowClient = HttpClientBuilder.create().disableRedirectHandling()
-                .build()) {
+        final String id = getRandomUniqueId();
+        final HttpPut httpPut = putObjMethod(id);
+        httpPut.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        httpPut.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "redirect", null));
 
-            final String id = getRandomUniqueId();
-            final HttpPut httpPut = putObjMethod(id);
-            httpPut.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
-            httpPut.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "redirect", null));
-
-            try (final CloseableHttpResponse response = execute(httpPut)) {
-                assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
-                final HttpGet get = new HttpGet(getLocation(response));
-                try (final CloseableHttpResponse getResponse = noFollowClient.execute(get)) {
-                    assertEquals(TEMPORARY_REDIRECT.getStatusCode(), getStatus(getResponse));
-                    assertLocation(getResponse, externalLocation);
-                }
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+            final HttpGet get = new HttpGet(getLocation(response));
+            try (final CloseableHttpResponse getResponse = noFollowClient.execute(get)) {
+                assertEquals(TEMPORARY_REDIRECT.getStatusCode(), getStatus(getResponse));
+                assertLocation(getResponse, externalLocation);
             }
         }
     }
@@ -728,6 +730,395 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
             assertEquals("Expected failure on creation", BAD_REQUEST.getStatusCode(),
                     getStatus(response));
             assertBodyContains(response, "Path did not match any allowed external content paths");
+        }
+    }
+
+    @Test
+    public void testCopyWithTransmissionFixityForLocalFile() throws Exception {
+        final File localFile = createExternalLocalFile(TEST_BINARY_CONTENT);
+
+        final String localPath = localFile.toURI().toString();
+        final HttpPut httpPut = setupExternalContentPut(localPath, "copy", "text/plain");
+        httpPut.addHeader("Digest", TEST_SHA_DIGEST_HEADER_VALUE);
+
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+
+            // fetch the copy of the object
+            final HttpGet get = new HttpGet(getLocation(response));
+            try (final CloseableHttpResponse getResponse = execute(get)) {
+                assertEquals(OK.getStatusCode(), getStatus(getResponse));
+                assertContentType(getResponse, "text/plain");
+                assertBodyMatches(getResponse, TEST_BINARY_CONTENT);
+            }
+        }
+    }
+
+    @Test
+    public void testCopyWithInvalidTransmissionFixityForLocalFile() throws Exception {
+        final String content = "Not the expected content";
+        final File localFile = createExternalLocalFile(content);
+        final String localPath = localFile.toURI().toString();
+
+        final HttpPut httpPut = setupExternalContentPut(localPath, "copy", "text/plain");
+        httpPut.addHeader("Digest", TEST_SHA_DIGEST_HEADER_VALUE);
+
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals(CONFLICT.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testCopyWithTransmissionFixityForHttpUri() throws Exception {
+        final String externalLocation = createHttpResource("text/plain", TEST_BINARY_CONTENT);
+        final HttpPut httpPut = setupExternalContentPut(externalLocation, "copy", "text/plain");
+        httpPut.addHeader("Digest", TEST_SHA_DIGEST_HEADER_VALUE);
+
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+
+            // fetch the copy of the object
+            final HttpGet get = new HttpGet(getLocation(response));
+            try (final CloseableHttpResponse getResponse = execute(get)) {
+                assertEquals(OK.getStatusCode(), getStatus(getResponse));
+                assertContentType(getResponse, "text/plain");
+                assertBodyMatches(getResponse, TEST_BINARY_CONTENT);
+            }
+        }
+    }
+
+    @Test
+    public void testProxyWithTransmissionFixityForLocalFile() throws Exception {
+        final File localFile = createExternalLocalFile(TEST_BINARY_CONTENT);
+
+        final String externalLocation = localFile.toURI().toString();
+        final HttpPut httpPut = setupExternalContentPut(externalLocation, "proxy", "text/plain");
+        httpPut.addHeader("Digest", TEST_SHA_DIGEST_HEADER_VALUE);
+
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));
+            assertIsProxyBinary(getLocation(response), externalLocation, TEST_BINARY_CONTENT, "text/plain");
+        }
+    }
+
+    @Test
+    public void testProxyWithInvalidTransmissionFixityForLocalFile() throws Exception {
+        final File localFile = createExternalLocalFile(TEST_BINARY_CONTENT);
+
+        final String externalLocation = localFile.toURI().toString();
+        final HttpPut httpPut = setupExternalContentPut(externalLocation, "proxy", "text/plain");
+        httpPut.addHeader("Digest", "sha=12345678910");
+
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals(CONFLICT.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testRedirectWithTransmissionFixityForHttpUri() throws Exception {
+        final String externalLocation = createHttpResource("text/plain", TEST_BINARY_CONTENT);
+        final HttpPut httpPut = setupExternalContentPut(externalLocation, "redirect", "text/plain");
+        httpPut.addHeader("Digest", TEST_SHA_DIGEST_HEADER_VALUE);
+
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            assertIsRedirectBinary(getLocation(response), externalLocation, TEST_BINARY_CONTENT, "text/plain");
+        }
+    }
+
+    @Test
+    public void testRedirectWithInvalidTransmissionFixityForHttpUri() throws Exception {
+        final String externalLocation = createHttpResource("text/plain", "bad content");
+        final HttpPut httpPut = setupExternalContentPut(externalLocation, "redirect", "text/plain");
+        httpPut.addHeader("Digest", TEST_SHA_DIGEST_HEADER_VALUE);
+
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals(CONFLICT.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testProxyPostWithTransmissionFixityForHttpUri() throws Exception {
+        final String externalLocation = createHttpResource("text/plain", TEST_BINARY_CONTENT);
+        final String id = getRandomUniqueId();
+        final HttpPost httpPost = postObjMethod(id);
+        httpPost.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        httpPost.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "redirect", "text/plain"));
+        httpPost.addHeader("Digest", TEST_SHA_DIGEST_HEADER_VALUE);
+
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            assertIsRedirectBinary(getLocation(response), externalLocation, TEST_BINARY_CONTENT, "text/plain");
+        }
+    }
+
+    @Test
+    public void testProxyPostWithInvalidTransmissionFixityForHttpUri() throws Exception {
+        final String externalLocation = createHttpResource("text/plain", "bad content");
+        final String id = getRandomUniqueId();
+        final HttpPost httpPost = postObjMethod(id);
+        httpPost.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        httpPost.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "redirect", "text/plain"));
+        httpPost.addHeader("Digest", TEST_SHA_DIGEST_HEADER_VALUE);
+
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals(CONFLICT.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testUpdateProxyHttpUri() throws Exception {
+        final String content2 = "<doc>some more content</doc>";
+        final String externalLocation1 = createHttpResource("text/plain", TEST_BINARY_CONTENT);
+        final String externalLocation2 = createHttpResource("text/xml", content2);
+
+        final String rescLoc = createExternalContentResource(externalLocation1, "proxy", null);
+        assertIsProxyBinary(rescLoc, externalLocation1, TEST_BINARY_CONTENT, "text/plain");
+
+        updateExternalContentResource(rescLoc, externalLocation2, "proxy", null);
+        assertIsProxyBinary(rescLoc, externalLocation2, content2, "text/xml");
+    }
+
+    @Test
+    public void testUpdateProxyLocalFile() throws Exception {
+        final String content2 = "<doc>some more content</doc>";
+        final File localFile1 = createExternalLocalFile(TEST_BINARY_CONTENT);
+        final File localFile2 = createExternalLocalFile(content2);
+        final String externalLocation1 = localFile1.toURI().toString();
+        final String externalLocation2 = localFile2.toURI().toString();
+
+        final String rescLoc = createExternalContentResource(externalLocation1, "proxy", null);
+        assertIsProxyBinary(rescLoc, externalLocation1, TEST_BINARY_CONTENT, "application/octet-stream");
+
+        updateExternalContentResource(rescLoc, externalLocation2, "proxy", "text/xml");
+        assertIsProxyBinary(rescLoc, externalLocation2, content2, "text/xml");
+    }
+
+    @Test
+    public void testUpdateRedirectHttpUri() throws Exception {
+        final String content2 = "<doc>some more content</doc>";
+        final String externalLocation1 = createHttpResource("text/plain", TEST_BINARY_CONTENT);
+        final String externalLocation2 = createHttpResource(content2);
+
+        final String rescLoc = createExternalContentResource(externalLocation1, "redirect", null);
+        assertIsRedirectBinary(rescLoc, externalLocation1, TEST_BINARY_CONTENT, "text/plain");
+
+        updateExternalContentResource(rescLoc, externalLocation2, "redirect", "text/xml");
+        assertIsRedirectBinary(rescLoc, externalLocation2, content2, "text/xml");
+    }
+
+    @Test
+    public void testUpdateProxyToRedirectForHttpUri() throws Exception {
+        // Create a resource
+        final String externalLocation = createHttpResource(TEST_BINARY_CONTENT);
+
+        final String rescLoc = createExternalContentResource(externalLocation, "proxy", null);
+        assertIsProxyBinary(rescLoc, externalLocation, TEST_BINARY_CONTENT, null);
+
+        updateExternalContentResource(rescLoc, externalLocation, "redirect", null);
+        assertIsRedirectBinary(rescLoc, externalLocation, TEST_BINARY_CONTENT, null);
+    }
+
+    @Test
+    public void testUpdateRedirectToProxyForHttpUri() throws Exception {
+        final String externalLocation = createHttpResource(TEST_BINARY_CONTENT);
+
+        final String rescLoc = createExternalContentResource(externalLocation, "redirect", null);
+        assertIsRedirectBinary(rescLoc, externalLocation, TEST_BINARY_CONTENT, null);
+
+        updateExternalContentResource(rescLoc, externalLocation, "proxy", null);
+        assertIsProxyBinary(rescLoc, externalLocation, TEST_BINARY_CONTENT, null);
+    }
+
+    @Test
+    public void testUpdateProxyToRedirectForLocalFile() throws Exception {
+        final String content2 = "<doc>some more content</doc>";
+        final File localFile1 = createExternalLocalFile(TEST_BINARY_CONTENT);
+        final File localFile2 = createExternalLocalFile(content2);
+        final String externalLocation1 = localFile1.toURI().toString();
+        final String externalLocation2 = localFile2.toURI().toString();
+
+        final String rescLoc = createExternalContentResource(externalLocation1, "proxy", "text/plain");
+        assertIsProxyBinary(rescLoc, externalLocation1, TEST_BINARY_CONTENT, "text/plain");
+
+        updateExternalContentResource(rescLoc, externalLocation2, "redirect", "text/xml");
+        // Not checking on the content, since following a redirect on a file is unlikely to work
+        assertIsRedirectBinary(rescLoc, externalLocation2, null, "text/xml");
+    }
+
+    @Test
+    public void testUpdateHttpUriToLocalFile() throws Exception {
+        final String content2 = "some more content";
+        final String externalLocation1 = createHttpResource(TEST_BINARY_CONTENT);
+        final File localFile2 = createExternalLocalFile(content2);
+        final String externalLocation2 = localFile2.toURI().toString();
+
+        final String rescLoc = createExternalContentResource(externalLocation1, "proxy", null);
+        assertIsProxyBinary(rescLoc, externalLocation1, TEST_BINARY_CONTENT, "text/plain");
+
+        updateExternalContentResource(rescLoc, externalLocation2, "proxy", null);
+        assertIsProxyBinary(rescLoc, externalLocation2, content2, "application/octet-stream");
+    }
+
+    @Test
+    public void testUpdateInternalToLocalFile() throws Exception {
+        final String id = getRandomUniqueId();
+        final String rescLoc;
+        try (final CloseableHttpResponse response = execute(putDSMethod(id, "x", TEST_BINARY_CONTENT))) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            rescLoc = getLocation(response);
+        }
+
+        final String content2 = "<doc>some more content</doc>";
+        final File localFile = createExternalLocalFile(content2);
+        final String externalLocation = localFile.toURI().toString();
+
+        updateExternalContentResource(rescLoc, externalLocation, "proxy", "text/xml");
+        assertIsProxyBinary(rescLoc, externalLocation, content2, "text/xml");
+    }
+
+    @Test
+    public void testUpdateLocalFileToInternal() throws Exception {
+        final File localFile = createExternalLocalFile(TEST_BINARY_CONTENT);
+        final String externalLocation = localFile.toURI().toString();
+
+        final String rescLoc = createExternalContentResource(externalLocation, "proxy", "text/plain");
+        assertIsProxyBinary(rescLoc, externalLocation, TEST_BINARY_CONTENT, "text/plain");
+
+        final String content2 = "<doc>some more content</doc>";
+        final HttpPut put = new HttpPut(rescLoc);
+        put.setEntity(new StringEntity(content2));
+        put.setHeader(CONTENT_TYPE, "text/xml");
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(put));
+
+        final HttpGet get = new HttpGet(rescLoc);
+        try (final CloseableHttpResponse resp = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(resp));
+            assertNull(resp.getFirstHeader("Content-Location"));
+            assertContentLength(resp, content2.length());
+            assertBodyMatches(resp, content2);
+            assertContentType(resp, "text/xml");
+        }
+    }
+
+    @Test
+    public void testUpdateInternalToHttpUri() throws Exception {
+        final String id = getRandomUniqueId();
+        final String rescLoc;
+        try (final CloseableHttpResponse response = execute(putDSMethod(id, "x", TEST_BINARY_CONTENT))) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            rescLoc = getLocation(response);
+        }
+
+        final String content2 = "<doc>some more content</doc>";
+        final String externalLocation = createHttpResource(content2);
+
+        updateExternalContentResource(rescLoc, externalLocation, "redirect", "text/xml");
+        assertIsRedirectBinary(rescLoc, externalLocation, content2, "text/xml");
+    }
+
+    @Test
+    public void testUpdateHttpUriToInternal() throws Exception {
+        final String externalLocation = createHttpResource(TEST_BINARY_CONTENT);
+
+        final String rescLoc = createExternalContentResource(externalLocation, "proxy", null);
+        assertIsProxyBinary(rescLoc, externalLocation, TEST_BINARY_CONTENT, "text/plain");
+
+        final String content2 = "<doc>some more content</doc>";
+        final HttpPut put = new HttpPut(rescLoc);
+        put.setEntity(new StringEntity(content2));
+        put.setHeader(CONTENT_TYPE, "text/xml");
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(put));
+
+        final HttpGet get = new HttpGet(rescLoc);
+        try (final CloseableHttpResponse resp = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(resp));
+            assertNull(resp.getFirstHeader("Content-Location"));
+            assertContentLength(resp, content2.length());
+            assertBodyMatches(resp, content2);
+            assertContentType(resp, "text/xml");
+        }
+    }
+
+    @Test
+    public void testLocalFileNotDeleted() throws Exception {
+        final File localFile = createExternalLocalFile(TEST_BINARY_CONTENT);
+        final String externalLocation = localFile.toURI().toString();
+
+        final String rescLoc = createExternalContentResource(externalLocation, "proxy", "text/plain");
+        final String id = StringUtils.substringAfterLast(rescLoc, "/");
+        assertIsProxyBinary(rescLoc, externalLocation, TEST_BINARY_CONTENT, "text/plain");
+
+        final HttpDelete delete = new HttpDelete(rescLoc);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(delete));
+        assertDeleted(id);
+        assertTrue("External binary must exist after resource deletion", localFile.exists());
+
+        final HttpDelete deleteTomb = new HttpDelete(rescLoc + "/" + FedoraTypes.FCR_TOMBSTONE);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(deleteTomb));
+        assertTrue("External binary must exist after deleting tombstone", localFile.exists());
+    }
+
+    private HttpPut setupExternalContentPut(final String externalLocation, final String handling,
+            final String contentType) {
+        final String id = getRandomUniqueId();
+        final HttpPut httpPut = putObjMethod(id);
+        httpPut.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+        httpPut.addHeader(LINK, getExternalContentLinkHeader(externalLocation, handling, contentType));
+        return httpPut;
+    }
+
+    private String createExternalContentResource(final String externalLocation, final String handling,
+            final String contentType) throws IOException {
+        final HttpPut httpPut = setupExternalContentPut(externalLocation, handling, contentType);
+
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+
+            return getLocation(response);
+        }
+    }
+
+    private void updateExternalContentResource(final String rescLoc, final String externalLocation,
+            final String handling, final String contentType) throws IOException {
+        final HttpPut httpPut = new HttpPut(rescLoc);
+        httpPut.addHeader(LINK, getExternalContentLinkHeader(externalLocation, handling, contentType));
+        try (final CloseableHttpResponse response = execute(httpPut)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+        }
+    }
+
+    private void assertIsProxyBinary(final String rescLocation, final String expectedLocation,
+            final String expectedContent, final String expectedType) throws IOException {
+        final HttpGet get = new HttpGet(rescLocation);
+        try (final CloseableHttpResponse resp = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(resp));
+            assertContentLocation(resp, expectedLocation);
+            assertContentLength(resp, expectedContent.length());
+            assertBodyMatches(resp, expectedContent);
+            if (expectedType != null) {
+                assertContentType(resp, expectedType);
+            }
+        }
+    }
+
+    private void assertIsRedirectBinary(final String rescLocation, final String expectedLocation,
+            final String expectedContent, final String expectedType) throws IOException {
+        final HttpGet get = new HttpGet(rescLocation);
+        try (final CloseableHttpResponse resp = noFollowClient.execute(get)) {
+            assertEquals(TEMPORARY_REDIRECT.getStatusCode(), getStatus(resp));
+            assertLocation(resp, expectedLocation);
+            if (expectedType != null) {
+                assertContentType(resp, expectedType);
+            }
+        }
+
+        if (expectedContent != null) {
+            // Follow redirect to the content
+            try (final CloseableHttpResponse resp = execute(get)) {
+                assertBodyMatches(resp, expectedContent);
+                assertContentLength(resp, expectedContent.length());
+            }
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -471,7 +471,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         final HttpPut httpPut = putObjMethod(id);
         httpPut.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
         final String fileUri = localFile.toURI().toString();
-        httpPut.addHeader(LINK, getExternalContentLinkHeader(fileUri.toString(), "proxy", "text/plain"));
+        httpPut.addHeader(LINK, getExternalContentLinkHeader(fileUri, "proxy", "text/plain"));
 
         try (final CloseableHttpResponse response = execute(httpPut)) {
             assertEquals("Didn't get a CREATED response!", CREATED.getStatusCode(), getStatus(response));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
@@ -45,7 +45,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -120,7 +119,6 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
         System.clearProperty("fcrepo.external.content.allowed");
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testAllowedPath() throws Exception {
         final HttpPost method = postObjMethod();
@@ -163,7 +161,6 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testAllowedFilePath() throws Exception {
         final String fileContent = "content";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1494,7 +1494,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateExternalBinaryProxyVersion() throws Exception {
         // Create binary to use as content for proxying

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ExternalMessageBodyException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ExternalMessageBodyException.java
@@ -35,4 +35,14 @@ public class ExternalMessageBodyException extends ConstraintViolationException {
     public ExternalMessageBodyException(final String msg) {
         super(msg);
     }
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     * @param rootCause the root cause
+     */
+    public ExternalMessageBodyException(final String msg, final Throwable rootCause) {
+        super(msg, rootCause);
+    }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Binary.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/Binary.java
@@ -17,12 +17,8 @@
  */
 package org.fcrepo.kernel.api.models;
 
-import org.fcrepo.kernel.api.exception.InvalidChecksumException;
-import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
-
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Collection;
 
 /**
  * @author cabeer
@@ -34,22 +30,6 @@ public interface Binary extends FedoraResource {
      * @return The InputStream of content associated with this datastream.
      */
     InputStream getContent();
-
-    /**
-     * Sets the content of this Datastream.
-     *
-     * @param content  InputStream of binary content to be stored
-     * @param contentType MIME type of content (optional)
-     * @param checksums Collection of checksum URIs of the content (optional)
-     * @param originalFileName Original file name of the content (optional)
-     * @param storagePolicyDecisionPoint Policy decision point for storing the content (optional)
-     * @throws InvalidChecksumException if invalid checksum exception occurred
-     */
-    @Deprecated
-    void setContent(InputStream content, String contentType, Collection<URI> checksums,
-                    String originalFileName,
-                    StoragePolicyDecisionPoint storagePolicyDecisionPoint)
-            throws InvalidChecksumException;
 
     /**
      * @return The size in bytes of content associated with this datastream.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ExternalContent.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ExternalContent.java
@@ -37,6 +37,12 @@ public interface ExternalContent {
     public String getContentType();
 
     /**
+     * Returns the size of the content located at the link header
+     * @return content size
+     */
+    public long getContentSize();
+
+    /**
      * Retrieve handling information
      * @return a String containing the type of handling requested ["proxy", "copy" or "redirect"]
      */

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -18,7 +18,6 @@
 package org.fcrepo.kernel.impl.models;
 
 import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
@@ -28,7 +27,6 @@ import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.ExternalContent;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
-import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -87,14 +85,6 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
         } catch (final PersistentStorageException | IOException e) {
             throw new RepositoryRuntimeException(e);
         }
-    }
-
-    @Override
-    public void setContent(final InputStream content, final String contentType, final Collection<URI> checksums,
-            final String originalFileName, final StoragePolicyDecisionPoint storagePolicyDecisionPoint)
-            throws InvalidChecksumException {
-        // TODO Auto-generated method stub
-
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -76,7 +76,7 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
     @Override
     public InputStream getContent() {
         try {
-            if (isProxy()) {
+            if (isProxy() || isRedirect()) {
                 return URI.create(getExternalURL()).toURL().openStream();
             } else {
                 return getSession().getBinaryContent(getFedoraId().asResourceId(), getMementoDatetime());

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -33,6 +33,7 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
@@ -75,11 +76,15 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
     @Override
     public InputStream getContent() {
         try {
-            return getSession().getBinaryContent(getFedoraId().asResourceId(), getMementoDatetime());
+            if (isProxy()) {
+                return URI.create(getExternalURL()).toURL().openStream();
+            } else {
+                return getSession().getBinaryContent(getFedoraId().asResourceId(), getMementoDatetime());
+            }
         } catch (final PersistentItemNotFoundException e) {
             throw new ItemNotFoundException("Unable to find content for " + getId()
                     + " version " + getMementoDatetime(), e);
-        } catch (final PersistentStorageException e) {
+        } catch (final PersistentStorageException | IOException e) {
             throw new RepositoryRuntimeException(e);
         }
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -88,7 +88,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
         final CreateNonRdfSourceOperationBuilder builder;
         String mimeType = contentType;
         Long size = contentSize;
-        if (externalContent == null) {
+        if (externalContent == null || externalContent.isCopy()) {
             builder = nonRdfSourceOperationFactory.createInternalBinaryBuilder(fedoraId, requestBody);
         } else {
             builder = nonRdfSourceOperationFactory.createExternalBinaryBuilder(fedoraId,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -36,6 +36,7 @@ import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.common.MultiDigestInputStreamWrapper;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -43,6 +44,7 @@ import javax.ws.rs.core.Link;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -98,6 +100,13 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             }
             if (contentSize == null) {
                 size = externalContent.getContentSize();
+            }
+            if (!digest.isEmpty()) {
+                final var multiDigestWrapper = new MultiDigestInputStreamWrapper(
+                        externalContent.fetchExternalContent(),
+                        digest,
+                        Collections.emptyList());
+                multiDigestWrapper.checkFixity();
             }
         }
         final ResourceOperation createOp = builder

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -37,6 +37,7 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.common.MultiDigestInputStreamWrapper;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -54,6 +55,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_PAIR_TREE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
+import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
 /**
@@ -63,6 +65,8 @@ import static org.springframework.util.CollectionUtils.isEmpty;
  */
 @Component
 public class CreateResourceServiceImpl extends AbstractService implements CreateResourceService {
+
+    private static final Logger LOGGER = getLogger(CreateResourceServiceImpl.class);
 
     @Inject
     private PersistentStorageSessionManager psManager;
@@ -91,13 +95,16 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
         String mimeType = contentType;
         Long size = contentSize;
         if (externalContent == null || externalContent.isCopy()) {
-            builder = nonRdfSourceOperationFactory.createInternalBinaryBuilder(fedoraId, requestBody);
+            var contentInputStream = requestBody;
+            if (externalContent != null) {
+                LOGGER.debug("External content COPY '{}', '{}'", fedoraId, externalContent.getURL());
+                contentInputStream = externalContent.fetchExternalContent();
+            }
+
+            builder = nonRdfSourceOperationFactory.createInternalBinaryBuilder(fedoraId, contentInputStream);
         } else {
             builder = nonRdfSourceOperationFactory.createExternalBinaryBuilder(fedoraId,
-                    externalContent.getHandling(), URI.create(externalContent.getURL()));
-            if (externalContent.getContentType() != null) {
-                mimeType = externalContent.getContentType();
-            }
+                    externalContent.getHandling(), externalContent.getURI());
             if (contentSize == null) {
                 size = externalContent.getContentSize();
             }
@@ -109,6 +116,11 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
                 multiDigestWrapper.checkFixity();
             }
         }
+
+        if (externalContent != null && externalContent.getContentType() != null) {
+            mimeType = externalContent.getContentType();
+        }
+
         final ResourceOperation createOp = builder
                 .parentId(parentId)
                 .userPrincipal(userPrincipal)

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -87,6 +87,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
         final CreateNonRdfSourceOperationBuilder builder;
         String mimeType = contentType;
+        Long size = contentSize;
         if (externalContent == null) {
             builder = nonRdfSourceOperationFactory.createInternalBinaryBuilder(fedoraId, requestBody);
         } else {
@@ -95,13 +96,16 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             if (externalContent.getContentType() != null) {
                 mimeType = externalContent.getContentType();
             }
+            if (contentSize == null) {
+                size = externalContent.getContentSize();
+            }
         }
         final ResourceOperation createOp = builder
                 .parentId(parentId)
                 .userPrincipal(userPrincipal)
                 .contentDigests(digest)
                 .mimeType(mimeType)
-                .contentSize(contentSize)
+                .contentSize(size)
                 .filename(filename)
                 .build();
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -26,13 +26,14 @@ import org.fcrepo.kernel.api.services.ReplaceBinariesService;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.common.MultiDigestInputStreamWrapper;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
-
+import java.util.Collections;
 import static java.lang.String.format;
 
 /**
@@ -79,6 +80,13 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
                 }
                 if (contentSize == null) {
                     size = externalContent.getContentSize();
+                }
+                if (!digests.isEmpty()) {
+                    final var multiDigestWrapper = new MultiDigestInputStreamWrapper(
+                            externalContent.fetchExternalContent(),
+                            digests,
+                            Collections.emptyList());
+                    multiDigestWrapper.checkFixity();
                 }
             }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -57,7 +57,7 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
                         final String contentType,
                         final Collection<URI> digests,
                         final InputStream contentBody,
-                        final Long size,
+                        final Long contentSize,
                         final ExternalContent externalContent) {
         try {
             final PersistentStorageSession pSession = this.psManager.getSession(txId);
@@ -65,6 +65,7 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
             hasRestrictedPath(fedoraId.getFullId());
 
             String mimeType = contentType;
+            Long size = contentSize;
             final NonRdfSourceOperationBuilder builder;
             if (externalContent == null) {
                 builder = factory.updateInternalBinaryBuilder(fedoraId, contentBody);
@@ -75,6 +76,9 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
 
                 if (externalContent.getContentType() != null) {
                     mimeType = externalContent.getContentType();
+                }
+                if (contentSize == null) {
+                    size = externalContent.getContentSize();
                 }
             }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -67,7 +67,7 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
             String mimeType = contentType;
             Long size = contentSize;
             final NonRdfSourceOperationBuilder builder;
-            if (externalContent == null) {
+            if (externalContent == null || externalContent.isCopy()) {
                 builder = factory.updateInternalBinaryBuilder(fedoraId, contentBody);
             } else {
                 builder = factory.updateExternalBinaryBuilder(fedoraId,

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
@@ -144,7 +144,6 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
                     NON_RDF_SOURCE.toString());
             headers.setObjectRoot(objectRoot);
             touchCreationHeaders(headers, op.getUserPrincipal(), timeWritten);
-            headers.setContentPath(contentPath);
         } else {
             headers = (ResourceHeadersImpl) readHeaders(objSession, headerPath);
         }
@@ -159,8 +158,16 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
                 digests);
 
         if (forExternalBinary(op)) {
+            // Clear any content path for externals
+            headers.setContentPath(null);
             populateExternalBinaryHeaders(headers, op.getContentUri().toString(),
                     op.getExternalHandling());
+        } else {
+            headers.setContentPath(contentPath);
+            if (!CREATE.equals(op.getType())) {
+                // If performing an update of an internal binary, ensure that no external properties are retained
+                populateExternalBinaryHeaders(headers, null, null);
+            }
         }
 
         return headers;
@@ -195,7 +202,7 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
      * @param op the operation
      * @return Returns true if the operation involved persisting an external binary
      */
-    private boolean forExternalBinary(final NonRdfSourceOperation op) {
+    protected boolean forExternalBinary(final NonRdfSourceOperation op) {
         return op.getContentUri() != null && op.getExternalHandling() != null;
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -91,7 +91,9 @@ class DeleteResourcePersister extends AbstractPersister {
     private void deletePath(final String path, final OcflObjectSession session, final ResourceHeadersImpl headers,
                             final String user, final Instant deleteTime, final String headerPath)
         throws PersistentStorageException {
-        session.delete(path);
+        if (path != null) {
+            session.delete(path);
+        }
         headers.setDeleted(true);
         ResourceHeaderUtils.touchModificationHeaders(headers, user, deleteTime);
         writeHeaders(session, headers, headerPath);

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
     <junit.version>4.13</junit.version>
     <system-rules.version>1.18.0</system-rules.version>
     <mockito.version>2.22.0</mockito.version>
-    <wiremock.version>2.13.0</wiremock.version>
     <!-- fcrepo5-specific plugins -->
     <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
     <war.plugin.version>3.2.2</war.plugin.version>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3239
Also addresses:
* https://jira.lyrasis.org/browse/FCREPO-3219
* https://jira.lyrasis.org/browse/FCREPO-3218

# What does this Pull Request do?
Implements external binaries in frepo6
* Persists PROXY and REDIRECT external binaries as header only records
* Implements Want-Digest and transmission fixity for external binaries
* Handles switching binaries between internal and external, cleaning up headers and content as needed
* Expands external binary tests to cover replacing external binaries and transmission fixity
* Returns a 4xx on creation if fedora cannot find or access the external content in all cases.
* Enables disabled external binary tests

# How should this be tested?
Aside from updated tests, it can be manually tested as follows:

```
mvn -Dfcrepo.home=target/fcrepo -Dfcrepo.external.content.allowed=fcrepo-http-api/src/test/resources/allowed_external_paths.txt clean jetty:run


# Create a proxy binary
curl -i -H"Link: <file:///Users/bbpennel/git/fcrepo4/README.md>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" -H"digest: sha=55d3a8ec8455931442f00fd95d14a4328b470371" -XPUT -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_proxy_local_file

HTTP/1.1 201 Created
...
Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel="type"
...
Content-Location: file:/Users/bbpennel/git/fcrepo4/README.md
Location: http://localhost:8080/rest/test_proxy_local_file
Content-Type: text/plain
Content-Length: 48


# Retrieve the binary
curl http://localhost:8080/rest/test_proxy_local_file -ufedoraAdmin:fedoraAdmin
# body of README.md


# HEAD request
curl -I http://localhost:8080/rest/test_proxy_local_file -ufedoraAdmin:fedoraAdmin

HTTP/1.1 200 OK
...
Content-Location: file:/Users/bbpennel/git/fcrepo4/README.md
Content-Length: 5519


# Update with bad sha1
curl -i -H"Link: <file:///Users/bbpennel/git/fcrepo4/README.md>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"proxy\"; type=\"text/plain\"" -H"digest: sha=55d3a8ec8455931442f00fd95d14a4328b47037" -XPUT -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_proxy_local_file

HTTP/1.1 409 Conflict


# Want-Digest request
curl -I -H "Want-Digest: sha-256" http://localhost:8080/rest/test_proxy_local_file -ufedoraAdmin:fedoraAdmin

HTTP/1.1 200 OK
Digest: sha-256=0e6bc0390b40a5d342dbaf25657d5767c48195312d4632c5ff57a741a926dcc0


# Want-Digest after modifying the file
echo "test" >> README.md

curl -I -H "Want-Digest: sha" http://localhost:8080/rest/test_proxy_local_file -ufedoraAdmin:fedoraAdmin

Digest: sha=f46d2cbc3284486ff421ce381016f6718437da60
# Digest no longer matches the sha1 originally provided, 55d3a8ec8455931442f00fd95d14a4328b470371


# Create a binary using COPY
curl -i -H"Link: <file:///Users/bbpennel/git/fcrepo4/README.md>; rel=\"http://fedora.info/definitions/fcrepo#ExternalContent\"; handling=\"copy\"; type=\"text/markdown\"" -XPUT -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_copy_local_file

# Head request, should be no Content-Location, should look like a normal binary
curl -I http://localhost:8080/rest/test_copy_local_file -ufedoraAdmin:fedoraAdmin
```
