### PR TITLE
FCREPO-3431 - Implement getChildren

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -18,8 +18,6 @@
 package org.fcrepo.kernel.api;
 
 import org.fcrepo.kernel.api.identifiers.FedoraId;
-import org.fcrepo.kernel.api.models.FedoraResource;
-
 import javax.annotation.Nonnull;
 import java.util.stream.Stream;
 
@@ -35,20 +33,20 @@ public interface ContainmentIndex {
      * Return a stream of fedora identifiers contained by the specified fedora resource.
      *
      * @param txId The transaction id, or null if no transaction
-     * @param fedoraResource The containing fedora resource
+     * @param fedoraId The ID of the containing fedora resource
      * @return A stream of contained identifiers
      */
-    Stream<String> getContains(String txId, FedoraResource fedoraResource);
+    Stream<String> getContains(String txId, FedoraId fedoraId);
 
     /**
      * Return a stream of fedora identifiers contained by the specified fedora resource that have deleted
      * relationships.
      *
      * @param txId The transaction id, or null if no transaction
-     * @param fedoraResource The containing fedora resource
+     * @param fedoraId The ID of the containing fedora resource
      * @return A stream of contained identifiers
      */
-    Stream<String> getContainsDeleted(String txId, FedoraResource fedoraResource);
+    Stream<String> getContainsDeleted(String txId, FedoraId fedoraId);
 
     /**
      * Return the ID of the containing resource for resourceID.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -142,6 +142,7 @@ public interface FedoraResource {
      * @param relPath the given path
      * @return the child of this resource
      */
+    @Deprecated
     FedoraResource getChild(String relPath);
 
     /**

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -137,15 +137,6 @@ public interface FedoraResource {
     FedoraResource getAcl();
 
     /**
-     * Get the child of this resource at the given path
-     *
-     * @param relPath the given path
-     * @return the child of this resource
-     */
-    @Deprecated
-    FedoraResource getChild(String relPath);
-
-    /**
      * Does this resource have a property
      * @param relPath the given path
      * @return the boolean value whether the resource has a property

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.models;
 
+import java.util.stream.Stream;
+
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -102,4 +104,12 @@ public interface ResourceFactory {
      * @return The containing resource or null if none.
      */
     public FedoraResource getContainer(final String transactionId, final FedoraId resourceId);
+
+    /**
+     * Get immediate children of the resource
+     * @param transactionId The transaction id
+     * @param resourceId Identifier of the resource
+     * @return Stream of child resources
+     */
+    public Stream<FedoraResource> getChildren(final String transactionId, final FedoraId resourceId);
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -22,7 +22,6 @@ import org.fcrepo.common.db.DbPlatform;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
-import org.fcrepo.kernel.api.models.FedoraResource;
 import org.slf4j.Logger;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -314,8 +313,8 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public Stream<String> getContains(final String txId, final FedoraResource fedoraResource) {
-        final String resourceId = fedoraResource.getFedoraId().getFullId();
+    public Stream<String> getContains(final String txId, final FedoraId fedoraId) {
+        final String resourceId = fedoraId.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("parent", resourceId);
 
@@ -334,8 +333,8 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public Stream<String> getContainsDeleted(final String txId, final FedoraResource fedoraResource) {
-        final String resourceId = fedoraResource.getFedoraId().getFullId();
+    public Stream<String> getContainsDeleted(final String txId, final FedoraId fedoraId) {
+        final String resourceId = fedoraId.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("parent", resourceId);
 
@@ -545,7 +544,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
         try {
             jdbcTemplate.update(TRUNCATE_TABLE + RESOURCES_TABLE, Collections.emptyMap());
             jdbcTemplate.update(TRUNCATE_TABLE + TRANSACTION_OPERATIONS_TABLE, Collections.emptyMap());
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new RepositoryRuntimeException("Failed to truncate containment tables", e);
         }
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -25,6 +25,7 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
@@ -64,4 +65,8 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
         return types;
     }
 
+    @Override
+    public Stream<FedoraResource> getChildren(final Boolean recursive) {
+        return resourceFactory.getChildren(txId, fedoraId);
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -61,7 +61,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     protected final ResourceFactory resourceFactory;
 
-    private FedoraId fedoraId;
+    protected final FedoraId fedoraId;
 
     private FedoraId parentId;
 
@@ -109,8 +109,7 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public Stream<FedoraResource> getChildren(final Boolean recursive) {
-        // TODO Auto-generated method stub
-        return null;
+        return Stream.empty();
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -191,12 +191,6 @@ public class FedoraResourceImpl implements FedoraResource {
     }
 
     @Override
-    public FedoraResource getChild(final String relPath) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
     public boolean hasProperty(final String relPath) {
         // TODO Auto-generated method stub
         return false;

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import java.time.Instant;
+import java.util.stream.Stream;
 
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
@@ -269,5 +270,12 @@ public class ResourceFactoryImpl implements ResourceFactory {
             session = persistentStorageSessionManager.getSession(transactionId);
         }
         return session;
+    }
+
+    @Override
+    public Stream<FedoraResource> getChildren(final String transactionId, final FedoraId resourceId) {
+//        containmentIndex.getContains(transactionId, fedoraResource).getContainedBy(transactionId, resourceId);
+        // TODO Auto-generated method stub
+        return null;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -21,6 +21,7 @@ import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionUtils;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ResourceTypeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -274,8 +275,13 @@ public class ResourceFactoryImpl implements ResourceFactory {
 
     @Override
     public Stream<FedoraResource> getChildren(final String transactionId, final FedoraId resourceId) {
-//        containmentIndex.getContains(transactionId, fedoraResource).getContainedBy(transactionId, resourceId);
-        // TODO Auto-generated method stub
-        return null;
+        return containmentIndex.getContains(transactionId, resourceId)
+            .map(childId -> {
+                try {
+                    return getResource(transactionId, FedoraId.create(childId));
+                } catch (final PathNotFoundException e) {
+                    throw new PathNotFoundRuntimeException(e);
+                }
+            });
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImpl.java
@@ -44,8 +44,9 @@ public class ContainmentTriplesServiceImpl implements ContainmentTriplesService 
 
     @Override
     public Stream<Triple> get(final Transaction tx, final FedoraResource resource) {
-        final Node currentNode = createURI(resource.getFedoraId().getFullId());
-        return containmentIndex.getContains(txId(tx), resource).map(c ->
+        final var fedoraId = resource.getFedoraId();
+        final Node currentNode = createURI(fedoraId.getFullId());
+        return containmentIndex.getContains(txId(tx), fedoraId).map(c ->
                 new Triple(currentNode, CONTAINS.asNode(), createURI(c)));
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
@@ -48,7 +48,7 @@ public class DeleteResourceServiceImpl extends AbstractDeleteResourceService imp
 
     @Override
     protected Stream<String> getContained(final Transaction tx, final FedoraResource resource) {
-        return containmentIndex.getContains(TransactionUtils.openTxId(tx), resource);
+        return containmentIndex.getContains(TransactionUtils.openTxId(tx), resource.getFedoraId());
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
@@ -48,7 +48,7 @@ public class PurgeResourceServiceImpl extends AbstractDeleteResourceService impl
 
     @Override
     protected Stream<String> getContained(final Transaction tx, final FedoraResource resource) {
-        return containmentIndex.getContainsDeleted(TransactionUtils.openTxId(tx), resource);
+        return containmentIndex.getContainsDeleted(TransactionUtils.openTxId(tx), resource.getFedoraId());
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -75,8 +75,8 @@ public class ContainmentIndexImplTest {
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
-    private Map<String, FedoraResource> id_to_resource = new HashMap<>();
-    private Map<String, Transaction> id_to_transaction = new HashMap<>();
+    private final Map<String, FedoraResource> id_to_resource = new HashMap<>();
+    private final Map<String, Transaction> id_to_transaction = new HashMap<>();
 
     @Before
     public void setUp() {
@@ -115,17 +115,17 @@ public class ContainmentIndexImplTest {
         stubObject("parent1");
         stubObject("child1");
         stubObject("transaction1");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).findFirst().get());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         // outside of the transaction, the containment shouldn't show up
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
     }
 
@@ -134,20 +134,20 @@ public class ContainmentIndexImplTest {
         stubObject("parent1");
         stubObject("child1");
         stubObject("transaction1");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
     }
 
     @Test
@@ -155,25 +155,25 @@ public class ContainmentIndexImplTest {
         stubObject("parent1");
         stubObject("child1");
         stubObject("transaction1");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(1, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
     }
 
     @Test
@@ -181,23 +181,23 @@ public class ContainmentIndexImplTest {
         stubObject("parent1");
         stubObject("child1");
         stubObject("transaction1");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
         containmentIndex.purgeResource(transaction1.getId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
     }
 
     @Test
@@ -205,26 +205,26 @@ public class ContainmentIndexImplTest {
         stubObject("parent1");
         stubObject("child1");
         stubObject("transaction1");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(1, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
         containmentIndex.purgeResource(transaction1.getId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1).count());
-        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContainsDeleted(transaction1.getId(), parent1.getFedoraId()).count());
     }
 
     @Test
@@ -232,21 +232,21 @@ public class ContainmentIndexImplTest {
         stubObject("parent1");
         stubObject("child1");
         stubObject("transaction1");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).findFirst().get());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
         containmentIndex.rollbackTransaction(transaction1.getId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
         assertNull(containmentIndex.getContainedBy(transaction1.getId(), child1.getFedoraId()));
     }
@@ -256,25 +256,25 @@ public class ContainmentIndexImplTest {
         stubObject("parent1");
         stubObject("child2");
         stubObject("transaction1");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child2.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).findFirst().get());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child2.getFedoraId()));
         assertNull(containmentIndex.getContainedBy(null, child2.getFedoraId()));
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(null, parent1).findFirst().get());
+                containmentIndex.getContains(null, parent1.getFedoraId()).findFirst().get());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(transaction1.getId(), child2.getFedoraId()));
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).findFirst().get());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child2.getFedoraId()));
     }
@@ -286,35 +286,35 @@ public class ContainmentIndexImplTest {
         stubObject("child2");
         stubObject("transaction1");
         stubObject("transaction2");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(null, parent1).findFirst().get());
+                containmentIndex.getContains(null, parent1.getFedoraId()).findFirst().get());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child2.getFedoraId());
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         // Still the same outside
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(null, parent1).findFirst().get());
+                containmentIndex.getContains(null, parent1.getFedoraId()).findFirst().get());
         // Still the same in a different transaction
