### PR TITLE
Inbound references service

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2827,7 +2827,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testGetObjectReferences() throws IOException {
         final String id = getRandomUniqueId();
         final String resource = serverAddress + id;
@@ -2842,7 +2841,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         updateObjectGraphMethod.setEntity(new StringEntity("INSERT { <" +
                 resourcea + "> <http://purl.org/dc/terms/isPartOf> <" + resourceb + "> . \n <" +
                 resourcea + "> <info:xyz#some-other-property> <" + resourceb + "> } WHERE {}"));
-        executeAndClose(updateObjectGraphMethod);
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(updateObjectGraphMethod));
 
         final HttpGet getObjMethod = new HttpGet(resourceb);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4018,7 +4018,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testInboundLinksDoNotUpdateEtag() throws IOException {
         final String id1 = getRandomUniqueId();
         final HttpPut httpPut = putObjMethod(id1);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -2878,12 +2878,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
             binaryUri = getLocation(response);
         }
 
-        final String linkRdf = "INSERT { <" + binaryUri + "> <http://awoods.com/pointsAt> <" + containerUri + "> . } " +
-                "WHERE {}";
-        final HttpPatch patchDesc = new HttpPatch(binaryUri + "/" + FCR_METADATA);
-        patchDesc.setHeader(CONTENT_TYPE, "application/sparql-update");
-        patchDesc.setEntity(new StringEntity(linkRdf));
-        assertEquals(NO_CONTENT.getStatusCode(), getStatus(patchDesc));
+        setProperty(binaryUri.replace(serverAddress, "") + "/" + FCR_METADATA, referenceProp.getURI(),
+                URI.create(containerUri));
 
         final HttpGet getContainer = new HttpGet(containerUri);
         getContainer.setHeader("Prefer", INBOUND_REFERENCE_PREFER_HEADER);

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -30,6 +30,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.services.CreateResourceService;
 import org.fcrepo.kernel.api.services.DeleteResourceService;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.api.services.ReplaceBinariesService;
 import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.kernel.api.services.UpdatePropertiesService;
