### PR TITLE
Adds tombstone specific exception message for 404 return exception

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapper.java
@@ -25,7 +25,6 @@ import javax.ws.rs.ext.Provider;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.slf4j.Logger;
 
-
 /**
  * Catch ItemNotFoundException
  *
@@ -43,8 +42,19 @@ public class ItemNotFoundExceptionMapper implements
 
         LOGGER.debug("Exception intercepted by ItemNotFoundExceptionMapper: {}\n", e.getMessage());
         debugException(this, e, LOGGER);
-        return Response.status(Response.Status.NOT_FOUND).
-                entity("Error: " + e.getMessage()).build();
+        String tmp = e.getMessage();
+        LOGGER.debug("tmp is {}\n", tmp);
+        final int idx = tmp.lastIndexOf("/");
+        if (idx != -1) {
+            tmp = tmp.substring(idx);
+        }
+        if (tmp.contains("fcr:tombstone")) {
+            return Response.status(Response.Status.NOT_FOUND).
+                            entity("Discovered tombstone resource at " + tmp).build();
+        } else {
+            return Response.status(Response.Status.NOT_FOUND).
+                            entity("Resource at " + tmp + " not found").build();
+        }
     }
 }
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapperTest.java
@@ -34,10 +34,13 @@ import org.junit.Test;
 public class ItemNotFoundExceptionMapperTest {
 
     private ItemNotFoundExceptionMapper testObj;
+    private ItemNotFoundExceptionMapper testObj2;
 
     @Before
     public void setUp() {
+
         testObj = new ItemNotFoundExceptionMapper();
+        testObj2 = new ItemNotFoundExceptionMapper();
     }
 
     @Test
@@ -45,6 +48,14 @@ public class ItemNotFoundExceptionMapperTest {
         final ItemNotFoundException input = new ItemNotFoundException("xyz");
         final Response actual = testObj.toResponse(input);
         assertEquals(NOT_FOUND.getStatusCode(), actual.getStatus());
-        assertEquals(actual.getEntity(), "Error: xyz");
+        assertEquals(actual.getEntity(), "Resource at xyz not found");
+    }
+    @Test
+    public void testToResponse2() {
+        //tombstone
+        final ItemNotFoundException input2 = new ItemNotFoundException("/fcr:tombstone");
+        final Response actual2 = testObj2.toResponse(input2);
+        assertEquals(NOT_FOUND.getStatusCode(), actual2.getStatus());
+        assertEquals(actual2.getEntity(), "Discovered tombstone resource at /fcr:tombstone");
     }
 }


### PR DESCRIPTION
- Checks if exception message contains /fcr:tombstone and returns custom excption message as per the suggestion in the ticket

Resolves: https://jira.lyrasis.org/projects/FCREPO/issues/FCREPO-3261


https://jira.lyrasis.org/projects/FCREPO/issues/FCREPO-3261

The ticket requests that if a user requests an item and the item does not exist anymore (due to deletion, etc) AND the item left a tombstone in its place, the message returned via the exception handler should be different than and item that has been removed but has no tombstone

Ideally, it should be tested by creating an item, deleting it in such a way to generate a tombstone then retrieving the deleted item as well as creating an item, deleting it in a way to not generate a tombstone and retrieving the item (to check the non-tombstone return message)

I'm sorry if the code doesn't work as intended or if the tests aren't as accurate as you'd like. I'm not sure how to create/delete/retrieve in a JUnit test.

@awoods