-        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction2.getId(), parent1).findFirst().get());
+                containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).findFirst().get());
         // Inside it has changed
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1.getId(), parent1).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).findFirst().get());
         containmentIndex.commitTransaction(transaction1.getId());
         // After commit() it is the same outside transactions.
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(null, parent1).findFirst().get());
+                containmentIndex.getContains(null, parent1.getFedoraId()).findFirst().get());
         // And now the same in a different transaction
-        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).count());
         assertEquals(child2.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction2.getId(), parent1).findFirst().get());
+                containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).findFirst().get());
     }
 
     @Test
@@ -324,27 +324,27 @@ public class ContainmentIndexImplTest {
         stubObject("child2");
         stubObject("transaction1");
         stubObject("transaction2");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child2.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(2, containmentIndex.getContains(null, parent1).count());
+        assertEquals(2, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         // Delete one object in separate transactions.
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.removeContainedBy(transaction2.getId(), parent1.getFedoraId(), child2.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).count());
         containmentIndex.commitTransaction(transaction1.getId());
         // Now only one record was removed
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         // Except in the second transaction as it should now have 0
-        assertEquals(0, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).count());
         containmentIndex.commitTransaction(transaction2.getId());
         // Now all are gone
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(0, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).count());
     }
 
     @Test
