### PR TITLE
Fedora 5.1.x - Remove the victims plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <wiremock.version>2.13.0</wiremock.version>
     <!-- fcrepo5-specific plugins -->
     <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
-    <enforce-victims.rule.version>1.3.4</enforce-victims.rule.version>
     <war.plugin.version>3.2.2</war.plugin.version>
     <!-- default properties that can be altered on the command line -->
     <fcrepo.test.context.path />
@@ -615,14 +614,6 @@
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>${enforcer.plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.redhat.victims</groupId>
-            <artifactId>enforce-victims-rule</artifactId>
-            <version>${enforce-victims.rule.version}</version>
-            <type>jar</type>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <goals>
@@ -651,21 +642,6 @@
                     <include>org.glassfish.jersey.test-framework.providers:*:*:*:test</include>
                   </includes>
                 </bannedDependencies>
-              </rules>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-victims-rule</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <rule implementation="com.redhat.victims.VictimsRule">
-                  <metadata>fatal</metadata>
-                  <fingerprint>fatal</fingerprint>
-                  <updates>daily</updates>
-                </rule>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
**Backport of**: https://github.com/fcrepo4/fcrepo4/pull/1707

Removes the victims plugin for the 5.1.x branch since it does not work anymore.