### PR TITLE
Support omit minimal container to restrict user rdf

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -285,7 +285,10 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
         final List<Stream<Triple>> streams = new ArrayList<>();
 
-        streams.add(resource.getTriples());
+        if (!ldpPreferences.preferNoUserRdf()) {
+            // provide user RDF only if we didn't receive an omit=ldp:PreferMinimalContainer
+            streams.add(resource.getTriples());
+        }
         if (returnPreference.getValue().equals("minimal")) {
             if (ldpPreferences.prefersServerManaged())  {
                 streams.add(this.managedPropertiesService.get(resource));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -99,6 +99,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_SERVER_MANAGED;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
@@ -735,22 +736,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(put)) {
             assertEquals(CREATED.getStatusCode(), response.getStatusLine().getStatusCode());
 
-        }
-    }
-
-    @Test
-    public void testGetRDFSourceWithPreferMinimal() throws IOException {
-        final String id = getRandomUniqueId();
-        createObjectAndClose(id);
-
-        final HttpGet getMethod = new HttpGet(serverAddress + id);
-        final String preferHeader = "return=minimal";
-        getMethod.addHeader("Prefer", preferHeader);
-
-        try (final CloseableHttpResponse response = execute(getMethod)) {
-            assertEquals(OK.getStatusCode(), getStatus(response));
-            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
-            assertTrue("Preference-Applied header doesn't matched", preferenceApplied.contains(preferHeader));
         }
     }
 
