### PR TITLE
Ensure that all Fedora modules are included in the default logback.xml

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -367,6 +367,7 @@ public class FedoraLdp extends ContentExposingResource {
             @HeaderParam("Digest") final String digest)
             throws InvalidChecksumException, MalformedRdfException, UnsupportedAlgorithmException,
                    PathNotFoundException {
+        LOGGER.info("PUT to create resource with ID: {}", externalPath());
 
         hasRestrictedPath(externalPath);
 
@@ -588,6 +589,8 @@ public class FedoraLdp extends ContentExposingResource {
         final FedoraId newFedoraId = mintNewPid(fedoraId, slug);
         final var providedContentType = getSimpleContentType(requestContentType);
 
+        LOGGER.info("POST to create resource with ID: {}, slug: {}", newFedoraId.getFullIdPath(), slug);
+
         if (isBinary(interactionModel,
                      providedContentType,
                      requestBodyStream != null && providedContentType != null,
@@ -798,7 +801,7 @@ public class FedoraLdp extends ContentExposingResource {
         final FedoraId fullTestPath = fedoraId.resolve(pid);
 
         if (doesResourceExist(transaction(), fullTestPath)) {
-            LOGGER.trace("Resource with path {} already exists; minting new path instead", fullTestPath);
+            LOGGER.debug("Resource with path {} already exists; minting new path instead", fullTestPath);
             return mintNewPid(fedoraId, null);
         }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
@@ -89,6 +89,7 @@ public class FedoraSearch extends FedoraBaseResource {
                              @DefaultValue("asc") @QueryParam("order") final String order,
                              @DefaultValue("fedora_id") @QueryParam("order_by") final String orderBy) {
 
+        LOGGER.info("GET on search with conditions: {}, and fields: {}", conditions, fields);
         try {
             final var conditionList = new ArrayList<Condition>();
             for (String condition : conditions) {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -79,7 +79,7 @@ public class HttpIdentifierConverter {
      * @return the internal identifier.
      */
     public String toInternalId(final String httpUri) {
-        LOGGER.debug("Translating http URI {} to Fedora ID", httpUri);
+        LOGGER.trace("Translating http URI {} to Fedora ID", httpUri);
 
         final String path = getPath(httpUri);
         if (path != null) {
@@ -100,7 +100,7 @@ public class HttpIdentifierConverter {
      * @return true if it is in domain.
      */
     public boolean inExternalDomain(final String httpUri) {
-        LOGGER.debug("Checking if http URI {} is in domain", httpUri);
+        LOGGER.trace("Checking if http URI {} is in domain", httpUri);
         return getPath(httpUri) != null;
     }
 
@@ -111,7 +111,7 @@ public class HttpIdentifierConverter {
      * @return the external URI.
      */
     public String toExternalId(final String fedoraId) {
-        LOGGER.debug("Translating Fedora ID {} to Http URI", fedoraId);
+        LOGGER.trace("Translating Fedora ID {} to Http URI", fedoraId);
         if (inInternalDomain(fedoraId)) {
             // If it starts with our prefix, strip the prefix and any leading slashes and use it as the path
             // part of the URI.
@@ -138,7 +138,7 @@ public class HttpIdentifierConverter {
      * @return true if it is in domain.
      */
     public boolean inInternalDomain(final String fedoraId) {
-        LOGGER.debug("Checking if fedora ID {} is in domain", fedoraId);
+        LOGGER.trace("Checking if fedora ID {} is in domain", fedoraId);
         return (fedoraId.startsWith(FEDORA_ID_PREFIX));
     }
 

--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/AbstractJMSPublisher.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/AbstractJMSPublisher.java
@@ -76,10 +76,10 @@ abstract class AbstractJMSPublisher {
     @Subscribe
     @AllowConcurrentEvents
     public void publishJCREvent(final Event event) throws JMSException {
-        LOGGER.debug("Received an event from the internal bus.");
+        LOGGER.debug("Received an event from the internal bus. {}", event);
         final Message tm =
                 eventFactory.getMessage(event, jmsSession);
-        LOGGER.debug("Transformed the event to a JMS message.");
+        LOGGER.trace("Transformed the event to a JMS message.");
         producer.send(tm);
 
         LOGGER.debug("Put event: {} onto JMS.", tm.getJMSMessageID());

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -89,9 +89,7 @@ public class TransactionImpl implements Transaction {
             this.getEventAccumulator().emitEvents(id, baseUri, userAgent);
             this.committed = true;
         } catch (final PersistentStorageException ex) {
-            if (log.isDebugEnabled()) {
-                log.debug("Failed to commit transaction: {}\n{}", ex.getMessage(), ExceptionUtils.getStackTrace(ex));
-            }
+            log.error("Failed to commit transaction: {}", id, ex);
 
             // Rollback on commit failure
             rollback();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.kernel.impl;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -88,6 +89,10 @@ public class TransactionImpl implements Transaction {
             this.getEventAccumulator().emitEvents(id, baseUri, userAgent);
             this.committed = true;
         } catch (final PersistentStorageException ex) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to commit transaction: {}\n{}", ex.getMessage(), ExceptionUtils.getStackTrace(ex));
+            }
+
             // Rollback on commit failure
             rollback();
             throw new RepositoryRuntimeException("Failed to commit transaction " + id, ex);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -65,7 +65,7 @@ public class TransactionManagerImpl implements TransactionManager {
      */
     @Scheduled(fixedDelayString = "#{systemProperties['fcrepo.session.timeout'] ?: 180000}")
     public void cleanupClosedTransactions() {
-        LOGGER.debug("Cleaning up expired transactions");
+        LOGGER.trace("Cleaning up expired transactions");
 
         final var txIt = transactions.entrySet().iterator();
         while (txIt.hasNext()) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImpl.java
@@ -103,7 +103,7 @@ public class EventAccumulatorImpl implements EventAccumulator {
 
     @Override
     public void clearEvents(final String transactionId) {
-        LOG.debug("Clearing events for transaction {}", transactionId);
+        LOG.trace("Clearing events for transaction {}", transactionId);
         transactionEventMap.remove(transactionId);
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
@@ -251,7 +251,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
         }
 
         this.state = State.COMMIT_STARTED;
-        LOGGER.debug("Starting storage session {} commit", sessionId);
+        LOGGER.trace("Starting storage session {} commit", sessionId);
 
         synchronized (this.phaser) {
             if (this.phaser.getRegisteredParties() > 0) {
@@ -259,7 +259,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
             }
         }
 
-        LOGGER.debug("All persisters are complete in session {}", sessionId);
+        LOGGER.trace("All persisters are complete in session {}", sessionId);
 
         // order map for testing
         final var sessions = new TreeMap<>(sessionMap);
@@ -271,7 +271,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
 
     private void commitObjectSessions(final Map<String, OcflObjectSession> sessions)
             throws PersistentStorageException {
-        LOGGER.debug("Committing session {}", sessionId);
+        LOGGER.trace("Committing session {}", sessionId);
 
         this.sessionsToRollback = new HashMap<>(sessionMap.size());
 
@@ -307,7 +307,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
         final boolean commitWasStarted = this.state != State.COMMIT_NOT_STARTED;
 
         this.state = State.ROLLING_BACK;
-        LOGGER.info("Rolling back storage session {}", sessionId);
+        LOGGER.debug("Rolling back storage session {}", sessionId);
 
         if (!commitWasStarted) {
             //if the commit had not been started at the time this method was invoked
@@ -333,7 +333,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
         }
 
         this.state = State.ROLLED_BACK;
-        LOGGER.debug("Successfully rolled back storage session {}", sessionId);
+        LOGGER.trace("Successfully rolled back storage session {}", sessionId);
     }
 
     /**

--- a/fcrepo-webapp/src/main/resources/logback.xml
+++ b/fcrepo-webapp/src/main/resources/logback.xml
@@ -10,6 +10,12 @@
   <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-null}">
     <appender-ref ref="STDOUT"/>
   </logger>
+  <logger name="org.fcrepo.config" additivity="false" level="${fcrepo.log.config:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.event" additivity="false" level="${fcrepo.log.event:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
   <logger name="org.fcrepo.http.api" additivity="false" level="${fcrepo.log.http.api:-null}">
     <appender-ref ref="STDOUT"/>
   </logger>
@@ -20,6 +26,15 @@
     <appender-ref ref="STDOUT"/>
   </logger>
   <logger name="org.fcrepo.kernel" additivity="false" level="${fcrepo.log.kernel:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.persistence" additivity="false" level="${fcrepo.log.persistence:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.search" additivity="false" level="${fcrepo.log.search:-null}">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+  <logger name="org.fcrepo.storage" additivity="false" level="${fcrepo.log.storage:-null}">
     <appender-ref ref="STDOUT"/>
   </logger>
   <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">


### PR DESCRIPTION
..and finetune the logging levels across the codebase.

Resolves: https://jira.lyrasis.org/browse/FCREPO-3415

# How should this be tested?
- Start Fedora and see if you like the default logging
- Start Fedora with different logging levels (other than the default, INFO) for specific modules 
   - e.g. `-Dfcrepo.log.storage=DEBUG`

# Interested parties
@fcrepo4/committers