@@ -72,6 +73,7 @@ import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 /**
  * <p>
@@ -123,6 +125,9 @@ abstract class AbstractJmsIT implements MessageListener {
     @Inject
     private ActiveMQConnectionFactory connectionFactory;
 
+    @Inject
+    private ReferenceService referenceService;
+
     private Connection connection;
 
     protected Session jmsSession;
@@ -134,6 +139,12 @@ abstract class AbstractJmsIT implements MessageListener {
     private static final Logger LOGGER = getLogger(AbstractJmsIT.class);
 
     protected abstract Destination createDestination() throws JMSException;
+
+    @Before
+    public void setUp() {
+        setField(createResourceService, "referenceService", referenceService);
+        setField(replacePropertiesService, "referenceService", referenceService);
+    }
 
     @Test(timeout = TIMEOUT)
     public void testIngestion() {

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -73,7 +73,6 @@ import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
 import static org.slf4j.LoggerFactory.getLogger;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 /**
  * <p>
@@ -139,12 +138,6 @@ abstract class AbstractJmsIT implements MessageListener {
     private static final Logger LOGGER = getLogger(AbstractJmsIT.class);
 
     protected abstract Destination createDestination() throws JMSException;
-
-    @Before
-    public void setUp() {
-        setField(createResourceService, "referenceService", referenceService);
-        setField(replacePropertiesService, "referenceService", referenceService);
-    }
 
     @Test(timeout = TIMEOUT)
     public void testIngestion() {
@@ -349,7 +342,7 @@ abstract class AbstractJmsIT implements MessageListener {
     private FedoraResource getResource(final FedoraId fedoraId) {
         try {
             return resourceFactory.getResource(fedoraId);
-        } catch (PathNotFoundException e) {
+        } catch (final PathNotFoundException e) {
             throw new RuntimeException(e);
         }
     }

--- a/fcrepo-jms/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-jms/src/test/resources/spring-test/fcrepo-config.xml
@@ -17,4 +17,8 @@
     
     <bean id="connectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager" />
 
+    <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+        <property name="driverClassName" value="org.h2.jdbcx.JdbcDataSource" />
+        <property name="url" value="jdbc:h2:mem:index;DB_CLOSE_DELAY=-1" />
+    </bean>
 </beans>

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
+
+/**
+ * Service to retrieve references to repository resources.
+ * @author whikloj
+ * @since 6.0.0
+ */
+public interface ReferenceService {
+
+    /**
+     * Return a RDFstream of statements referring the provided resource.
+     *
+     * @param txId the transaction ID or null if no transaction.
+     * @param resource the resource to get inbound references for.
+     * @return RDF stream of inbound reference triples.
+     */
+    RdfStream getInboundReferences(final String txId, final FedoraResource resource);
+
+    /**
+     * Parse the stream of triples for references, add any new ones and remove any missing ones.
+     * @param txId the transaction ID
+     * @param resourceId the subject ID of the triples.
+     * @param rdfStream the RDF stream.
+     */
+    void updateReferences(final String txId, final FedoraId resourceId, final RdfStream rdfStream);
+
+    /**
+     * Commit any pending references.
+     * @param txId the transaction id.
+     */
+    void commitTransaction(final String txId);
+
+    /**
+     * Rollback any pending references.
+     * @param txId the transaction id.
+     */
+    void rollbackTransaction(final String txId);
+
+    /**
+     * Truncates the reference index. This should only be called when rebuilding the index.
+     */
+    void reset();
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
@@ -29,7 +29,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 public interface ReferenceService {
 
     /**
-     * Return a RDFstream of statements referring the provided resource.
+     * Return a RDFstream of statements referring to the provided resource.
      *
      * @param txId the transaction ID or null if no transaction.
      * @param resource the resource to get inbound references for.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
@@ -38,6 +38,14 @@ public interface ReferenceService {
     RdfStream getInboundReferences(final String txId, final FedoraResource resource);
 
     /**
+     * Delete all references from a resource to any other resource.
+     *
+     * @param txId the transaction ID
+     * @param resourceId the ID of the resource referencing others.
+     */
+    void deleteAllReferences(final String txId, final FedoraId resourceId);
+
+    /**
      * Parse the stream of triples for references, add any new ones and remove any missing ones.
      * @param txId the transaction ID
      * @param resourceId the subject ID of the triples.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
@@ -29,7 +29,7 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 public interface ReferenceService {
 
     /**
-     * Return a RDFstream of statements referring to the provided resource.
+     * Return a RDF stream of statements referring to the provided resource.
      *
      * @param txId the transaction ID or null if no transaction.
      * @param resource the resource to get inbound references for.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -23,6 +23,7 @@ import org.fcrepo.kernel.api.TransactionManager;
 import org.fcrepo.kernel.api.exception.TransactionClosedException;
 import org.fcrepo.kernel.api.exception.TransactionNotFoundException;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,9 @@ public class TransactionManagerImpl implements TransactionManager {
 
     @Inject
     private EventAccumulator eventAccumulator;
+
+    @Inject
+    private ReferenceService referenceService;
 
     TransactionManagerImpl() {
         transactions = new ConcurrentHashMap<>();
@@ -137,4 +141,7 @@ public class TransactionManagerImpl implements TransactionManager {
         return eventAccumulator;
     }
 
+    protected ReferenceService getReferenceService() {
+        return referenceService;
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -59,6 +59,7 @@ import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.slf4j.Logger;
 
 
@@ -84,6 +85,9 @@ public abstract class AbstractService {
 
     @Inject
     private EventAccumulator eventAccumulator;
+
+    @Inject
+    protected ReferenceService referenceService;
 
     /**
      * Utility to determine the correct interaction model from elements of a request.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -31,6 +31,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_ACCESS_TO;
 import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_ACCESS_TO_CLASS;
 import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_ACCESS_TO_PROPERTY;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.inject.Inject;
@@ -226,6 +227,17 @@ public abstract class AbstractService {
 
     protected void recordEvent(final String transactionId, final FedoraId fedoraId, final ResourceOperation operation) {
         this.eventAccumulator.recordEventForOperation(transactionId, fedoraId, operation);
+    }
+
+    /**
+     * Wrapper to call the referenceService updateReference method
+     * @param transactionId the transaction ID.
+     * @param resourceId the resource's ID.
+     * @param model the model of the request body.
+     */
+    protected void updateReferences(final String transactionId, final FedoraId resourceId, final Model model) {
+        referenceService.updateReferences(transactionId, resourceId,
+                fromModel(model.getResource(resourceId.getFullId()).asNode(), model));
     }
 
     /**

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -32,6 +32,7 @@ import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.kernel.api.services.CreateResourceService;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
@@ -76,6 +77,9 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
     @Inject
     private NonRdfSourceOperationFactory nonRdfSourceOperationFactory;
+
+    @Inject
+    private ReferenceService referenceService;
 
     @Override
     public void perform(final String txId, final String userPrincipal, final FedoraId fedoraId,
@@ -180,6 +184,8 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
         try {
             pSession.persist(createOp);
+            referenceService.updateReferences(txId, fedoraId,
+                    fromModel(model.getResource(fedoraId.getFullId()).asNode(), model));
             addToContainmentIndex(txId, parentId, fedoraId);
             recordEvent(txId, fedoraId, createOp);
         } catch (final PersistentStorageException exc) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -32,7 +32,6 @@ import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.kernel.api.services.CreateResourceService;
-import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
@@ -77,9 +76,6 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
     @Inject
     private NonRdfSourceOperationFactory nonRdfSourceOperationFactory;
-
-    @Inject
-    private ReferenceService referenceService;
 
     @Override
     public void perform(final String txId, final String userPrincipal, final FedoraId fedoraId,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -180,8 +180,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
         try {
             pSession.persist(createOp);
-            referenceService.updateReferences(txId, fedoraId,
-                    fromModel(model.getResource(fedoraId.getFullId()).asNode(), model));
+            updateReferences(txId, fedoraId, model);
             addToContainmentIndex(txId, parentId, fedoraId);
             recordEvent(txId, fedoraId, createOp);
         } catch (final PersistentStorageException exc) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
@@ -61,6 +61,8 @@ public class DeleteResourceServiceImpl extends AbstractDeleteResourceService imp
                 .build();
         pSession.persist(deleteOp);
         containmentIndex.removeResource(tx.getId(), fedoraId);
+        referenceService.deleteAllReferences(tx.getId(), fedoraId);
+
         recordEvent(tx.getId(), fedoraId, deleteOp);
         log.debug("deleted {}", fedoraId.getFullId());
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
@@ -209,6 +209,15 @@ public class ReferenceServiceImpl implements ReferenceService {
         return references.stream();
     }
 
+    @Override
+    public void deleteAllReferences(@Nonnull final String txId, final FedoraId resourceId) {
+        final Stream<Triple> deleteReferences = getOutboundReferences(txId, resourceId);
+        // Remove all the existing references.
+        deleteReferences.forEach(t ->
+                removeReference(txId, resourceId.getFullId(), t.getPredicate().getURI(), t.getObject().getURI())
+        );
+    }
+
     /**
      * Get a stream of triples of resources being referenced from the provided resource.
      * @param txId transaction Id or null if none.
@@ -241,7 +250,7 @@ public class ReferenceServiceImpl implements ReferenceService {
 
     @Override
     @Transactional
-    public void updateReferences(final String txId, final FedoraId resourceId, final RdfStream rdfStream) {
+    public void updateReferences(@Nonnull final String txId, final FedoraId resourceId, final RdfStream rdfStream) {
         try {
             final Stream<Triple> deleteReferences = getOutboundReferences(txId, resourceId);
             // Remove all the existing references.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
@@ -1,0 +1,370 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.sql.DataSource;
+import javax.transaction.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import com.google.common.base.Preconditions;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.fcrepo.common.db.DbPlatform;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+import org.fcrepo.kernel.api.services.ReferenceService;
+import org.slf4j.Logger;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.init.DatabasePopulatorUtils;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementation of reference service.
+ * @author whikloj
+ * @since 6.0.0
+ */
+@Component
+public class ReferenceServiceImpl implements ReferenceService {
+
+    private static final Logger LOGGER = getLogger(ReferenceServiceImpl.class);
+
+    @Inject
+    private DataSource dataSource;
+
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    private static final String TABLE_NAME = "reference";
+
+    private static final String TRANSACTION_TABLE = "reference_transaction_operations";
+
+    private static final String SUBJECT_COLUMN = "fedora_id";
+
+    private static final String PROPERTY_COLUMN = "property";
+
+    private static final String TARGET_COLUMN = "target_id";
+
+    private static final String OPERATION_COLUMN = "operation";
+
+    private static final String TRANSACTION_COLUMN = "transaction_id";
+
+    private static final String SELECT_INBOUND = "SELECT " + SUBJECT_COLUMN + ", " + PROPERTY_COLUMN + " FROM " +
+            TABLE_NAME + " WHERE " + TARGET_COLUMN + " = :targetId";
+
+    private static final String SELECT_INBOUND_IN_TRANSACTION = "SELECT x." + SUBJECT_COLUMN + ", x." +
+            PROPERTY_COLUMN + " FROM " + "(SELECT " + SUBJECT_COLUMN + ", " + PROPERTY_COLUMN + " FROM " + TABLE_NAME +
+            " WHERE " + TARGET_COLUMN + " = :targetId UNION " + "SELECT " + SUBJECT_COLUMN + ", " + PROPERTY_COLUMN +
+            " FROM " + TRANSACTION_TABLE + " WHERE " + TARGET_COLUMN + " = :targetId AND "
+            + TRANSACTION_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'add') x WHERE NOT EXISTS " +
+            "(SELECT 1 FROM " + TRANSACTION_TABLE + " WHERE " + TARGET_COLUMN + " = :targetId AND " +
+            OPERATION_COLUMN + " = 'delete')";
+
+    private static final String SELECT_OUTBOUND = "SELECT " + TARGET_COLUMN + ", " + PROPERTY_COLUMN + " FROM " +
+            TABLE_NAME + " WHERE " + SUBJECT_COLUMN + " = :resourceId";
+
+    private static final String SELECT_OUTBOUND_IN_TRANSACTION = "SELECT x." + TARGET_COLUMN + ", x." +
+            PROPERTY_COLUMN + " FROM " + "(SELECT " + TARGET_COLUMN + ", " + PROPERTY_COLUMN + " FROM " + TABLE_NAME +
+            " WHERE " + SUBJECT_COLUMN + " = :resourceId UNION " + "SELECT " + TARGET_COLUMN + ", " + PROPERTY_COLUMN +
+            " FROM " + TRANSACTION_TABLE + " WHERE " + SUBJECT_COLUMN + " = :resourceId " +
+            "AND " + TRANSACTION_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'add') x WHERE NOT " +
+            "EXISTS (SELECT 1 FROM " + TRANSACTION_TABLE + " WHERE " + SUBJECT_COLUMN + " = :resourceId AND " +
+            OPERATION_COLUMN + " = 'delete')";
+
+    private static final String INSERT_REFERENCE_IN_TRANSACTION = "INSERT INTO " + TRANSACTION_TABLE + "(" +
+            SUBJECT_COLUMN + ", " + PROPERTY_COLUMN + ", " + TARGET_COLUMN + ", " + TRANSACTION_COLUMN + ", " +
+            OPERATION_COLUMN + ") VALUES (:resourceId, :property, :targetId, :transactionId, 'add')";
+
+    private static final String UNDO_INSERT_REFERENCE_IN_TRANSACTION = "DELETE FROM " + TRANSACTION_TABLE + " WHERE " +
+            SUBJECT_COLUMN + " = :resourceId AND " + PROPERTY_COLUMN + " = :property AND " + TARGET_COLUMN +
+            " = :targetId AND " + TRANSACTION_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'add'";
+
+    private static final String DELETE_REFERENCE_IN_TRANSACTION = "INSERT INTO " + TRANSACTION_TABLE + "(" +
+            SUBJECT_COLUMN + ", " + PROPERTY_COLUMN + ", " + TARGET_COLUMN + ", " + TRANSACTION_COLUMN + ", " +
+            OPERATION_COLUMN + ") VALUES (:resourceId, :property, :targetId, :transactionId, 'delete')";
+
+    private static final String UNDO_DELETE_REFERENCE_IN_TRANSACTION = "DELETE FROM " + TRANSACTION_TABLE + " WHERE " +
+            SUBJECT_COLUMN + " = :resourceId AND " + PROPERTY_COLUMN + " = :property AND " + TARGET_COLUMN +
+            " = :targetId AND " + TRANSACTION_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'delete'";
+
+    private static final String IS_REFERENCE_ADDED_IN_TRANSACTION = "SELECT TRUE FROM " + TRANSACTION_TABLE + " WHERE "
+            + SUBJECT_COLUMN + " = :resourceId AND " + PROPERTY_COLUMN + " = :property AND " + TARGET_COLUMN +
+            " = :targetId AND " + TRANSACTION_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'add'";
+
+    private static final String IS_REFERENCE_DELETED_IN_TRANSACTION = "SELECT TRUE FROM " + TRANSACTION_TABLE +
+            " WHERE " + SUBJECT_COLUMN + " = :resourceId AND " + PROPERTY_COLUMN + " = :property AND " + TARGET_COLUMN +
+            " = :targetId AND " + TRANSACTION_COLUMN + " = :transactionId AND " + OPERATION_COLUMN + " = 'delete'";
+
+    private static final String COMMIT_ADD_RECORDS = "INSERT INTO " + TABLE_NAME + " ( " + SUBJECT_COLUMN + ", "
+            + PROPERTY_COLUMN + ", " + TARGET_COLUMN + " ) SELECT " + SUBJECT_COLUMN + ", " + PROPERTY_COLUMN + ", " +
+            TARGET_COLUMN + " FROM " + TRANSACTION_TABLE + " WHERE " + TRANSACTION_COLUMN + " = :transactionId AND " +
+            OPERATION_COLUMN + " = 'add'";
+
+    private static final String COMMIT_DELETE_RECORDS = "DELETE FROM " + TABLE_NAME + " WHERE " +
+            "EXISTS (SELECT * FROM " + TRANSACTION_TABLE + " t WHERE t." +
+            TRANSACTION_COLUMN + " = :transactionId AND t." +  OPERATION_COLUMN + " = 'delete' AND" +
+            " t." + SUBJECT_COLUMN + " = " + TABLE_NAME + "." + SUBJECT_COLUMN +
+            " AND t." + PROPERTY_COLUMN + " = " + TABLE_NAME + "." + PROPERTY_COLUMN +
+            " AND t." + TARGET_COLUMN + " = " + TABLE_NAME + "." + TARGET_COLUMN + ")";
+
+    private static final String DELETE_TRANSACTION = "DELETE FROM " + TRANSACTION_TABLE + " WHERE " +
+            TRANSACTION_COLUMN + " = :transactionId";
+
+    private static final String TRUNCATE_TABLE = "TRUNCATE TABLE " + TABLE_NAME;
+
+    private static final Map<DbPlatform, String> DDL_MAP = Map.of(
+            DbPlatform.MYSQL, "sql/mysql-references.sql",
+            DbPlatform.H2, "sql/default-references.sql",
+            DbPlatform.POSTGRESQL, "sql/default-references.sql",
+            DbPlatform.MARIADB, "sql/default-references.sql"
+    );
+
+    @PostConstruct
+    public void setUp() {
+        jdbcTemplate = new NamedParameterJdbcTemplate(getDataSource());
+
+        final var dbPlatform = DbPlatform.fromDataSource(dataSource);
+
+        Preconditions.checkArgument(DDL_MAP.containsKey(dbPlatform),
+                "Missing DDL mapping for %s", dbPlatform);
+
+        final var ddl = DDL_MAP.get(dbPlatform);
+        LOGGER.info("Applying ddl: {}", ddl);
+        DatabasePopulatorUtils.execute(
+                new ResourceDatabasePopulator(new DefaultResourceLoader().getResource("classpath:" + ddl)),
+                dataSource);
+    }
+
+    @Override
+    public RdfStream getInboundReferences(final String txId, final FedoraResource resource) {
+        final String resourceId = resource.getFedoraId().getFullId();
+        final Node subject = NodeFactory.createURI(resourceId);
+        final Stream<Triple> stream = getReferencesInternal(txId, resourceId);
+        if (resource instanceof NonRdfSourceDescription) {
+            final Stream<Triple> stream2 = getReferencesInternal(txId, resource.getFedoraId().getBaseId());
+            return new DefaultRdfStream(subject, Stream.concat(stream, stream2));
+        }
+        return new DefaultRdfStream(subject, stream);
+    }
+
+    /**
+     * Get the inbound references for the resource Id and the transaction id.
+     * @param txId transaction id or null for none.
+     * @param resourceId the resource id.
+     * @return RDF stream of inbound references
+     */
+    private Stream<Triple> getReferencesInternal(final String txId, final String resourceId) {
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+        parameterSource.addValue("targetId", resourceId);
+        final Node targetNode = NodeFactory.createURI(resourceId);
+
+        final RowMapper<Triple> inboundMapper = (rs, rowNum) ->
+                Triple.create(NodeFactory.createURI(rs.getString(SUBJECT_COLUMN)),
+                        NodeFactory.createURI(rs.getString(PROPERTY_COLUMN)),
+                        targetNode);
+
+        final List<Triple> references;
+        if (txId != null) {
+            // we are in a transaction
+            parameterSource.addValue("transactionId", txId);
+            references = jdbcTemplate.query(SELECT_INBOUND_IN_TRANSACTION, parameterSource, inboundMapper);
+        } else {
+            // not in a transaction
+            references = jdbcTemplate.query(SELECT_INBOUND, parameterSource, inboundMapper);
+        }
+        LOGGER.debug("getInboundReferences for {} in transaction {} found {} references",
+                resourceId, txId, references.size());
+        return references.stream();
+    }
+
+    /**
+     * Get a stream of triples of resources being referenced from the provided resource.
+     * @param txId transaction Id or null if none.
+     * @param resourceId the resource Id.
+     * @return stream of Triples
+     */
+    private Stream<Triple> getOutboundReferences(final String txId, final FedoraId resourceId) {
+        final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+        parameterSource.addValue("resourceId", resourceId.getFullId());
+        final Node subjectNode = NodeFactory.createURI(resourceId.getFullId());
+
+        final RowMapper<Triple> outboundMapper = (rs, rowNum) ->
+                Triple.create(subjectNode,
+                        NodeFactory.createURI(rs.getString(PROPERTY_COLUMN)),
+                        NodeFactory.createURI(rs.getString(TARGET_COLUMN)));
+
+        final List<Triple> references;
+        if (txId != null) {
+            // we are in a transaction
+            parameterSource.addValue("transactionId", txId);
+            references = jdbcTemplate.query(SELECT_OUTBOUND_IN_TRANSACTION, parameterSource, outboundMapper);
+        } else {
+            // not in a transaction
+            references = jdbcTemplate.query(SELECT_OUTBOUND, parameterSource, outboundMapper);
+        }
+        LOGGER.debug("getOutboundReferences for {} in transaction {} found {} references",
+                resourceId, txId, references.size());
+        return references.stream();
+    }
+
+    @Override
+    @Transactional
+    public void updateReferences(final String txId, final FedoraId resourceId, final RdfStream rdfStream) {
+        try {
+            final Stream<Triple> deleteReferences = getOutboundReferences(txId, resourceId);
+            // Remove all the existing references.
+            deleteReferences.forEach(t ->
+                removeReference(txId, resourceId.getFullId(), t.getPredicate().getURI(), t.getObject().getURI())
+            );
+            final Stream<Triple> addReferences = getReferencesFromRdf(rdfStream);
+            addReferences.forEach(r -> addReference(txId, resourceId.getFullId(),
+                    r.getPredicate().getURI(), r.getObject().getURI()));
+        } catch (final Exception e) {
+            LOGGER.warn("Unable to update reference index for resource {} in transaction {}: {}",
+                    resourceId.getFullId(), txId, e.getMessage());
+            throw new RepositoryRuntimeException("Unable to update reference index", e);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void commitTransaction(final String txId) {
+        try {
+            final Map<String, String> parameterSource = Map.of("transactionId", txId);
+            jdbcTemplate.update(COMMIT_DELETE_RECORDS, parameterSource);
+            jdbcTemplate.update(COMMIT_ADD_RECORDS, parameterSource);
+            jdbcTemplate.update(DELETE_TRANSACTION, parameterSource);
+        } catch (final Exception e) {
+            LOGGER.warn("Unable to commit reference index transaction {}: {}", txId, e.getMessage());
+            throw new RepositoryRuntimeException("Unable to commit reference index transaction", e);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void rollbackTransaction(final String txId) {
+        try {
+            final Map<String, String> parameterSource = Map.of("transactionId", txId);
+            jdbcTemplate.update(DELETE_TRANSACTION, parameterSource);
+        } catch (final Exception e) {
+            LOGGER.warn("Unable to rollback reference index transaction {}: {}", txId, e.getMessage());
+            throw new RepositoryRuntimeException("Unable to rollback reference index transaction", e);
+        }
+    }
+
+    @Override
+    public void reset() {
+        try {
+            jdbcTemplate.update(TRUNCATE_TABLE, Map.of());
+        } catch (final Exception e) {
+            LOGGER.warn("Unable to reset reference index: {}", e.getMessage());
+            throw new RepositoryRuntimeException("Unable to reset reference index", e);
+        }
+    }
+
+    /**
+     * Remove a reference.
+     * @param txId transaction Id.
+     * @param resourceId the subject resource Id.
+     * @param targetId the target resource Id.
+     */
+    private void removeReference(@Nonnull final String txId, final String resourceId, final String property,
+                                 final String targetId) {
+        final Map<String, String> parameterSource = Map.of("transactionId", txId,
+                "resourceId", resourceId,
+                "property", property,
+                "targetId", targetId);
+        final boolean addedInTx = !jdbcTemplate.queryForList(IS_REFERENCE_ADDED_IN_TRANSACTION, parameterSource)
+                .isEmpty();
+        if (addedInTx) {
+            jdbcTemplate.update(UNDO_INSERT_REFERENCE_IN_TRANSACTION, parameterSource);
+        } else {
+            jdbcTemplate.update(DELETE_REFERENCE_IN_TRANSACTION, parameterSource);
+        }
+    }
+
+    /**
+     * Add a reference
+     * @param txId the transaction Id.
+     * @param resourceId the subject resource Id.
+     * @param targetId the target resource Id.
+     */
+    private void addReference(@Nonnull final String txId, final String resourceId, final String property,
+                              final String targetId) {
+        final Map<String, String> parameterSource = Map.of("transactionId", txId,
+                "resourceId", resourceId,
+                "property", property,
+                "targetId", targetId);
+        final boolean addedInTx = !jdbcTemplate.queryForList(IS_REFERENCE_DELETED_IN_TRANSACTION, parameterSource)
+                .isEmpty();
+        if (addedInTx) {
+            jdbcTemplate.update(UNDO_DELETE_REFERENCE_IN_TRANSACTION, parameterSource);
+        } else {
+            jdbcTemplate.update(INSERT_REFERENCE_IN_TRANSACTION, parameterSource);
+        }
+    }
+
+    /**
+     * Utility to filter a RDFStream to just the URIs from subjects and objects within the repository.
+     * @param stream the provided stream
+     * @return stream of triples with internal references.
+     */
+    private Stream<Triple> getReferencesFromRdf(final RdfStream stream) {
+        final Predicate<Triple> isInternalReference = t -> {
+            final Node s = t.getSubject();
+            final Node o = t.getObject();
+            return (s.isURI() && s.getURI().startsWith(FEDORA_ID_PREFIX) && o.isURI() &&
+                    o.getURI().startsWith(FEDORA_ID_PREFIX));
+        };
+        return stream.peek(t -> LOGGER.trace("Before reference filtering: {}", t)).filter(isInternalReference)
+                .peek(t -> LOGGER.trace("After reference filtering: {}", t));
+    }
+
+    /**
+     * Set the JDBC datastore.
+     * @param dataSource the dataStore.
+     */
+    public void setDataSource(final DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /**
+     * Get the JDBC datastore.
+     * @return the dataStore.
+     */
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
@@ -357,8 +357,7 @@ public class ReferenceServiceImpl implements ReferenceService {
             return (s.isURI() && s.getURI().startsWith(FEDORA_ID_PREFIX) && o.isURI() &&
                     o.getURI().startsWith(FEDORA_ID_PREFIX));
         };
-        return stream.peek(t -> LOGGER.trace("Before reference filtering: {}", t)).filter(isInternalReference)
-                .peek(t -> LOGGER.trace("After reference filtering: {}", t));
+        return stream.filter(isInternalReference);
     }
 
     /**

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -24,7 +24,6 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
-import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
@@ -47,9 +46,6 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
 
     @Inject
     private RdfSourceOperationFactory factory;
-
-    @Inject
-    private ReferenceService referenceService;
 
     @Override
     public void perform(final String txId,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -24,6 +24,7 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
@@ -46,6 +47,9 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
 
     @Inject
     private RdfSourceOperationFactory factory;
+
+    @Inject
+    private ReferenceService referenceService;
 
     @Override
     public void perform(final String txId,
@@ -70,6 +74,8 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
                 .build();
 
             pSession.persist(updateOp);
+            referenceService.updateReferences(txId, fedoraId,
+                    fromModel(inputModel.createResource(fedoraId.getFullId()).asNode(), inputModel));
             recordEvent(txId, fedoraId, updateOp);
         } catch (final PersistentStorageException ex) {
             throw new RepositoryRuntimeException(String.format("failed to replace resource %s",

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -70,8 +70,7 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
                 .build();
 
             pSession.persist(updateOp);
-            referenceService.updateReferences(txId, fedoraId,
-                    fromModel(inputModel.createResource(fedoraId.getFullId()).asNode(), inputModel));
+            updateReferences(txId, fedoraId, inputModel);
             recordEvent(txId, fedoraId, updateOp);
         } catch (final PersistentStorageException ex) {
             throw new RepositoryRuntimeException(String.format("failed to replace resource %s",

--- a/fcrepo-kernel-impl/src/main/resources/sql/default-references.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/default-references.sql
@@ -1,0 +1,34 @@
+-- DDL for setting up reference tables in H2, MariaDB 10.5, and PostgreSQL 12.3
+-- MySQL 8 will only supports varchar up to 503 characters
+
+-- Holds the ID and the item it references.
+CREATE TABLE IF NOT EXISTS reference (
+    fedora_id varchar(503) NOT NULL,
+    property varchar(503) NOT NULL,
+    target_id varchar(503) NOT NULL
+);
+
+-- Create an index to speed searches for a resource.
+CREATE INDEX IF NOT EXISTS reference_idx1
+    ON reference (fedora_id);
+
+-- Create an index to speed searches for target of a reference.
+CREATE INDEX IF NOT EXISTS reference_idx2
+    ON reference (target_id);
+
+-- Holds operations to add or delete records from the REFERENCE table.
+CREATE TABLE IF NOT EXISTS reference_transaction_operations (
+    fedora_id varchar(503) NOT NULL,
+    property varchar(503) NOT NULL,
+    target_id varchar(503) NOT NULL,
+    transaction_id varchar(255) NOT NULL,
+    operation varchar(10) NOT NULL
+);
+
+-- Create an index to speed searches for records targeting a resource to adding/excluding transaction records
+CREATE INDEX IF NOT EXISTS reference_transaction_operations_idx1
+    ON reference_transaction_operations (target_id, transaction_id, operation);
+
+-- Create an index to speed finding records related to a transaction.
+CREATE INDEX IF NOT EXISTS reference_transaction_operations_idx2
+    ON reference_transaction_operations (transaction_id);

--- a/fcrepo-kernel-impl/src/main/resources/sql/default-references.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/default-references.sql
@@ -4,6 +4,7 @@
 -- Holds the ID and the item it references.
 CREATE TABLE IF NOT EXISTS reference (
     fedora_id varchar(503) NOT NULL,
+    subject_id varchar(503) NOT NULL,
     property varchar(503) NOT NULL,
     target_id varchar(503) NOT NULL
 );
@@ -12,13 +13,18 @@ CREATE TABLE IF NOT EXISTS reference (
 CREATE INDEX IF NOT EXISTS reference_idx1
     ON reference (fedora_id);
 
--- Create an index to speed searches for target of a reference.
+-- Create an index to speed searches for the subject of a reference.
 CREATE INDEX IF NOT EXISTS reference_idx2
+    ON reference (subject_id);
+
+-- Create an index to speed searches for target of a reference.
+CREATE INDEX IF NOT EXISTS reference_idx3
     ON reference (target_id);
 
 -- Holds operations to add or delete records from the REFERENCE table.
 CREATE TABLE IF NOT EXISTS reference_transaction_operations (
     fedora_id varchar(503) NOT NULL,
+    subject_id varchar(503) NOT NULL,
     property varchar(503) NOT NULL,
     target_id varchar(503) NOT NULL,
     transaction_id varchar(255) NOT NULL,

--- a/fcrepo-kernel-impl/src/main/resources/sql/mysql-references.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/mysql-references.sql
@@ -1,0 +1,52 @@
+-- DDL for setting up containment tables in MySQL 8
+-- MySQL 8 will only supports varchar up to 503 characters
+
+-- Holds the ID and the item it references.
+CREATE TABLE IF NOT EXISTS reference (
+    fedora_id varchar(503) NOT NULL,
+    property varchar(503) NOT NULL,
+    target_id varchar(503) NOT NULL
+);
+
+-- Create an index to speed searches for a resource.
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'reference' AND index_name = 'reference_idx1' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX reference_idx1 ON reference (fedora_id)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+-- Create an index to speed searches for target of a reference.
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'reference' AND index_name = 'reference_idx2' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX reference_idx2 ON reference (target_id)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+-- Holds operations to add or delete records from the REFERENCE table.
+CREATE TABLE IF NOT EXISTS reference_transaction_operations (
+    fedora_id varchar(503) NOT NULL,
+    property varchar(503) NOT NULL,
+    target_id varchar(503) NOT NULL,
+    transaction_id varchar(255) NOT NULL,
+    operation varchar(10) NOT NULL
+);
+
+-- Create an index to speed searches for records related to adding/excluding transaction records
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'reference_transaction_operations' AND index_name = 'reference_transaction_operations_idx1' AND
+    table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX reference_transaction_operations_idx1 ON reference_transaction_operations (target_id, transaction_id, operation)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+-- Create an index to speed finding records related to a transaction.
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'reference_transaction_operations' AND index_name = 'reference_transaction_operations_idx2' AND
+    table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX reference_transaction_operations_idx2 ON reference_transaction_operations (transaction_id)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;

--- a/fcrepo-kernel-impl/src/main/resources/sql/mysql-references.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/mysql-references.sql
@@ -4,6 +4,7 @@
 -- Holds the ID and the item it references.
 CREATE TABLE IF NOT EXISTS reference (
     fedora_id varchar(503) NOT NULL,
+    subject_id varchar(503) NOT NULL,
     property varchar(503) NOT NULL,
     target_id varchar(503) NOT NULL
 );
@@ -16,17 +17,26 @@ SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
 PREPARE stmt FROM @sqlstmt;
 EXECUTE stmt;
 
--- Create an index to speed searches for target of a reference.
+-- Create an index to speed searches for the subject of a reference.
 SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
     WHERE table_name = 'reference' AND index_name = 'reference_idx2' AND table_schema = database());
 SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
-    'CREATE INDEX reference_idx2 ON reference (target_id)');
+    'CREATE INDEX reference_idx2 ON reference (subject_id)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+-- Create an index to speed searches for target of a reference.
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'reference' AND index_name = 'reference_idx3' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX reference_idx3 ON reference (target_id)');
 PREPARE stmt FROM @sqlstmt;
 EXECUTE stmt;
 
 -- Holds operations to add or delete records from the REFERENCE table.
 CREATE TABLE IF NOT EXISTS reference_transaction_operations (
     fedora_id varchar(503) NOT NULL,
+    subject_id varchar(503) NOT NULL,
     property varchar(503) NOT NULL,
     target_id varchar(503) NOT NULL,
     transaction_id varchar(255) NOT NULL,

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
@@ -32,6 +32,7 @@ import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.TransactionRuntimeException;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -68,12 +69,16 @@ public class TransactionImplTest {
     @Mock
     private EventAccumulator eventAccumulator;
 
+    @Mock
+    private ReferenceService referenceService;
+
     @Before
     public void setUp() {
         when(pssManager.getSession("123")).thenReturn(psSession);
         when(txManager.getPersistentStorageSessionManager()).thenReturn(pssManager);
         when(txManager.getContainmentIndex()).thenReturn(containmentIndex);
         when(txManager.getEventAccumulator()).thenReturn(eventAccumulator);
+        when(txManager.getReferenceService()).thenReturn(referenceService);
         testTx = new TransactionImpl("123", txManager);
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
@@ -30,6 +30,7 @@ import org.fcrepo.kernel.api.exception.TransactionClosedException;
 import org.fcrepo.kernel.api.exception.TransactionNotFoundException;
 import org.fcrepo.kernel.api.exception.TransactionRuntimeException;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.junit.After;
@@ -63,6 +64,9 @@ public class TransactionManagerImplTest {
     @Mock
     private EventAccumulator eventAccumulator;
 
+    @Mock
+    private ReferenceService referenceService;
+
     @Before
     public void setUp() {
         testTxManager = new TransactionManagerImpl();
@@ -70,6 +74,7 @@ public class TransactionManagerImplTest {
         setField(testTxManager, "pSessionManager", pssManager);
         setField(testTxManager, "containmentIndex", containmentIndex);
         setField(testTxManager, "eventAccumulator", eventAccumulator);
+        setField(testTxManager, "referenceService", referenceService);
         testTx = (TransactionImpl) testTxManager.create();
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -80,6 +80,7 @@ import org.fcrepo.kernel.api.operations.NonRdfSourceOperationFactory;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.impl.operations.CreateNonRdfSourceOperation;
 import org.fcrepo.kernel.impl.operations.NonRdfSourceOperationFactoryImpl;
 import org.fcrepo.kernel.impl.operations.RdfSourceOperationFactoryImpl;
@@ -144,6 +145,9 @@ public class CreateResourceServiceImplTest {
     @Mock
     private Transaction transaction;
 
+    @Mock
+    private ReferenceService referenceService;
+
     @Captor
     private ArgumentCaptor<ResourceOperation> operationCaptor;
 
@@ -184,6 +188,7 @@ public class CreateResourceServiceImplTest {
         setField(createResourceService, "nonRdfSourceOperationFactory", nonRdfSourceOperationFactory);
         setField(createResourceService, "containmentIndex", containmentIndex);
         setField(createResourceService, "eventAccumulator", eventAccumulator);
+        setField(createResourceService, "referenceService", referenceService);
         when(psManager.getSession(ArgumentMatchers.any())).thenReturn(psSession);
         when(transaction.getId()).thenReturn(TX_ID);
         // Always try to clean up root.

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -27,6 +27,7 @@ import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.models.WebacAcl;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.impl.operations.DeleteResourceOperation;
 import org.fcrepo.kernel.impl.operations.DeleteResourceOperationFactoryImpl;
 import org.fcrepo.persistence.api.PersistentStorageSession;
@@ -44,6 +45,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.inject.Inject;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -99,6 +101,9 @@ public class DeleteResourceServiceImplTest {
     @Mock
     private NonRdfSourceDescription binaryDesc;
 
+    @Mock
+    private ReferenceService referenceService;
+
     @Captor
     private ArgumentCaptor<DeleteResourceOperation> operationCaptor;
 
@@ -121,6 +126,7 @@ public class DeleteResourceServiceImplTest {
         setField(service, "deleteResourceFactory", factoryImpl);
         setField(service, "containmentIndex", containmentIndex);
         setField(service, "eventAccumulator", eventAccumulator);
+        setField(service, "referenceService", referenceService);
         when(container.getFedoraId()).thenReturn(RESOURCE_ID);
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReferenceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReferenceServiceImplTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.services.ReferenceService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Reference Service Tests
+ * @author whikloj
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/containmentIndexTest.xml")
+public class ReferenceServiceImplTest {
+
+    @Inject
+    private ReferenceService referenceService;
+
+    @Mock
+    private FedoraResource targetResource;
+
+    private FedoraId subject1Id;
+
+    private FedoraId subject2Id;
+
+    private Resource subject1;
+
+    private Resource subject2;
+
+    private Resource target;
+
+    private static Property referenceProp = ResourceFactory.createProperty("http://example.org/pointer");
+
+    private String transactionId;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        transactionId = UUID.randomUUID().toString();
+        subject1Id = FedoraId.create(UUID.randomUUID().toString());
+        subject2Id = FedoraId.create(UUID.randomUUID().toString());
+        final FedoraId targetId = FedoraId.create(UUID.randomUUID().toString());
+        when(targetResource.getFedoraId()).thenReturn(targetId);
+        subject1 =  ResourceFactory.createResource(subject1Id.getFullId());
+        subject2 = ResourceFactory.createResource(subject2Id.getFullId());
+        target = ResourceFactory.createResource(targetId.getFullId());
+        referenceService.reset();
+    }
+
+    @Test
+    public void testAddAReference() {
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+
+        final Model model = createDefaultModel();
+        model.add(subject1, referenceProp, target);
+        final RdfStream stream = fromModel(subject1.asNode(), model);
+        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.commitTransaction(transactionId);
+
+        final List<Triple> refs = referenceService.getInboundReferences(null, targetResource)
+                .collect(Collectors.toList());
+
+        assertEquals(1, refs.size());
+        assertEquals(subject1Id.getFullId(), refs.get(0).getSubject().getURI());
+        assertEquals(referenceProp.getURI(), refs.get(0).getPredicate().getURI());
+    }
+
+    @Test
+    public void testAddNoReference() {
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+        final Model model = createDefaultModel();
+        model.add(subject1, referenceProp, "http://some/text/uri");
+        final RdfStream stream = fromModel(subject1.asNode(), model);
+        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.commitTransaction(transactionId);
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+    }
+
+    @Test
+    public void testAdd2References() {
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+        final Model model = createDefaultModel();
+        model.add(subject1, referenceProp, target);
+        final RdfStream stream = fromModel(subject1.asNode(), model);
+        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.commitTransaction(transactionId);
+        final List<Triple> refs = referenceService.getInboundReferences(null, targetResource).collect(
+                Collectors.toList());
+        assertEquals(1, refs.size());
+        assertEquals(subject1Id.getFullId(), refs.get(0).getSubject().getURI());
+        // Now make another object reference the target.
+        model.remove(subject1, referenceProp, target);
+        model.add(subject2, referenceProp, target);
+        final RdfStream stream2 = fromModel(subject2.asNode(),
+                model);
+        referenceService.updateReferences(transactionId, subject2Id, stream2);
+        referenceService.commitTransaction(transactionId);
+        final List<Triple> refs2 = referenceService.getInboundReferences(null, targetResource).collect(
+                Collectors.toList());
+        assertEquals(2, refs2.size());
+        assertEquals(subject2Id.getFullId(), refs2.get(1).getSubject().getURI());
+    }
+
+    @Test
+    public void testAddExternalReference() {
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+
+        final Model model = createDefaultModel();
+        final Resource external = ResourceFactory.createResource("http://someother.org/pointer");
+        model.add(external, referenceProp, target);
+        final RdfStream stream = fromModel(external.asNode(), model);
+
+        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.commitTransaction(transactionId);
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+
+        model.remove(external, referenceProp, target);
+        model.add(subject1, referenceProp, target);
+        final RdfStream stream2 = fromModel(subject1.asNode(), model);
+        referenceService.updateReferences(transactionId, subject1Id, stream2);
+        referenceService.commitTransaction(transactionId);
+        assertEquals(1, referenceService.getInboundReferences(null, targetResource).count());
+
+    }
+
+    @Test
+    public void testRollback() {
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+
+        final Model model = createDefaultModel();
+        model.add(subject1, referenceProp, target);
+        final RdfStream stream = fromModel(subject1.asNode(), model);
+        referenceService.updateReferences(transactionId, subject1Id, stream);
+        // Still nothing outside the transaction.
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+        // One inside the transaction
+        assertEquals(1, referenceService.getInboundReferences(transactionId, targetResource).count());
+        referenceService.rollbackTransaction(transactionId);
+        // Still nothing outside or inside the transaction.
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+        assertEquals(0, referenceService.getInboundReferences(transactionId, targetResource).count());
+    }
+
+    @Test
+    public void testCommit() {
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+
+        final Model model = createDefaultModel();
+        model.add(subject1, referenceProp, target);
+        final RdfStream stream = fromModel(subject1.asNode(), model);
+        referenceService.updateReferences(transactionId, subject1Id, stream);
+        // Still nothing outside the transaction.
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+        // One inside the transaction
+        assertEquals(1, referenceService.getInboundReferences(transactionId, targetResource).count());
+        referenceService.commitTransaction(transactionId);
+        // Now 1 outside or inside the transaction.
+        assertEquals(1, referenceService.getInboundReferences(null, targetResource).count());
+        assertEquals(1, referenceService.getInboundReferences(transactionId, targetResource).count());
+    }
+
+    @Test
+    public void testAddAndRemove() {
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+
+        // Add a reference.
+        final Model model = createDefaultModel();
+        model.add(subject1, referenceProp, target);
+        final RdfStream stream = fromModel(subject1.asNode(), model);
+        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.commitTransaction(transactionId);
+        assertEquals(1, referenceService.getInboundReferences(null, targetResource).count());
+
+        // Change the RDF to remove the reference.
+        final String transaction2 = UUID.randomUUID().toString();
+        model.add(subject1, ResourceFactory.createProperty("http://someother/description"), "Some text");
+        model.remove(subject1, referenceProp, target);
+        final RdfStream stream2 = fromModel(subject1.asNode(), model);
+        referenceService.updateReferences(transaction2, subject1Id, stream2);
+        referenceService.commitTransaction(transaction2);
+        assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
+    }
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
@@ -38,6 +38,7 @@ import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.impl.operations.RdfSourceOperationFactoryImpl;
 import org.fcrepo.kernel.impl.operations.UpdateRdfSourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
@@ -76,6 +77,9 @@ public class ReplacePropertiesServiceImplTest {
     @Mock
     private EventAccumulator eventAccumulator;
 
+    @Mock
+    private ReferenceService referenceService;
+
     @InjectMocks
     private UpdateRdfSourceOperation operation;
 
@@ -98,6 +102,7 @@ public class ReplacePropertiesServiceImplTest {
         factory = new RdfSourceOperationFactoryImpl();
         setField(service, "factory", factory);
         setField(service, "eventAccumulator", eventAccumulator);
+        setField(service, "referenceService", referenceService);
         when(tx.getId()).thenReturn(TX_ID);
         when(psManager.getSession(anyString())).thenReturn(pSession);
         when(resource.getId()).thenReturn(FEDORA_ID.getFullId());

--- a/fcrepo-kernel-impl/src/test/resources/containmentIndexTest.xml
+++ b/fcrepo-kernel-impl/src/test/resources/containmentIndexTest.xml
@@ -21,4 +21,9 @@
     <bean id="containmentIndex" class="org.fcrepo.kernel.impl.ContainmentIndexImpl">
         <property name="dataSource" ref="containmentIndexDataSource"/>
     </bean>
+
+    <!-- ReferenceService index to test -->
+    <bean id="referenceIndex" class="org.fcrepo.kernel.impl.services.ReferenceServiceImpl">
+        <property name="dataSource" ref="containmentIndexDataSource" />
+    </bean>
 </beans>

--- a/fcrepo-kernel-impl/src/test/resources/containmentIndexTest.xml
+++ b/fcrepo-kernel-impl/src/test/resources/containmentIndexTest.xml
@@ -9,21 +9,21 @@
 
     <!-- Creating TransactionManager Bean -->
     <bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-        <property name="dataSource" ref="containmentIndexDataSource" />
+        <property name="dataSource" ref="dataSource" />
     </bean>
 
-    <bean id="containmentIndexDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+    <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
         <property name="driverClassName" value="org.h2.jdbcx.JdbcDataSource" />
         <property name="url" value="jdbc:h2:mem:index;DB_CLOSE_DELAY=-1" />
     </bean>
 
     <!-- Containment Index to test -->
     <bean id="containmentIndex" class="org.fcrepo.kernel.impl.ContainmentIndexImpl">
-        <property name="dataSource" ref="containmentIndexDataSource"/>
+        <property name="dataSource" ref="dataSource"/>
     </bean>
 
     <!-- ReferenceService index to test -->
     <bean id="referenceIndex" class="org.fcrepo.kernel.impl.services.ReferenceServiceImpl">
-        <property name="dataSource" ref="containmentIndexDataSource" />
+        <property name="dataSource" ref="dataSource" />
     </bean>
 </beans>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
@@ -143,7 +143,7 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
     public boolean isOpen() {
         return inner.isOpen();
     }
-
+    
     @Override
     public void close() {
         exec(inner::close);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
@@ -143,7 +143,7 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
     public boolean isOpen() {
         return inner.isOpen();
     }
-    
+
     @Override
     public void close() {
         exec(inner::close);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
@@ -166,7 +166,7 @@ public class IndexBuilderImpl implements IndexBuilder {
                                 fedoraId.getFullId()));
                     }
                 }
-                if (!headers.getInteractionModel().equalsIgnoreCase(NON_RDF_SOURCE.toString())) {
+                if (!headers.getInteractionModel().equals(NON_RDF_SOURCE.toString())) {
                     final Optional<InputStream> content = session.readContent(fedoraId.getFullId()).getContentStream();
                     if (content.isPresent()) {
                         final RdfStream rdf = parseRdf(fedoraId, content.get());

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
@@ -24,6 +24,7 @@ import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.operations.CreateResourceOperation;
 import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
+import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.impl.operations.DeleteResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
@@ -82,6 +83,9 @@ public class IndexBuilderImplTest {
     @Mock
     private SearchIndex searchIndex;
 
+    @Mock
+    private ReferenceService referenceService;
+
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -118,6 +122,7 @@ public class IndexBuilderImplTest {
         setField(indexBuilder, "objectSessionFactory", ocflObjectSessionFactory);
         setField(indexBuilder, "containmentIndex", containmentIndex);
         setField(indexBuilder, "searchIndex", searchIndex);
+        setField(indexBuilder, "referenceService", referenceService);
     }
 
     @Test
@@ -234,6 +239,7 @@ public class IndexBuilderImplTest {
         when(operation.getResourceId()).thenReturn(resourceId);
         when(((CreateResourceOperation) operation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(operation.getType()).thenReturn(CREATE);
+        when(((CreateResourceOperation) operation).getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
         when(((CreateResourceOperation)operation).isArchivalGroup()).thenReturn(isArchivalGroup);
         if (isArchivalGroup) {
             when(((CreateResourceOperation) operation).getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
@@ -256,6 +262,7 @@ public class IndexBuilderImplTest {
         when(operation.getContentStream()).thenReturn(stream);
         when(operation.getMimeType()).thenReturn("text/plain");
         when(operation.getFilename()).thenReturn("test");
+        when(((CreateResourceOperation)operation).getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
         when(((CreateResourceOperation)operation).getParentId()).thenReturn(parentId);
         when(((CreateResourceOperation) operation).getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
         session.persist(operation);

--- a/fcrepo-persistence-ocfl/src/test/resources/spring-test/fcrepo-config.xml
+++ b/fcrepo-persistence-ocfl/src/test/resources/spring-test/fcrepo-config.xml
@@ -24,6 +24,10 @@
   <bean id="searchIndex" class="org.mockito.Mockito" factory-method="mock">
     <constructor-arg value="org.fcrepo.search.api.SearchIndex" />
   </bean>
+
+  <bean id="referenceService" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.fcrepo.kernel.api.services.ReferenceService" />
+  </bean>
   
   <bean id="transactionManager" class="org.mockito.Mockito" factory-method="mock">
     <constructor-arg value="org.fcrepo.kernel.api.TransactionManager" />


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3166

# What does this Pull Request do?

Adds an API and implementation of a new service to parse incoming RDF for internal references and stores them in a new index, then allows this index to be queried.

# How should this be tested?

1. Create a resource.
1. Create another resource with any reference to the first ie. `<> <http://awoods.com/pointsTo> <http://localhost:8080/rest/firstResource>`
1. Get the first resource, see no inbound reference triples
1. Get the first resource with the header `Prefer: return=representation; include="http://fedora.info/definitions/fcrepo#PreferInboundReferences"`, see the inbound reference.

For binaries when requesting the inbound references on the `fcr:metadata` endpoint you will get both references to the actual binary URI and the `fcr:metadata` URI.

**Note**: I messed up and forgot to remove the references from the index on deletion, I am implementing this now and will make this PR live once it is added.

# Interested parties
@bbpennel  @fcrepo4/committers
