### PR TITLE
Change default home Fedora data dir to `fcrepo-home`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,7 @@ ObjectStore/
 .cache
 .DS_Store
 *~
-fcrepo4-data/
-fcrepo/
+fcrepo-home/
 *.iml
 .idea/
 .checkstyle

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -43,7 +43,7 @@ public class FedoraPropsConfig {
 
     private static final String DATA_DIR = "data";
 
-    @Value("${" + FCREPO_HOME + ":fcrepo}")
+    @Value("${" + FCREPO_HOME + ":fcrepo-home}")
     private Path fedoraHome;
 
     @Value("#{fedoraPropsConfig.fedoraHome.resolve('" + DATA_DIR + "')}")


### PR DESCRIPTION
Resolves: https://jira.lyrasis.org/browse/FCREPO-3398

# What does this Pull Request do?
This pull-request changes the default Fedora data/home directory from `fcrepo` to `fcrepo-home`.

# How should this be tested?
- Run the one-click application and see the Fedora home directory: `fcrepo-home`

# Interested parties
@fcrepo4/committers