@@ -354,26 +354,26 @@ public class ContainmentIndexImplTest {
         stubObject("child2");
         stubObject("transaction1");
         stubObject("transaction2");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child2.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(2, containmentIndex.getContains(null, parent1).count());
+        assertEquals(2, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         // Delete one object in separate transactions.
         containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.removeContainedBy(transaction2.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).count());
         containmentIndex.commitTransaction(transaction1.getId());
         // Now only one record was removed
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).count());
         containmentIndex.commitTransaction(transaction2.getId());
         // No change as the first transaction already committed.
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction2.getId(), parent1.getFedoraId()).count());
     }
 
     @Test
@@ -382,14 +382,14 @@ public class ContainmentIndexImplTest {
         stubObject("parent2");
         stubObject("child1");
         stubObject("transaction1");
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(null, parent2).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(null, parent2.getFedoraId()).count());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.addContainedBy(transaction1.getId(), parent2.getFedoraId(), child1.getFedoraId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(null, parent2).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(null, parent2.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2.getFedoraId()).count());
         try {
             containmentIndex.commitTransaction(transaction1.getId());
             // We should get an exception.
@@ -398,10 +398,10 @@ public class ContainmentIndexImplTest {
             // This was an expected exception. Now continue the test.
         }
         // This should be rolled back so the additions should still be in the transaction operation table.
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
-        assertEquals(0, containmentIndex.getContains(null, parent2).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1).count());
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        assertEquals(0, containmentIndex.getContains(null, parent2.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2.getFedoraId()).count());
     }
 
     @Test
