### PR TITLE
Rewrite PATCH request repository URIs to internal IDs

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -513,7 +513,9 @@ public class FedoraLdp extends ContentExposingResource {
             evaluateRequestPreconditions(request, servletResponse, resource(), transaction);
 
             LOGGER.info("PATCH for '{}'", externalPath);
-            patchResourcewithSparql(resource(), requestBody);
+            final String newRequest = httpRdfService.patchRequestToInternalString(resource().getFedoraId().getFullId(),
+                    requestBody, identifierConverter());
+            patchResourcewithSparql(resource(), newRequest);
             transaction.commitIfShortLived();
 
             addCacheControlHeaders(servletResponse, resource(), transaction);
@@ -627,7 +629,7 @@ public class FedoraLdp extends ContentExposingResource {
         try {
             final var resource = getFedoraResource(transaction, newFedoraId);
             return createUpdateResponse(resource, true);
-        } catch (PathNotFoundException e) {
+        } catch (final PathNotFoundException e) {
             throw new PathNotFoundRuntimeException(e);
         }
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -515,6 +515,7 @@ public class FedoraLdp extends ContentExposingResource {
             LOGGER.info("PATCH for '{}'", externalPath);
             final String newRequest = httpRdfService.patchRequestToInternalString(resource().getFedoraId().getFullId(),
                     requestBody, identifierConverter());
+            LOGGER.debug("PATCH request translated to '{}'", newRequest);
             patchResourcewithSparql(resource(), newRequest);
             transaction.commitIfShortLived();
 
@@ -630,7 +631,7 @@ public class FedoraLdp extends ContentExposingResource {
             final var resource = getFedoraResource(transaction, newFedoraId);
             return createUpdateResponse(resource, true);
         } catch (final PathNotFoundException e) {
-            throw new PathNotFoundRuntimeException(e);
+            throw new PathNotFoundRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -167,14 +167,14 @@ public class HttpRdfService {
     /**
      * Takes a PATCH request body and translates any subjects and objects that are in the domain of the repository
      * to use internal IDs.
-     * @param extResourceId the internal ID of the current resource.
+     * @param resourceId the internal ID of the current resource.
      * @param requestBody the request body.
      * @param idTranslator an ID converter for the current context.
-     * @return the converted string.
+     * @return the converted PATCH request.
      */
-    public String patchRequestToInternalString(final String extResourceId, final String requestBody,
+    public String patchRequestToInternalString(final String resourceId, final String requestBody,
                                                final HttpIdentifierConverter idTranslator) {
-        final UpdateRequest request = UpdateFactory.create(requestBody, extResourceId);
+        final UpdateRequest request = UpdateFactory.create(requestBody, resourceId);
         final List<Update> updates = request.getOperations();
         final SparqlTranslateVisitor visitor = new SparqlTranslateVisitor(idTranslator);
         for (final Update update : updates) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api.services;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.modify.request.QuadAcc;
+import org.apache.jena.sparql.modify.request.QuadDataAcc;
+import org.apache.jena.sparql.modify.request.UpdateData;
+import org.apache.jena.sparql.modify.request.UpdateDataDelete;
+import org.apache.jena.sparql.modify.request.UpdateDataInsert;
+import org.apache.jena.sparql.modify.request.UpdateDeleteWhere;
+import org.apache.jena.sparql.modify.request.UpdateModify;
+import org.apache.jena.sparql.modify.request.UpdateVisitorBase;
+import org.apache.jena.sparql.syntax.Element;
+import org.apache.jena.update.Update;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateRequest;
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.slf4j.Logger;
+
+/**
+ * A special UpdateVisitor to translate Fedora URIs to internal FedoraIDs.
+ * @author whikloj
+ */
+public class SparqlTranslateVisitor extends UpdateVisitorBase {
+
+    private static final Logger LOGGER = getLogger(SparqlTranslateVisitor.class);
+
+    private List<Update> newUpdates = new ArrayList<>();
+
+    private HttpIdentifierConverter idTranslator;
+
+    public SparqlTranslateVisitor(final HttpIdentifierConverter identifierConverter) {
+        idTranslator = identifierConverter;
+    }
+
+    @Override
+    public void visit(final UpdateDataInsert update) {
+        translateUpdate(update);
+    }
+
+    @Override
+    public void visit(final UpdateDataDelete update) {
+        translateUpdate(update);
+    }
+
+    @Override
+    public void visit(final UpdateDeleteWhere update) {
+        translateUpdate(update);
+    }
+
+    @Override
+    public void visit(final UpdateModify update) {
+        translateUpdate(update);
+    }
+
+    /**
+     * Get the new UpdateRequest based on the parsed Updates.
+     * @return the new updaterequest object.
+     */
+    public UpdateRequest getTranslatedRequest() {
+        final UpdateRequest newRequest = UpdateFactory.create();
+        newUpdates.forEach(newRequest::add);
+        return newRequest;
+    }
+
+    /**
+     * Perform a translation of all the triples in an Update adding them to the internal list.
+     * @param update the update request to translate.
+     */
+    private void translateUpdate(final Update update) {
+        final List<Quad> sourceQuads;
+        if (update instanceof UpdateDeleteWhere) {
+            sourceQuads = ((UpdateDeleteWhere)update).getQuads();
+        } else {
+            sourceQuads = ((UpdateData) update).getQuads();
+        }
+        final List<Quad> newQuads = translateQuads(sourceQuads);
+        final Update newUpdate = makeUpdate(update.getClass(), newQuads);
+        newUpdates.add(newUpdate);
+    }
+
+    /**
+     * Perform a translation of all the triples in an UpdateModify request.
+     * @param update the update request to translate
+     */
+    private void translateUpdate(final UpdateModify update) {
+        final UpdateModify newUpdate = new UpdateModify();
+        final List<Quad> insertQuads = (update.hasInsertClause() ? translateQuads(update.getInsertQuads()) :
+                Collections.emptyList());
+        insertQuads.forEach(q -> newUpdate.getInsertAcc().addQuad(q));
+
+        final List<Quad> deleteQuads = (update.hasDeleteClause() ? translateQuads(update.getDeleteQuads()) :
+                Collections.emptyList());
+        deleteQuads.forEach(q -> newUpdate.getDeleteAcc().addQuad(q));
+
+        final Element where = update.getWherePattern();
+        newUpdate.setElement(where);
+        newUpdates.add(newUpdate);
+    }
+
+    /**
+     * Perform the translation to a list of quads.
+     * @param quadsList the quads
+     * @return the translated list of quads.
+     */
+    private List<Quad> translateQuads(final List<Quad> quadsList) {
+        final List<Quad> newQuads = new ArrayList<>();
+        for (final Quad q : quadsList) {
+            final Node subject = translateId(q.getSubject());
+            final Node object = translateId(q.getObject());
+            final Quad quad = new Quad(q.getGraph(), subject, q.getPredicate(), object);
+            LOGGER.trace("Translated quad is: {}", quad);
+            newQuads.add(quad);
+        }
+        return newQuads;
+    }
+
+    /**
+     * Quads insert/delete data statements don't contain variables and use QuadDataAcc to accumulate,
+     * insert {} delete {} where {} statements can't contain variables and use QuadAcc to accumulate. This function
+     * simplifies the creation of the eventual Update.
+     * @param updateClass the class of Update we are starting with.
+     * @param quadList the list of Quads to generate the above class with.
+     * @return a subclass of Update with the provided Quads.
+     */
+    private Update makeUpdate(final Class<? extends Update> updateClass, final List<Quad> quadList) {
+        try {
+            if (updateClass.equals(UpdateDeleteWhere.class)) {
+                final QuadAcc quadAcc = new QuadAcc();
+                quadList.forEach(quadAcc::addQuad);
+                return new UpdateDeleteWhere(quadAcc);
+            } else {
+                final QuadDataAcc quadsAcc = new QuadDataAcc();
+                quadList.forEach(quadsAcc::addQuad);
+                final Constructor<? extends Update> update = updateClass.getConstructor(QuadDataAcc.class);
+                return update.newInstance(quadsAcc);
+            }
+        } catch (final ReflectiveOperationException exc) {
+            LOGGER.warn("Could not find constructor UpdateRequest");
+            throw new RepositoryRuntimeException("Could not find constructor UpdateRequest", exc);
+        }
+    }
+
+    /**
+     * If the node is a URI with the external domain translate it, otherwise leave it alone
+     * @param externalNode the node to translate
+     * @return the original or translated node.
+     */
+    private Node translateId(final Node externalNode) {
+        if (externalNode.isURI()) {
+            final String externalId = externalNode.getURI();
+            if (idTranslator.inExternalDomain(externalId)) {
+                return NodeFactory.createURI(idTranslator.toInternalId(externalId));
+            }
+        }
+        return externalNode;
+    }
+
+}

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -85,7 +85,7 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
 
     /**
      * Get the new UpdateRequest based on the parsed Updates.
-     * @return the new updaterequest object.
+     * @return the new update request object.
      */
     public UpdateRequest getTranslatedRequest() {
         final UpdateRequest newRequest = UpdateFactory.create();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -64,6 +64,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
@@ -1042,7 +1043,7 @@ public class FedoraLdpTest {
                 eq(mockTransaction.getId()),
                 anyString(),
                 eq(binaryDescId),
-                anyString()
+                contains("<http://some/predicate> \"xyz\"")
         );
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -1021,7 +1021,7 @@ public class FedoraLdpTest {
 
         setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("PATCH");
-        testObj.updateSparql(toInputStream("xyz", UTF_8));
+        testObj.updateSparql(toInputStream("INSERT DATA { <> <http://some/predicate> \"xyz\" }", UTF_8));
     }
 
 
@@ -1037,12 +1037,12 @@ public class FedoraLdpTest {
 
         when(resourceFactory.getResource(mockTransaction, binaryDescId))
                 .thenReturn(mockNonRdfSourceDescription);
-        testObj.updateSparql(toInputStream("xyz", UTF_8));
+        testObj.updateSparql(toInputStream("INSERT DATA { <> <http://some/predicate> \"xyz\" }", UTF_8));
         verify(updatePropertiesService).updateProperties(
                 eq(mockTransaction.getId()),
                 anyString(),
                 eq(binaryDescId),
-                eq("xyz")
+                anyString()
         );
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.http.api.services;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.when;
@@ -157,8 +158,8 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> INSERT { <> test:pointer <http://other.com/resource>" +
                 " } WHERE {}";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<http://other.com/resource>"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <http://other.com/resource>",
+                translated);
     }
 
     @Test
@@ -166,8 +167,8 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> INSERT DATA { <> test:pointer " +
                 "<http://other.com/resource> }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<http://other.com/resource>"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <http://other.com/resource>",
+                translated);
     }
 
     @Test
@@ -175,8 +176,8 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> DELETE DATA { <> test:pointer " +
                 "<http://other.com/resource> }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<http://other.com/resource>"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <http://other.com/resource>",
+                translated);
     }
 
     @Test
@@ -184,8 +185,8 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> INSERT { <" + FEDORA_URI_1 + "> test:pointer " +
                 "<http://other.com/resource> } WHERE {}";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<http://other.com/resource>"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <http://other.com/resource>",
+                translated);
     }
 
     @Test
@@ -193,8 +194,8 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> INSERT DATA { <" + FEDORA_URI_1 + "> test:pointer " +
                 "<http://other.com/resource> }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<http://other.com/resource>"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <http://other.com/resource>",
+                translated);
     }
 
     @Test
@@ -202,8 +203,8 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> DELETE DATA { <" + FEDORA_URI_1 + "> test:pointer " +
                 "<http://other.com/resource> }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<http://other.com/resource>"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <http://other.com/resource>",
+                translated);
     }
 
     @Test
@@ -211,9 +212,9 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> DELETE { <> test:pointer ?o } INSERT { <> test:pointer" +
                 " <http://other.com/resource> } WHERE { <> test:pointer ?o }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> ?o "));
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<http://other.com/resource>"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> ?o ", translated);
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <http://other.com/resource>",
+                translated);
     }
 
     @Test