@@ -2349,20 +2334,64 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     @Test
     public void testGetObjectGraphMinimal() throws IOException {
-        final String id = getRandomUniqueId();
-        createObjectAndClose(id, BASIC_CONTAINER_LINK_HEADER);
-        createObjectAndClose(id + "/a");
-        final HttpGet getObjMethod = getObjMethod(id);
-        getObjMethod.addHeader("Prefer", "return=minimal");
-        try (final CloseableDataset dataset = getDataset(getObjMethod)) {
+        final String uri;
+        final HttpPost httpPost = postObjMethod();
+        httpPost.setHeader("Link", BASIC_CONTAINER_LINK_HEADER);
+        httpPost.setHeader(CONTENT_TYPE, "text/turtle");
+        httpPost.setEntity(new StringEntity("<> <" + DCTITLE.getURI() + "> \"The title\" ."));
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            uri = getLocation(response);
+        }
+        final Node resource = createURI(uri);
+        // Create a contained child.
+        final HttpPut httpPut = new HttpPut(uri + "/a");
+        assertEquals(CREATED.getStatusCode(), getStatus(httpPut));
+
+        final HttpGet getObjMethod = new HttpGet(uri);
+        final String preferHeader = "return=minimal";
+        getObjMethod.addHeader("Prefer", preferHeader);
+        try (final CloseableHttpResponse response = execute(getObjMethod);
+             final CloseableDataset dataset = getDataset(response)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
             final DatasetGraph graph = dataset.asDatasetGraph();
-            final Node resource = createURI(serverAddress + id);
             assertFalse("Didn't expect members", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't matched", preferenceApplied.contains(preferHeader));
+            assertTrue("Missing a user RDF triple", graph.contains(ANY, resource, DCTITLE, ANY));
+        }
+        // Now test with include preference
+        final HttpGet httpGet = new HttpGet(uri);
+        final String preferHeader2 = "return=representation; include=\"" +
+                PREFER_MINIMAL_CONTAINER.getURI() + "\"";
+        httpGet.setHeader("Prefer", preferHeader2);
+        try (final CloseableHttpResponse response = execute(httpGet);
+             final CloseableDataset dataset = getDataset(response)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertFalse("Didn't expect members", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't matched",
+                    preferenceApplied.contains(preferHeader2));
+            assertTrue("Missing a user RDF triple", graph.contains(ANY, resource, DCTITLE, ANY));
+        }
+        // Now try with Omit minimal
+        final HttpGet getOmit = new HttpGet(uri);
+        final String preferOmitHeader = "return=representation; omit=\"" + PREFER_MINIMAL_CONTAINER + "\"";
+        getOmit.addHeader("Prefer", preferOmitHeader);
+        try (final CloseableHttpResponse response = execute(getOmit);
+             final CloseableDataset dataset = getDataset(response)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue("Expected members", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't matched",
+                    preferenceApplied.contains(preferOmitHeader));
+            assertFalse("Should not return user RDF triples", graph.contains(ANY, resource, DCTITLE, ANY));
         }
     }
 
     @Test
-@Ignore
     public void testGetObjectOmitMembership() throws IOException {
         final String id = getRandomUniqueId();
         final Node resource = createURI(serverAddress + id);
@@ -2379,10 +2408,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
             assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
             assertTrue("Expected server managed", graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
-            assertTrue("Expected server managed", graph.find(ANY, resource, CREATED_BY.asNode(), ANY).hasNext());
             assertTrue("Expected server managed",
                     graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
-            assertTrue("Expected server managed", graph.find(ANY, resource, LAST_MODIFIED_BY.asNode(), ANY).hasNext());
+            assertFalse("Expected no members", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
         }
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/PreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/PreferTag.java
@@ -19,7 +19,9 @@ package org.fcrepo.http.commons.domain;
 
 import static java.util.Arrays.asList;
 import static java.util.Optional.ofNullable;
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_CONTAINMENT;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_SERVER_MANAGED;
 import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
@@ -90,7 +92,7 @@ public class PreferTag implements Comparable<PreferTag> {
                         params = new HashMap<>();
                     }
                 }
-            } catch (ParseException e) {
+            } catch (final ParseException e) {
                 throw new IllegalArgumentException("Could not parse 'Prefer' header", e);
             }
         } else {
@@ -145,9 +147,9 @@ public class PreferTag implements Comparable<PreferTag> {
 
         if (!(value.equals("minimal") || receivedParam.equals("minimal"))) {
             final List<String> appliedPrefs = asList(PREFER_SERVER_MANAGED.toString(),
-                    LDP_NAMESPACE + "PreferMinimalContainer",
-                    LDP_NAMESPACE + "PreferMembership",
-                    LDP_NAMESPACE + "PreferContainment");
+                    PREFER_MINIMAL_CONTAINER.toString(),
+                    PREFER_MEMBERSHIP.toString(),
+                    PREFER_CONTAINMENT.toString());
             final List<String> includePrefs = asList(EMBED_CONTAINED.toString(),
                     INBOUND_REFERENCES.toString());
             includes.forEach(param -> includeBuilder.append(

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
@@ -21,7 +21,9 @@ import static java.util.Arrays.asList;
 import static java.util.Optional.ofNullable;
 import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_CONTAINMENT;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_SERVER_MANAGED;
 
 import java.util.List;
@@ -46,6 +48,8 @@ public class LdpPreferTag extends PreferTag {
 
     private final boolean managedProperties;
 
+    private final boolean noMinimal;
+
     /**
      * Standard constructor.
      *
@@ -63,14 +67,17 @@ public class LdpPreferTag extends PreferTag {
 
         final boolean minimal = preferTag.getValue().equals("minimal") || received.orElse("").equals("minimal");
 
-        final boolean preferMinimalContainer = includes.contains(LDP_NAMESPACE + "PreferMinimalContainer") || minimal;
+        final boolean preferMinimalContainer = (!omits.contains(PREFER_MINIMAL_CONTAINER.toString()) &&
+                (includes.contains(PREFER_MINIMAL_CONTAINER.toString()) || minimal));
 
-        membership = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferMembership")) ||
-                includes.contains(LDP_NAMESPACE + "PreferMembership");
+        noMinimal = omits.contains(PREFER_MINIMAL_CONTAINER.toString());
 
-        containment = (!preferMinimalContainer && !omits.contains(LDP_NAMESPACE + "PreferContainment") &&
+        membership = (!preferMinimalContainer && !omits.contains(PREFER_MEMBERSHIP.toString())) ||
+                includes.contains(PREFER_MEMBERSHIP.toString());
+
+        containment = (!preferMinimalContainer && !omits.contains(PREFER_CONTAINMENT.toString()) &&
                 !omits.contains(PREFER_SERVER_MANAGED.toString()))
-                || includes.contains(LDP_NAMESPACE + "PreferContainment");
+                || includes.contains(PREFER_CONTAINMENT.toString());
 
         references = includes.contains(INBOUND_REFERENCES.toString());
 
@@ -111,5 +118,12 @@ public class LdpPreferTag extends PreferTag {
      */
     public boolean prefersServerManaged() {
         return managedProperties;
+    }
+
+    /**
+     * @return Whether this prefer tag demands no minimal container, ie. no user RDF.
+     */
+    public boolean preferNoUserRdf() {
+        return noMinimal;
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -205,6 +205,11 @@ public final class RdfLexicon {
     // RDF EXTRACTION
     public static final Property INBOUND_REFERENCES = createProperty(FCREPO_API_NAMESPACE + "PreferInboundReferences");
     public static final Property PREFER_SERVER_MANAGED = createProperty(REPOSITORY_NAMESPACE + "ServerManaged");
+    public static final Property PREFER_MINIMAL_CONTAINER = createProperty(LDP_NAMESPACE +
+            "PreferMinimalContainer");
+    public static final Property PREFER_CONTAINMENT = createProperty(LDP_NAMESPACE + "PreferContainment");
+    public static final Property PREFER_MEMBERSHIP = createProperty(LDP_NAMESPACE + "PreferMembership");
+
 
     public static final Property EMBED_CONTAINED = createProperty(OA_NAMESPACE + "PreferContainedDescriptions");
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3037

# What does this Pull Request do?
Adds a check for specifically omitting a minimal container representation to exclude user RDF.

Also defines some LDP prefer headers in RdfLexicon for consistency and modifies some tests.

# How should this be tested?

With an object like
```
> curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/userRdf 

@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .
@prefix dc:  <http://purl.org/dc/elements/1.1/> .

<http://localhost:8080/rest/userRdf>
        dc:title               "Some title" ;
        dc:author              "Some author" ;
        fedora:created         "2020-09-11T17:51:46.806653Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2020-09-11T17:51:46.806653Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy       "fedoraAdmin" ;
        fedora:lastModifiedBy  "fedoraAdmin" ;
        rdf:type               ldp:BasicContainer ;
        rdf:type               ldp:Resource ;
        rdf:type               fedora:Resource ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        rdf:type               fedora:Container ;
        ldp:contains           <http://localhost:8080/rest/userRdf/childA> .
```

Try to omit a minimal container and see no differences
```
> curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/userRdf -H"Prefer: return=representation; omit=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\""

@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .
@prefix dc:  <http://purl.org/dc/elements/1.1/> .

<http://localhost:8080/rest/userRdf>
        dc:title               "Some title" ;
        dc:author              "Some author" ;
        fedora:created         "2020-09-11T17:51:46.806653Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2020-09-11T17:51:46.806653Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy       "fedoraAdmin" ;
        fedora:lastModifiedBy  "fedoraAdmin" ;
        rdf:type               ldp:BasicContainer ;
        rdf:type               ldp:Resource ;
        rdf:type               fedora:Resource ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        rdf:type               fedora:Container ;
        ldp:contains           <http://localhost:8080/rest/userRdf/childA> .
```

But with this PR see the user RDF (dc:title and dc:author) dissappear
```
> curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/userRdf -H"Prefer: return=representation; omit=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\""

@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora:  <http://fedora.info/definitions/v4/repository#> .
@prefix ldp:  <http://www.w3.org/ns/ldp#> .

<http://localhost:8080/rest/userRdf>
        fedora:created         "2020-09-11T17:51:46.806653Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2020-09-11T17:51:46.806653Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy       "fedoraAdmin" ;
        fedora:lastModifiedBy  "fedoraAdmin" ;
        rdf:type               ldp:BasicContainer ;
        rdf:type               ldp:Resource ;
        rdf:type               fedora:Resource ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        rdf:type               fedora:Container ;
        ldp:contains           <http://localhost:8080/rest/userRdf/childA> .
```

# Interested parties
@fcrepo4/committers