@@ -456,12 +456,12 @@ public class ContainmentIndexImplTest {
         stubObject("transaction1");
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
         containmentIndex.removeResource(transaction1.getId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
     }
 
@@ -476,19 +476,19 @@ public class ContainmentIndexImplTest {
         containmentIndex.addContainedBy(transaction2.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction2.getId());
         containmentIndex.addContainedBy(transaction1.getId(), parent2.getFedoraId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2.getFedoraId()).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1.getId(), parent2).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent2.getFedoraId()).findFirst().get());
         containmentIndex.removeResource(transaction2.getId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction2.getId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2).count());
+        assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent2.getFedoraId()).count());
         assertEquals(child1.getFedoraId().getFullId(),
-                containmentIndex.getContains(transaction1.getId(), parent2).findFirst().get());
+                containmentIndex.getContains(transaction1.getId(), parent2.getFedoraId()).findFirst().get());
     }
 
     @Test
@@ -500,18 +500,18 @@ public class ContainmentIndexImplTest {
         stubObject("transaction2");
         containmentIndex.addContainedBy(transaction2.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction2.getId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
         containmentIndex.removeResource(transaction1.getId(), child1.getFedoraId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(0, containmentIndex.getContains(null, parent1).count());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertNull(containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1).count());
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
     }
 
     /**
@@ -525,7 +525,7 @@ public class ContainmentIndexImplTest {
         final FedoraId fedoraID = FedoraId.create(child1.getFedoraId().getFullId());
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
         assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId()));
@@ -543,7 +543,7 @@ public class ContainmentIndexImplTest {
         final FedoraId fedoraID = FedoraId.create(child1.getFedoraId().getFullId() + "/");
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction1.getId());
-        assertEquals(1, containmentIndex.getContains(null, parent1).count());
+        assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
         assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId()));

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ContainerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ContainerImplTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.models;
+
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.Binary;
+import org.fcrepo.kernel.api.models.Container;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/containmentIndexTest.xml")
+public class ContainerImplTest {
+    @Mock
+    private PersistentStorageSessionManager sessionManager;
+    @Mock
+    private ResourceFactory resourceFactory;
+
+    private final static String TX_ID = "transacted";
+
+    private FedoraId fedoraId;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        final var fedoraIdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
+        fedoraId = FedoraId.create(fedoraIdStr);
+    }
+
+    @Test
+    public void getChildren_WithChildren() {
+        final var child1 = mock(Container.class);
+        final var child2 = mock(Binary.class);
+        final var childrenStream = Stream.of(child1, child2);
+
+        when(resourceFactory.getChildren(TX_ID, fedoraId)).thenReturn(childrenStream);
+
+        final Container container = new ContainerImpl(fedoraId, TX_ID, sessionManager, resourceFactory);
+
+        final var resultStream = container.getChildren();
+        final var childrenList = resultStream.collect(Collectors.toList());
+        assertEquals(2, childrenList.size());
+
+        assertTrue(childrenList.stream().anyMatch(c -> c instanceof Container));
+        assertTrue(childrenList.stream().anyMatch(c -> c instanceof Binary));
+    }
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ContainerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ContainerImplTest.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.kernel.impl.models;
 
-import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -58,8 +57,7 @@ public class ContainerImplTest {
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
-        final var fedoraIdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
-        fedoraId = FedoraId.create(fedoraIdStr);
+        fedoraId = FedoraId.create(UUID.randomUUID().toString());
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
@@ -205,6 +205,12 @@ public class FedoraResourceImplTest {
         assertEquals(expectedTypes.size(), resourceTypes.size());
     }
 
+    @Test
+    public void testGetChildren() {
+        final var resource = new FedoraResourceImpl(FEDORA_ID, null, sessionManager, resourceFactory);
+        assertEquals(0, resource.getChildren().count());
+    }
+
     private void expectMementos(final String... instants) {
         final var mementos = new ArrayList<FedoraResource>(instants.length);
         for (int i = 0; i < instants.length; i++) {

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
@@ -49,6 +49,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
@@ -416,6 +417,67 @@ public class ResourceFactoryImplTest {
         when(psSession.getHeaders(fedoraMementoId, fedoraMementoId.getMementoInstant()))
                 .thenThrow(PersistentSessionClosedException.class);
         factory.doesResourceExist(null, fedoraMementoId);
+    }
+
+    @Test
+    public void getChildren_NoChildren() throws Exception {
+        populateHeaders(resourceHeaders, BASIC_CONTAINER);
+
+        final var childrenStream = factory.getChildren(sessionId, fedoraId);
+
+        assertEquals(0, childrenStream.count());
+    }
+
+    @Test
+    public void getChildren_DoesNotExist() throws Exception {
+        final var childrenStream = factory.getChildren(sessionId, fedoraId);
+        assertEquals(0, childrenStream.count());
+    }
+
+    @Test
+    public void getChildren_WithChildren() throws Exception {
+        populateHeaders(resourceHeaders, BASIC_CONTAINER);
+
+        final var child1IdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
+        final var child1Id = FedoraId.create(child1IdStr);
+        final var child1Headers = new ResourceHeadersImpl();
+        child1Headers.setId(child1Id);
+        populateHeaders(child1Headers, BASIC_CONTAINER);
+        when(psSession.getHeaders(child1Id, null)).thenReturn(child1Headers);
+
+        final var childNestedIdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
+        final var childNestedId = FedoraId.create(childNestedIdStr);
+        final var childNestedHeaders = new ResourceHeadersImpl();
+        childNestedHeaders.setId(childNestedId);
+        populateHeaders(childNestedHeaders, BASIC_CONTAINER);
+        when(psSession.getHeaders(childNestedId, null)).thenReturn(childNestedHeaders);
+
+        final var child2IdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
+        final var child2Id = FedoraId.create(child2IdStr);
+        final var child2Headers = new ResourceHeadersImpl();
+        child2Headers.setId(child2Id);
+        populateHeaders(child2Headers, NON_RDF_SOURCE);
+        populateInternalBinaryHeaders(child2Headers);
+        when(psSession.getHeaders(child2Id, null)).thenReturn(child2Headers);
+
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
+        containmentIndex.addContainedBy(mockTx.getId(), fedoraId, child1Id);
+        containmentIndex.addContainedBy(mockTx.getId(), child1Id, childNestedId);
+        containmentIndex.addContainedBy(mockTx.getId(), fedoraId, child2Id);
+        containmentIndex.commitTransaction(mockTx.getId());
+
+        final var childrenStream = factory.getChildren(sessionId, fedoraId);
+        final var childrenList = childrenStream.collect(Collectors.toList());
+
+        assertEquals(2, childrenList.size());
+
+        final var child1 = childrenList.stream().filter(c -> c.getFedoraId().equals(child1Id)).findFirst();
+        assertTrue(child1.isPresent());
+        assertTrue(child1.get() instanceof Container);
+
+        final var child2 = childrenList.stream().filter(c -> c.getFedoraId().equals(child2Id)).findFirst();
+        assertTrue(child2.isPresent());
+        assertTrue(child2.get() instanceof Binary);
     }
 
     private void assertStateFieldsMatches(final FedoraResource resc) {

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
@@ -107,7 +107,7 @@ public class ResourceFactoryImplTest {
 
     private String sessionId;
 
-    private FedoraId rootId = FedoraId.getRepositoryRootId();
+    private final FedoraId rootId = FedoraId.getRepositoryRootId();
 
     private FedoraId fedoraId;
 
@@ -156,7 +156,7 @@ public class ResourceFactoryImplTest {
     public void cleanUp() {
         when(mockResource.getFedoraId()).thenReturn(rootId);
         containmentIndex.rollbackTransaction(mockTx.getId());
-        containmentIndex.getContains(null, mockResource).forEach(c ->
+        containmentIndex.getContains(null, rootId).forEach(c ->
                 containmentIndex.removeContainedBy(mockTx.getId(), rootId, FedoraId.create(c)));
         containmentIndex.commitTransaction(mockTx.getId());
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceFactoryImplTest.java
@@ -438,22 +438,19 @@ public class ResourceFactoryImplTest {
     public void getChildren_WithChildren() throws Exception {
         populateHeaders(resourceHeaders, BASIC_CONTAINER);
 
-        final var child1IdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
-        final var child1Id = FedoraId.create(child1IdStr);
+        final var child1Id = FedoraId.create(UUID.randomUUID().toString());
         final var child1Headers = new ResourceHeadersImpl();
         child1Headers.setId(child1Id);
         populateHeaders(child1Headers, BASIC_CONTAINER);
         when(psSession.getHeaders(child1Id, null)).thenReturn(child1Headers);
 
-        final var childNestedIdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
-        final var childNestedId = FedoraId.create(childNestedIdStr);
+        final var childNestedId = FedoraId.create(UUID.randomUUID().toString());
         final var childNestedHeaders = new ResourceHeadersImpl();
         childNestedHeaders.setId(childNestedId);
         populateHeaders(childNestedHeaders, BASIC_CONTAINER);
         when(psSession.getHeaders(childNestedId, null)).thenReturn(childNestedHeaders);
 
-        final var child2IdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
-        final var child2Id = FedoraId.create(child2IdStr);
+        final var child2Id = FedoraId.create(UUID.randomUUID().toString());
         final var child2Headers = new ResourceHeadersImpl();
         child2Headers.setId(child2Id);
         populateHeaders(child2Headers, NON_RDF_SOURCE);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImplTest.java
@@ -81,7 +81,7 @@ public class ContainmentTriplesServiceImplTest {
 
     @After
     public void cleanUp() {
-        containmentIndex.getContains(transaction.getId(), parentResource).forEach(c ->
+        containmentIndex.getContains(transaction.getId(), parentResource.getFedoraId()).forEach(c ->
                 containmentIndex.removeContainedBy(transaction.getId(), parentResource.getFedoraId(),
                         FedoraId.create(c)));
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -193,8 +193,7 @@ public class CreateResourceServiceImplTest {
     @After
     public void cleanUp() {
         cleanupList.forEach(parentID -> {
-            when(fedoraResource.getFedoraId()).thenReturn(parentID);
-            containmentIndex.getContains(transaction.getId(), fedoraResource).forEach(c ->
+            containmentIndex.getContains(transaction.getId(), parentID).forEach(c ->
                     containmentIndex.removeContainedBy(TX_ID, parentID, FedoraId.create(c)));
         });
         cleanupList.clear();
@@ -272,8 +271,7 @@ public class CreateResourceServiceImplTest {
         final FedoraId persistedId = operationCaptor.getValue().getResourceId();
         assertNotEquals(fedoraId, persistedId);
         assertTrue(persistedId.getFullId().startsWith(fedoraId.getFullId()));
-        when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
+        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraId).count());
     }
 
     /**
@@ -297,8 +295,7 @@ public class CreateResourceServiceImplTest {
         assertTrue(persistedId.getFullId().startsWith(fedoraId.getFullId()));
         assertBinaryPropertiesPresent(operation);
         assertEquals(fedoraId, operation.getParentId());
-        when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
+        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraId).count());
     }
 
     /**
@@ -344,8 +341,7 @@ public class CreateResourceServiceImplTest {
         assertEquals(relaxedUser, rdfOp.getLastModifiedBy());
         assertEquals(createdDate, rdfOp.getCreatedDate());
         assertEquals(lastModifiedDate, rdfOp.getLastModifiedDate());
-        when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
+        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraId).count());
     }
 
     /**
@@ -376,8 +372,7 @@ public class CreateResourceServiceImplTest {
 
         final var descOperation = getOperation(operations, CreateRdfSourceOperation.class);
         assertEquals(persistedId.asDescription(), descOperation.getResourceId());
-        when(fedoraResource.getFedoraId()).thenReturn(fedoraId);
-        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraResource).count());
+        assertEquals(1, containmentIndex.getContains(transaction.getId(), fedoraId).count());
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -127,7 +127,7 @@ public class DeleteResourceServiceImplTest {
     @After
     public void cleanUp() {
         containmentIndex.rollbackTransaction(tx.getId());
-        containmentIndex.getContains(null, container).forEach(c ->
+        containmentIndex.getContains(null, RESOURCE_ID).forEach(c ->
                 containmentIndex.removeContainedBy(tx.getId(), container.getFedoraId(), FedoraId.create(c)));
         containmentIndex.commitTransaction(tx.getId());
     }
@@ -156,7 +156,7 @@ public class DeleteResourceServiceImplTest {
         when(container.isAcl()).thenReturn(false);
         when(container.getAcl()).thenReturn(null);
 
-        assertEquals(1, containmentIndex.getContains(tx.getId(), container).count());
+        assertEquals(1, containmentIndex.getContains(tx.getId(), RESOURCE_ID).count());
         service.perform(tx, container, USER);
 
         verify(pSession, times(2)).persist(operationCaptor.capture());
@@ -166,7 +166,7 @@ public class DeleteResourceServiceImplTest {
         assertEquals(CHILD_RESOURCE_ID, operations.get(0).getResourceId());
         assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
 
-        assertEquals(0, containmentIndex.getContains(tx.getId(), container).count());
+        assertEquals(0, containmentIndex.getContains(tx.getId(), RESOURCE_ID).count());
     }
 
     private void verifyResourceOperation(final FedoraId fedoraID,

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
@@ -160,7 +160,7 @@ public class PurgeResourceServiceImplTest {
         assertEquals(CHILD_RESOURCE_ID, operations.get(0).getResourceId());
         assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
 
-        assertEquals(0, containmentIndex.getContains(tx.getId(), container).count());
+        assertEquals(0, containmentIndex.getContains(tx.getId(), RESOURCE_ID).count());
     }
 
     private void verifyResourceOperation(final FedoraId fedoraID,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3431

# What does this Pull Request do?
* Implements getChildren for FedoraResource, Container and ResourceFactory
* All ContainmentIndex methods now take FedoraIds instead of FedoraResource.
* Deprecates unused `getChild` method (which seems modeshape oriented)


# How should this be tested?

New tests were added. No functional changes.