@@ -221,8 +222,8 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> INSERT DATA { <> test:pointer " +
                 "<" + FEDORA_URI_2 + "> }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<" + FEDORA_ID_2 + ">"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <" + FEDORA_ID_2 + ">",
+                translated);
     }
 
     @Test
@@ -230,26 +231,25 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> INSERT DATA { <" + FEDORA_URI_1 + "> " +
                 "test:pointer <" + FEDORA_URI_2 + "> }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<" + FEDORA_ID_2 + ">"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <" + FEDORA_ID_2 + ">",
+                translated);
     }
 
     @Test
     public void testPatchToInternal_EmptySubjectExplicitObjectDelete() {
-        final String rdf = "prefix test: <http://example.org#> DELETE DATA { <> test:pointer " +
-                "<" + FEDORA_URI_2 + "> }";
+        final String rdf = "prefix test: <http://example.org#> DELETE DATA { <> test:pointer <" + FEDORA_URI_2 + "> }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<" + FEDORA_ID_2 + ">"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <" + FEDORA_ID_2 + ">",
+                translated);
     }
 
     @Test
     public void testPatchToInternal_ExplicitSubjectObjectDelete() {
-        final String rdf = "prefix test: <http://example.org#> DELETE DATA { <" + FEDORA_URI_1 + "> " +
-                "test:pointer <" + FEDORA_URI_2 + "> }";
+        final String rdf = "prefix test: <http://example.org#> DELETE DATA { <" + FEDORA_URI_1 + "> test:pointer <" +
+                FEDORA_URI_2 + "> }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<" + FEDORA_ID_2 + ">"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <" + FEDORA_ID_2 + ">",
+                translated);
     }
 
     @Test
