### PR TITLE
Reject sparql-update as rdf for object creation.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -48,6 +48,7 @@ import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.exception.UnsupportedMediaTypeException;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
@@ -209,6 +210,11 @@ public class HttpRdfService {
         }
 
         final Lang format = contentTypeToLang(contentTypeWithoutCharset);
+        if (format == null) {
+            // No valid RDF format for the mimeType.
+            throw new UnsupportedMediaTypeException("Media type " + contentTypeWithoutCharset + " is not a valid RDF " +
+                    "format");
+        }
         try {
             final Model inputModel = createDefaultModel();
             inputModel.read(requestBodyStream, extResourceId, format.getName().toUpperCase());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -756,7 +756,7 @@ public class FedoraLdpTest {
         verify(builder, times(0)).entity(any());
     }
 
-    @Ignore("Can't properly omit triples - FCREPO-3037")
+    @Ignore("Needs membership triples - FCREPO-3165")
     @Test
     public void testGetWithObjectOmitContainment() throws Exception {
         setResource(Container.class);
@@ -774,7 +774,7 @@ public class FedoraLdpTest {
         }
     }
 
-    @Ignore("Membership Triples not implemented - FCREPO-3165 & Can't properly omit triples - FCREPO-3037")
+    @Ignore("Membership Triples not implemented - FCREPO-3165 & Needs membership triples - FCREPO-3165")
     @Test
     public void testGetWithObjectOmitMembership() throws Exception {
         setResource(Container.class);

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/UnsupportedMediaTypeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/UnsupportedMediaTypeExceptionMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import static javax.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+import static javax.ws.rs.core.Response.status;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.fcrepo.kernel.api.exception.UnsupportedMediaTypeException;
+import org.slf4j.Logger;
+
+/**
+ * UnsupportedMediaType mapper
+ * @author whikloj
+ * @since 6.0.0
+ */
+@Provider
+public class UnsupportedMediaTypeExceptionMapper implements
+        ExceptionMapper<UnsupportedMediaTypeException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER =
+        getLogger(UnsupportedMediaTypeExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final UnsupportedMediaTypeException e) {
+        debugException(this, e, LOGGER);
+
+        return status(UNSUPPORTED_MEDIA_TYPE).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/UnsupportedMediaTypeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/UnsupportedMediaTypeException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Exception when trying to use an unsupported media type.
+ * @author whikloj
+ * @since 6.0.0
+ */
+public class UnsupportedMediaTypeException extends RepositoryRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Default constructor.
+     * @param msg the exception message.
+     */
+    public UnsupportedMediaTypeException(final String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3429

# What does this Pull Request do?
Previously we allowed people to POST/PUT with application/sparql-update. This is no longer supported and as such we need to reject the mimetype. This adds a new Exception and Mapper and throws it from the HttpRdfService if we can't get a Jena RDF format from the mimeType.

Also corrects some tickets and removes an old test.

# How should this be tested?

Before the PR.
Post with application/sparql-update
```
curl -i -ufedoraAdmin:fedoraAdmin -H"Content-type: application/sparql-update" -d"INSERT { <> <http://purl.org/dc/elements/1.1/title> \"title\" } WHERE {}" -XPOST http://localhost:8080/rest
```
Get a `500 Server Error`.
Pull in this PR.
Do the same thing, get a `415 Unsupported Media Type` 

# Interested parties
@fcrepo4/committers
