### PR TITLE
Add remaining SMTs

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -50,6 +50,7 @@ import static org.apache.http.entity.ContentType.parse;
 import static org.apache.http.impl.client.cache.CacheConfig.DEFAULT;
 import static org.apache.jena.datatypes.TypeMapper.getInstance;
 import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDinteger;
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
@@ -68,6 +69,7 @@ import static org.apache.jena.vocabulary.DC_11.title;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_VARIANTS;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_FIXITY;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
 import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
@@ -77,11 +79,15 @@ import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_FIXITY_SERVICE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.IS_MEMBER_OF_RELATION;
@@ -93,6 +99,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_SERVER_MANAGED;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
@@ -3173,6 +3180,52 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
         replaceMethod.addHeader(CONTENT_TYPE, "application/n-triples");
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(replaceMethod));
+    }
+
+    @Test
+    public void testDefaultBinaryDescriptionTriples() throws Exception {
+        final String id = getRandomUniqueId();
+        final HttpPost post = postObjMethod();
+        final String binaryUri = serverAddress + id;
+        final Node binaryNode = createURI(binaryUri);
+
+        post.setHeader("Slug", id);
+        post.setHeader(CONTENT_TYPE, TEXT_PLAIN);
+        post.setEntity(new StringEntity("some text", UTF_8));
+        post.setHeader(CONTENT_DISPOSITION, "attachment; filename=\"mytest.txt\"");
+        assertEquals(CREATED.getStatusCode(), getStatus(post));
+
+        final HttpGet get = getObjMethod(id + "/" + FCR_METADATA);
+        try (final CloseableHttpResponse response = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            try (final CloseableDataset dataset = getDataset(response)) {
+                final DatasetGraph graph = dataset.asDatasetGraph();
+                // Not checking for CreatedBy and LastModifiedBy as they require authentication.
+                assertFalse(dataset.isEmpty());
+                assertTrue(graph.contains(ANY, binaryNode, CREATED_DATE.asNode(), ANY));
+                assertTrue(graph.contains(ANY, binaryNode, LAST_MODIFIED_DATE.asNode(), ANY));
+                assertTrue(graph.contains(ANY, binaryNode, type.asNode(), NON_RDF_SOURCE.asNode()));
+                assertTrue(graph.contains(ANY, binaryNode, type.asNode(), RESOURCE.asNode()));
+                assertTrue(graph.contains(ANY, binaryNode, type.asNode(), FEDORA_RESOURCE.asNode()));
+                assertTrue(graph.contains(ANY, binaryNode, type.asNode(), FEDORA_BINARY.asNode()));
+                assertTrue(graph.contains(ANY, binaryNode, HAS_SIZE.asNode(), createLiteral("9", XSDlong)));
+                assertTrue(graph.contains(ANY, binaryNode, HAS_MESSAGE_DIGEST.asNode(), ANY));
+                assertTrue(graph.contains(ANY, binaryNode, HAS_FIXITY_SERVICE.asNode(),
+                        createURI(binaryUri + "/" + FCR_FIXITY)));
+                assertTrue(graph.contains(ANY, binaryNode, HAS_ORIGINAL_NAME.asNode(),
+                        createLiteral("mytest.txt")));
+            }
+        }
+
+        // Now get with ServerManaged omitted
+        final HttpGet get2 = getObjMethod(id + "/" + FCR_METADATA);
+        get2.setHeader("Prefer", "return=representation; omit=\"" + PREFER_SERVER_MANAGED + "\"");
+        try (final CloseableHttpResponse response = execute(get2)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            try (final CloseableDataset dataset = getDataset(response)) {
+                assertTrue(dataset.isEmpty());
+            }
+        }
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -34,7 +34,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
 
 
@@ -180,5 +182,13 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
      */
     protected void setDigests(final Collection<URI> digests) {
         this.digests = digests;
+    }
+
+    @Override
+    public List<URI> getSystemTypes(final boolean forRdf) {
+        final var types = super.getSystemTypes(forRdf);
+        // Add fedora:Binary type.
+        types.add(URI.create(FEDORA_BINARY.getURI()));
+        return types;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 
 
@@ -61,7 +60,7 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
     public List<URI> getSystemTypes(final boolean forRdf) {
         final var types = super.getSystemTypes(forRdf);
         types.addAll(List.of(URI.create(RDF_SOURCE.toString()), URI.create(CONTAINER.toString()),
-                URI.create(FEDORA_CONTAINER.toString()), URI.create(FEDORA_RESOURCE.toString())));
+                URI.create(FEDORA_CONTAINER.toString())));
         return types;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -44,6 +44,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
@@ -235,6 +236,7 @@ public class FedoraResourceImpl implements FedoraResource {
             types.add(create(headers.getInteractionModel()));
             // ldp:Resource is on all resources
             types.add(create(RESOURCE.toString()));
+            types.add(create(FEDORA_RESOURCE.getURI()));
             if (!forRdf) {
                 // These types are not exposed as RDF triples.
                 if (headers.isArchivalGroup()) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -26,6 +26,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
@@ -75,6 +76,9 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
 
             triples.add(Triple.create(subject, HAS_SIZE.asNode(),
                     createLiteral(String.valueOf(binary.getContentSize()), XSDlong)));
+            if (binary.getFilename() != null) {
+                triples.add(Triple.create(subject, HAS_ORIGINAL_NAME.asNode(), createLiteral(binary.getFilename())));
+            }
             if (binary.getMimeType() != null) {
                 triples.add(Triple.create(subject, HAS_MIME_TYPE.asNode(), createLiteral(binary.getMimeType())));
             }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
@@ -43,7 +43,9 @@ import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
@@ -147,6 +149,7 @@ public class FedoraResourceImplTest {
                 create(exampleType),
                 create(BASIC_CONTAINER.toString()),
                 create(RESOURCE.toString()),
+                create(FEDORA_RESOURCE.toString()),
                 create(VERSIONED_RESOURCE.getURI()),
                 create(VERSIONING_TIMEGATE_TYPE)
         );
@@ -185,6 +188,8 @@ public class FedoraResourceImplTest {
                 create(exampleType),
                 create(NON_RDF_SOURCE.toString()),
                 create(RESOURCE.toString()),
+                create(FEDORA_RESOURCE.toString()),
+                create(FEDORA_BINARY.toString()),
                 create(VERSIONED_RESOURCE.getURI()),
                 create(VERSIONING_TIMEGATE_TYPE)
         );


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3269

# What does this Pull Request do?
Adds in some remaining server managed triples for Binaries (and actually for Containers too).

# How should this be tested?

1. Create a binary
     ```
     curl -i -ufedoraAdmin:fedoraAdmin -H"Content-type: text/plain" -d"Some example text" -XPOST -H"Slug: binary" http://localhost:8080/rest
     ```
1. Get the NonRdfSourceDescription
     ```
     curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary
     ```
1.  Before this PR see:
     ```
     <http://localhost:8081/rest/binary>
         fedora:created "2020-04-01T20:50:09.916295Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
         fedora:lastModified "2020-04-01T20:50:09.916295Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
         rdf:type ldp:NonRDFSource ;
         fedora:hasFixityService <http://localhost:8081/rest/binary/fcr:fixity> .
     ```
1. After this PR see:
    ```
     <http://localhost:8081/rest/binary>
        fedora:created           "2020-09-08T20:29:39.273341Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified      "2020-09-08T20:29:39.273341Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy         "fedoraAdmin" ;
        fedora:lastModifiedBy    "fedoraAdmin" ;
        rdf:type                 ldp:NonRDFSource ;
        rdf:type                 ldp:Resource ;
        rdf:type                 fedora:Resource ;
        rdf:type                 fedora:Binary ;
        premis:hasSize           "17"^^<http://www.w3.org/2001/XMLSchema#long> ;
        ebucore:hasMimeType      "text/plain" ;
        premis:hasMessageDigest  <urn:sha-512:2b416c46c884b38418d91151719a3af1f04cbb5686bc84b4057b3f99124d1920febe43bac16b8a734a13969270a9411186ff5e4ad20af60a8a11d412f96df8c2> ;
        fedora:hasFixityService  <http://localhost:8081/rest/binary/fcr:fixity> .
     ```
# Interested parties
@fcrepo4/committers