@@ -257,9 +257,9 @@ public class HttpRdfServiceTest {
         final String rdf = "prefix test: <http://example.org#> DELETE { <> test:pointer ?o } INSERT { <> test:pointer" +
                 " <" + FEDORA_URI_2 + "> } WHERE { <> test:pointer ?o }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
-                "<" + FEDORA_ID_2 + ">"));
-        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> ?o"));
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> <" + FEDORA_ID_2 + ">",
+                translated);
+        assertStringMatch("<" + FEDORA_ID_1 + "> <http://example.org#pointer> ?o", translated);
     }
 
     @Test
@@ -268,9 +268,42 @@ public class HttpRdfServiceTest {
                 "test:pointer ?o } INSERT { <" + FEDORA_URI_2 + "> test:pointer" +
                 " <" + FEDORA_URI_1 + "> } WHERE { <" + FEDORA_URI_2 + "> test:pointer ?o }";
         final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_2, rdf, idTranslator);
-        assertTrue(translated.contains("<" + FEDORA_ID_2 + "> <http://example.org#pointer> " +
-                "<" + FEDORA_ID_1 + ">"));
-        assertTrue(translated.contains("<" + FEDORA_ID_2 + "> <http://example.org#pointer> ?o"));
+        assertStringMatch("<" + FEDORA_ID_2 + "> <http://example.org#pointer> <" + FEDORA_ID_1 + ">",
+                translated);
+        assertStringMatch("<" + FEDORA_ID_2 + "> <http://example.org#pointer> ?o", translated);
+    }
+
+    @Test
+    public void testPatchToInternal_ExplicitSubjectObjectUpdateWhereSubject() {
+        final String rdf = "prefix test: <http://example.org#> INSERT { <" + FEDORA_URI_2 + "> test:pointer" +
+                " <" + FEDORA_URI_1 + "> } WHERE { <" + FEDORA_URI_2 + "> test:pointer ?o }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_2, rdf, idTranslator);
+        assertStringMatch("<" + FEDORA_ID_2 + "> <http://example.org#pointer> " +
+                "<" + FEDORA_ID_1 + ">", translated);
+        assertStringMatch("<" + FEDORA_ID_2 + "> <http://example.org#pointer> ?o", translated);
+    }
+
+    @Test
+    public void testPatchToInternal_ExplicitSubjectObjectUpdateWhereObject() {
+        final String rdf = "prefix test: <http://example.org#> INSERT { <" + FEDORA_URI_2 + "> test:pointer" +
+                " <" + FEDORA_URI_1 + "> } WHERE { ?o test:pointer <" + FEDORA_URI_2 + "> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_2, rdf, idTranslator);
+        assertStringMatch("<" + FEDORA_ID_2 + "> <http://example.org#pointer> " +
+                "<" + FEDORA_ID_1 + ">", translated);
+        assertStringMatch("?o <http://example.org#pointer> <" + FEDORA_ID_2 + ">", translated);
+    }
+
+    /**
+     * Assert 2 strings match regardless of whitespace.
+     * @param expected the expected string.
+     * @param comparison the string to test.
+     */
+    private void assertStringMatch(final String expected, final String comparison) {
+        final String cleanedExpected = expected.replaceAll("[\t\n]", "")
+                .replaceAll(" {2,}", " ");
+        final String cleanedTest = comparison.replaceAll("[\t\n]", "")
+                .replaceAll(" {2,}", " ");
+        assertEquals(cleanedExpected, cleanedExpected);
     }
 
     private void verifyTriples(final Model model)  {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
@@ -152,6 +152,127 @@ public class HttpRdfServiceTest {
         assertFalse(model.containsResource(FEDORA_ID_2_RESOURCE));
     }
 
+    @Test
+    public void testPatchToInternal_EmptySubjectUpdate() {
+        final String rdf = "prefix test: <http://example.org#> INSERT { <> test:pointer <http://other.com/resource>" +
+                " } WHERE {}";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<http://other.com/resource>"));
+    }
+
+    @Test
+    public void testPatchToInternal_EmptySubjectInsert() {
+        final String rdf = "prefix test: <http://example.org#> INSERT DATA { <> test:pointer " +
+                "<http://other.com/resource> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<http://other.com/resource>"));
+    }
+
+    @Test
+    public void testPatchToInternal_EmptySubjectDelete() {
+        final String rdf = "prefix test: <http://example.org#> DELETE DATA { <> test:pointer " +
+                "<http://other.com/resource> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<http://other.com/resource>"));
+    }
+
+    @Test
+    public void testPatchToInternal_ExplicitSubjectUpdate() {
+        final String rdf = "prefix test: <http://example.org#> INSERT { <" + FEDORA_URI_1 + "> test:pointer " +
+                "<http://other.com/resource> } WHERE {}";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<http://other.com/resource>"));
+    }
+
+    @Test
+    public void testPatchToInternal_ExplicitSubjectInsert() {
+        final String rdf = "prefix test: <http://example.org#> INSERT DATA { <" + FEDORA_URI_1 + "> test:pointer " +
+                "<http://other.com/resource> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<http://other.com/resource>"));
+    }
+
+    @Test
+    public void testPatchToInternal_ExplicitSubjectDelete() {
+        final String rdf = "prefix test: <http://example.org#> DELETE DATA { <" + FEDORA_URI_1 + "> test:pointer " +
+                "<http://other.com/resource> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<http://other.com/resource>"));
+    }
+
+    @Test
+    public void testPatchToInternal_EmptySubjectInsertDeleteWhere() {
+        final String rdf = "prefix test: <http://example.org#> DELETE { <> test:pointer ?o } INSERT { <> test:pointer" +
+                " <http://other.com/resource> } WHERE { <> test:pointer ?o }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> ?o "));
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<http://other.com/resource>"));
+    }
+
+    @Test
+    public void testPatchToInternal_EmptySubjectObjectInsert() {
+        final String rdf = "prefix test: <http://example.org#> INSERT DATA { <> test:pointer " +
+                "<" + FEDORA_URI_2 + "> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<" + FEDORA_ID_2 + ">"));
+    }
+
+    @Test
+    public void testPatchToInternal_ExplicitSubjectObjectInsert() {
+        final String rdf = "prefix test: <http://example.org#> INSERT DATA { <" + FEDORA_URI_1 + "> " +
+                "test:pointer <" + FEDORA_URI_2 + "> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<" + FEDORA_ID_2 + ">"));
+    }
+
+    @Test
+    public void testPatchToInternal_EmptySubjectExplicitObjectDelete() {
+        final String rdf = "prefix test: <http://example.org#> DELETE DATA { <> test:pointer " +
+                "<" + FEDORA_URI_2 + "> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<" + FEDORA_ID_2 + ">"));
+    }
+
+    @Test
+    public void testPatchToInternal_ExplicitSubjectObjectDelete() {
+        final String rdf = "prefix test: <http://example.org#> DELETE DATA { <" + FEDORA_URI_1 + "> " +
+                "test:pointer <" + FEDORA_URI_2 + "> }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<" + FEDORA_ID_2 + ">"));
+    }
+
+    @Test
+    public void testPatchToInternal_EmptySubjectExplicitObjectUpdate() {
+        final String rdf = "prefix test: <http://example.org#> DELETE { <> test:pointer ?o } INSERT { <> test:pointer" +
+                " <" + FEDORA_URI_2 + "> } WHERE { <> test:pointer ?o }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_1, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> " +
+                "<" + FEDORA_ID_2 + ">"));
+        assertTrue(translated.contains("<" + FEDORA_ID_1 + "> <http://example.org#pointer> ?o"));
+    }
+
+    @Test
+    public void testPatchToInternal_ExplicitSubjectObjectUpdate() {
+        final String rdf = "prefix test: <http://example.org#> DELETE { <" + FEDORA_URI_2 + "> " +
+                "test:pointer ?o } INSERT { <" + FEDORA_URI_2 + "> test:pointer" +
+                " <" + FEDORA_URI_1 + "> } WHERE { <" + FEDORA_URI_2 + "> test:pointer ?o }";
+        final String translated = httpRdfService.patchRequestToInternalString(FEDORA_ID_2, rdf, idTranslator);
+        assertTrue(translated.contains("<" + FEDORA_ID_2 + "> <http://example.org#pointer> " +
+                "<" + FEDORA_ID_1 + ">"));
+        assertTrue(translated.contains("<" + FEDORA_ID_2 + "> <http://example.org#pointer> ?o"));
+    }
+
     private void verifyTriples(final Model model)  {
 
         final Resource fedoraResource = model.createResource(FEDORA_ID_1);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2957,7 +2957,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testUpdateAndReplaceObjectGraph() throws IOException {
         final String subjectURI = getLocation(postObjMethod());
         final HttpPatch updateObjectGraphMethod = new HttpPatch(subjectURI);
@@ -3101,7 +3100,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         patch.addHeader(CONTENT_TYPE, "application/sparql-update");
         patch.setEntity(new StringEntity(
                 "PREFIX ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> " +
-                "INSERT { <" + subjectURI + "> ebucore:hasMimeType> \"-- invalid syntax! --\" } WHERE {}")
+                "INSERT { <" + subjectURI + "> ebucore:hasMimeType \"-- invalid syntax! --\" } WHERE {}")
         );
 
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(patch));
@@ -3261,7 +3260,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testLinkedDeletion() {
         final String linkedFrom = getRandomUniqueId();
         final String linkedTo = getRandomUniqueId();

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundRuntimeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundRuntimeExceptionMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
+import org.slf4j.Logger;
+
+
+/**
+ * Catch PathNotFoundRuntimeException(s)
+ *
+ * @author whikloj
+ */
+@Provider
+public class PathNotFoundRuntimeExceptionMapper implements
+        ExceptionMapper<PathNotFoundRuntimeException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER =
+        getLogger(PathNotFoundRuntimeExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final PathNotFoundRuntimeException e) {
+
+        LOGGER.debug("Exception intercepted by PathNotFoundRuntimeExceptionMapper: {}\n", e.getMessage());
+        debugException(this, e, LOGGER);
+        return Response.status(Response.Status.NOT_FOUND).
+                entity("Error: " + e.getMessage()).build();
+    }
+}
+

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PathNotFoundRuntimeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PathNotFoundRuntimeException.java
@@ -32,4 +32,13 @@ public class PathNotFoundRuntimeException extends RepositoryRuntimeException {
     public PathNotFoundRuntimeException(final Throwable rootCause) {
         super(rootCause);
     }
+
+    /**
+     * Wrap a PathNotFoundException in a runtime exception
+     * @param message the original message.
+     * @param rootCause the root cause.
+     */
+    public PathNotFoundRuntimeException(final String message, final Throwable rootCause) {
+        super(message, rootCause);
+    }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3311

# What does this Pull Request do?

We use the HttpRdfService on PUT/POST requests to ensure RDF has URIs for items in the repository converted to internal IDs. But for Sparql we didn't do this. So while the RDF appears correct the repository doesn't realize it is referencing an item inside the repository.

This adds an "UpdateVisitor" to generate a new Sparql request based on the old one but with any in domain URIs converted to internal IDs

# How should this be tested?

I'm not sure if this is testable except by checking the actual RDF stored in the OCFL objects.

1. Create a RDFSource object.
     `curl -i -ufedoraAdmin:fedoraAdmin -XPOST http://localhost:8080/rest `
1. Patch the resource with some internal IDs.
     `curl -ufedoraAdmin:fedoraAdmin -i -XPATCH -d"INSERT DATA { <http://localhost:8080/rest/resource1> <http://example.org/some/predicate> <http://localhost:8080/rest/someOtherResource> }" -H"Content-type: application/sparql-update" (the URL created above)`
1. Locate and check the `fcr-container.nt` file in the OCFL storage root. It should be in the `v2` directory.

Before the PR it will look like
```
<http://localhost:8080/rest/resource1> <http://example.org/some/predicate> <http://localhost:8080/rest/someOtherResource> .
```
and after it should look like 
```
<info:fedora/resource1> <http://example.org/some/predicate> <info:fedora/someOtherResource> .
```

# Interested parties
@fcrepo4/committers
